### PR TITLE
Move GraphiQL license attribution into README.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -19,6 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-Part of the distributed code (elasticgraph-rack/lib/elastic_graph/rack/graphiql/index.html)
-comes from the GraphiQL project, licensed under the MIT License. Copyright (c) GraphQL Contributors.

--- a/README.md
+++ b/README.md
@@ -247,3 +247,11 @@ to follow SemVer with a `0.MAJOR.MINOR.PATCH` versioning scheme.
 Note that _all_ gems in this repository share the same version number. Every time we cut a release, we increment the version
 for _all_ gems and release _all_ gems, even if a gem has had no changes since the last release. This is simpler to work with
 than the alternatives.
+
+## License
+
+ElasticGraph is released under the [MIT License](https://opensource.org/licenses/MIT).
+
+[Part of the distributed code](elasticgraph-rack/lib/elastic_graph/rack/graphiql/index.html)
+comes from the [GraphiQL project](https://github.com/graphql/graphiql), also licensed under the
+MIT License, Copyright (c) GraphQL Contributors.

--- a/elasticgraph-rack/LICENSE.txt
+++ b/elasticgraph-rack/LICENSE.txt
@@ -19,6 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-Part of the distributed code (lib/elastic_graph/rack/graphiql/index.html)
-comes from the GraphiQL project, licensed under the MIT License. Copyright (c) GraphQL Contributors.

--- a/elasticgraph-rack/README.md
+++ b/elasticgraph-rack/README.md
@@ -34,3 +34,11 @@ run ElasticGraph::Rack::GraphiQL.new(graphql)
 ```
 
 Run this with `rackup` (after installing the `rackup` gem) or any other rack-compatible server.
+
+## License
+
+elasticgraph-rack is released under the [MIT License](https://opensource.org/licenses/MIT).
+
+[Part of the distributed code](lib/elastic_graph/rack/graphiql/index.html)
+comes from the [GraphiQL project](https://github.com/graphql/graphiql), also licensed under the
+MIT License, Copyright (c) GraphQL Contributors.

--- a/elasticgraph-rack/lib/elastic_graph/rack/graphiql/README.md
+++ b/elasticgraph-rack/lib/elastic_graph/rack/graphiql/README.md
@@ -1,10 +1,7 @@
 ## GraphiQL for ElasticGraph
 
 This directory provides the GraphiQL in browser UI for working with ElasticGraph
-applications. The GraphiQL license is included in `LICENSE.txt`, copied verbatim
-from:
-
-https://github.com/graphql/graphiql/blob/graphiql%402.4.0/LICENSE
+applications.
 
 The `index.html` file is copied from:
 
@@ -36,3 +33,8 @@ index 55cf5d05..a672ead9 100644
            defaultEditorToolsVisibility: true,
          }),
 ```
+
+## License
+
+[index.html](index.html) comes from the [GraphiQL project](https://github.com/graphql/graphiql),
+licensed under the MIT License, Copyright (c) GraphQL Contributors.

--- a/script/update_readme
+++ b/script/update_readme
@@ -216,3 +216,11 @@ to follow SemVer with a `0.MAJOR.MINOR.PATCH` versioning scheme.
 Note that _all_ gems in this repository share the same version number. Every time we cut a release, we increment the version
 for _all_ gems and release _all_ gems, even if a gem has had no changes since the last release. This is simpler to work with
 than the alternatives.
+
+## License
+
+ElasticGraph is released under the [MIT License](https://opensource.org/licenses/MIT).
+
+[Part of the distributed code](elasticgraph-rack/lib/elastic_graph/rack/graphiql/index.html)
+comes from the [GraphiQL project](https://github.com/graphql/graphiql), also licensed under the
+MIT License, Copyright (c) GraphQL Contributors.


### PR DESCRIPTION
Previously it was appended to `LICENSE.txt` but GitHub's automatic license detection isn't able to detect that it's an MIT license.

The `licensee` gem, which GitHub uses for license detection, shows the problem:

```
$ licensee detect https://github.com/block/elasticgraph
License:        NOASSERTION
Matched files:  LICENSE.txt
LICENSE.txt:
  Content hash:  73812563c638c8691288d777f43f7d738fef02b1
  License:       NOASSERTION
  Closest non-matching licenses:
    MIT similarity:      75.61%
    NCSA similarity:     66.18%
    BSL-1.0 similarity:  64.38%
$ licensee diff https://github.com/block/elasticgraph --license=MIT
Comparing to MIT License:
Input Length:      1213
License length:    1020
Similarity:      75.61%
diff --git a/LICENSE b/LICENSE
index 49b0d1f..0cf6233 100644
--- a/LICENSE
+++ b/LICENSE
@@ -11,4 +11,7 @@ merchantability, fitness for a particular purpose and noninfringement. in no
event shall the authors or copyright holders be liable for any claim, damages or
other liability, whether in an action of contract, tort or otherwise, arising
from, out of or in connection with the software or the use or other dealings in
the software. {+part of the distributed code+}
{+(elasticgraph-rack/lib/elastic_graph/rack/graphiql/index.html) comes from the+}
{+graphiql project, licensed under the mit license. copyright (c) graphql+}
{+contributors.+}
```

GitHub[^1] recommends putting this extra bit of license info in the README:

> To have your license detected, simplify your LICENSE file and note the complexity somewhere else, such as your repository's README file.

[^1]: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository#detecting-a-license