### PR TITLE
Remove unnecessary use of `_$bundler_version\_`.

### DIFF
--- a/script/ci_parts/run_misc_checks
+++ b/script/ci_parts/run_misc_checks
@@ -8,17 +8,17 @@ script/type_check
 script/update_codebase_overview --verify
 script/update_ci_yaml --verify
 
-bundle _$bundler_version\_ exec standardrb
-bundle _$bundler_version\_ exec rake schema_artifacts:check VERBOSE=true
+bundle exec standardrb
+bundle exec rake schema_artifacts:check VERBOSE=true
 
 # verify that we can index fake data locally. Note: this must come _after_ `rake schema_artifacts:check`
 # because the `index_fake_data:widgets:local` task depends on `schema_artifacts:dump`.
-bundle _$bundler_version\_ exec rake "index_fake_data:widgets[1]"
-bundle _$bundler_version\_ exec rspec config/linting
+bundle exec rake "index_fake_data:widgets[1]"
+bundle exec rspec config/linting
 
 # Validate the website. We get frozen string errors form liquid if we leave
 # frozen string literals enabled, so we have to disable them here.
-RUBYOPT=--disable-frozen-string-literal bundle _$bundler_version\_ exec rake site:validate
+RUBYOPT=--disable-frozen-string-literal bundle exec rake site:validate
 
 # The apollo compatibility tests boot docker containers and need all the resources we can provide them.
 # There does not appear to be enough resources on GitHub Actions for them to run while the the datastore

--- a/script/ci_parts/run_specs_file_by_file
+++ b/script/ci_parts/run_specs_file_by_file
@@ -7,7 +7,7 @@ source "script/ci_parts/setup_env" "test" $1 $2
 unset COVERAGE
 
 # Setup standalone binstubs for RSpec that we use below.
-bundle _$bundler_version\_ install --standalone && bundle _$bundler_version\_ binstubs rspec-core --standalone
+bundle install --standalone && bundle binstubs rspec-core --standalone
 
 function run_gem_specs_file_by_file() {
   gem=$1

--- a/script/ci_parts/setup_env
+++ b/script/ci_parts/setup_env
@@ -30,7 +30,6 @@ export NO_VCR=1
 # track test coverage for all specs
 export COVERAGE=1
 
-export bundler_version=$(cat Gemfile.lock | grep "BUNDLED WITH" -A 2 | grep "[0-9]" | xargs)
 export all_gems=$(script/list_eg_gems.rb)
 
 # elasticgraph-local contains the rake tasks that manage our datastores. Running the acceptance tests for it can
@@ -61,10 +60,10 @@ else
   datastore_version=$(echo "${datastore}" | cut -d ":" -f 2)
 
   function halt_datastore_daemon() {
-    bundle _$bundler_version\_ exec rake ${datastore_backend}:${boot_env}:${datastore_version}:halt
+    bundle exec rake ${datastore_backend}:${boot_env}:${datastore_version}:halt
   }
 
-  bundle _$bundler_version\_ exec rake ${datastore_backend}:${boot_env}:${datastore_version}:daemon
+  bundle exec rake ${datastore_backend}:${boot_env}:${datastore_version}:daemon
 
   # Occasionally, we've see transient "Partial shards failure (N shards unavailable)" errors from
   # Elasticsearch/OpenSearch on CI from the first tests that run after booting it. Locally that

--- a/script/run_gem_specs
+++ b/script/run_gem_specs
@@ -28,6 +28,6 @@ pushd $gem
   #      is a dependency of any other elasticgraph gem). To ensure that there is a proper `Gemfile` in
   #      each gem subdirectory, we pass the ENV var here. If the file does not exist, we'll get an error.
   cp ../Gemfile.lock Gemfile.lock
-  BUNDLE_GEMFILE=Gemfile bundle _$bundler_version\_ check || (rm -rf Gemfile.lock && bundle _$bundler_version\_ install)
-  BUNDLE_GEMFILE=Gemfile bundle _$bundler_version\_ exec rspec --backtrace --format progress
+  BUNDLE_GEMFILE=Gemfile bundle check || (rm -rf Gemfile.lock && bundle install)
+  BUNDLE_GEMFILE=Gemfile bundle exec rspec --backtrace --format progress
 popd


### PR DESCRIPTION
Our build scripts used this to ensure that the expected version of bundler (e.g. the version recorded as `BUNDLED WITH` in the `Gemfile.lock`) is used. While there was a time this was necessary and useful, modern versions of bundler do this automatically. If you run a `bundle` command with a different version of bundler compared to what is recorded under `BUNDLED WITH`, it'll install the expected version of bundler and re-run the command with it. We simply no longer need this and it adds complexity.