### PR TITLE
Change anyOf behaviour to evaluate to true for empty predicates

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/boolean_query.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/boolean_query.rb
@@ -33,12 +33,7 @@ module ElasticGraph
           bool_node[occurrence].concat(clauses)
         end
 
-        # For `any_of: []` we need a way to force the datastore to match no documents, but
-        # I haven't found any sort of literal `false` we can pass in the compound expression
-        # or even a literal `1 = 0` as is sometimes used in SQL. Instead, we use this for that
-        # case.
-        empty_array = [] # : ::Array[untyped]
-        ALWAYS_FALSE_FILTER = filter({ids: {values: empty_array}})
+        ALWAYS_FALSE_FILTER = filter({match_none: {}})
       end
     end
   end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_value_set_extractor.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_value_set_extractor.rb
@@ -83,7 +83,7 @@ module ElasticGraph
         # to a particular field.
         def filter_value_set_for_filter_hash_entry(field_or_op, filter_value, target_field_path_parts, traversed_field_path_parts, negate:)
           if filter_value.nil?
-            # Any filter with a `nil` value is effectively ignored by our filtering logic, so we need
+            # Any filter with a `nil` value is effectively treated as `true` by our filtering logic, so we need
             # to return our `@all_values_set` to indicate this filter matches all documents.
             @all_values_set
           elsif field_or_op == @schema_names.not

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/sub_aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/sub_aggregations_spec.rb
@@ -193,7 +193,7 @@ module ElasticGraph
         }]
       end
 
-      it "ignores empty filters" do
+      it "treats empty filters as `true`" do
         query = aggregation_query_of(name: "teams", sub_aggregations: [
           nested_sub_aggregation_of(path_in_index: ["current_players_nested"], query: sub_aggregation_query_of(name: "current_players_nested", filter: {
             "name" => {"equal_to_any_of" => nil}

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/ungrouped_sub_aggregation_shared_examples.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/ungrouped_sub_aggregation_shared_examples.rb
@@ -253,7 +253,7 @@ module ElasticGraph
           }]
         end
 
-        it "ignores an empty filter" do
+        it "treats an empty filter treating as `true`" do
           aggs = {
             "target:seasons_nested" => {"doc_count" => 423, "meta" => outer_meta}
           }

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/shard_routing_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/shard_routing_spec.rb
@@ -253,9 +253,31 @@ module ElasticGraph
         ]})).to search_all_shards
       end
 
-      it "searches all shards when we have an `any_of: []` filter because that will match all results" do
+      # TODO: Change behaviour so no shards are matched when given `anyOf => []`.
+      #       Updated references of ignore and prune to use language such as "treated ... as `true`"
+      it "searches no shards when we have an `any_of: []` filter because that will match no results" do
         expect(shard_routing_for(["name"], {
           "any_of" => []
+        })).to search_all_shards
+      end
+
+      # TODO: Change behaviour so no shards are matched when given `anyOf => {anyOf => []}`
+      #       Updated references of ignore and prune to use language such as "treated ... as `true`"
+      it "searches no shards when we have an `any_of: [{anyof: []}]` filter because that will match no results" do
+        expect(shard_routing_for(["name"], {
+          "any_of" => [{"any_of" => []}]
+        })).to search_all_shards
+      end
+
+      it "searches all shards when we have an `any_of: [{field: nil}]` filter because that will match all results" do
+        expect(shard_routing_for(["name"], {
+          "any_of" => [{"name" => nil}]
+        })).to search_all_shards
+      end
+
+      it "searches all shards when we have an `any_of: [{field: nil}, {...}]` filter because that will match all results" do
+        expect(shard_routing_for(["name"], {
+          "any_of" => [{"name" => nil}, {"id" => {"equal_to_any_of" => ["abc"]}}]
         })).to search_all_shards
       end
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/sub_aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/sub_aggregations_spec.rb
@@ -178,7 +178,7 @@ module ElasticGraph
         })
       end
 
