### PR TITLE
Move development dependencies into `Gemfile`.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,6 +113,28 @@ else
   end
 end
 
+# Gems needed by the test suite and other CI checks.
+group :development do
+  gem "aws_lambda_ric", "~> 2.0"
+  gem "coderay", "~> 1.1"
+  gem "factory_bot", "~> 6.4"
+  gem "faker", "~> 3.5"
+  gem "flatware-rspec", "~> 2.3", ">= 2.3.3"
+  gem "httpx", "~> 1.3"
+  gem "method_source", "~> 1.1"
+  gem "rubocop-factory_bot", "~> 2.26"
+  gem "rubocop-rake", "~> 0.6"
+  gem "rubocop-rspec", "~> 3.1"
+  gem "rspec", "~> 3.13"
+  gem "rspec-retry", "~> 0.6"
+  gem "simplecov", "~> 0.22"
+  gem "simplecov-console", "~> 0.9"
+  gem "standard", "~> 1.41.0"
+  gem "steep", "~> 1.9.0"
+  gem "super_diff", "~> 0.13"
+  gem "vcr", "~> 6.3", ">= 6.3.1"
+end
+
 # Documentation generation gems
 group :site do
   gem "filewatcher", "~> 2.1"

--- a/elasticgraph-admin_lambda/elasticgraph-admin_lambda.gemspec
+++ b/elasticgraph-admin_lambda/elasticgraph-admin_lambda.gemspec
@@ -15,5 +15,4 @@ ElasticGraphGemspecHelper.define_elasticgraph_gem(gemspec_file: __FILE__, catego
 
   spec.add_dependency "elasticgraph-admin", eg_version
   spec.add_dependency "elasticgraph-lambda_support", eg_version
-  spec.add_development_dependency "httpx", "~> 1.3"
 end

--- a/elasticgraph-elasticsearch/elasticgraph-elasticsearch.gemspec
+++ b/elasticgraph-elasticsearch/elasticgraph-elasticsearch.gemspec
@@ -15,6 +15,4 @@ ElasticGraphGemspecHelper.define_elasticgraph_gem(gemspec_file: __FILE__, catego
   spec.add_dependency "elasticsearch", "~> 8.16"
   spec.add_dependency "faraday", "~> 2.12"
   spec.add_dependency "faraday-retry", "~> 2.2"
-
-  spec.add_development_dependency "httpx", "~> 1.3"
 end

--- a/elasticgraph-graphql_lambda/elasticgraph-graphql_lambda.gemspec
+++ b/elasticgraph-graphql_lambda/elasticgraph-graphql_lambda.gemspec
@@ -16,5 +16,4 @@ ElasticGraphGemspecHelper.define_elasticgraph_gem(gemspec_file: __FILE__, catego
 
   spec.add_development_dependency "elasticgraph-elasticsearch", eg_version
   spec.add_development_dependency "elasticgraph-query_registry", eg_version
-  spec.add_development_dependency "httpx", "~> 1.3"
 end

--- a/elasticgraph-indexer_lambda/elasticgraph-indexer_lambda.gemspec
+++ b/elasticgraph-indexer_lambda/elasticgraph-indexer_lambda.gemspec
@@ -19,6 +19,4 @@ ElasticGraphGemspecHelper.define_elasticgraph_gem(gemspec_file: __FILE__, catego
   # we have to add an explicit dependency. It supports ox, oga, libxml, nokogiri or rexml, and of those, ox seems to be the
   # best choice: it leads benchmarks, is well-maintained, has no dependencies, and is MIT-licensed.
   spec.add_dependency "ox", "~> 2.14"
-
-  spec.add_development_dependency "httpx", "~> 1.3"
 end

--- a/elasticgraph-lambda_support/elasticgraph-lambda_support.gemspec
+++ b/elasticgraph-lambda_support/elasticgraph-lambda_support.gemspec
@@ -18,5 +18,4 @@ ElasticGraphGemspecHelper.define_elasticgraph_gem(gemspec_file: __FILE__, catego
   spec.add_development_dependency "elasticgraph-graphql", eg_version
   spec.add_development_dependency "elasticgraph-indexer", eg_version
   spec.add_development_dependency "elasticgraph-indexer_autoscaler_lambda", eg_version
-  spec.add_development_dependency "httpx", "~> 1.3"
 end

--- a/elasticgraph-local/elasticgraph-local.gemspec
+++ b/elasticgraph-local/elasticgraph-local.gemspec
@@ -22,5 +22,4 @@ ElasticGraphGemspecHelper.define_elasticgraph_gem(gemspec_file: __FILE__, catego
 
   spec.add_development_dependency "elasticgraph-elasticsearch", eg_version
   spec.add_development_dependency "elasticgraph-opensearch", eg_version
-  spec.add_development_dependency "httpx", "~> 1.3"
 end

--- a/elasticgraph-opensearch/elasticgraph-opensearch.gemspec
+++ b/elasticgraph-opensearch/elasticgraph-opensearch.gemspec
@@ -15,6 +15,4 @@ ElasticGraphGemspecHelper.define_elasticgraph_gem(gemspec_file: __FILE__, catego
   spec.add_dependency "faraday", "~> 2.12"
   spec.add_dependency "faraday-retry", "~> 2.2"
   spec.add_dependency "opensearch-ruby", "~> 3.4"
-
-  spec.add_development_dependency "httpx", "~> 1.3"
 end

--- a/gemspec_helper.rb
+++ b/gemspec_helper.rb
@@ -50,54 +50,6 @@ module ElasticGraphGemspecHelper
       spec.require_paths = ["lib"]
       spec.required_ruby_version = "~> 3.2"
 
-      # Here we define common development dependencies used for the CI build of most of our gems.
-
-      # Linting and style checking gems.
-      spec.add_development_dependency "rubocop-factory_bot", "~> 2.26"
-      spec.add_development_dependency "rubocop-rake", "~> 0.6"
-      spec.add_development_dependency "rubocop-rspec", "~> 3.1"
-      spec.add_development_dependency "standard", "~> 1.41.0"
-
-      # Steep is our type checker. Only needed if there's a `sig` directory.
-      if ::Dir.exist?(::File.join(gem_dir, "sig"))
-        # New steep minor versions often introduce stricter type checks that we may initially fail,
-        # so we don't want to automatically upgrade when a new steep minor version is released.
-        # Therefore, we list 3 digits (in contrast to most gems).
-        spec.add_development_dependency "steep", "~> 1.9.0"
-      end
-
-      # If the gem has a `spec` directory then it needs our standard set of testing gems.
-      if ::Dir.exist?(::File.join(gem_dir, "spec"))
-        spec.add_development_dependency "coderay", "~> 1.1"
-        spec.add_development_dependency "flatware-rspec", "~> 2.3", ">= 2.3.3"
-        spec.add_development_dependency "rspec", "~> 3.13"
-        spec.add_development_dependency "super_diff", "~> 0.13"
-        spec.add_development_dependency "simplecov", "~> 0.22"
-        spec.add_development_dependency "simplecov-console", "~> 0.9"
-
-        # In addition, if any specs have the `:uses_datastore` tag then we need to pull in gems used by that tag.
-        if `git grep -l ":uses_datastore" #{gem_dir}/spec | wc -l`.strip.to_i > 0
-          spec.add_development_dependency "httpx", "~> 1.3"
-          spec.add_development_dependency "method_source", "~> 1.1"
-          spec.add_development_dependency "rspec-retry", "~> 0.6"
-          spec.add_development_dependency "vcr", "~> 6.3", ">= 6.3.1"
-        end
-
-        # In addition, if any specs have the `:uses_datastore` tag then we need to pull in gems used by that tag.
-        if `git grep -l ":factories" #{gem_dir}/spec | wc -l`.strip.to_i > 0
-          spec.add_development_dependency "factory_bot", "~> 6.4"
-          spec.add_development_dependency "faker", "~> 3.5"
-        end
-
-        # If any specs use the `spec_support/lambda_function` helper, then pull in the `aws_lambda_ric` gem,
-        # as it contains code that AWS bootstraps Ruby lambdas with. Note that we don't depend on anything
-        # specific in this gem, but we want to include it so that our CI build can detect any incompatibilities
-        # we may have with it.
-        if `git grep -l "spec_support\/lambda_function" #{gem_dir}/spec | wc -l`.strip.to_i > 0
-          spec.add_development_dependency "aws_lambda_ric", "~> 2.0"
-        end
-      end
-
       yield spec, ElasticGraph::VERSION
 
       if (symlink_files = spec.files.select { |f| ::File.exist?(f) && ::File.ftype(f) == "link" }).any?


### PR DESCRIPTION
I'm working on getting dependabot to work with this repo. It generally works better with dependencies declared in `Gemfile`. Also, I need to move away from `gemspec_helper.rb` as it's causing parse errors for dependabot.