### PR TITLE
Upgrade Steep to 1.9 and address new type check failures.

### DIFF
--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/rollover_index_template.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/rollover_index_template.rb
@@ -185,7 +185,7 @@ module ElasticGraph
             return matching_custom_range.index_name_suffix
           end
 
-          timestamp_value.strftime(ROLLOVER_SUFFIX_FORMATS_BY_FREQUENCY[frequency])
+          timestamp_value.strftime(ROLLOVER_SUFFIX_FORMATS_BY_FREQUENCY.fetch(frequency))
         end
 
         def concrete_rollover_index_for(index_name, setting_overrides, time_set = nil)

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_optimizer.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_optimizer.rb
@@ -154,7 +154,7 @@ module ElasticGraph
           # If there are no aggregations, there's nothing to unmerge--just return it as is.
           return response_from_merged_query unless (aggs = response_from_merged_query["aggregations"])
 
-          prefix = @unique_prefix_by_query[original_query]
+          prefix = @unique_prefix_by_query[original_query] # : ::String
           agg_names = original_query.aggregations.keys.map { |name| "#{prefix}#{name}" }.to_set
 
           filtered_aggs = aggs

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_args_translator.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_args_translator.rb
@@ -26,7 +26,7 @@ module ElasticGraph
         # vs GraphQL.
         def translate_filter_args(field:, args:)
           return nil unless (filter_hash = args[filter_arg_name])
-          filter_type = field.schema.type_from(field.graphql_field.arguments[filter_arg_name].type)
+          filter_type = field.schema.type_from(field.graphql_field.arguments.fetch(filter_arg_name).type)
           convert(filter_type, filter_hash)
         end
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb
@@ -197,7 +197,7 @@ module ElasticGraph
       end
 
       def content_type
-        @content_type ||= normalized_headers["CONTENT-TYPE"]
+        normalized_headers["CONTENT-TYPE"]
       end
 
       def self.normalize_header_name(header)

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/query_source.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/query_source.rb
@@ -25,7 +25,7 @@ module ElasticGraph
         def fetch(queries)
           responses_by_query = @datastore_router.msearch(queries, query_tracker: @query_tracker)
           @query_tracker.record_datastore_queries_for_single_request(queries)
-          queries.map { |q| responses_by_query[q] }
+          queries.map { |q| responses_by_query.fetch(q) }
         end
 
         def self.execute_many(queries, for_context:)

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/http_endpoint.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/http_endpoint.rbs
@@ -84,8 +84,7 @@ module ElasticGraph
       @normalized_headers: ::Hash[::String, ::String]?
       def normalized_headers: () -> ::Hash[::String, ::String]
 
-      @content_type: ::String?
-      def content_type: () -> ::String
+      def content_type: () -> ::String?
 
       def self.normalize_header_name: (::String) -> ::String
     end

--- a/elasticgraph-health_check/lib/elastic_graph/health_check/health_checker.rb
+++ b/elasticgraph-health_check/lib/elastic_graph/health_check/health_checker.rb
@@ -169,7 +169,7 @@ module ElasticGraph
         #
         # So below, filter to types that have all of their datastore clusters available for querying.
         available_type_names, unavailable_type_names = valid_type_names.partition do |type_name|
-          @indexed_document_types_by_name[type_name].search_index_definitions.all? do |search_index_definition|
+          @indexed_document_types_by_name.fetch(type_name).search_index_definitions.all? do |search_index_definition|
             @datastore_clients_by_name.key?(search_index_definition.cluster_to_query.to_s)
           end
         end
@@ -190,6 +190,7 @@ module ElasticGraph
             .fields_by_name[check.timestamp_field]
 
           if field&.type&.unwrap_fully&.name.to_s == "DateTime"
+            # @type var field: GraphQL::Schema::Field
             # Convert the config so that we have a reference to the index field name.
             normalized_data_recency_checks[type] = check.with(timestamp_field: field.name_in_index.to_s)
           else

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/datastore_indexing_router.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/datastore_indexing_router.rb
@@ -77,10 +77,8 @@ module ElasticGraph
         # Before writing these operations, verify their destination index mapping are consistent.
         validate_mapping_completeness_of!(:accessible_cluster_names_to_index_into, *operations.map(&:destination_index_def).uniq)
 
