### PR TITLE
Officially support Ruby 3.4.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,7 @@ jobs:
         ruby:
           - "3.2"
           - "3.3"
+          - "3.4"
         datastore:
           - "elasticsearch:8.16.1"
           - "opensearch:2.18.0"
@@ -37,13 +38,13 @@ jobs:
           # these others against every combination of `ruby` and `datastore` so we just run each with one
           # configuration here.
           - build_part: "run_misc_checks"
-            ruby: "3.3"
+            ruby: "3.4"
             datastore: "elasticsearch:8.16.1"
           - build_part: "run_specs_with_vcr"
-            ruby: "3.3"
+            ruby: "3.4"
             datastore: "elasticsearch:8.16.1"
           - build_part: "run_specs_file_by_file"
-            ruby: "3.3"
+            ruby: "3.4"
             datastore: "elasticsearch:8.16.1"
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,11 @@ This guide is for you.
 
 ## Development Prerequisites
 
-| Requirement    | Tested Version | Installation Instructions                                                 |
-|----------------|----------------|---------------------------------------------------------------------------|
-| Ruby           | 3.2.x, 3.3.x   | [ruby-lang.org](https://www.ruby-lang.org/en/documentation/installation/) |
-| Docker Engine  | 27.x           | [docker.com](https://docs.docker.com/engine/install/)                     |
-| Docker Compose | 2.29.x         | [docker.com](https://docs.docker.com/compose/install/)                    |
+| Requirement    | Tested Version      | Installation Instructions                                                 |
+|----------------|---------------------|---------------------------------------------------------------------------|
+| Ruby           | 3.2.x, 3.3.x, 3.4.x | [ruby-lang.org](https://www.ruby-lang.org/en/documentation/installation/) |
+| Docker Engine  | 27.x                | [docker.com](https://docs.docker.com/engine/install/)                     |
+| Docker Compose | 2.29.x              | [docker.com](https://docs.docker.com/compose/install/)                    |
 
 ### Ruby
 
@@ -26,7 +26,7 @@ You may verify your `ruby` installation via the terminal:
 
 ```bash
 $ ruby -v
-ruby 3.3.4 (2024-07-09 revision be1089c8ec) [arm64-darwin23]
+ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
 ```
 
 If you do not have Ruby, we recommend installing it using one of the following:

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :development do
   gem "coderay", "~> 1.1"
   gem "factory_bot", "~> 6.4"
   gem "faker", "~> 3.5"
-  gem "flatware-rspec", "~> 2.3"
+  gem "flatware-rspec", "~> 2.3", ">= 2.3.4"
   gem "httpx", "~> 1.3"
   gem "method_source", "~> 1.1"
   gem "rubocop-factory_bot", "~> 2.26"
@@ -44,6 +44,7 @@ repo_root = ::Pathname.new(__dir__).ascend.find { |dir| ::Dir.exist?("#{dir}/ela
 
 # `tmp` and `log` are git-ignored but many of our build tasks and scripts expect them to exist.
 # We create them here since `Gemfile` evaluation happens before anything else.
+require "fileutils"
 ::FileUtils.mkdir_p("#{repo_root}/log")
 ::FileUtils.mkdir_p("#{repo_root}/tmp")
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,17 +274,10 @@ GEM
     faraday_middleware-aws-sigv4 (1.0.1)
       aws-sigv4 (~> 1.0)
       faraday (>= 2.0, < 3)
-    ffi (1.17.0)
-    ffi (1.17.0-aarch64-linux-gnu)
-    ffi (1.17.0-aarch64-linux-musl)
-    ffi (1.17.0-arm-linux-gnu)
-    ffi (1.17.0-arm-linux-musl)
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86-linux-gnu)
-    ffi (1.17.0-x86-linux-musl)
-    ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
-    ffi (1.17.0-x86_64-linux-musl)
+    ffi (1.17.1)
+    ffi (1.17.1-arm-linux-gnu)
+    ffi (1.17.1-arm-linux-musl)
+    ffi (1.17.1-arm64-darwin)
     fiber-storage (1.0.0)
     fileutils (1.7.3)
     filewatcher (2.1.0)
@@ -297,11 +290,6 @@ GEM
       rspec (>= 3.6)
     forwardable-extended (2.6.0)
     google-protobuf (3.25.5)
-    google-protobuf (3.25.5-aarch64-linux)
-    google-protobuf (3.25.5-arm64-darwin)
-    google-protobuf (3.25.5-x86-linux)
-    google-protobuf (3.25.5-x86_64-darwin)
-    google-protobuf (3.25.5-x86_64-linux)
     graphql (2.4.8)
       base64
       fiber-storage
@@ -384,7 +372,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (3.8.0)
+    rbs (3.8.1)
       logger
     regexp_parser (2.10.0)
     rexml (3.4.0)
@@ -432,10 +420,6 @@ GEM
       rake (>= 13)
     sass-embedded (1.77.5-aarch64-linux-android)
       google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.5-aarch64-linux-gnu)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.5-aarch64-linux-musl)
-      google-protobuf (>= 3.25, < 5.0)
     sass-embedded (1.77.5-aarch64-mingw-ucrt)
       google-protobuf (>= 3.25, < 5.0)
     sass-embedded (1.77.5-arm-linux-androideabi)
@@ -456,21 +440,11 @@ GEM
       google-protobuf (>= 3.25, < 5.0)
     sass-embedded (1.77.5-x86-linux-android)
       google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.5-x86-linux-gnu)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.5-x86-linux-musl)
-      google-protobuf (>= 3.25, < 5.0)
     sass-embedded (1.77.5-x86-mingw-ucrt)
       google-protobuf (>= 3.25, < 5.0)
     sass-embedded (1.77.5-x86_64-cygwin)
       google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.5-x86_64-darwin)
-      google-protobuf (>= 3.25, < 5.0)
     sass-embedded (1.77.5-x86_64-linux-android)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.5-x86_64-linux-gnu)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.5-x86_64-linux-musl)
       google-protobuf (>= 3.25, < 5.0)
     securerandom (0.4.1)
     simplecov (0.22.0)
