### PR TITLE
Prevent misuse of `SchemaElements::FieldPath::Resolver`.

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/relationship_resolver.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/relationship_resolver.rb
@@ -11,12 +11,11 @@ module ElasticGraph
     module Indexing
       # @private
       class RelationshipResolver
-        def initialize(schema_def_state:, object_type:, relationship_name:, sourced_fields:, field_path_resolver:)
+        def initialize(schema_def_state:, object_type:, relationship_name:, sourced_fields:)
           @schema_def_state = schema_def_state
           @object_type = object_type
           @relationship_name = relationship_name
           @sourced_fields = sourced_fields
-          @field_path_resolver = field_path_resolver
         end
 
         def resolve
@@ -51,8 +50,8 @@ module ElasticGraph
 
         private
 
-        # @dynamic schema_def_state, object_type, relationship_name, sourced_fields, field_path_resolver
-        attr_reader :schema_def_state, :object_type, :relationship_name, :sourced_fields, :field_path_resolver
+        # @dynamic schema_def_state, object_type, relationship_name, sourced_fields
+        attr_reader :schema_def_state, :object_type, :relationship_name, :sourced_fields
 
         # Helper method for building the prefix of relationship-related error messages.
         def relationship_error_prefix
@@ -67,7 +66,7 @@ module ElasticGraph
         end
 
         def validate_foreign_key(foreign_key_parent_type, relation_metadata)
-          foreign_key_field = field_path_resolver.resolve_public_path(foreign_key_parent_type, relation_metadata.foreign_key) { true }
+          foreign_key_field = schema_def_state.field_path_resolver.resolve_public_path(foreign_key_parent_type, relation_metadata.foreign_key) { true }
           # If its an inbound foreign key, verify that the foreign key exists on the related type.
           # Note: we don't verify this for outbound foreign keys, because when we define a relationship with an outbound foreign
           # key, we automatically define an indexing only field for the foreign key (since it exists on the same type). We don't

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
@@ -180,9 +180,6 @@ module ElasticGraph
       # Builds a map, keyed by object type name, of extra `update_targets` that have been generated
       # from any fields that use `sourced_from` on other types.
       def identify_extra_update_targets_by_object_type_name
-        # The field_path_resolver memoizes some calculations, and we want the same instance to be
-        # used by all UpdateTargetBuilders to maximize its effectiveness.
-        field_path_resolver = SchemaElements::FieldPath::Resolver.new
         sourced_field_errors = [] # : ::Array[::String]
         relationship_errors = [] # : ::Array[::String]
 
@@ -210,8 +207,7 @@ module ElasticGraph
               schema_def_state: state,
               object_type: object_type,
               relationship_name: relationship_name,
-              sourced_fields: sourced_fields,
-              field_path_resolver: field_path_resolver
+              sourced_fields: sourced_fields
             )
 
             resolved_relationship, relationship_error = relationship_resolver.resolve
@@ -222,7 +218,7 @@ module ElasticGraph
                 object_type: object_type,
                 resolved_relationship: resolved_relationship,
                 sourced_fields: sourced_fields,
-                field_path_resolver: field_path_resolver
+                field_path_resolver: state.field_path_resolver
               )
 
               update_target, errors = update_target_resolver.resolve

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/relationship.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/relationship.rb
@@ -191,11 +191,15 @@ module ElasticGraph
 
         # @private
         def runtime_metadata
-          field_path_resolver = SchemaElements::FieldPath::Resolver.new
           resolved_related_type = (_ = related_type.unwrap_list.as_object_type) # : indexableType
-          foreign_key_nested_paths = field_path_resolver.determine_nested_paths(resolved_related_type, @foreign_key)
+          foreign_key_nested_paths = schema_def_state.field_path_resolver.determine_nested_paths(resolved_related_type, @foreign_key)
           foreign_key_nested_paths ||= [] # : ::Array[::String]