-        # @type var ops_by_client: ::Hash[DatastoreCore::_Client, ::Array[_Operation]]
-        ops_by_client = ::Hash.new { |h, k| h[k] = [] }
-        # @type var unsupported_ops: ::Set[_Operation]
-        unsupported_ops = ::Set.new
+        ops_by_client = ::Hash.new { |h, k| h[k] = [] } # : ::Hash[DatastoreCore::_Client, ::Array[_Operation]]
+        unsupported_ops = ::Set.new # : ::Set[_Operation]
 
         operations.reject { |op| op.to_datastore_bulk.empty? }.each do |op|
           # Note: this intentionally does not use `accessible_cluster_names_to_index_into`.
@@ -90,7 +88,8 @@ module ElasticGraph
 
           cluster_names.each do |cluster_name|
             if (client = @datastore_clients_by_name[cluster_name])
-              ops_by_client[client] << op
+              ops = ops_by_client[client] # : ::Array[::ElasticGraph::Indexer::_Operation]
+              ops << op
             else
               unsupported_ops << op
             end
@@ -293,8 +292,7 @@ module ElasticGraph
         if failures.empty?
           client_names_and_results.each_with_object(_ = {}) do |(client_name, _success_or_failure, results), accum|
             results.each do |op, version|
-              accum[op] ||= _ = {}
-              accum[op][client_name] = version
+              (accum[op] ||= {})[client_name] = version
             end
           end
         else

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/operation/factory.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/operation/factory.rb
@@ -96,7 +96,7 @@ module ElasticGraph
         end
 
         def validator(type, selected_json_schema_version)
-          factory = validator_factories_by_version[selected_json_schema_version]
+          factory = validator_factories_by_version[selected_json_schema_version] # : JSONSchema::ValidatorFactory
           factory.validator_for(type)
         end
 

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/record_preparer.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/record_preparer.rb
@@ -31,7 +31,7 @@ module ElasticGraph
 
         # Gets the `RecordPreparer` for the given JSON schema version.
         def for_json_schema_version(json_schema_version)
-          @preparers_by_json_schema_version[json_schema_version]
+          @preparers_by_json_schema_version[json_schema_version] # : RecordPreparer
         end
 
         # Gets the `RecordPreparer` for the latest JSON schema version. Intended primarily

--- a/elasticgraph-indexer_autoscaler_lambda/lib/elastic_graph/indexer_autoscaler_lambda/concurrency_scaler.rb
+++ b/elasticgraph-indexer_autoscaler_lambda/lib/elastic_graph/indexer_autoscaler_lambda/concurrency_scaler.rb
@@ -130,7 +130,8 @@ module ElasticGraph
           ]
         })
 
-        metric_response.metric_data_results.first.values.first
+        results = metric_response.metric_data_results.first # : ::Aws::CloudWatch::Types::MetricDataResult
+        results.values.first.to_f
       end
 
       def get_queue_attributes(queue_urls)

--- a/elasticgraph-json_schema/lib/elastic_graph/json_schema/validator_factory.rb
+++ b/elasticgraph-json_schema/lib/elastic_graph/json_schema/validator_factory.rb
@@ -55,7 +55,7 @@ module ElasticGraph
       # @param type_name [String] name of an ElasticGraph type
       # @return [Validator]
       def validator_for(type_name)
-        @validators_by_type_name[type_name]
+        @validators_by_type_name[type_name] # : Validator
       end
 
       # Returns a new factory configured to disallow unknown properties. By default, JSON schema

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/query_validator.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/query_validator.rb
@@ -60,8 +60,8 @@ module ElasticGraph
           return [{"message" => "No dumped variables for this operation exist. Correct by running: `#{rake_task}`"}]
         end
 
-        old_op_vars = old_dumped_variables[operation_name]
-        new_op_vars = new_dumped_variables[operation_name]
+        old_op_vars = old_dumped_variables.fetch(operation_name)
+        new_op_vars = new_dumped_variables.fetch(operation_name)
 
         if old_op_vars == new_op_vars
           # The previously dumped variables are up-to-date. No errors in this case.

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/variable_backward_incompatibility_detector.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/variable_backward_incompatibility_detector.rb
@@ -32,12 +32,12 @@ module ElasticGraph
         end
 
         incompatible_commonalities = commonalities.flat_map do |name|
-          incompatibilities_for("#{path}#{name}", normalize_type_info(old[name]), normalize_type_info(new[name]))
+          incompatibilities_for("#{path}#{name}", normalize_type_info(old.fetch(name)), normalize_type_info(new.fetch(name)))
         end
 
         incompatible_additions = additions.filter_map do |name|
           # Additions are only incompatible if it's required (non-nullable).