@@ -533,33 +507,23 @@ GEM
       yard
 
 PLATFORMS
-  aarch64-linux
   aarch64-linux-android
-  aarch64-linux-gnu
-  aarch64-linux-musl
   aarch64-mingw-ucrt
   arm-linux-androideabi
   arm-linux-gnu
   arm-linux-gnueabihf
   arm-linux-musl
   arm-linux-musleabihf
-  arm64-darwin
+  arm64-darwin-24
   riscv64-linux-android
   riscv64-linux-gnu
   riscv64-linux-musl
   ruby
   x86-cygwin
-  x86-linux
   x86-linux-android
-  x86-linux-gnu
-  x86-linux-musl
   x86-mingw-ucrt
   x86_64-cygwin
-  x86_64-darwin
-  x86_64-linux
   x86_64-linux-android
-  x86_64-linux-gnu
-  x86_64-linux-musl
 
 DEPENDENCIES
   aws_lambda_ric (~> 2.0)
@@ -590,7 +554,7 @@ DEPENDENCIES
   faker (~> 3.5)
   faraday (~> 2.12)
   filewatcher (~> 2.1)
-  flatware-rspec (~> 2.3)
+  flatware-rspec (~> 2.3, >= 2.3.4)
   httpx (~> 1.3)
   jekyll (~> 4.3)
   method_source (~> 1.1)

--- a/elasticgraph-admin/elasticgraph-admin.gemspec
+++ b/elasticgraph-admin/elasticgraph-admin.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-datastore_core", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-indexer", ElasticGraph::VERSION

--- a/elasticgraph-admin_lambda/elasticgraph-admin_lambda.gemspec
+++ b/elasticgraph-admin_lambda/elasticgraph-admin_lambda.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "rake", "~> 13.2"
   spec.add_dependency "elasticgraph-admin", ElasticGraph::VERSION

--- a/elasticgraph-apollo/elasticgraph-apollo.gemspec
+++ b/elasticgraph-apollo/elasticgraph-apollo.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/entities_field_resolver.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/entities_field_resolver.rb
@@ -290,6 +290,7 @@ module ElasticGraph
             self
           end
 
+          # :nocov: -- these methods are not called on an adapter when `indexed?` returns `false`.
           def customize_query(query, representations)
             nil
           end
@@ -297,6 +298,7 @@ module ElasticGraph
           def index_search_hits(response)
             nil
           end
+          # :nocov:
 
           def identify_matching_hit(indexed_search_hits, representation, context:, index:)
             representation.representation_hash

--- a/elasticgraph-datastore_core/elasticgraph-datastore_core.gemspec
+++ b/elasticgraph-datastore_core/elasticgraph-datastore_core.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-schema_artifacts", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION

--- a/elasticgraph-elasticsearch/elasticgraph-elasticsearch.gemspec
+++ b/elasticgraph-elasticsearch/elasticgraph-elasticsearch.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
   spec.add_dependency "elasticsearch", "~> 8.16"

