### PR TITLE
Update site success story metrics

### DIFF
--- a/config/site/src/_config.yaml
+++ b/config/site/src/_config.yaml
@@ -8,8 +8,7 @@ x_url: https://x.com/elasticgraph
 x_username: "@ElasticGraph"
 support_email: elasticgraph@squareup.com
 tagline: Schema-driven, scalable, cloud-native, batteries-included GraphQL with superpowers.
-description: ElasticGraph is an open-source framework for indexing, searching, grouping, and aggregating data.
-
+description: ElasticGraph is an open-source framework for indexing, searching, and aggregating data powered by GraphQL and OpenSearch.
 
 # Reusable CSS styling for the site, available via the `site.style` variable, ex: `{{ site.style.body }}`
 style:

--- a/config/site/src/_includes/success_stories.html
+++ b/config/site/src/_includes/success_stories.html
@@ -19,42 +19,75 @@
         <div class="flex flex-col md:flex-row justify-between gap-6">
           <!-- Ingestion Performance Card -->
           <div class="bg-gray-100 dark:bg-gray-700 p-6 rounded-lg md:w-1/3">
-            <h4 class="text-xl font-bold mb-4">Ingestion Latency</h4>
+            <h4 class="text-xl font-bold mb-4">Ingestion</h4>
             <p
               class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mb-2">
-              &lt; 400ms</p>
-            <p class="text-sm text-gray-700 dark:text-gray-300">p99 latency</p>
+              &lt; 400ms
+            </p>
+            <p class="text-sm text-gray-700 dark:text-gray-300">
+              p99 latency
+            </p>
             <p
               class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mt-4">
-              &lt; 1s</p>
-            <p class="text-sm text-gray-700 dark:text-gray-300">p99.99 latency
+              &lt; 1s
+            </p>
+            <p class="text-sm text-gray-700 dark:text-gray-300">
+              p99.99 latency
+            </p>
+            <p class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mt-4">
+              200k/s
+            </p>
+            <p class="text-sm text-gray-700 dark:text-gray-300">
+              documents/s ingested
             </p>
           </div>
           <!-- GraphQL API Latency Card -->
           <div class="bg-gray-100 dark:bg-gray-700 p-6 rounded-lg md:w-1/3">
-            <h4 class="text-xl font-bold mb-4">Query Latency</h4>
+            <h4 class="text-xl font-bold mb-4">Query</h4>
             <p
               class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mb-2">
-              &lt; 350ms</p>
-            <p class="text-sm text-gray-700 dark:text-gray-300">p99 latency</p>
+              &lt; 350ms
+            </p>
+            <p class="text-sm text-gray-700 dark:text-gray-300">
+              p99 latency
+            </p>
             <p
               class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mt-4">
-              &lt; 2.5s</p>
-            <p class="text-sm text-gray-700 dark:text-gray-300">p99.99 latency
+              &lt; 2.5s
+            </p>
+            <p class="text-sm text-gray-700 dark:text-gray-300">
+              p99.99 latency
+            </p>
+            <p class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mt-4">
+              500 QPS
+            </p>
+            <p class="text-sm text-gray-700 dark:text-gray-300">
+              queries/s
             </p>
           </div>
           <!-- Dataset Card -->
           <div class="bg-gray-100 dark:bg-gray-700 p-6 rounded-lg md:w-1/3">
             <h4 class="text-xl font-bold mb-4">Dataset</h4>
-            <p class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mb-2">
-              100TB</p>
-            <p class="text-sm text-gray-700 dark:text-gray-300">indexed data</p>
-            <p class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mt-4">
+            <p
+              class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mb-2">
+              100TB
+            </p>
+            <p class="text-sm text-gray-700 dark:text-gray-300">
+              indexed data
+            </p>
+            <p
+              class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mt-4">
               &gt; 100B</p>
-            <p class="text-sm text-gray-700 dark:text-gray-300">indexed documents</p>
-            <p class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mt-4">
-              &gt; 100 QPS</p>
-            <p class="text-sm text-gray-700 dark:text-gray-300">both query & ingestion</p>
+            <p class="text-sm text-gray-700 dark:text-gray-300">
+              indexed documents
+            </p>
+            <p
+              class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mt-4">
+              &gt; 99.999%
+            </p>
+            <p class="text-sm text-gray-700 dark:text-gray-300">
+              availability
+            </p>
           </div>
         </div>
       </div>

--- a/config/site/src/_includes/testimonials.html
+++ b/config/site/src/_includes/testimonials.html
@@ -25,7 +25,7 @@
       </div>
       <div class="bg-gray-100 dark:bg-gray-700 p-6 rounded-lg shadow">
         <p class="text-lg italic mb-4">
-          Use ElasticGraph and love it? We'd love to hear from you! Send us a testimonial.
+          Use ElasticGraph and love it? We'd love to hear from you! Send us your feedback.
         </p>
         <div class="font-bold">
 

--- a/config/site/src/index.html
+++ b/config/site/src/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: ElasticGraph
+title: ElasticGraph - Open-source GraphQL & OpenSearch framework
 ---
 
 <!-- Main Content -->


### PR DESCRIPTION
Also, for discoverability (SEO) we should include both keywords `GraphQL` and `OpenSearch` in the page homepage  (max 60char) title and description.

Updated metrics
<img width="1018" alt="Screenshot 2024-11-01 at 9 51 31 AM" src="https://github.com/user-attachments/assets/cbc7a6ab-7124-4fe3-b223-93300570be1b">
