### PR TITLE
Fix CODEOWNERS so that @BrianSigafoos-SQ and I are both owners.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,8 +9,7 @@
 # The format is described: https://github.blog/2017-07-06-introducing-code-owners/
 
 # These owners will be the default owners for everything in the repo.
-*       @myronmarston
-*       @BrianSigafoos-SQ
+*       @myronmarston @BrianSigafoos-SQ
 
 # -----------------------------------------------
 # BELOW THIS LINE ARE TEMPLATES, UNUSED


### PR DESCRIPTION
I thought it was a markdown list but it turns out the `*` is a wildcard and all owners have to be listed on the same line, as per the docs[^1]:

> If you want to match two or more code owners with the same pattern,
> all the code owners must be on the same line. If the code owners are
> not on the same line, the pattern matches only the last mentioned
> code owner.

[^1]: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax