### PR TITLE
Fix code scanning alert no. 1: Overly permissive regular expression range

### DIFF
--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/decoded_cursor_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/decoded_cursor_spec.rb
@@ -25,7 +25,7 @@ module ElasticGraph
         it "encodes the provided sort fields and values to a URL-safe string" do
           cursor = DecodedCursor.new(sort_values).encode
 
-          expect(cursor).to match(/\A[a-zA-z0-9_-]{32,128}\z/)
+          expect(cursor).to match(/\A[a-zA-Z0-9_-]{32,128}\z/)
         end
 
         it "returns the special singleton cursor string when called on the singleton cursor" do


### PR DESCRIPTION
Fixes [https://github.com/block/elasticgraph/security/code-scanning/1](https://github.com/block/elasticgraph/security/code-scanning/1)

To fix the problem, we need to correct the overly permissive range in the regular expression. Specifically, we should replace the range `A-z` with `A-Z` to ensure that only uppercase letters are matched. This change will make the regular expression unambiguous and ensure it matches only the expected characters.

- Locate the regular expression on line 28 in the file `elasticgraph-graphql/spec/unit/elastic_graph/graphql/decoded_cursor_spec.rb`.
- Replace the range `A-z` with `A-Z` in the regular expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