--- a/elasticgraph-graphql/elasticgraph-graphql.gemspec
+++ b/elasticgraph-graphql/elasticgraph-graphql.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-datastore_core", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-schema_artifacts", ElasticGraph::VERSION

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/misc_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/misc_spec.rb
@@ -22,8 +22,8 @@ module ElasticGraph
       end
 
       it "inspects nicely, but redacts filters since they could contain PII" do
-        expect(new_query(filter: {"ssn" => {"equal_to_any_of" => ["123-45-6789"]}}, individual_docs_needed: true).inspect).to eq(<<~EOS.strip)
-          #<ElasticGraph::GraphQL::DatastoreQuery index="widgets_rollover__*" size=#{default_page_size + 1} sort=[{"id"=>{"order"=>"asc", "missing"=>"_first"}}] track_total_hits=false query=<REDACTED> _source=false>
+        expect(new_query(filter: {"ssn" => {"equal_to_any_of" => ["123-45-6789"]}}, individual_docs_needed: true).inspect).to eq(inspect_output_of(<<~EOS.strip))
+          #<ElasticGraph::GraphQL::DatastoreQuery index="widgets_rollover__*" size=#{default_page_size + 1} sort=[{"id" => {"order" => "asc", "missing" => "_first"}}] track_total_hits=false query=<REDACTED> _source=false>
         EOS
       end
     end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
@@ -152,7 +152,7 @@ module ElasticGraph
           expect {
             router.msearch([query1, query2])
           }.to raise_error(Errors::SearchFailedError, a_string_including(
-            "2) ", '{"index":"widgets"}', '{"bad stuff"=>"happened"}'
+            "2) ", '{"index":"widgets"}', inspect_output_of('{"bad stuff" => "happened"}')
           ).and(excluding(
             # These are parts of the body of the request, which we don't want included because it could contain PII!.
             "track_total_hits", "size"

--- a/elasticgraph-graphql_lambda/elasticgraph-graphql_lambda.gemspec
+++ b/elasticgraph-graphql_lambda/elasticgraph-graphql_lambda.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-lambda_support", ElasticGraph::VERSION

--- a/elasticgraph-health_check/elasticgraph-health_check.gemspec
+++ b/elasticgraph-health_check/elasticgraph-health_check.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-datastore_core", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION

--- a/elasticgraph-indexer/elasticgraph-indexer.gemspec
+++ b/elasticgraph-indexer/elasticgraph-indexer.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-datastore_core", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-json_schema", ElasticGraph::VERSION

--- a/elasticgraph-indexer_autoscaler_lambda/elasticgraph-indexer_autoscaler_lambda.gemspec
+++ b/elasticgraph-indexer_autoscaler_lambda/elasticgraph-indexer_autoscaler_lambda.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-datastore_core", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-lambda_support", ElasticGraph::VERSION

--- a/elasticgraph-indexer_lambda/elasticgraph-indexer_lambda.gemspec
+++ b/elasticgraph-indexer_lambda/elasticgraph-indexer_lambda.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-indexer", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-lambda_support", ElasticGraph::VERSION

--- a/elasticgraph-json_schema/elasticgraph-json_schema.gemspec
+++ b/elasticgraph-json_schema/elasticgraph-json_schema.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
   spec.add_dependency "json_schemer", "~> 2.3"

--- a/elasticgraph-lambda_support/elasticgraph-lambda_support.gemspec
+++ b/elasticgraph-lambda_support/elasticgraph-lambda_support.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-opensearch", ElasticGraph::VERSION
   spec.add_dependency "faraday_middleware-aws-sigv4", "~> 1.0"

--- a/elasticgraph-local/elasticgraph-local.gemspec
+++ b/elasticgraph-local/elasticgraph-local.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-admin", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION

--- a/elasticgraph-local/spec/unit/elastic_graph/local/rake_tasks_spec.rb
+++ b/elasticgraph-local/spec/unit/elastic_graph/local/rake_tasks_spec.rb
@@ -105,7 +105,10 @@ module ElasticGraph
             list_datastore_management_tasks do |t|
               t.env_port_mapping = {local: "123"}
             end
-          }.to raise_error a_string_including('`env_port_mapping` has invalid ports: {:local=>"123"}')
+          }.to raise_error a_string_including(
+            "`env_port_mapping` has invalid ports: ",
+            inspect_output_of('{local: "123"}')
+          )
         end
 
         it "raises an error when a port number is too high" do
@@ -113,7 +116,10 @@ module ElasticGraph
             list_datastore_management_tasks do |t|
               t.env_port_mapping = {local: "45000"}
             end
-          }.to raise_error a_string_including('`env_port_mapping` has invalid ports: {:local=>"45000"}')
+          }.to raise_error a_string_including(
+            "`env_port_mapping` has invalid ports: ",
+            inspect_output_of('{local: "45000"}')
+          )
         end
 
         context "when `opensearch_versions` is empty" do

