### PR TITLE
Add `Gemfile.lock` to source control.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@
 /bin/
 /bundle/
 /.bundle
-Gemfile.lock
-rbs_collection.lock.yaml
 /*/bin/
 /*/bundle/
 /*/.bundle

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ This project is written in Ruby, a dynamic, open source programming language wit
 
 You may verify your `ruby` installation via the terminal:
 
-```
+```bash
 $ ruby -v
 ruby 3.3.4 (2024-07-09 revision be1089c8ec) [arm64-darwin23]
 ```
@@ -36,7 +36,16 @@ If you do not have Ruby, we recommend installing it using one of the following:
 * [rbenv](https://rbenv.org/)
 * [ruby-install](https://github.com/postmodern/ruby-install)
 
-Once you have Ruby installed, install the development dependencies by running `bundle install`.
+### Ruby Dependencies
+
+Ruby dependencies are managed using [bundler](https://bundler.io/), which comes installed with Ruby.
+To install Ruby dependencies, run:
+
+```bash
+$ bundle install
+```
+
+Once that is done, prefix Ruby commands with `bundle exec` in order to run them in the context of the project bundle.
 
 ### Docker and Docker Compose
 
@@ -45,8 +54,22 @@ This project uses Docker Engine and Docker Compose to run Elasticsearch and Open
 
 ## Customizing the Development Environment
 
-Additional gems can be included in the bundle by defining `Gemfile-custom`.
-See [Gemfile-custom.example](Gemfile-custom.example) for an example.
+The project bundle only contains the gems necessary for what runs on CI.
+For local development, you may want to use some additional gems, such as:
+
+* [debug](https://github.com/ruby/debug) for debugging
+* [vernier](https://github.com/jhawthorn/vernier) for profiling
+* [solargraph](https://solargraph.org/) for an LSP implementation used by an IDE
+
+Different engineers have different preferences around what gems to include, so the standard project bundle
+does not include gems like these. However, support is included to customize the development environment:
+
+* Make a `Gemfile-custom` file listing the additional gems you want to include.
+  See [Gemfile-custom.example](Gemfile-custom.example) for an example.
+* Run `source script/enable_custom_gemfile`.
+
+This will set the `BUNDLE_GEMFILE` and `BUNDLE_LOCKFILE` environment variables in your shell session
+so that `bundle exec` will run in the context of your custom bundle.
 
 ## Codebase Overview
 

--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,3 @@ group :site do
   gem "yard", "~> 0.9", ">= 0.9.36"
   gem "yard-doctest", "~> 0.1", ">= 0.1.17"
 end
-
-custom_gem_file = ::File.join(repo_root, "Gemfile-custom")
-eval_gemfile(custom_gem_file) if ::File.exist?(custom_gem_file)

--- a/Gemfile-custom.example
+++ b/Gemfile-custom.example
@@ -1,3 +1,6 @@
-# Make a copy of this at `Gemfile-custom` and edit as needed to include whatever local development gems you want.
+# To customize the development environment:
+#
+# 1. Make a copy of this at `Gemfile-custom` and edit as needed to include whatever local development gems you want.
+# 2. Run `source script/enable_custom_gemfile`.
 gem "debug"
 gem "solargraph"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,614 @@
+PATH
+  remote: elasticgraph-admin_lambda
+  specs:
+    elasticgraph-admin_lambda (0.19.0.0)
+      elasticgraph-admin (= 0.19.0.0)
+      elasticgraph-lambda_support (= 0.19.0.0)
+      rake (~> 13.2)
+
+PATH
+  remote: elasticgraph-admin
+  specs:
+    elasticgraph-admin (0.19.0.0)
+      elasticgraph-datastore_core (= 0.19.0.0)
+      elasticgraph-indexer (= 0.19.0.0)
+      elasticgraph-schema_artifacts (= 0.19.0.0)
+      elasticgraph-support (= 0.19.0.0)
+      rake (~> 13.2)
+
+PATH
+  remote: elasticgraph-apollo
+  specs:
+    elasticgraph-apollo (0.19.0.0)
+      apollo-federation (~> 3.8)
+      elasticgraph-graphql (= 0.19.0.0)
+      elasticgraph-support (= 0.19.0.0)
+      graphql (~> 2.4.8)
+
+PATH
+  remote: elasticgraph-datastore_core
+  specs:
+    elasticgraph-datastore_core (0.19.0.0)
+      elasticgraph-schema_artifacts (= 0.19.0.0)
+      elasticgraph-support (= 0.19.0.0)
+
+PATH
+  remote: elasticgraph-elasticsearch
+  specs:
+    elasticgraph-elasticsearch (0.19.0.0)
+      elasticgraph-support (= 0.19.0.0)
+      elasticsearch (~> 8.16)
+      faraday (~> 2.12)
+      faraday-retry (~> 2.2)
+
+PATH
+  remote: elasticgraph-graphql_lambda
+  specs:
+    elasticgraph-graphql_lambda (0.19.0.0)
+      elasticgraph-graphql (= 0.19.0.0)
+      elasticgraph-lambda_support (= 0.19.0.0)
+
+PATH
+  remote: elasticgraph-graphql
+  specs:
+    elasticgraph-graphql (0.19.0.0)
+      elasticgraph-datastore_core (= 0.19.0.0)
+      elasticgraph-schema_artifacts (= 0.19.0.0)
+      graphql (~> 2.4.8)
+
+PATH
+  remote: elasticgraph-health_check
+  specs:
+    elasticgraph-health_check (0.19.0.0)
+      elasticgraph-datastore_core (= 0.19.0.0)
+      elasticgraph-graphql (= 0.19.0.0)
+      elasticgraph-support (= 0.19.0.0)
+
+PATH
+  remote: elasticgraph-indexer_autoscaler_lambda
+  specs:
+    elasticgraph-indexer_autoscaler_lambda (0.19.0.0)
+      aws-sdk-cloudwatch (~> 1.108)
+      aws-sdk-lambda (~> 1.144)
+      aws-sdk-sqs (~> 1.89)
+      elasticgraph-datastore_core (= 0.19.0.0)
+      elasticgraph-lambda_support (= 0.19.0.0)
+      ox (~> 2.14, >= 2.14.18)
+
+PATH
+  remote: elasticgraph-indexer_lambda
+  specs:
+    elasticgraph-indexer_lambda (0.19.0.0)
+      aws-sdk-s3 (~> 1.176)
+      elasticgraph-indexer (= 0.19.0.0)
+      elasticgraph-lambda_support (= 0.19.0.0)
+      ox (~> 2.14)
+
+PATH
+  remote: elasticgraph-indexer
+  specs:
+    elasticgraph-indexer (0.19.0.0)
+      elasticgraph-datastore_core (= 0.19.0.0)
+      elasticgraph-json_schema (= 0.19.0.0)
+      elasticgraph-schema_artifacts (= 0.19.0.0)
+      elasticgraph-support (= 0.19.0.0)
+      hashdiff (~> 1.1)
+
+PATH
+  remote: elasticgraph-json_schema
+  specs:
+    elasticgraph-json_schema (0.19.0.0)
+      elasticgraph-support (= 0.19.0.0)
+      json_schemer (~> 2.3)
+
+PATH
+  remote: elasticgraph-lambda_support
+  specs:
+    elasticgraph-lambda_support (0.19.0.0)
+      elasticgraph-opensearch (= 0.19.0.0)
+      faraday_middleware-aws-sigv4 (~> 1.0)
+
+PATH
+  remote: elasticgraph-local
+  specs:
+    elasticgraph-local (0.19.0.0)
+      elasticgraph-admin (= 0.19.0.0)
+      elasticgraph-graphql (= 0.19.0.0)
+      elasticgraph-indexer (= 0.19.0.0)
+      elasticgraph-rack (= 0.19.0.0)
+      elasticgraph-schema_definition (= 0.19.0.0)
+      rackup (~> 2.2)
+      rake (~> 13.2)
+      webrick (~> 1.9)
+
+PATH
+  remote: elasticgraph-opensearch
+  specs:
+    elasticgraph-opensearch (0.19.0.0)
+      elasticgraph-support (= 0.19.0.0)
+      faraday (~> 2.12)
+      faraday-retry (~> 2.2)
+      opensearch-ruby (~> 3.4)
+
+PATH
+  remote: elasticgraph-query_interceptor
+  specs:
+    elasticgraph-query_interceptor (0.19.0.0)
+      elasticgraph-graphql (= 0.19.0.0)
+      elasticgraph-schema_artifacts (= 0.19.0.0)
+
+PATH
+  remote: elasticgraph-query_registry
+  specs:
+    elasticgraph-query_registry (0.19.0.0)
+      elasticgraph-graphql (= 0.19.0.0)
+      elasticgraph-support (= 0.19.0.0)
+      graphql (~> 2.4.8)
+      rake (~> 13.2)
+
+PATH
+  remote: elasticgraph-rack
+  specs:
+    elasticgraph-rack (0.19.0.0)
+      elasticgraph-graphql (= 0.19.0.0)
+      rack (~> 3.1)
+
+PATH
+  remote: elasticgraph-schema_artifacts
+  specs:
+    elasticgraph-schema_artifacts (0.19.0.0)
+      elasticgraph-support (= 0.19.0.0)
+
+PATH
+  remote: elasticgraph-schema_definition
+  specs:
+    elasticgraph-schema_definition (0.19.0.0)
+      elasticgraph-graphql (= 0.19.0.0)
+      elasticgraph-indexer (= 0.19.0.0)
+      elasticgraph-json_schema (= 0.19.0.0)
+      elasticgraph-schema_artifacts (= 0.19.0.0)
+      elasticgraph-support (= 0.19.0.0)
+      graphql (~> 2.4.8)
+      rake (~> 13.2)
+
+PATH
+  remote: elasticgraph-support
+  specs:
+    elasticgraph-support (0.19.0.0)
+      logger (~> 1.6, >= 1.6.2)
+
+PATH
+  remote: elasticgraph
+  specs:
+    elasticgraph (0.19.0.0)
+      elasticgraph-admin (= 0.19.0.0)
+      elasticgraph-graphql (= 0.19.0.0)
+      elasticgraph-indexer (= 0.19.0.0)
+      elasticgraph-local (= 0.19.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (8.0.1)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    ansi (1.5.0)
+    apollo-federation (3.8.5)
+      google-protobuf (~> 3.22)
+      graphql (>= 1.10.14)
+    ast (2.4.2)
+    attr_extras (7.1.0)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.1029.0)
+    aws-sdk-cloudwatch (1.108.0)
+      aws-sdk-core (~> 3, >= 3.210.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-core (3.214.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.96.0)
+      aws-sdk-core (~> 3, >= 3.210.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-lambda (1.144.0)
+      aws-sdk-core (~> 3, >= 3.210.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.176.1)
+      aws-sdk-core (~> 3, >= 3.210.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-sqs (1.89.0)
+      aws-sdk-core (~> 3, >= 3.210.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.10.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    aws_lambda_ric (2.0.0)
+    base64 (0.2.0)
+    benchmark (0.4.0)
+    bigdecimal (3.1.9)
+    coderay (1.1.3)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.4)
+    connection_pool (2.4.1)
+    csv (3.3.2)
+    diff-lcs (1.5.1)
+    docile (1.4.1)
+    drb (2.2.1)
+    elastic-transport (8.3.5)
+      faraday (< 3)
+      multi_json
+    elasticsearch (8.17.0)
+      elastic-transport (~> 8.3)
+      elasticsearch-api (= 8.17.0)
+    elasticsearch-api (8.17.0)
+      multi_json
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    factory_bot (6.5.0)
+      activesupport (>= 5.0.0)
+    faker (3.5.1)
+      i18n (>= 1.8.11, < 2)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
+    faraday-retry (2.2.1)
+      faraday (~> 2.0)
+    faraday_middleware-aws-sigv4 (1.0.1)
+      aws-sigv4 (~> 1.0)
+      faraday (>= 2.0, < 3)
+    ffi (1.17.0)
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-aarch64-linux-musl)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm-linux-musl)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86-linux-musl)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-musl)
+    fiber-storage (1.0.0)
+    fileutils (1.7.3)
+    filewatcher (2.1.0)
+      module_methods (~> 0.1.0)
+    flatware (2.3.3)
+      drb
+      thor (< 2.0)
+    flatware-rspec (2.3.3)
+      flatware (= 2.3.3)
+      rspec (>= 3.6)
+    forwardable-extended (2.6.0)
+    google-protobuf (3.25.5)
+    google-protobuf (3.25.5-aarch64-linux)
+    google-protobuf (3.25.5-arm64-darwin)
+    google-protobuf (3.25.5-x86-linux)
+    google-protobuf (3.25.5-x86_64-darwin)
+    google-protobuf (3.25.5-x86_64-linux)
+    graphql (2.4.8)
+      base64
+      fiber-storage
+    hana (1.3.7)
+    hashdiff (1.1.2)
+    http-2 (1.0.2)
+    http_parser.rb (0.8.0)
+    httpx (1.4.0)
+      http-2 (>= 1.0.0)
+    i18n (1.14.6)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.3.4)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (>= 0.3.6, < 0.5)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-sass-converter (3.0.0)
+      sass-embedded (~> 1.54)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    jmespath (1.6.2)
+    json (2.9.1)
+    json_schemer (2.3.0)
+      bigdecimal
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.6.4)
+    mercenary (0.4.0)
+    method_source (1.1.0)
+    minitest (5.25.4)
+    module_methods (0.1.0)
+    multi_json (1.15.0)
+    net-http (0.6.0)
+      uri
+    opensearch-ruby (3.4.0)
+      faraday (>= 1.0, < 3)
+      multi_json (>= 1.0)
+    optimist (3.2.0)
+    ox (2.14.19)
+      bigdecimal (>= 3.0)
+    parallel (1.26.3)
+    parser (3.3.6.0)
+      ast (~> 2.4.1)
+      racc
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    patience_diff (1.2.0)
+      optimist (~> 3.0)
+    public_suffix (6.0.1)
+    racc (1.8.1)
+    rack (3.1.8)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rackup (2.2.1)
+      rack (>= 3)
+    rainbow (3.1.1)
+    rake (13.2.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rbs (3.8.0)
+      logger
+    regexp_parser (2.10.0)
+    rexml (3.4.0)
+    rouge (4.5.1)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.2)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
+    rspec-support (3.13.2)
+    rubocop (1.66.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.4, < 3.0)
+      rubocop-ast (>= 1.32.2, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.37.0)
+      parser (>= 3.3.1.0)
+    rubocop-factory_bot (2.26.1)
+      rubocop (~> 1.61)
+    rubocop-performance (1.23.0)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
+    rubocop-rspec (3.3.0)
+      rubocop (~> 1.61)
+    ruby-progressbar (1.13.0)
+    safe_yaml (1.0.5)
+    sass-embedded (1.77.5)
+      google-protobuf (>= 3.25, < 5.0)
+      rake (>= 13)
+    sass-embedded (1.77.5-aarch64-linux-android)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-aarch64-linux-gnu)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-aarch64-linux-musl)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-aarch64-mingw-ucrt)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-arm-linux-androideabi)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-arm-linux-gnueabihf)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-arm-linux-musleabihf)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-arm64-darwin)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-riscv64-linux-android)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-riscv64-linux-gnu)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-riscv64-linux-musl)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-x86-cygwin)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-x86-linux-android)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-x86-linux-gnu)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-x86-linux-musl)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-x86-mingw-ucrt)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-x86_64-cygwin)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-x86_64-darwin)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-x86_64-linux-android)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-x86_64-linux-gnu)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.5-x86_64-linux-musl)
+      google-protobuf (>= 3.25, < 5.0)
+    securerandom (0.4.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-console (0.9.2)
+      ansi
+      simplecov
+      terminal-table
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
+    simpleidn (0.2.3)
+    standard (1.41.1)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.66.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.5)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.6.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.23.0)
+    steep (1.9.3)
+      activesupport (>= 5.1)
+      concurrent-ruby (>= 1.1.10)
+      csv (>= 3.0.9)
+      fileutils (>= 1.1.0)
+      json (>= 2.1.0)
+      language_server-protocol (>= 3.15, < 4.0)
+      listen (~> 3.0)
+      logger (>= 1.3.0)
+      parser (>= 3.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rbs (~> 3.8)
+      securerandom (>= 0.1)
+      strscan (>= 1.0.0)
+      terminal-table (>= 2, < 4)
+      uri (>= 0.12.0)
+    strscan (3.1.2)
+    super_diff (0.14.0)
+      attr_extras (>= 6.2.4)
+      diff-lcs
+      patience_diff
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    thor (1.3.2)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.6.0)
+    uri (1.0.2)
+    vcr (6.3.1)
+      base64
+    webrick (1.9.1)
+    yard (0.9.37)
+    yard-doctest (0.1.17)
+      minitest
+      yard
+
+PLATFORMS
+  aarch64-linux
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  aarch64-mingw-ucrt
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-cygwin
+  x86-linux
+  x86-linux-android
+  x86-linux-gnu
+  x86-linux-musl
+  x86-mingw-ucrt
+  x86_64-cygwin
+  x86_64-darwin
+  x86_64-linux
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  aws_lambda_ric (~> 2.0)
+  coderay (~> 1.1)
+  elasticgraph (= 0.19.0.0)!
+  elasticgraph-admin (= 0.19.0.0)!
+  elasticgraph-admin_lambda (= 0.19.0.0)!
+  elasticgraph-apollo (= 0.19.0.0)!
+  elasticgraph-datastore_core (= 0.19.0.0)!
+  elasticgraph-elasticsearch (= 0.19.0.0)!
+  elasticgraph-graphql (= 0.19.0.0)!
+  elasticgraph-graphql_lambda (= 0.19.0.0)!
+  elasticgraph-health_check (= 0.19.0.0)!
+  elasticgraph-indexer (= 0.19.0.0)!
+  elasticgraph-indexer_autoscaler_lambda (= 0.19.0.0)!
+  elasticgraph-indexer_lambda (= 0.19.0.0)!
+  elasticgraph-json_schema (= 0.19.0.0)!
+  elasticgraph-lambda_support (= 0.19.0.0)!
+  elasticgraph-local (= 0.19.0.0)!
+  elasticgraph-opensearch (= 0.19.0.0)!
+  elasticgraph-query_interceptor (= 0.19.0.0)!
+  elasticgraph-query_registry (= 0.19.0.0)!
+  elasticgraph-rack (= 0.19.0.0)!
+  elasticgraph-schema_artifacts (= 0.19.0.0)!
+  elasticgraph-schema_definition (= 0.19.0.0)!
+  elasticgraph-support (= 0.19.0.0)!
+  factory_bot (~> 6.4)
+  faker (~> 3.5)
+  faraday (~> 2.12)
+  filewatcher (~> 2.1)
+  flatware-rspec (~> 2.3, >= 2.3.3)
+  httpx (~> 1.3)
+  jekyll (~> 4.3)
+  method_source (~> 1.1)
+  rack-test (~> 2.1)
+  rake (~> 13.2)
+  rspec (~> 3.13)
+  rspec-retry (~> 0.6)
+  rubocop-factory_bot (~> 2.26)
+  rubocop-rake (~> 0.6)
+  rubocop-rspec (~> 3.1)
+  simplecov (~> 0.22)
+  simplecov-console (~> 0.9)
+  standard (~> 1.41.0)
+  steep (~> 1.9.0)
+  super_diff (~> 0.13)
+  vcr (~> 6.3, >= 6.3.1)
+  yard (~> 0.9, >= 0.9.36)
+  yard-doctest (~> 0.1, >= 0.1.17)
+
+BUNDLED WITH
+   2.6.2

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -1,0 +1,356 @@
+---
+path: ".gem_rbs_collection"
+gems:
+- name: activesupport
+  version: '7.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: addressable
+  version: '2.8'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: ast
+  version: '2.4'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: aws-sdk-cloudwatch
+  version: 1.108.0
+  source:
+    type: rubygems
+- name: aws-sdk-core
+  version: 3.214.0
+  source:
+    type: rubygems
+- name: aws-sdk-kms
+  version: 1.96.0
+  source:
+    type: rubygems
+- name: aws-sdk-lambda
+  version: 1.144.0
+  source:
+    type: rubygems
+- name: aws-sdk-s3
+  version: 1.176.1
+  source:
+    type: rubygems
+- name: aws-sdk-sqs
+  version: 1.89.0
+  source:
+    type: rubygems
+- name: base64
+  version: '0'
+  source:
+    type: stdlib
+- name: benchmark
+  version: '0'
+  source:
+    type: stdlib
+- name: bigdecimal
+  version: '0'
+  source:
+    type: stdlib
+- name: cgi
+  version: '0'
+  source:
+    type: stdlib
+- name: concurrent-ruby
+  version: '1.1'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: connection_pool
+  version: '2.4'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: csv
+  version: '0'
+  source:
+    type: stdlib
+- name: date
+  version: '0'
+  source:
+    type: stdlib
+- name: diff-lcs
+  version: '1.5'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: digest
+  version: '0'
+  source:
+    type: stdlib
+- name: erb
+  version: '0'
+  source:
+    type: stdlib
+- name: faker
+  version: '2.23'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: faraday
+  version: '2.7'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: fileutils
+  version: '0'
+  source:
+    type: stdlib
+- name: forwardable
+  version: '0'
+  source:
+    type: stdlib
+- name: google-protobuf
+  version: '3.22'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: hashdiff
+  version: '1.1'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: i18n
+  version: '1.10'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: json
+  version: '0'
+  source:
+    type: stdlib
+- name: listen
+  version: '3.9'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: logger
+  version: '0'
+  source:
+    type: stdlib
+- name: minitest
+  version: '0'
+  source:
+    type: stdlib
+- name: monitor
+  version: '0'
+  source:
+    type: stdlib
+- name: mutex_m
+  version: '0'
+  source:
+    type: stdlib
+- name: net-http
+  version: '0'
+  source:
+    type: stdlib
+- name: net-protocol
+  version: '0'
+  source:
+    type: stdlib
+- name: openssl
+  version: '0'
+  source:
+    type: stdlib
+- name: optparse
+  version: '0'
+  source:
+    type: stdlib
+- name: parallel
+  version: '1.20'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: parser
+  version: '3.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: pathname
+  version: '0'
+  source:
+    type: stdlib
+- name: rack
+  version: '2.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rainbow
+  version: '3.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rake
+  version: '13.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rbs
+  version: 3.8.0
+  source:
+    type: rubygems
+- name: rdoc
+  version: '0'
+  source:
+    type: stdlib
+- name: regexp_parser
+  version: '2.8'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: ripper
+  version: '0'
+  source:
+    type: stdlib
+- name: rubocop
+  version: '1.57'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rubocop-ast
+  version: '1.30'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: securerandom
+  version: '0'
+  source:
+    type: stdlib
+- name: simplecov
+  version: '0.22'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: singleton
+  version: '0'
+  source:
+    type: stdlib
+- name: socket
+  version: '0'
+  source:
+    type: stdlib
+- name: stringio
+  version: '0'
+  source:
+    type: stdlib
+- name: strscan
+  version: '0'
+  source:
+    type: stdlib
+- name: tempfile
+  version: '0'
+  source:
+    type: stdlib
+- name: thor
+  version: '1.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: time
+  version: '0'
+  source:
+    type: stdlib
+- name: timeout
+  version: '0'
+  source:
+    type: stdlib
+- name: tsort
+  version: '0'
+  source:
+    type: stdlib
+- name: tzinfo
+  version: '2.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: uri
+  version: '0'
+  source:
+    type: stdlib
+- name: webrick
+  version: 1.9.1
+  source:
+    type: rubygems
+- name: yard
+  version: '0.9'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+gemfile_lock_path: Gemfile.lock

--- a/script/enable_custom_gemfile
+++ b/script/enable_custom_gemfile
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Run this script via: `source script/enable_custom_gemfile`
+#
+# This script:
+#   1. Ensures tmp/Gemfile-local exists and references Gemfile and Gemfile-custom
+#   2. Copies Gemfile.lock to tmp/Gemfile-local.lock if needed
+#   3. Sets environment variables to use tmp/Gemfile-local and tmp/Gemfile-local.lock
+#   4. Installs gems in a "conservative" mode (i.e., doesn’t update existing versions)
+
+# Check if the script is being run or sourced
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  echo "Error: This script must be sourced, not executed directly."
+  echo "Usage: source script/enable_custom_gemfile"
+  exit 1
+fi
+
+# 1. Ensure Gemfile-local exists
+if [[ ! -f "tmp/Gemfile-local" ]]; then
+  echo "Creating tmp/Gemfile-local..."
+  cat <<EOF > tmp/Gemfile-local
+eval_gemfile("../Gemfile")
+eval_gemfile("../Gemfile-custom")
+EOF
+fi
+
+# 2. Copy Gemfile.lock to Gemfile-local.lock if it doesn't exist
+if [[ -f "Gemfile.lock" ]]; then
+  echo "Copying Gemfile.lock to tmp/Gemfile-local.lock..."
+  cp Gemfile.lock tmp/Gemfile-local.lock
+else
+  echo "No Gemfile.lock found. You might need to run 'bundle install' using the main Gemfile first."
+  return 1
+fi
+
+# 3. Set environment variables so Bundler uses Gemfile-local and Gemfile-local.lock
+export BUNDLE_GEMFILE=tmp/Gemfile-local
+export BUNDLE_LOCKFILE=tmp/Gemfile-local.lock
+
+# 4. Run bundle install in a conservative mode (does not upgrade existing gems)
+echo "Installing gems using tmp/Gemfile-local and tmp/Gemfile-local.lock..."
+bundle update --conservative
+
+echo "Done! Your local environment is set to use tmp/Gemfile-local and tmp/Gemfile-local.lock."

--- a/script/type_check
+++ b/script/type_check
@@ -17,7 +17,6 @@ set -o pipefail
 # Verbose form of `set -x`.
 set -o xtrace
 
-bundle exec rbs collection update
 # Unfortunately, one of steep's dependencies crashes when you use frozen string literals,
 # so we disable that flag when running it here.
 RUBYOPT=--disable-frozen-string-literal bundle exec steep check


### PR DESCRIPTION
Previously, `Gemfile.lock` was git-ignored. This provided a couple of benefits:

1. CI builds would automatically pick up new versions of gems (within the bounds of the specified version constraints) without us needing to update them.
2. Contributors could easily customize the development environment simply by adding custom gems to `Gemfile-custom`.

However, this approach also came with some downsides:

1. New gem releases could cause our CI builds to fail, which is confusing for contributors.
2. Automatic upgrade tooling like dependabot requires the `Gemfile.lock` to be under source control.
3. Failures may be encountered when running commands against old SHAs. For example, when an old SHA is checked out while using `git bisect`, the code may only be compatible against a specific old version of a dependency. The fact that `Gemfile.lock` isn't under source control means there's no easy way to run against the dependency versions that we know that version of the code is compatible with.

I'd like to begin using dependabot in this repo (which provides a more controlled way to achieve the first benefit). To retain the ability to customize the development environment, I've added `script/enable_custom_gemfile`, which will use an alternate, git-ignored `Gemfile` and `Gemfile.lock` which incorporate the base `Gemfile` and `Gemfile.lock` while allowing extra gems to be included.