### PR TITLE
Avoid warnings from graphql-ruby when running `rake site:doctest`.

### DIFF
--- a/config/site/support/doctest_helper.rb
+++ b/config/site/support/doctest_helper.rb
@@ -50,6 +50,11 @@ module ElasticGraph
         # so we set it here.
         @api.json_schema_version 1
 
+        @api.object_type "SomeIndexedTypeToEnsureQueryTypeHasFields" do |t|
+          t.field "id", "ID"
+          t.index "some_indexed_type"
+        end
+
         # Store the api instance so that `ElasticGraph.define_schema` can access it.
         ::Thread.current[:ElasticGraph_SchemaDefinition_API_instance] = @api
       end


### PR DESCRIPTION
Without this change, we get lots of warnings like:

```
Object types must have fields, but Query doesn't have any. Define a field for this type, remove it from your schema, or add `has_no_fields(true)` to its definition.

This will raise an error in a future GraphQL-Ruby version.
```

This avoids the warning by ensuring `Query` always has at least one field.