--- a/elasticgraph-opensearch/elasticgraph-opensearch.gemspec
+++ b/elasticgraph-opensearch/elasticgraph-opensearch.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
   spec.add_dependency "faraday", "~> 2.12"

--- a/elasticgraph-query_interceptor/elasticgraph-query_interceptor.gemspec
+++ b/elasticgraph-query_interceptor/elasticgraph-query_interceptor.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-schema_artifacts", ElasticGraph::VERSION

--- a/elasticgraph-query_registry/elasticgraph-query_registry.gemspec
+++ b/elasticgraph-query_registry/elasticgraph-query_registry.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION

--- a/elasticgraph-rack/elasticgraph-rack.gemspec
+++ b/elasticgraph-rack/elasticgraph-rack.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION
   spec.add_dependency "rack", "~> 3.1"

--- a/elasticgraph-schema_artifacts/elasticgraph-schema_artifacts.gemspec
+++ b/elasticgraph-schema_artifacts/elasticgraph-schema_artifacts.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
 

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names_spec.rb
@@ -105,7 +105,7 @@ module ElasticGraph
         it "inspects nicely" do
           names = new_with(form: :camelCase, overrides: {foo: :bar})
 
-          expect(names.inspect).to eq "#<ElasticGraph::SchemaArtifacts::RuntimeMetadata::ExampleElementNames form=camelCase, overrides={:foo=>:bar}>"
+          expect(names.inspect).to eq inspect_output_of("#<ElasticGraph::SchemaArtifacts::RuntimeMetadata::ExampleElementNames form=camelCase, overrides={foo: :bar}>")
           expect(names.to_s).to eq names.inspect
         end
 

--- a/elasticgraph-schema_definition/elasticgraph-schema_definition.gemspec
+++ b/elasticgraph-schema_definition/elasticgraph-schema_definition.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION # needed since we validate that scalar `coerce_with` options are valid (which loads scalar coercion adapters)
   spec.add_dependency "elasticgraph-indexer", ElasticGraph::VERSION # needed since we validate that scalar `prepare_for_indexing_with` options are valid (which loads indexing preparer adapters)

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/abstract_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/abstract_types_spec.rb
@@ -164,7 +164,15 @@ module ElasticGraph
                   t.index "things"
                 end
               end
-            }.to raise_error(Errors::SchemaError, a_string_including("Conflicting definitions", "field `owner_id`", "subtypes of `Thing`", "Widget", "Component", '"type"=>"keyword"', '"type"=>"integer"').and(excluding("Animal")))
+            }.to raise_error(Errors::SchemaError, a_string_including(
+              "Conflicting definitions",
+              "field `owner_id`",
+              "subtypes of `Thing`",
+              "Widget",
+              "Component",
+              inspect_output_of('"type" => "keyword"'),
+              inspect_output_of('"type" => "integer"')
+            ).and(excluding("Animal")))
           end
 
           it "allows the different mapping setting issue to be resolved by configuring a different index field name for one field" do

--- a/elasticgraph-support/elasticgraph-support.gemspec
+++ b/elasticgraph-support/elasticgraph-support.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   # Ruby 3.4 warns about using `logger` being moved out of the standard library, and in Ruby 3.5
   # it'll no longer be available without declaring a dependency.

--- a/elasticgraph/elasticgraph.gemspec
+++ b/elasticgraph/elasticgraph.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     end - [".rspec", "Gemfile", ".yardopts"]
   end
 
-  spec.required_ruby_version = "~> 3.2"
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-admin", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -6,7 +6,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: addressable
@@ -14,7 +14,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ast
@@ -22,7 +22,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: aws-sdk-cloudwatch
@@ -30,7 +30,7 @@ gems:
   source:
     type: rubygems
 - name: aws-sdk-core
-  version: 3.214.0
+  version: 3.214.1
   source:
     type: rubygems
 - name: aws-sdk-kms
@@ -42,11 +42,11 @@ gems:
   source:
     type: rubygems
 - name: aws-sdk-s3
-  version: 1.176.1
+  version: 1.177.0
   source:
     type: rubygems
 - name: aws-sdk-sqs
-  version: 1.89.0
+  version: 1.90.0
   source:
     type: rubygems
 - name: base64