-          _ = if normalize_type_info(new[name]).fetch("type").end_with?("!")
+          _ = if normalize_type_info(new.fetch(name)).fetch("type").end_with?("!")
             Incompatibility.new("#{path}#{name}", "new required #{entry_type}")
           end
         end

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/from_disk.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/from_disk.rb
@@ -47,7 +47,7 @@ module ElasticGraph
             "Available versions: #{available_json_schema_versions.sort.join(", ")}."
         end
 
-        json_schemas_by_version[version]
+        json_schemas_by_version[version] # : ::Hash[::String, untyped]
       end
 
       def available_json_schema_versions

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/extension_loader.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/extension_loader.rb
@@ -117,7 +117,7 @@ module ElasticGraph
           # @type var file_name: ::String?
           # @type var line_number: ::Integer?
           file_name, line_number = object.instance_method(method_name).source_location
-          ::File.read(file_name.to_s).split("\n")[line_number.to_i - 1].strip
+          ::File.read(file_name.to_s).split("\n").fetch(line_number.to_i - 1).strip
         end
       end
     end

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_derived_graphql_type_customizations.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_derived_graphql_type_customizations.rb
@@ -50,7 +50,8 @@ module ElasticGraph
             derived_type_customizations_for_all_types << customization_block
           else
             type_names.each do |t|
-              derived_type_customizations_by_name[t.to_s] << customization_block
+              derived_type_customizations = derived_type_customizations_by_name[t.to_s] # : ::Array[^(::ElasticGraph::SchemaDefinition::_Type) -> void]
+              derived_type_customizations << customization_block
             end
           end
         end
@@ -75,21 +76,23 @@ module ElasticGraph
         #     end
         #   end
         def customize_derived_type_fields(type_name, *field_names, &customization_block)
-          customizations_by_field = derived_field_customizations_by_type_and_field_name[type_name]
+          customizations_by_field = derived_field_customizations_by_type_and_field_name[type_name] # : ::Hash[::String, ::Array[^(::ElasticGraph::SchemaDefinition::SchemaElements::Field) -> void]]
 
           field_names.each do |field_name|
-            customizations_by_field[field_name] << customization_block
+            customizations = customizations_by_field[field_name] # : ::Array[^(::ElasticGraph::SchemaDefinition::SchemaElements::Field) -> void]
+            customizations << customization_block
           end
         end
 
         # @private
         def derived_type_customizations_for_type(type)
-          derived_type_customizations_by_name[type.name] + derived_type_customizations_for_all_types
+          derived_type_customizations = derived_type_customizations_by_name[type.name] # : ::Array[^(::ElasticGraph::SchemaDefinition::_Type) -> void]
+          derived_type_customizations + derived_type_customizations_for_all_types
         end
 
         # @private
         def derived_field_customizations_by_name_for_type(type)
-          derived_field_customizations_by_type_and_field_name[type.name]
+          derived_field_customizations_by_type_and_field_name[type.name] # : ::Hash[::String, ::Array[^(SchemaElements::Field) -> void]]
         end
 
         # @private

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_subtypes.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_subtypes.rb
@@ -75,8 +75,9 @@ module ElasticGraph
             fields_by_name.merge(yield subtype) do |field_name, def1, def2|
               if (def1.name_in_index == def2.name_in_index && def1.resolve_mapping != def2.resolve_mapping) || (def1.type.unwrap_non_null != def2.type.unwrap_non_null)
                 def_strings = resolved_subtypes.each_with_object([]) do |st, defs|
-                  field = st.graphql_fields_by_name[field_name]
-                  defs << "on #{st.name}:\n#{field.to_sdl.strip} mapping: #{field.resolve_mapping.inspect}" if st.graphql_fields_by_name.key?(field_name)
+                  if (field = st.graphql_fields_by_name[field_name])
+                    defs << "on #{st.name}:\n#{field.to_sdl.strip} mapping: #{field.resolve_mapping.inspect}"
+                  end
                 end
 
                 raise Errors::SchemaError,

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/implements_interfaces.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/implements_interfaces.rb
@@ -43,7 +43,8 @@ module ElasticGraph
         def implements(*interface_names)
           interface_refs = interface_names.map do |interface_name|
             schema_def_state.type_ref(interface_name).to_final_form.tap do |interface_ref|
