### PR TITLE
Lazily resolve `index.rollover` and `index.route_with` field paths.

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
@@ -109,6 +109,7 @@ module ElasticGraph
       def after_initialize
         # Record that we are now generating results so that caching can kick in.
         state.user_definition_complete = true
+        state.user_definition_complete_callbacks.each(&:call)
       end
 
       def json_schema_with_metadata_merger

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/state.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/state.rb
@@ -44,6 +44,7 @@ module ElasticGraph
       :initially_registered_built_in_types,
       :built_in_types_customization_blocks,
       :user_definition_complete,
+      :user_definition_complete_callbacks,
       :sub_aggregation_paths_by_type,
       :type_refs_by_name,
       :output,
@@ -86,6 +87,7 @@ module ElasticGraph
           initially_registered_built_in_types: ::Set.new,
           built_in_types_customization_blocks: [],
           user_definition_complete: false,
+          user_definition_complete_callbacks: [],
           sub_aggregation_paths_by_type: {},
           type_refs_by_name: {},
           type_namer: SchemaElements::TypeNamer.new(
@@ -189,6 +191,10 @@ module ElasticGraph
             # :nocov:
           end
         end
+      end
+
+      def after_user_definition_complete(&block)
+        user_definition_complete_callbacks << block
       end
 
       private

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/state.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/state.rbs
@@ -22,6 +22,7 @@ module ElasticGraph
       attr_accessor initially_registered_built_in_types: ::Set[::String]
       attr_accessor built_in_types_customization_blocks: ::Array[^(SchemaElements::graphQLType) -> void]
       attr_accessor user_definition_complete: bool
+      attr_accessor user_definition_complete_callbacks: ::Array[^() -> void]
       attr_accessor sub_aggregation_paths_by_type: ::Hash[Mixins::SupportsFilteringAndAggregation, ::Array[SchemaElements::SubAggregationPath]]
       attr_accessor type_refs_by_name: ::Hash[::String, SchemaElements::TypeReference]
       attr_reader type_namer: SchemaElements::TypeNamer
@@ -50,6 +51,7 @@ module ElasticGraph
         initially_registered_built_in_types: ::Set[::String],
         built_in_types_customization_blocks: ::Array[^(SchemaElements::graphQLType) -> void],
         user_definition_complete: bool,
+        user_definition_complete_callbacks: ::Array[^() -> void],
         sub_aggregation_paths_by_type: ::Hash[Mixins::SupportsFilteringAndAggregation, ::Array[SchemaElements::SubAggregationPath]],
         type_refs_by_name: ::Hash[::String, SchemaElements::TypeReference],
         type_namer: SchemaElements::TypeNamer,
@@ -92,6 +94,9 @@ module ElasticGraph
 
       @user_defined_field_references_by_type_name: ::Hash[::String, ::Array[SchemaElements::Field]]?
       def user_defined_field_references_by_type_name: () -> ::Hash[::String, ::Array[SchemaElements::Field]]
+
+      def after_user_definition_complete: () { () -> void } -> void
+
       private
 
       RESERVED_TYPE_NAMES: ::Set[::String]


### PR DESCRIPTION
Previously, we eagerly evaluated them. This worked fine as long as the referenced fields were defined before the `index`, but would fail otherwise.

To resolve them lazily, I've introduced a new generalized mechanism for deferring computation until the user-defined parts of the schema are completely defined: `state.after_user_definition_complete`.

Fixes #94.