### PR TITLE
Treat anyOf: [] as matching no routing shards

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/index_expression_builder.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/index_expression_builder.rb
@@ -15,7 +15,7 @@ module ElasticGraph
       # Responsible for building a search index expression for a specific query based on the filters.
       class IndexExpressionBuilder
         def initialize(schema_names:)
-          @filter_value_set_extractor = Filtering::FilterValueSetExtractor.new(schema_names, Support::TimeSet::ALL) do |operator, filter_value|
+          @filter_value_set_extractor = Filtering::FilterValueSetExtractor.new(schema_names, Support::TimeSet::ALL, Support::TimeSet::EMPTY) do |operator, filter_value|
             case operator
             when :gt, :gte, :lt, :lte
               if date_string?(filter_value)

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/routing_picker.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/routing_picker.rb
@@ -16,8 +16,9 @@ module ElasticGraph
         def initialize(schema_names:)
           # @type var all_values_set: _RoutingValueSet
           all_values_set = RoutingValueSet::ALL
+          empty_set = RoutingValueSet::EMPTY
 
-          @filter_value_set_extractor = Filtering::FilterValueSetExtractor.new(schema_names, all_values_set) do |operator, filter_value|
+          @filter_value_set_extractor = Filtering::FilterValueSetExtractor.new(schema_names, all_values_set, empty_set) do |operator, filter_value|
             if operator == :equal_to_any_of
               # This calls `.compact` to remove `nil` filter_value values
               RoutingValueSet.of(filter_value.compact)
@@ -70,6 +71,7 @@ module ElasticGraph
         end
 
         ALL = of_all_except([])
+        EMPTY = of([])
 
         def intersection(other_set)
           # Here we return `self` to preserve the commutative property of `intersection`. Returning `self`

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/filters.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/filters.rb
@@ -101,7 +101,7 @@ module ElasticGraph
 
         def filter_value_set_extractor
           @filter_value_set_extractor ||=
-            Filtering::FilterValueSetExtractor.new(schema_element_names, IncludesNilSet) do |operator, filter_value|
+            Filtering::FilterValueSetExtractor.new(schema_element_names, IncludesNilSet, ExcludesNilSet) do |operator, filter_value|
               if operator == :equal_to_any_of && filter_value.include?(nil)
                 IncludesNilSet
               else

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/datastore_query/routing_picker.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/datastore_query/routing_picker.rbs
@@ -45,6 +45,7 @@ module ElasticGraph
         def self.of_all_except: (::Enumerable[routingValue]) -> RoutingValueSet
 
         ALL: RoutingValueSet
+        EMPTY: RoutingValueSet
         INVERTED_TYPES: ::Hash[routingValueSetType, routingValueSetType]
 
         def inclusive?: () -> bool

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/filtering/filter_value_set_extractor.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/filtering/filter_value_set_extractor.rbs
@@ -2,13 +2,14 @@ module ElasticGraph
   class GraphQL
     module Filtering
       class FilterValueSetExtractor[S < Support::_NegatableSet[S]]
-        def initialize: (SchemaArtifacts::RuntimeMetadata::SchemaElementNames, S) { (::Symbol, untyped) -> S? } -> void
+        def initialize: (SchemaArtifacts::RuntimeMetadata::SchemaElementNames, S, S) { (::Symbol, untyped) -> S? } -> void
         def extract_filter_value_set: (::Array[::Hash[::String, untyped]], ::Array[::String]) -> S
 
         private
 
         @schema_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames
         @all_values_set: S
+        @empty_set: S
         @build_set_for_filter: ^(::Symbol, untyped) -> S?
 
         def filter_value_set_for_target_field_path: (::String, ::Array[::Hash[::String, untyped]]) -> S

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/search_index_expression_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/search_index_expression_spec.rb
@@ -364,18 +364,16 @@ module ElasticGraph
               expect(parts).to target_all_widget_indices
             end
 
-            # TODO: Change behaviour so no indices are matched when given `anyOf => []`
             it "excludes all indices when we have an `any_of: []` filter because that will match no results" do
               parts = search_index_expression_parts_for({"any_of" => []})
 
-              expect(parts).to target_all_widget_indices
+              expect(parts).to target_no_indices
             end
 
-            # TODO: Change behaviour so no indices are matched when given `anyOf => {anyOf => []}`
             it "excludes all indices when we have an `any_of: [{anyof: []}]` filter because that will match no results" do
               parts = search_index_expression_parts_for({"any_of" => [{"any_of" => []}]})
 
-              expect(parts).to target_all_widget_indices
+              expect(parts).to target_no_indices
             end
 
             it "excludes no indices when we have an `any_of: [{field: nil}]` filter because that will match all results" do
@@ -454,6 +452,10 @@ module ElasticGraph
 
         def target_all_widget_indices
           contain_exactly("widgets_rollover__*")
+        end
+
+        def target_no_indices
+          eq []
         end
 
         def target_widget_indices_excluding_2021_months(*month_num_strings)


### PR DESCRIPTION
# Context

As part of #6 we have changed the behaviour of anyOf, such that:

* `anyOf: []` is treated as false
* `anyOf: [{anyOf: []}]` is treated as false

# Change

This PR looks to adopt that behaviour for routing as well, such that:

* `anyOf: []` will route to nothing
* `anyOf: [{anyOf: []}]` will route to nothing

Also, updated `shard_routing_spec` to use language different from `ignore` where it makes sense (e.g. `ignore` -> `treat ... as matching everything`).