### PR TITLE
Refactor: simplify and optimize `ElasticGraph::GraphQL::Schema`.

### DIFF
--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
@@ -70,21 +70,6 @@ module ElasticGraph
         end
       end
 
-      describe "#defined_types" do
-        it "returns a list containing all explicitly defined types (excluding built-ins)" do
-          schema = define_schema do |s|
-            s.enum_type "Options" do |t|
-              t.value "firstOption"
-            end
-            s.object_type "Color"
-          end
-
-          expect(schema.defined_types).to all be_a Schema::Type
-          expect(schema.defined_types.map(&:name)).to include(:Options, :Color, :Query)
-            .and exclude(:Int, :Float, :Boolean, :String, :ID)
-        end
-      end
-
       describe "#indexed_document_types" do
         it "returns a list containing all types defined as indexed types" do
           schema = define_schema do |s|


### PR DESCRIPTION
- Avoid calling `::GraphQL::Schema#types` repeatedly. As reported in rmosolgo/graphql-ruby#5154, accessing `#types` repeatedly can be quite slow (at least on 2.4.0 - 2.4.2). While it's been optimized in 2.4.3, there's no need to access it more than once. Previously, we accessed it in `#lookup_type_by_name`; instead we can just use the type objects as we iterate over `::GraphQL::Schema#types` a single time.
- Remove unused `#defined_types` method.
- Inline the old `#lookup_type_by_name` logic into `#type_named`.