### PR TITLE
Fix `Gemfile` to be compatible with dependabot.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,8 +39,8 @@ group :site do
 end
 
 # Since this file gets symlinked both at the repo root and into each Gem directory, we have
-# to dynamically detect the repo root, by looking for a file that only exists at the root.
-repo_root = ::Pathname.new(::Dir.pwd).ascend.find { |dir| ::File.exist?("#{dir}/CODE_OF_CONDUCT.md") }.to_s
+# to dynamically detect the repo root, by looking for one of the subdirs at the root.
+repo_root = ::Pathname.new(__dir__).ascend.find { |dir| ::Dir.exist?("#{dir}/elasticgraph-support") }.to_s
 
 # `tmp` and `log` are git-ignored but many of our build tasks and scripts expect them to exist.
 # We create them here since `Gemfile` evaluation happens before anything else.
@@ -48,8 +48,9 @@ repo_root = ::Pathname.new(::Dir.pwd).ascend.find { |dir| ::File.exist?("#{dir}/
 ::FileUtils.mkdir_p("#{repo_root}/tmp")
 
 # Identify the gems that live in the ElasticGraph repository.
-require "#{repo_root}/script/list_eg_gems"
-gems_in_this_repo = ::ElasticGraphGems.list.to_set
+gems_in_this_repo = ::Dir.glob("#{repo_root}/*/*.gemspec").map do |gemspec|
+  ::File.basename(::File.dirname(gemspec))
+end.to_set
 
 # Here we override the `gem` method to automatically add the ElasticGraph version
 # to all ElasticGraph gems. If we don't do this, we can get confusing bundler warnings

--- a/script/list_eg_gems.rb
+++ b/script/list_eg_gems.rb
@@ -20,5 +20,7 @@ module ElasticGraphGems
 end
 
 if $PROGRAM_NAME == __FILE__
+  # :nocov: -- specs only require this file, not run it as a script.
   puts ElasticGraphGems.list.join("\n")
+  # :nocov:
 end


### PR DESCRIPTION
My earlier attempts (e.g. #82) did not work. Using the `dry_run` script[^1], I've discovered that dependabot runs bundler commands in a temporary directory that only contains _some_ of the source controlled files (e.g. the `Gemfile`, `*.gemspec` files, etc). To be compatible with dependabot, our `Gemfile` cannot assume the presence of any files beyond these.

[^1]: https://github.com/dependabot/dependabot-core/blob/v0.291.0/bin/dry-run.rb