### PR TITLE
Avoid "Object types must have fields" warnings.

### DIFF
--- a/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
+++ b/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
@@ -575,6 +575,7 @@ module ElasticGraph
               t.field "id", "ID" do |f|
                 expect(f).not_to respond_to(*field_extensions)
               end
+              t.index "t1"
             end
 
             schema.interface_type "T2" do |t|

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/type_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/type_spec.rb
@@ -15,7 +15,9 @@ module ElasticGraph
       RSpec.describe Type, :ensure_no_orphaned_types do
         it "exposes the name as a capitalized symbol" do
           type = define_schema do |schema|
-            schema.object_type "Color"
+            schema.object_type "Color" do |t|
+              t.field "name", "String"
+            end
           end.type_named("Color")
 
           expect(type.name).to eq :Color
@@ -23,7 +25,9 @@ module ElasticGraph
 
         it "inspects well" do
           type = define_schema do |schema|
-            schema.object_type "Color"
+            schema.object_type "Color" do |t|
+              t.field "name", "String"
+            end
           end.type_named("Color")
 
           expect(type.inspect).to eq "#<ElasticGraph::GraphQL::Schema::Type Color>"
@@ -608,7 +612,7 @@ module ElasticGraph
         describe "#search_index_definitions" do
           it "returns an empty array for a non-union type that is not indexed" do
             search_index_definitions = search_index_definitions_from do |schema, type|
-              schema.object_type(type) {}
+              schema.object_type(type) { |t| t.field "name", "String" }
             end
 
             expect(search_index_definitions).to eq []

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
@@ -34,7 +34,9 @@ module ElasticGraph
       describe "#type_named" do
         let(:schema) do
           define_schema do |s|
-            s.object_type "Color"
+            s.object_type "Color" do |f|
+              f.field "name", "String"
+            end
           end
         end
 
@@ -77,7 +79,9 @@ module ElasticGraph
             s.enum_type "Options" do |t|
               t.value "firstOption"
             end
-            s.object_type "Color"
+            s.object_type "Color" do |t|
+              t.field "name", "String"
+            end
           end
 
           expect(schema.defined_types).to all be_a Schema::Type

--- a/elasticgraph-health_check/spec/unit/envoy_extension_spec.rb
+++ b/elasticgraph-health_check/spec/unit/envoy_extension_spec.rb
@@ -147,6 +147,10 @@ module ElasticGraph
           config = {http_path_segment: http_path_segment}.compact
           schema_artifacts = generate_schema_artifacts do |schema|
             schema.register_graphql_extension(EnvoyExtension, defined_at: "elastic_graph/health_check/envoy_extension", **config)
+            schema.object_type "Widget" do |t|
+              t.field "id", "ID"
+              t.index "widgets"
+            end
           end
 
           build_graphql(schema_artifacts: schema_artifacts)

--- a/elasticgraph-query_interceptor/spec/unit/elastic_graph/query_interceptor/graphql_extension_spec.rb
+++ b/elasticgraph-query_interceptor/spec/unit/elastic_graph/query_interceptor/graphql_extension_spec.rb
@@ -163,6 +163,18 @@ module ElasticGraph
         expect(query_adapter.interceptors).to match_array(yield) # we yield to make it lazy since the interceptors are loaded lazily
         expect(query_adapter.interceptors.map(&:elasticgraph_graphql)).to all be graphql
       end
+
+      def generate_schema_artifacts
+        super do |schema|
+          yield schema
+
+          # Ensure there's at least one indexed type defined to avoid GraphQL validation errors.
+          schema.object_type "Widget" do |t|
+            t.field "id", "ID"
+            t.index "widgets"
+          end
+        end
+      end
     end
   end
 end

--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
@@ -633,6 +633,9 @@ module ElasticGraph
                   f.renamed_from "old_description"
                 end
                 t.renamed_from "Widget3"
+
+                t.field "id", "ID"
+                t.index "widgets"
               end
             end
           EOS


### PR DESCRIPTION
The GraphQL gem, starting in v2.4.5, is issuing warnings about object types with no fields:

```
Object types must have fields, but Color doesn't have any. Define a field for this type, remove it from your schema, or add `has_no_fields(true)` to its definition.

This will raise an error in a future GraphQL-Ruby version.
```

This fixes specs that accidentally trigger this warning.