### PR TITLE
Increase default docker `daemon_timeout`.

### DIFF
--- a/elasticgraph-local/lib/elastic_graph/local/rake_tasks.rb
+++ b/elasticgraph-local/lib/elastic_graph/local/rake_tasks.rb
@@ -362,7 +362,7 @@ module ElasticGraph
         self.enforce_json_schema_version = true
         self.env_port_mapping = {}
         self.output = $stdout
-        self.daemon_timeout = 120
+        self.daemon_timeout = 180
 
         datastore_versions = ::YAML.load_file("#{__dir__}/tested_datastore_versions.yaml")
         self.elasticsearch_versions = datastore_versions.fetch("elasticsearch")


### PR DESCRIPTION
Our CI builds have been timing out at 120 seconds recently. Giving it 60 more seconds should help them fail less often.