### PR TITLE
Fix CodeQL parse errors.

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
@@ -504,7 +504,8 @@ module ElasticGraph
 
           schema_def_api.factory.new_aggregated_values_type_for_index_leaf_type "NonNumeric" do |t|
             t.documentation "A return type used from aggregations to provided aggregated values over non-numeric fields."
-          end.tap { |t| schema_def_api.state.register_object_interface_or_union_type(t) }
+            schema_def_api.state.register_object_interface_or_union_type(t)
+          end
 
           register_framework_object_type "AggregationCountDetail" do |t|
             t.documentation "Provides detail about an aggregation `#{names.count}`."

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/relation_fields_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/relation_fields_spec.rb
@@ -15,7 +15,7 @@ module ElasticGraph
 
       context "on a relation with an outbound foreign key" do
         it "includes a foreign key field for a GraphQL relation field" do
-          one, many = index_mappings_for "my_type_one", "my_type_many" do |s|
+          mappings = index_mappings_for "my_type_one", "my_type_many" do |s|
             s.object_type "OtherType" do |t|
               t.field "id", "ID!"
               t.index "other_type"
@@ -32,7 +32,9 @@ module ElasticGraph
               t.relates_to_many "other", "OtherType", via: "other_id", dir: :out, singular: "other"
               t.index "my_type_many"
             end
-          end.map { |h| h.dig("properties") }
+          end
+
+          one, many = mappings.map { |h| h.dig("properties") }
 
           expect([one, many]).to all include({
             "id" => {"type" => "keyword"},


### PR DESCRIPTION
```
[2025-01-01 21:04:07] [build-stdout] [2025-01-01 21:04:07] [build-stdout]  WARN /home/runner/work/elasticgraph/elasticgraph/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb:507: A parse error occurred. Check the syntax of the file. If the file is invalid, correct the error or exclude the file from analysis.
```

```
[2025-01-01 21:04:08] [build-stdout] [2025-01-01 21:04:08] [build-stdout]  WARN /home/runner/work/elasticgraph/elasticgraph/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/relation_fields_spec.rb:35: A parse error occurred. Check the syntax of the file. If the file is invalid, correct the error or exclude the file from analysis.
```