### PR TITLE
Remove unneeded parts of the gemspec.

### DIFF
--- a/gemspec_helper.rb
+++ b/gemspec_helper.rb
@@ -45,9 +45,6 @@ module ElasticGraphGemspecHelper
         end - [".rspec", "Gemfile", ".yardopts"]
       end
 
-      spec.bindir = "exe"
-      spec.executables = spec.files.grep(%r{\Aexe/}) { |f| ::File.basename(f) }
-      spec.require_paths = ["lib"]
       spec.required_ruby_version = "~> 3.2"
 
       yield spec, ElasticGraph::VERSION


### PR DESCRIPTION
- We don't have any `exe` files.
- `lib` is the default require path[^1].

[^1]: https://guides.rubygems.org/specification-reference/#require_paths=