### PR TITLE
Restore `GraphQL::Schema#defined_types`.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
@@ -106,7 +106,11 @@ module ElasticGraph
 
       # The list of user-defined types that are indexed document types. (Indexed aggregation types will not be included in this.)
       def indexed_document_types
-        @indexed_document_types ||= @types_by_name.values.select(&:indexed_document?)
+        @indexed_document_types ||= defined_types.select(&:indexed_document?)
+      end
+
+      def defined_types
+        @defined_types ||= @types_by_name.except(*BUILT_IN_TYPE_NAMES).values
       end
 
       def to_s

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
@@ -70,6 +70,22 @@ module ElasticGraph
         end
       end
 
+      describe "#defined_types" do
+        # Note: `defined_type` isn't used internally by ElasticGraph itself, but it's exposed for use by extensions.
+        it "returns a list containing all explicitly defined types (excluding built-ins)" do
+          schema = define_schema do |s|
+            s.enum_type "Options" do |t|
+              t.value "firstOption"
+            end
+            s.object_type "Color"
+          end
+
+          expect(schema.defined_types).to all be_a Schema::Type
+          expect(schema.defined_types.map(&:name)).to include(:Options, :Color, :Query)
+            .and exclude(:Int, :Float, :Boolean, :String, :ID)
+        end
+      end
+
       describe "#indexed_document_types" do
         it "returns a list containing all types defined as indexed types" do
           schema = define_schema do |s|


### PR DESCRIPTION
I removed it in #31 because ElasticGraph didn't rely on it or need it. However, I discovered that Block has an internal extension library that relies on it, and it's a generally useful API to offer for extension libraries. This restores it (but with a simplified implementation).