### PR TITLE
Change `NullOrEmptyFilters` to `EmptyFilters` to match file name.

### DIFF
--- a/config/site/examples/music/queries/filtering/EmptyFilters.graphql
+++ b/config/site/examples/music/queries/filtering/EmptyFilters.graphql
@@ -1,4 +1,4 @@
-query NullOrEmptyFilters {
+query EmptyFilters {
   artists(filter: {
     name: {equalToAnyOf: null}
     bio: {yearFormed: {}}


### PR DESCRIPTION
`null` and `{}` are two ways of passing empty filters.