-          SchemaArtifacts::RuntimeMetadata::Relation.new(foreign_key: @foreign_key, direction: @direction, additional_filter: @additional_filter, foreign_key_nested_paths: foreign_key_nested_paths)
+          SchemaArtifacts::RuntimeMetadata::Relation.new(
+            foreign_key: @foreign_key,
+            direction: @direction,
+            additional_filter: @additional_filter,
+            foreign_key_nested_paths: foreign_key_nested_paths
+          )
         end
 
         private

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/state.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/state.rb
@@ -11,6 +11,7 @@ require "elastic_graph/errors"
 require "elastic_graph/schema_definition/factory"
 require "elastic_graph/schema_definition/mixins/has_readable_to_s_and_inspect"
 require "elastic_graph/schema_definition/schema_elements/enum_value_namer"
+require "elastic_graph/schema_definition/schema_elements/field_path"
 require "elastic_graph/schema_definition/schema_elements/type_namer"
 require "elastic_graph/schema_definition/schema_elements/sub_aggregation_path"
 
@@ -195,6 +196,10 @@ module ElasticGraph
 
       def after_user_definition_complete(&block)
         user_definition_complete_callbacks << block
+      end
+
+      def field_path_resolver
+        @field_path_resolver ||= SchemaElements::FieldPath::Resolver.new(self)
       end
 
       private

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/relationship_resolver.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/relationship_resolver.rbs
@@ -6,8 +6,7 @@ module ElasticGraph
           schema_def_state: State,
           object_type: indexableType,
           relationship_name: ::String,
-          sourced_fields: ::Array[SchemaElements::Field],
-          field_path_resolver: SchemaElements::FieldPath::Resolver
+          sourced_fields: ::Array[SchemaElements::Field]
         ) -> void
 
         def resolve: () -> untyped
@@ -18,7 +17,6 @@ module ElasticGraph
         attr_reader object_type: indexableType
         attr_reader relationship_name: ::String
         attr_reader sourced_fields: ::Array[SchemaElements::Field]
-        attr_reader field_path_resolver: SchemaElements::FieldPath::Resolver
 
         def relationship_error_prefix: () -> ::String
         def validate_foreign_key: (

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/field_path.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/field_path.rbs
@@ -20,7 +20,7 @@ module ElasticGraph
 
         class Resolver
           @indexing_fields_by_public_name_by_type: ::Hash[indexableType, ::Hash[::String, Field]]
-          def initialize: () -> void
+          def initialize: (State) -> void
           def resolve_public_path: (indexableType, ::String) { (Field) -> bool } -> FieldPath?
           def determine_nested_paths: (indexableType, ::String) -> ::Array[::String]?
         end

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/state.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/state.rbs
@@ -97,6 +97,9 @@ module ElasticGraph
 
       def after_user_definition_complete: () { () -> void } -> void
 
+      @field_path_resolver: SchemaElements::FieldPath::Resolver?
+      def field_path_resolver: () -> SchemaElements::FieldPath::Resolver
+
       private
 
       RESERVED_TYPE_NAMES: ::Set[::String]

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/schema_elements/field_path_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/schema_elements/field_path_spec.rb
@@ -1,0 +1,35 @@
+# Copyright 2024 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/schema_definition/api"
+require "elastic_graph/schema_definition/schema_elements/field_path"
+
+module ElasticGraph
+  module SchemaDefinition
+    module SchemaElements
+      class FieldPath
+        RSpec.describe Resolver do
+          it "can only be created after the user definition is complete, to avoid problems" do
+            schema_elements = SchemaArtifacts::RuntimeMetadata::SchemaElementNames.new(form: "snake_case")
+            api = API.new(schema_elements, true)
+
+            expect {
+              Resolver.new(api.state)
+            }.to raise_error Errors::SchemaError, a_string_including(
+              "cannot be created before the user definition of the schema is complete"
+            )
+
+            api.results # signals the definition is complete
+
+            expect(Resolver.new(api.state)).to be_a Resolver
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
For the bug reported in #94, and fixed in #113, the root cause is the way we used the field path resolver. It's not safe to use before the user has finished defining the schema.

* Since some types and fields may not have been defined yet, it may not be able to resolve field paths that it'll be able to resolve later.
* It memoizes some calculations internally for performance reasons, and it's not safe to do that until the schema definition state is complete.

To prevent this kind of misuse, I've updated it to raise an error if it is created before the user definition is complete.