### PR TITLE
Treat nil values as empty predicate

### DIFF
--- a/elasticgraph-graphql/sig/elastic_graph/graphql/filtering/filter_interpreter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/filtering/filter_interpreter.rbs
@@ -41,7 +41,8 @@ module ElasticGraph
         def process_sub_field_expression: (stringOrSymbolHash, stringHash, FieldPath) -> void
         def process_list_count_expression: (stringOrSymbolHash, stringHash, FieldPath) -> void
         def build_bool_hash: () { (stringOrSymbolHash) -> void } -> stringOrSymbolHash?
-        def excludes_zero?: (stringHash) -> bool
+        def filters_to_range_including_zero?: (stringHash) -> bool
+        def operator_excludes_zero?: (::String, untyped) -> bool
         def required_matching_clause_count: (stringOrSymbolHash) -> ::Integer
       end
     end


### PR DESCRIPTION
This is a prep PR before changing the behaviour of how `anyOf` works.