### PR TITLE
Change how we determine the `repo_root` in `Gemfile`.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,8 +39,8 @@ group :site do
 end
 
 # Since this file gets symlinked both at the repo root and into each Gem directory, we have
-# to dynamically detect the repo root, by looking for the `.git` directory.
-repo_root = ::Pathname.new(::Dir.pwd).ascend.find { |dir| ::Dir.exist?("#{dir}/.git") }.to_s
+# to dynamically detect the repo root, by looking for a file that only exists at the root.
+repo_root = ::Pathname.new(::Dir.pwd).ascend.find { |dir| ::File.exist?("#{dir}/CODE_OF_CONDUCT.md") }.to_s
 
 # `tmp` and `log` are git-ignored but many of our build tasks and scripts expect them to exist.
 # We create them here since `Gemfile` evaluation happens before anything else.


### PR DESCRIPTION
The old way doesn't appear to be working when dependabot is parsing our `Gemfile`. We're getting errors like:

```
Dependabot encountered the following error:

Bundler::Dsl::DSLError with message: [!] There was an error parsing `Gemfile`: Permission denied @ dir_s_mkdir - /log. Bundler cannot continue.

 #  from dependabot_tmp_dir/Gemfile:48
 #  -------------------------------------------
 #  # We create them here since `Gemfile` evaluation happens before anything else.
 >  ::FileUtils.mkdir_p("#{repo_root}/log")
 #  ::FileUtils.mkdir_p("#{repo_root}/tmp")
 #  -------------------------------------------
```

I think the `.git` directory may not be there when dependabot parses the `Gemfile`. Checking for a different file at the root will hopefully fix this.