### PR TITLE
Upgrade GraphQL gem to 2.4.5 and deal with eager loading.

### DIFF
--- a/elasticgraph-apollo/elasticgraph-apollo.gemspec
+++ b/elasticgraph-apollo/elasticgraph-apollo.gemspec
@@ -13,7 +13,7 @@ ElasticGraphGemspecHelper.define_elasticgraph_gem(gemspec_file: __FILE__, catego
 
   spec.add_dependency "elasticgraph-graphql", eg_version
   spec.add_dependency "elasticgraph-support", eg_version
-  spec.add_dependency "graphql", "~> 2.4.3"
+  spec.add_dependency "graphql", "~> 2.4.5"
   spec.add_dependency "apollo-federation", "~> 3.8"
 
   # Note: technically, this is not purely a development dependency, but since `eg-schema_def`

--- a/elasticgraph-graphql/elasticgraph-graphql.gemspec
+++ b/elasticgraph-graphql/elasticgraph-graphql.gemspec
@@ -13,7 +13,7 @@ ElasticGraphGemspecHelper.define_elasticgraph_gem(gemspec_file: __FILE__, catego
 
   spec.add_dependency "elasticgraph-datastore_core", eg_version
   spec.add_dependency "elasticgraph-schema_artifacts", eg_version
-  spec.add_dependency "graphql", "~> 2.4.3"
+  spec.add_dependency "graphql", "~> 2.4.5"
 
   spec.add_development_dependency "elasticgraph-admin", eg_version
   spec.add_development_dependency "elasticgraph-elasticsearch", eg_version

--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -250,6 +250,9 @@ module ElasticGraph
     # at boot time instead of deferring dependency loading until we handle the first query. In other environments (such as tests),
     # it's nice to load dependencies when needed.
     def load_dependencies_eagerly
+      require "graphql"
+      ::GraphQL.eager_load!
+
       # run a simple GraphQL query to force load any dependencies needed to handle GraphQL queries
       graphql_query_executor.execute(EAGER_LOAD_QUERY, client: Client::ELASTICGRAPH_INTERNAL)
       graphql_http_endpoint # force load this too.

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/query_source.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/query_source.rb
@@ -6,7 +6,7 @@
 #
 # frozen_string_literal: true
 
-require "graphql/dataloader/source"
+require "graphql"
 
 module ElasticGraph
   class GraphQL

--- a/elasticgraph-graphql/sig/graphql_gem.rbs
+++ b/elasticgraph-graphql/sig/graphql_gem.rbs
@@ -2,6 +2,8 @@ module GraphQL
   class CoercionError < StandardError
   end
 
+  def self.eager_load!: () -> void
+
   class Dataloader
     class Source
       def load_all: [Req, Res] (::Array[Req]) -> ::Array[Res]

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/query_source_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/query_source_spec.rb
@@ -8,7 +8,7 @@
 
 require "elastic_graph/graphql/query_details_tracker"
 require "elastic_graph/graphql/resolvers/query_source"
-require "graphql/dataloader"
+require "graphql"
 
 module ElasticGraph
   class GraphQL

--- a/elasticgraph-graphql/spec/support/resolver.rb
+++ b/elasticgraph-graphql/spec/support/resolver.rb
@@ -9,7 +9,7 @@
 require "elastic_graph/graphql/query_details_tracker"
 require "elastic_graph/graphql/resolvers/query_adapter"
 require "elastic_graph/graphql/resolvers/query_source"
-require "graphql/dataloader"
+require "graphql"
 
 module ResolverHelperMethods
   def resolve(type_name, field_name, document = nil, **options)

--- a/elasticgraph-query_registry/elasticgraph-query_registry.gemspec
+++ b/elasticgraph-query_registry/elasticgraph-query_registry.gemspec
@@ -14,7 +14,7 @@ ElasticGraphGemspecHelper.define_elasticgraph_gem(gemspec_file: __FILE__, catego
 
   spec.add_dependency "elasticgraph-graphql", eg_version
   spec.add_dependency "elasticgraph-support", eg_version
-  spec.add_dependency "graphql", "~> 2.4.3"
+  spec.add_dependency "graphql", "~> 2.4.5"
   spec.add_dependency "rake", "~> 13.2"
 
   spec.add_development_dependency "elasticgraph-elasticsearch", eg_version

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/graphql_extension.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/graphql_extension.rb
@@ -8,7 +8,7 @@
 
 require "elastic_graph/graphql/query_executor"
 require "elastic_graph/query_registry/registry"
-require "graphql/query/result"
+require "graphql"
 require "pathname"
 
 module ElasticGraph

--- a/elasticgraph-schema_definition/elasticgraph-schema_definition.gemspec
+++ b/elasticgraph-schema_definition/elasticgraph-schema_definition.gemspec
@@ -16,7 +16,7 @@ ElasticGraphGemspecHelper.define_elasticgraph_gem(gemspec_file: __FILE__, catego
   spec.add_dependency "elasticgraph-json_schema", eg_version
   spec.add_dependency "elasticgraph-schema_artifacts", eg_version
   spec.add_dependency "elasticgraph-support", eg_version
-  spec.add_dependency "graphql", "~> 2.4.3"
+  spec.add_dependency "graphql", "~> 2.4.5"
   spec.add_dependency "rake", "~> 13.2"
 
   spec.add_development_dependency "elasticgraph-admin", eg_version

--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
@@ -11,7 +11,6 @@ require "elastic_graph/constants"
 require "elastic_graph/schema_definition/rake_tasks"
 require "elastic_graph/schema_definition/schema_elements/type_namer"
 require "graphql"
-require "graphql/language/block_string"
 require "yaml"
 
 module ElasticGraph


### PR DESCRIPTION
GraphQL gem 2.4.5 includes some changes related to code loading:

https://github.com/rmosolgo/graphql-ruby/pull/5178

I've made a few changes to deal with that:

* I've introduced `::GraphQL.eager_load!` where we do eager loading for production.
* I've stopped requiring files nested under `graphql`--instead, we should load `graphql` and rely on the autoloading.