### PR TITLE
Ignore gem sigstore artifacts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ Gemfile-custom
 # Ignore artifacts from building the gems.
 /pkg/
 /*/pkg/
+/*/*.gem.sigstore.json
 
 # Ignore Byebug command history file.
 .byebug_history


### PR DESCRIPTION
I don't believe they should be stored under source control.