### PR TITLE
Install analysis-icu plugin locally

### DIFF
--- a/elasticgraph-local/lib/elastic_graph/local/elasticsearch/Dockerfile
+++ b/elasticgraph-local/lib/elastic_graph/local/elasticsearch/Dockerfile
@@ -1,3 +1,3 @@
 ARG VERSION=latest
 FROM elasticsearch:${VERSION}
-RUN bin/elasticsearch-plugin install mapper-size
+RUN bin/elasticsearch-plugin install mapper-size analysis-icu

--- a/elasticgraph-local/lib/elastic_graph/local/opensearch/Dockerfile
+++ b/elasticgraph-local/lib/elastic_graph/local/opensearch/Dockerfile
@@ -1,4 +1,4 @@
 ARG VERSION=latest
 FROM opensearchproject/opensearch:${VERSION}
 RUN /usr/share/opensearch/bin/opensearch-plugin remove opensearch-security
-RUN /usr/share/opensearch/bin/opensearch-plugin install --batch mapper-size
+RUN /usr/share/opensearch/bin/opensearch-plugin install --batch mapper-size analysis-icu


### PR DESCRIPTION
The analysis ICU plugin is included in AWS OpenSearch from version 1.0 and all Elasticsearch domains. Including it locally for testing its usage.

See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-plugins.html