-              schema_def_state.implementations_by_interface_ref[interface_ref] << self
+              implementations = schema_def_state.implementations_by_interface_ref[interface_ref] # : ::Set[SchemaElements::TypeWithSubfields]
+              implementations << self
             end
           end
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
@@ -329,7 +329,7 @@ module ElasticGraph
 
       def recursively_add_referenced_types_to(source_type_ref, references_cache)
         return unless (source_type = source_type_ref.as_object_type)
-        references_set = references_cache[source_type_ref.name]
+        references_set = references_cache[source_type_ref.name] # : ::Set[::String]
 
         # Recursive references are allowed only when its a relation, so skip that case.
         source_type.graphql_fields_by_name.values.reject { |f| f.relationship }.each do |field|
@@ -339,7 +339,8 @@ module ElasticGraph
             recursively_add_referenced_types_to(field_type, references_cache)
           end
 
-          references_set.merge(references_cache[field_type.name])
+          field_type_references_set = references_cache[field_type.name] # : ::Set[::String]
+          references_set.merge(field_type_references_set)
         end
       end
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/enum_value_namer.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/enum_value_namer.rb
@@ -29,7 +29,8 @@ module ElasticGraph
 
         # Returns the name that should be used for the given `type_name` and `value_name`.
         def name_for(type_name, value_name)
-          @used_value_names_by_type_name[type_name] << value_name
+          used_value_names = @used_value_names_by_type_name[type_name] # : ::Array[::String]
+          used_value_names << value_name
           overrides_by_type_name.dig(type_name, value_name) || value_name
         end
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/state.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/state.rb
@@ -139,7 +139,8 @@ module ElasticGraph
       end
 
       def register_renamed_field(type_name, from:, to:, defined_at:, defined_via:)
-        renamed_fields_by_type_name_and_old_field_name[type_name][from] = factory.new_deprecated_element(
+        renamed_fields_by_old_field_name = renamed_fields_by_type_name_and_old_field_name[type_name] # : ::Hash[::String, SchemaElements::DeprecatedElement]
+        renamed_fields_by_old_field_name[from] = factory.new_deprecated_element(
           to,
           defined_at: defined_at,
           defined_via: defined_via
@@ -147,7 +148,8 @@ module ElasticGraph
       end
 
       def register_deleted_field(type_name, field_name, defined_at:, defined_via:)
-        deleted_fields_by_type_name_and_old_field_name[type_name][field_name] = factory.new_deprecated_element(
+        deleted_fields_by_old_field_name = deleted_fields_by_type_name_and_old_field_name[type_name] # : ::Hash[::String, SchemaElements::DeprecatedElement]
+        deleted_fields_by_old_field_name[field_name] = factory.new_deprecated_element(
           field_name,
           defined_at: defined_at,
           defined_via: defined_via

--- a/gemspec_helper.rb
+++ b/gemspec_helper.rb
@@ -60,7 +60,10 @@ module ElasticGraphGemspecHelper
 
       # Steep is our type checker. Only needed if there's a `sig` directory.
       if ::Dir.exist?(::File.join(gem_dir, "sig"))
-        spec.add_development_dependency "steep", "~> 1.8"
+        # New steep minor versions often introduce stricter type checks that we may initially fail,
+        # so we don't want to automatically upgrade when a new steep minor version is released.
+        # Therefore, we list 3 digits (in contrast to most gems).
+        spec.add_development_dependency "steep", "~> 1.9.0"
       end
 
       # If the gem has a `spec` directory then it needs our standard set of testing gems.


### PR DESCRIPTION
Steep 1.9 introduced support for `implicitly-returns-nil`[^1], which causes it to treat all `hash[key]` and `array[index]` expressions as nullable since the key or index might no be in the hash or array. This makes the type checking stricter, yielding type checking errors for some cases that could previously have failed at runtime due to unexpected `nil` values.

To fix the new type check failures, I used a few different approaches:

* When doing a lookup in a hash that has a default proc, we know that `hash[key]` will never be `nil`. To communicate this to steep I've added a type assertion comment (e.g. `# : ::String`). Sometimes this forced me to break a single expression into multiple lines (so that I could put a type assertion on one part of the expression).
* Otherwise, if a value of `nil` would lead to a later runtime exception, I generally changed a hash lookup to use `hash.fetch(key)` instead. `fetch` is _not_ implicitly nil as it raises an error instead of returning `nil` when the key is not found. This provides a better error message than we would get from allowing a `nil` value.
* For other cases, I changed the code to accomodate possible `nil` values.

[^1]: https://github.com/soutaro/steep/wiki/Release-Note-1.9#implicitly-returns-nil-support