### PR TITLE
Treat emptyPredicates as always true, instead of pruning them

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/boolean_query.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/boolean_query.rb
@@ -33,12 +33,12 @@ module ElasticGraph
           bool_node[occurrence].concat(clauses)
         end
 
-        # For `any_of: []` we need a way to force the datastore to match no documents, but
-        # I haven't found any sort of literal `false` we can pass in the compound expression
-        # or even a literal `1 = 0` as is sometimes used in SQL. Instead, we use this for that
-        # case.
-        empty_array = [] # : ::Array[untyped]
-        ALWAYS_FALSE_FILTER = filter({ids: {values: empty_array}})
+        MATCH_ALL = {match_all: {}}
+        MATCH_ALL_FILTER = filter(MATCH_ALL)
+        MATCH_ALL_FILTER_HASH = {bool: {filter: [MATCH_ALL]}}
+        MATCH_NONE = {match_none: {}}
+        MATCH_NONE_FILTER = filter(MATCH_NONE)
+        MATCH_NONE_FILTER_HASH = {bool: {filter: [MATCH_NONE]}}
       end
     end
   end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/filtering/boolean_query.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/filtering/boolean_query.rbs
@@ -26,7 +26,12 @@ module ElasticGraph
         def self.should: (*stringOrSymbolHash) -> BooleanQuery
         def merge_into: (stringOrSymbolHash) -> void
 
-        ALWAYS_FALSE_FILTER: BooleanQuery
+        MATCH_ALL: ::Hash[Symbol, untyped]
+        MATCH_ALL_FILTER: BooleanQuery
+        MATCH_ALL_FILTER_HASH: ::Hash[Symbol, untyped]
+        MATCH_NONE: ::Hash[Symbol, untyped]
+        MATCH_NONE_FILTER: BooleanQuery
+        MATCH_NONE_FILTER_HASH: ::Hash[Symbol, untyped]
       end
     end
   end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/filtering/filter_interpreter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/filtering/filter_interpreter.rbs
@@ -29,8 +29,15 @@ module ElasticGraph
 
         private
 
+        def reduce_query: (stringOrSymbolHash?) -> stringOrSymbolHash?
+        def reduce_must: (stringOrSymbolHash?) -> bool
+        def reduce_filter: (stringOrSymbolHash?) -> bool
+        def reduce_should: (stringOrSymbolHash?) -> bool
+        def reduce_must_not: (stringOrSymbolHash?) -> bool
+        def reduce_nested: (stringOrSymbolHash?) -> bool
         def process_filter_hash: (stringOrSymbolHash, stringHash, FieldPath) -> void
         def filters_on_sub_fields?: (stringHash) -> bool
+        def process_empty_or_nil_expression: (stringOrSymbolHash, ::String) -> void
         def process_not_expression: (stringOrSymbolHash, stringHash, FieldPath) -> void
         def process_list_any_filter_expression: (stringOrSymbolHash, stringHash, FieldPath) -> void
         def process_any_satisfy_filter_expression_on_nested_object_list: (stringOrSymbolHash, stringHash, FieldPath) -> void

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/filtering/filter_interpreter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/filtering/filter_interpreter.rbs
@@ -37,7 +37,7 @@ module ElasticGraph
         def reduce_nested: (stringOrSymbolHash?) -> bool
         def process_filter_hash: (stringOrSymbolHash, stringHash, FieldPath) -> void
         def filters_on_sub_fields?: (stringHash) -> bool
-        def process_empty_or_nil_expression: (stringOrSymbolHash, ::String) -> void
+        def process_empty_expression: (stringOrSymbolHash, ::String) -> void
         def process_not_expression: (stringOrSymbolHash, stringHash, FieldPath) -> void
         def process_list_any_filter_expression: (stringOrSymbolHash, stringHash, FieldPath) -> void
         def process_any_satisfy_filter_expression_on_nested_object_list: (stringOrSymbolHash, stringHash, FieldPath) -> void

--- a/elasticgraph-graphql/spec/acceptance/search_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/search_spec.rb
@@ -310,6 +310,28 @@ module ElasticGraph
           string_hash_of(widget3, :id, :amount_cents)
         ])
 
+        # Test `not: {any_of: []}` results in all matching documents
+        widgets = list_widgets_with(:amount_cents,
+          filter: {not: {any_of: []}})
+
+        expect(widgets).to match([
+          string_hash_of(widget3, :id, :amount_cents),
+          string_hash_of(widget2, :id, :amount_cents),
+          string_hash_of(widget1, :id, :amount_cents)
+        ])
+
+        # Test `not: {any_of: emptyPredicate}` results in no matching documents
+        widgets = list_widgets_with(:amount_cents,
+          filter: {not: {any_of: [{name: {equal_to_any_of: nil}}]}})
+
+        expect(widgets).to eq []
+
+        # Test `not: {any_of: emptyPredicate && <non emptyPredicate>}` results in no matching documents
+        widgets = list_widgets_with(:amount_cents,
+          filter: {not: {any_of: [{name: {equal_to_any_of: nil}}, {amount_cents: {gt: 150}}]}})
+
+        expect(widgets).to eq []
+
         # Test `equal_to_any_of` with `[nil, other_value]`
         widgets = list_widgets_with(:amount_cents,
           filter: {name: {equal_to_any_of: [nil, "thing2", "", " ", "\n"]}}, # empty strings should be ignored.,
@@ -753,7 +775,7 @@ module ElasticGraph
 
           # Verify `all_of: [{not: null}]` works as expected.
           results = query_teams_with(filter: {seasons_nested: {all_of: [{not: nil}]}})
-          # All teams should be returned since the `nil` part of the filter expression is pruned.
+          # No teams should be returned since the `nil` part of the filter expression evaluates to `true`.
           expect(results).to eq []
 
           # Verify `all_of: [{not: null}]` works as expected.

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/filtering_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/filtering_spec.rb
@@ -1157,7 +1157,7 @@ module ElasticGraph
           expect(triple_nested_not).to match_array(ids_of(widget1, widget3))
         end
 
-        it "is ignored when set to nil" do
+        it "returns the standard always false filter when set to nil" do
           index_into(
             graphql,
             widget1 = build(:widget, amount_cents: 100),
@@ -1195,9 +1195,42 @@ module ElasticGraph
             "amount_cents" => {"equal_to_any_of" => nil}
           }})
 