@@ -70,7 +70,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: connection_pool
@@ -78,7 +78,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: csv
@@ -94,7 +94,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: digest
@@ -110,7 +110,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: faraday
@@ -118,7 +118,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: fileutils
@@ -134,7 +134,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: hashdiff
@@ -142,7 +142,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: i18n
@@ -150,7 +150,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: json
@@ -162,7 +162,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: logger
@@ -202,7 +202,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: parser
@@ -210,7 +210,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: pathname
@@ -222,7 +222,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rainbow
@@ -230,7 +230,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rake
@@ -238,7 +238,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rbs
@@ -254,7 +254,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ripper
@@ -266,7 +266,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rubocop-ast
@@ -274,7 +274,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: securerandom
@@ -286,7 +286,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: singleton
@@ -314,7 +314,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: time
@@ -334,7 +334,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: uri
@@ -350,7 +350,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ccbd2bbc6be5c195df1d90aa68d64916a9e7d0ab
+    revision: '09beb2100db10cbf4773ed0e71ddf79280a2f275'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 gemfile_lock_path: Gemfile.lock

--- a/script/update_ci_yaml
+++ b/script/update_ci_yaml
@@ -109,6 +109,7 @@ jobs:
         ruby:
           - "3.2"
           - "3.3"
+          - "3.4"
         datastore:
 <% datastore_versions.each do |datastore_version| -%>
           - "<%= datastore_version %>"
@@ -119,13 +120,13 @@ jobs:
           # these others against every combination of `ruby` and `datastore` so we just run each with one
           # configuration here.
           - build_part: "run_misc_checks"
-            ruby: "3.3"
+            ruby: "3.4"
             datastore: "<%= primary_datastore_version %>"
           - build_part: "run_specs_with_vcr"
-            ruby: "3.3"
+            ruby: "3.4"
             datastore: "<%= primary_datastore_version %>"
           - build_part: "run_specs_file_by_file"
-            ruby: "3.3"
+            ruby: "3.4"
             datastore: "<%= primary_datastore_version %>"
 
     steps:

--- a/spec_support/spec_helper.rb
+++ b/spec_support/spec_helper.rb
@@ -325,6 +325,26 @@ module ElasticGraph
       CommonSpecHelpers.parsed_test_settings_yaml
     end
 
+    # Ruby 3.4 improved the `#inspect` output of a `Hash`:
+    # - `{foo: 1}` inspects as `{foo: 1}` instead of `{:foo=>1}`
+    # - `{"foo" => 1}` inspects as `{"foo" => 1}` instead of `{"foo"=>1}`
+    #
+    # Some of our specs expect `#inspect` output or an error message generated from `#inspect` output.
+    # We've updated those expectations to match the new Ruby 3.4 formatting. To pass against older
+    # Rubies, `#inspect_output_of` downgrades the output to match the old output seen on Ruby 3.3 and before.
+    # :nocov: -- only one side of this branch is covered on a given test suite run (based on the Ruby version)
+    if RUBY_VERSION >= "3.4"
+      def inspect_output_of(output) = output
+    else
+      def inspect_output_of(output)
+        output
+          .gsub(/(\S) =>/, '\1=>')
+          .gsub(/=> (\S)/, '=>\1')
+          .gsub(/(\w+): /, ':\1=>')
+      end
+    end
+    # :nocov:
+
     module_function
 
     def expect_to_return_non_nil_values_from_all_attributes(object)


### PR DESCRIPTION
Officially support Ruby 3.4.

Ruby 3.4 was released on 2024-12-25. ElasticGraph already works against
Ruby 3.4, but there were a few things I needed to adjust:

- Deal with improved `#inspect` output provided by Ruby 3.4.
- Add Ruby 3.4 to the CI build matrix.
- Require `flatware-rspec` `>= 2.3.4` because `2.3.3` and before did not support Ruby 3.4.
- Update the `required_ruby_version` on our gems to disallow Ruby 3.5+ since we don't know what changes we may have to make to support that future release.
- Require `fileutils` before using it in `Gemfile` -- otherwise we get an error on Ruby 3.4.
- I had to regenerate the `Gemfile.lock` on Ruby 3.4 because the pure Ruby `google-protobuf` 3.25.5 allows Ruby 3.4[^1] but the `x86-linux` release does not[^2].
- Ruby 3.4's coverage library apparently reports coverage a bit differently; there were some lines of code in `entities_field_resolver.rb` that are apparently uncovered on all Ruby versions but were not reported as such.

[^1]: https://rubygems.org/gems/google-protobuf/versions/3.25.5
[^2]: https://rubygems.org/gems/google-protobuf/versions/3.25.5-x86-linux
