### PR TITLE
Validate `variables` to make sure they are a JSON object as expected.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb
@@ -130,6 +130,10 @@ module ElasticGraph
         # Ignore an empty string operationName.
         params = params.merge("operationName" => nil) if params["operationName"] && params["operationName"].empty?
 
+        if (variables = params["variables"]) && !variables.is_a?(::Hash)
+          return HTTPResponse.error(400, "`variables` must be a JSON object but was not.")
+        end
+
         yield params
       end
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/http_endpoint_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/http_endpoint_spec.rb
@@ -189,6 +189,13 @@ module ElasticGraph
             expect(datastore_queries.size).to eq(1)
             expect(datastore_queries.first.filters.to_a).to eq [filter]
           end
+
+          it "returns a 400 response when the variables are not a JSON object" do
+            query = "query Multiply($operands: Operands!) { multiply(operands: $operands) }"
+            response = process_graphql_expecting(400, query: query, variables: "not a JSON object")
+
+            expect(response).to eq error_with("`variables` must be a JSON object but was not.")
+          end
         end
 
         def submitted_value_for(option_name, ...)


### PR DESCRIPTION
The GraphQL gem internally raises an exception when given `variables` that is a string:

```
Query variables should be a Hash, not a String. Try JSON.parse to prepare variables.
```

This avoids that exception and returns a friendly 400 error when the client passes `variables` that are not an object as expected.