-          expect(inner_not_result1).to eq(outer_not_result1).and match_array(ids_of(widget1, widget2, widget3))
-          expect(inner_not_result2).to eq(outer_not_result2).and match_array(ids_of(widget1))
-          expect(inner_not_result3).to eq(outer_not_result3).and match_array(ids_of(widget1, widget2, widget3))
+          expect(inner_not_result1).to eq(outer_not_result1).and eq []
+          expect(inner_not_result2).to eq(outer_not_result2).and eq []
+          expect(inner_not_result3).to eq(outer_not_result3).and eq []
+        end
+
+        it "is ignored when set to nil inside `any_of`" do
+          index_into(
+            graphql,
+            widget1 = build(:widget, amount_cents: 100),
+            widget2 = build(:widget, amount_cents: 205),
+            widget3 = build(:widget, amount_cents: 400)
+          )
+
+          inner_not_result1 = search_with_freeform_filter({"amount_cents" => {
+            "any_of" => [
+              {"not" => nil},
+              {"lt" => 200}
+            ]
+          }})
+
+          outer_not_result1 = search_with_freeform_filter({
+            "any_of" => [
+              {
+                "not" => {
+                  "amount_cents" => nil
+                }
+              },
+              {
+                "amount_cents" => {
+                  "lt" => 200
+                }
+              }
+            ]
+          })
+
+          expect(inner_not_result1).to eq(outer_not_result1).and match_array(ids_of(widget1))
         end
       end
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/search_index_expression_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/search_index_expression_spec.rb
@@ -369,6 +369,24 @@ module ElasticGraph
 
               expect(parts).to target_all_widget_indices
             end
+
+            it "excludes no indices when we have an `any_of: [{anyof: []}]` filter because that will match all results" do
+              parts = search_index_expression_parts_for({"any_of" => [{"any_of" => []}]})
+
+              expect(parts).to target_all_widget_indices
+            end
+
+            it "excludes no indices when we have an `any_of: [{field: nil}]` filter because that will match all results" do
+              parts = search_index_expression_parts_for({"any_of" => [{"created_at" => nil}]})
+
+              expect(parts).to target_all_widget_indices
+            end
+
+            it "excludes no indices when we have an `any_of: [{field: nil}, {...}]` filter because that will match all results" do
+              parts = search_index_expression_parts_for({"any_of" => [{"created_at" => nil}, {"id" => {"equal_to_any_of" => "some-id"}}]})
+
+              expect(parts).to target_all_widget_indices
+            end
           end
 
           context "for a query that includes aggregations" do

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/shard_routing_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/shard_routing_spec.rb
@@ -259,6 +259,24 @@ module ElasticGraph
         })).to search_all_shards
       end
 
+      it "searches all shards when we have an `any_of: [{anyof: []}]` filter because that will match all results" do
+        expect(shard_routing_for(["name"], {
+          "any_of" => [{"any_of" => []}]
+        })).to search_all_shards
+      end
+
+      it "searches all shards when we have an `any_of: [{field: nil}]` filter because that will match all results" do
+        expect(shard_routing_for(["name"], {
+          "any_of" => [{"name" => nil}]
+        })).to search_all_shards
+      end
+
+      it "searches all shards when we have an `any_of: [{field: nil}, {...}]` filter because that will match all results" do
+        expect(shard_routing_for(["name"], {
+          "any_of" => [{"name" => nil}, {"id" => {"equal_to_any_of" => ["abc"]}}]
+        })).to search_all_shards
+      end
+
       describe "not" do
         it "searches all shards when there are values in an `equal_to_any_of` filter" do
           expect(shard_routing_for(["name"],


### PR DESCRIPTION
# Context

Currently empty predicates are ignored.  Within an AND context (the normal context), that works correctly. Within an OR context (under an anyOf) it does not work correctly: empty predicates should essentially be treated as `true`: 

* `predicate AND emptyPredicate` should be like `predicate AND true` which reduces to predicate (and thus is equivalent to ignoring the empty predicate).

* `predicate OR emptyPredicate` should be like `predicate OR true` which just reduces to `true`

Notably, `filter: A` and `filter: {anyOf: [A]}` should behave the same but right now they do not when `A` is an empty predicate – `filter: emptyPredicate` returns all results whereas `filter: {anyOf: [emptyPredicate]}` returns no results.

# Change

This PR as mentioned above, looks to change `filter: {field: nil}` and `filter: {field: {}}` to evaluate to true. This in turns changes how anyOf behaves to be more like an `OR` block, as shown below:

* `filter: {anyOf: [emptyPredicate]}` will evaluate to `true`, instead of `false`
* `filter: {anyOf: [emptyPredicate, {name: {equalToAnyOf: ["test"]}}]}` will evaluate to `true`, instead of `false`

At the same time the behaviour of `(filter: {anyOf: []})` matching no documents is still preserved.

Because of the way emptyPredicates are treated now, the following changes occured for how `not` behaves:

* `filter: {not: {field: nil}}` will evaluate to `false`, instead of being ignored