### PR TITLE
Deal with rackup 2.2 release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ These libraries are used for local development of ElasticGraph applications, but
 
 ```mermaid
 graph LR;
-    elasticgraph-local --> elasticgraph-admin & elasticgraph-graphql & elasticgraph-indexer & elasticgraph-rack & elasticgraph-schema_definition & rackup & rake
+    elasticgraph-local --> elasticgraph-admin & elasticgraph-graphql & elasticgraph-indexer & elasticgraph-rack & elasticgraph-schema_definition & rackup & rake & webrick
     elasticgraph-rack --> elasticgraph-graphql & rack
     elasticgraph-schema_definition --> elasticgraph-graphql & elasticgraph-indexer & elasticgraph-json_schema & elasticgraph-schema_artifacts & elasticgraph-support & graphql & rake
     style elasticgraph-local color: DodgerBlue;
@@ -191,6 +191,7 @@ graph LR;
     style elasticgraph-indexer color: Green;
     style rackup color: Red;
     style rake color: Red;
+    style webrick color: Red;
     style rack color: Red;
     style elasticgraph-json_schema color: Green;
     style elasticgraph-schema_artifacts color: Green;
@@ -200,6 +201,7 @@ click graphql href "https://rubygems.org/gems/graphql"
 click rack href "https://rubygems.org/gems/rack"
 click rackup href "https://rubygems.org/gems/rackup"
 click rake href "https://rubygems.org/gems/rake"
+click webrick href "https://rubygems.org/gems/webrick"
 ```
 
 

--- a/elasticgraph-apollo/apollo_tests_implementation/Gemfile
+++ b/elasticgraph-apollo/apollo_tests_implementation/Gemfile
@@ -24,4 +24,5 @@ source "https://rubygems.org"
   gem "elasticgraph-#{suffix}", path: "elasticgraph-#{suffix}"
 end
 
-gem "rackup", "~> 2.1"
+gem "rackup", "~> 2.2"
+gem "webrick", "~> 1.9"

--- a/elasticgraph-local/elasticgraph-local.gemspec
+++ b/elasticgraph-local/elasticgraph-local.gemspec
@@ -16,8 +16,9 @@ ElasticGraphGemspecHelper.define_elasticgraph_gem(gemspec_file: __FILE__, catego
   spec.add_dependency "elasticgraph-indexer", eg_version
   spec.add_dependency "elasticgraph-rack", eg_version
   spec.add_dependency "elasticgraph-schema_definition", eg_version
-  spec.add_dependency "rackup", "~> 2.1"
+  spec.add_dependency "rackup", "~> 2.2"
   spec.add_dependency "rake", "~> 13.2"
+  spec.add_dependency "webrick", "~> 1.9"
 
   spec.add_development_dependency "elasticgraph-elasticsearch", eg_version
   spec.add_development_dependency "elasticgraph-opensearch", eg_version


### PR DESCRIPTION
Rackup 2.2 no longer depends on `webrick`, and our usage of `rackup` fails if we don't add a dependency on `webrick`. For details on the `rackup` change, see:

https://github.com/rack/rackup/pull/23

Note that the `rackup` maintainers recommend using `falcon` or `puma` instead of `webrick`. However, `falcon` and `puma` are heavier weight. `falcon` has lots of runtime dependencies and `puma` depends on `nio4r` which has native code. As a result, it's more likely to hit installation issues for ElasticGraph users than `webrick`. So for now we are sticking with `webrick` but I'm open to changing this in the future.