### PR TITLE
Fix github pages site to use proper relative links.

### DIFF
--- a/config/site/Rakefile
+++ b/config/site/Rakefile
@@ -126,9 +126,17 @@ module ElasticGraph
           end
         end
 
+        common_jekyll_args = [
+          "--source #{SITE_SOURCE_DIR}",
+          "--destination #{JEKYLL_SITE_DIR}",
+          "--baseUrl /elasticgraph",
+          "--strict-front-matter",
+          "--trace"
+        ].join(" ")
+
         desc "Build Jekyll site with freshly generated YARD documentation"
         task build: [:build_docs, :build_css, "examples:compile_queries"] do
-          sh "bundle exec jekyll build --source #{SITE_SOURCE_DIR} --destination #{JEKYLL_SITE_DIR}"
+          sh "bundle exec jekyll build #{common_jekyll_args}"
         end
 
         desc "Serve Jekyll site locally"
@@ -170,7 +178,7 @@ module ElasticGraph
             end
           end
 
-          sh "bundle exec jekyll serve --source #{SITE_SOURCE_DIR} --destination #{JEKYLL_SITE_DIR} --trace"
+          sh "bundle exec jekyll serve #{common_jekyll_args}"
         end
 
         desc "Perform validations of the website, including doc tests and doc coverage"

--- a/config/site/src/_includes/navbar.html
+++ b/config/site/src/_includes/navbar.html
@@ -2,14 +2,14 @@
 <nav class="w-full py-4 bg-gray-200 dark:bg-gray-800 shadow">
   <div class="container mx-auto flex justify-between items-center px-4">
     <div class="text-xl flex items-center space-x-4">
-      <a href="/" class="font-bold hover:underline">ElasticGraph</a>
-      <a href="/docs/main" class="{{ site.style.link }}">Docs</a>
-      <a href="/query-api" class="{{ site.style.link }}">Query API</a>
+      <a href="{{ '/' | relative_url }}" class="font-bold hover:underline">ElasticGraph</a>
+      <a href="{{ '/docs/main' | relative_url }}" class="{{ site.style.link }}">Docs</a>
+      <a href="{{ '/query-api' | relative_url }}" class="{{ site.style.link }}">Query API</a>
     </div>
     <div>
       <a href="{{ site.github_url }}" target="_blank"
         class="{{ site.style.link }} mr-2">GitHub</a>
-      <a href="/about" class="{{ site.style.link }}">About</a>
+      <a href="{{ '/about' | relative_url }}" class="{{ site.style.link }}">About</a>
     </div>
   </div>
 
@@ -19,7 +19,7 @@
       <ol class="list-reset flex">
         {% if page.url != "/" %}
         <li>
-          <a href="/" class="hover:underline">Home</a>
+          <a href="{{ '/' | relative_url }}" class="hover:underline">Home</a>
         </li>
         {% endif %}
 
@@ -39,7 +39,7 @@
             {% if page.url == link %}
               {{ page_title }}
             {% else %}
-              <a href="{{ link }}" class="hover:underline capitalize">
+              <a href="{{ link | relative_url }}" class="hover:underline capitalize">
                 {{ page_title }}
               </a>
             {% endif %}

--- a/config/site/src/_includes/subpages.html
+++ b/config/site/src/_includes/subpages.html
@@ -7,7 +7,7 @@
       {% assign subpage_url_parts = subpage.url | split: '/' | size %}
       {% if subpage_url_parts == needed_subpage_part_count %}
         <li>
-          <a href="{{ subpage.url }}" class="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-600 transition-colors duration-300">
+          <a href="{{ subpage.url | relative_url }}" class="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-600 transition-colors duration-300">
             {{ subpage.subpage_title }}
           </a>
         </li>

--- a/config/site/src/index.html
+++ b/config/site/src/index.html
@@ -13,7 +13,7 @@ title: ElasticGraph
       A general-purpose framework and platform for indexing, searching,
       grouping, and aggregating data.
     </p>
-    <a href="/docs/main"
+    <a href="{{ '/docs/main' | relative_url }}"
       class="inline-block bg-blue-600 dark:bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-500 dark:hover:bg-blue-400 transition">
       Documentation
     </a>


### PR DESCRIPTION
It's hosted at https://block.github.io/elasticgraph/ and the links were all broken because they assume it's served from a domain root.