### PR TITLE
Fix `derived_type_name_formats` docs.

### DIFF
--- a/elasticgraph-local/lib/elastic_graph/local/rake_tasks.rb
+++ b/elasticgraph-local/lib/elastic_graph/local/rake_tasks.rb
@@ -102,7 +102,7 @@ module ElasticGraph
       #     local_config_yaml: "config/settings/local.yaml",
       #     path_to_schema: "config/schema.rb"
       #   ) do |tasks|
-      #     tasks.derived_type_name_formats = {AggregatedValues: "Metrics"}
+      #     tasks.derived_type_name_formats = {AggregatedValues: "%{base}Metrics"}
       #   end
       #
       # @dynamic derived_type_name_formats, derived_type_name_formats=


### PR DESCRIPTION
The formats should have placeholders like `%{base}`.