### PR TITLE
Update the FullTextSearch docs to provide an example of their optionality

### DIFF
--- a/config/site/examples/music/queries/filtering/OptionalMatchingFilter.graphql
+++ b/config/site/examples/music/queries/filtering/OptionalMatchingFilter.graphql
@@ -1,0 +1,18 @@
+query OptionalMatchingFilter(
+    $optionalMatchQuery: MatchesQueryFilterInput = null
+) {
+    artists(filter: {
+        bio: {
+            description:{
+                matchesQuery: $optionalMatchQuery
+            }
+        }
+    }) {
+        nodes {
+            name
+            bio {
+                description
+            }
+        }
+    }
+}

--- a/config/site/src/_includes/filtering_predicate_definitions/fulltext.md
+++ b/config/site/src/_includes/filtering_predicate_definitions/fulltext.md
@@ -3,11 +3,11 @@
   full text search. This is stricter than `matchesQuery`: all terms must match
   and be in the same order as the provided phrase.
 
-  Will be ignored when `null` is passed.
+  Will be ignored when `null` is passed as the `MatchesPhraseFilterInput`.
 
 [`matchesQuery`]({% link query-api/filtering/full-text-search.md %})
 : Matches records where the field value matches the provided query using full text search.
   This is more lenient than `matchesPhrase`: the order of terms is ignored, and, by default,
   only one search term is required to be in the field value.
 
-  Will be ignored when `null` is passed.
+  Will be ignored when `null` is passed as the `MatchesQueryFilterInput`.

--- a/config/site/src/query-api/filtering/full-text-search.md
+++ b/config/site/src/query-api/filtering/full-text-search.md
@@ -39,3 +39,11 @@ are supported to control both aspects to make matching stricter:
 {% highlight graphql %}
 {{ site.data.music_queries.filtering.PhraseSearch }}
 {% endhighlight %}
+
+### Bypassing matchesPhrase and matchesQuery
+
+In order to ignore a `matchesPhrase` or `matchesQuery` filter, you can supply `null` to the `MatchesQueryFilterInput` parameter, as such:
+
+{% highlight graphql %}
+{{ site.data.music_queries.filtering.OptionalMatchingFilter }}
+{% endhighlight %}


### PR DESCRIPTION
In order to ignore a `matchesQuery` or `matchesPhrase` filter predicate, you can supply `null` to the `MatchesQueryFilterInput` or `MatchesQueryFilterInput` types, respectively. However, this is not entirely clear from the docs, as they describe supplying `null`, but not to which field/value. This documentation update aims to make that more clear, and provides an example to highlight the ability to use a null-able variable with these predicates.

## Tested
Ran the site locally. Here are the screenshots of updates:
![image](https://github.com/user-attachments/assets/52d4b761-ce6e-43c5-890a-014ca68337bb)

![image](https://github.com/user-attachments/assets/469993e6-b80a-4755-9d60-b91ca84b9442)
