### PR TITLE
Move `UnboundedWithExclusions` into `FilterValueSetExtractor`.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/index_expression_builder.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/index_expression_builder.rb
@@ -73,6 +73,8 @@ module ElasticGraph
 
           time_set = @filter_value_set_extractor.extract_filter_value_set(filter_hashes, [index_def.timestamp_field_path])
 
+          return IndexExpression.only(index_def.index_expression_for_search) if time_set.nil?
+
           if time_set.empty?
             return require_indices ?
               # Indices are required. Given the time set is empty, it's impossible for any documents to match our search.

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/filters.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/filters.rb
@@ -96,7 +96,8 @@ module ElasticGraph
         # on `filter_value_set_extractor` to determine it, since it understands the semantics
         # of `any_of`, `not`, etc.
         def can_match_nil_values_at?(path, filter)
-          filter_value_set_extractor.extract_filter_value_set([filter], [path]).includes_nil?
+          value_set = filter_value_set_extractor.extract_filter_value_set([filter], [path])
+          (_ = value_set).nil? || value_set.includes_nil?
         end
 
         def filter_value_set_extractor

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/datastore_query/routing_picker.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/datastore_query/routing_picker.rbs
@@ -10,16 +10,10 @@ module ElasticGraph
 
         private
 
-        @filter_value_set_extractor: Filtering::FilterValueSetExtractor[_RoutingValueSet]
+        @filter_value_set_extractor: Filtering::FilterValueSetExtractor[RoutingValueSet]
       end
 
       type routingValue = untyped
-
-      interface _RoutingValueSet
-        include Support::_NegatableSet[_RoutingValueSet]
-        def to_return_value: () -> ::Array[routingValue]?
-        def ==: (untyped) -> bool
-      end
 
       type routingValueSetType = :inclusive | :exclusive
 
@@ -40,13 +34,15 @@ module ElasticGraph
       end
 
       class RoutingValueSet < RoutingValueSetSupertype
-        include _RoutingValueSet
+        include Support::_NegatableSet[RoutingValueSet]
         def self.of: (::Enumerable[routingValue]) -> RoutingValueSet
         def self.of_all_except: (::Enumerable[routingValue]) -> RoutingValueSet
 
         ALL: RoutingValueSet
         EMPTY: RoutingValueSet
         INVERTED_TYPES: ::Hash[routingValueSetType, routingValueSetType]
+
+        def to_return_value: () -> ::Array[routingValue]?
 
         def inclusive?: () -> bool
         def exclusive?: () -> bool
@@ -56,10 +52,6 @@ module ElasticGraph
         def get_included_and_excluded_values: (
           RoutingValueSet
         ) -> [::Set[routingValue], ::Set[routingValue]]
-
-        module UnboundedWithExclusions
-          extend _RoutingValueSet
-        end
       end
     end
   end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/filtering/filter_value_set_extractor.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/filtering/filter_value_set_extractor.rbs
@@ -2,29 +2,61 @@ module ElasticGraph
   class GraphQL
     module Filtering
       class FilterValueSetExtractor[S < Support::_NegatableSet[S]]
-        def initialize: (SchemaArtifacts::RuntimeMetadata::SchemaElementNames, S, S) { (::Symbol, untyped) -> S? } -> void
-        def extract_filter_value_set: (::Array[::Hash[::String, untyped]], ::Array[::String]) -> S
+        type setType[out S] = S | singleton(UnboundedSetWithExclusions)
+
+        def initialize: (SchemaArtifacts::RuntimeMetadata::SchemaElementNames, setType[S], setType[S]) { (::Symbol, untyped) -> S? } -> void
+        def extract_filter_value_set: (::Array[::Hash[::String, untyped]], ::Array[::String]) -> S?
 
         private
 
         @schema_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames
-        @all_values_set: S
-        @empty_set: S
+        @all_values_set: setType[S]
+        @empty_set: setType[S]
         @build_set_for_filter: ^(::Symbol, untyped) -> S?
 
-        def filter_value_set_for_target_field_path: (::String, ::Array[::Hash[::String, untyped]]) -> S
-        def filter_value_set_for_filter_hash: (::Hash[::String, untyped], ::Array[::String], ?::Array[::String], negate: bool) -> S
-        def filter_value_set_for_filter_hash_entry: (::String, untyped, ::Array[::String], ::Array[::String], negate: bool) -> S
-        def filter_value_set_for_any_of: (::Array[::Hash[::String, untyped]], ::Array[::String], ::Array[::String], negate: bool) -> S
-        def filter_value_set_for_field_filter: (::String, untyped) -> S
+        def filter_value_set_for_target_field_path: (
+          ::String,
+          ::Array[::Hash[::String, untyped]]
+        ) -> setType[S]
+
+        def filter_value_set_for_filter_hash: (
+          ::Hash[::String, untyped],
+          ::Array[::String],
+          ?::Array[::String],
+          negate: bool
+        ) -> setType[S]
+
+        def filter_value_set_for_filter_hash_entry: (
+          ::String,
+          untyped,
+          ::Array[::String],
+          ::Array[::String],
+          negate: bool
+        ) -> setType[S]
+
+        def filter_value_set_for_any_of: (
+          ::Array[::Hash[::String, untyped]],
+          ::Array[::String],
+          ::Array[::String],
+          negate: bool
+        ) -> setType[S]
+
+        def filter_value_set_for_field_filter: (
+          ::String,
+          untyped
+        ) -> setType[S]
 
         type setReductionOperator = :union | :intersection
 
         def map_reduce_sets:
-          [E] (::Array[E], setReductionOperator, negate: bool) { (E) -> S } -> S |
-          [K, V] (::Hash[K, V], setReductionOperator, negate: bool) { ([K, V]) -> S } -> S
+          [E] (::Array[E], setReductionOperator, negate: bool) { (E) -> setType[S] } -> setType[S] |
+          [K, V] (::Hash[K, V], setReductionOperator, negate: bool) { ([K, V]) -> setType[S] } -> setType[S]
 
         REDUCTION_INVERSIONS: ::Hash[setReductionOperator, setReductionOperator]
+
+        module UnboundedSetWithExclusions
+          extend Support::_NegatableSet[untyped]
+        end
       end
     end
   end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/shard_routing_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/shard_routing_spec.rb
@@ -315,6 +315,23 @@ module ElasticGraph
           }})).to search_shards_identified_by "def"
         end
 
+        it "correctly handles filters with `not` at multiple levels" do
+          expect(shard_routing_for(["name"], {"name" => {
+            "not" => {
+              "not" => {"equal_to_any_of" => ["abc"]},
+              "equal_to_any_of" => ["abc", "def"]
+            }
+          }})).to search_all_shards
+
+          # nil value shouldn't matter
+          expect(shard_routing_for(["name"], {"name" => {
+            "not" => {
+              "not" => {"equal_to_any_of" => ["abc", nil]},
+              "equal_to_any_of" => ["abc", "def"]
+            }
+          }})).to search_all_shards
+        end
+
         it "searches all shards when `any_of` is an empty set" do
           expect(shard_routing_for(["name"], {
             "not" => {"any_of" => []}


### PR DESCRIPTION
The case of a set which is unbounded but excludes some values is possible for more than just `RoutingPicker` (where we previously had it defined). It's possible for any usage of `FilterValueSetExtractor`!

However, we haven't run into this in `IndexExpressionBuilder` because `FilterValueSetExtractor` has a subtle bug that accidentally works around this issue. In a later PR, I'm going to be reworking `FilterValueSetExtractor` to move away from the bug (by leveraging `FilterNodeInterpreter`) and this bug must be fixed first.