-      it "ignores empty filters" do
+      it "treats empty filters treating as `true`" do
         query = new_query(aggregations: [aggregation_query_of(name: "teams", sub_aggregations: [
           nested_sub_aggregation_of(path_in_index: ["current_players_nested"], query: sub_aggregation_query_of(name: "current_players_nested", filter: {
             "name" => {"equal_to_any_of" => nil}

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/filters_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/filters_spec.rb
@@ -533,7 +533,7 @@ module ElasticGraph
           end
 
           describe "`null` leaves" do
-            it "ignores `filter: null`" do
+            it "treats `filter: null` as true" do
               query = datastore_query_for(:Query, :components, <<~QUERY)
                 query {
                   components(filter: null) {
@@ -547,7 +547,7 @@ module ElasticGraph
               expect(query.filters).to contain_exactly(exclude_incomplete_docs_filter)
             end
 
-            it "ignores a `field: null` filter since it will get pruned" do
+            it "treats `field: null` filter as `true`" do
               query = datastore_query_for(:Query, :components, <<~QUERY)
                 query {
                   components(filter: {cost: null}) {
@@ -579,7 +579,7 @@ module ElasticGraph
               expect(query.filters).to contain_exactly({"cost" => nil, "name" => {"equal_to_any_of" => ["thingy"]}})
             end
 
-            it "ignores a `field: {predicate: null}` filter since it will get pruned" do
+            it "treats `field: {predicate: null}` filter as `true`" do
               query = datastore_query_for(:Query, :components, <<~QUERY)
                 query {
                   components(filter: {cost: {equal_to_any_of: null}}) {
@@ -614,7 +614,7 @@ module ElasticGraph
               })
             end
 
-            it "ignores a `null` filter since it will get pruned" do
+            it "treats `null` filter as `true`" do
               query = datastore_query_for(:Query, :components, <<~QUERY)
                 query {
                   components(filter: {options: null}) {
@@ -649,7 +649,7 @@ module ElasticGraph
               })
             end
 
-            it "ignores a `parent_field: {child_field: null}` filter since it will get pruned" do
+            it "treats `parent_field: {child_field: null}` as true" do
               query = datastore_query_for(:Query, :components, <<~QUERY)
                 query {
                   components(filter: {options: {size: null}}) {
@@ -684,7 +684,7 @@ module ElasticGraph
               })
             end
 
-            it "ignores a `parent_field: {child_field: {predicate: null}}` filter since it will get pruned" do
+            it "treats `parent_field: {child_field: {predicate: null}}` as true" do
               query = datastore_query_for(:Query, :components, <<~QUERY)
                 query {
                   components(filter: {options: {size: {equal_to_any_of: null}}}) {
@@ -932,7 +932,7 @@ module ElasticGraph
               )
             end
 
-            it "includes the incomplete doc exclusion filter when there are no sub-clauses, because the filter is ignored" do
+            it "includes the incomplete doc exclusion filter when there are no sub-clauses, because the filter is treated as `false` for being empty" do
               query = datastore_query_for(:Query, :components, <<~QUERY)
                 query {
                   components(filter: {any_of: []}) {


### PR DESCRIPTION
# Context

Currently empty predicates are ignored.  Within an AND context (the normal context), that works correctly. Within an OR context (under an anyOf) it does not work correctly: empty predicates should essentially be treated as `true`: 

* `predicate AND emptyPredicate` should be like `predicate AND true` which reduces to predicate (and thus is equivalent to ignoring the empty predicate).

* `predicate OR emptyPredicate` should be like `predicate OR true` which just reduces to `true`

Notably, `filter: A` and `filter: {anyOf: [A]}` should behave the same but right now they do not when `A` is an empty predicate – `filter: emptyPredicate` returns all results whereas `filter: {anyOf: [emptyPredicate]}` returns no results.

# Change

This PR as mentioned above, looks to change `filter: {field: nil}` and `filter: {field: {}}` to evaluate to true. This in turns changes how anyOf behaves to be more like an `OR` block, as shown below:

* `filter: {anyOf: [emptyPredicate]}` will evaluate to `true`, instead of `false`
* `filter: {anyOf: [emptyPredicate, {name: {equalToAnyOf: ["test"]}}]}` will evaluate to `true`, instead of `false`

At the same time the behaviour of `(filter: {anyOf: []})` matching no documents is still preserved.

Because of the way emptyPredicates are treated now, the following changes occured for how `not` behaves:

* `filter: {not: {field: nil}}` will evaluate to `false`, instead of being ignored