### PR TITLE
Simplify `cli_new_spec.rb`: remove need to rewrite the `Gemfile`.

### DIFF
--- a/elasticgraph/lib/elastic_graph/cli.rb
+++ b/elasticgraph/lib/elastic_graph/cli.rb
@@ -42,7 +42,8 @@ module ElasticGraph
       setup_env = SetupEnv.new(
         app_name: app_name,
         app_module: app_name.split("_").map(&:capitalize).join,
-        datastore: options.fetch(:datastore)
+        datastore: options.fetch(:datastore),
+        gemfile_elasticgraph_details_code_snippet: %(["#{VERSION}"])
       )
 
       say "Creating a new #{setup_env.datastore_name} ElasticGraph project called '#{app_name}' at: #{new_app_path}", :green
@@ -76,7 +77,7 @@ module ElasticGraph
     end
   end
 
-  class SetupEnv < ::Data.define(:app_name, :app_module, :datastore)
+  class SetupEnv < ::Data.define(:app_name, :app_module, :datastore, :gemfile_elasticgraph_details_code_snippet)
     DATASTORE_NAMES = {"elasticsearch" => "Elasticsearch", "opensearch" => "OpenSearch"}
     DATASTORE_UI_NAMES = {"elasticsearch" => "Kibana", "opensearch" => "OpenSearch Dashboards"}
     OTHER_DATASTORE = {"elasticsearch" => "opensearch", "opensearch" => "elasticsearch"}

--- a/elasticgraph/lib/elastic_graph/project_template/Gemfile.tt
+++ b/elasticgraph/lib/elastic_graph/project_template/Gemfile.tt
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 # Gem details for the elasticgraph gems.
-elasticgraph_details = ["<%= ElasticGraph::VERSION %>"]
+elasticgraph_details = <%= ElasticGraph.setup_env.gemfile_elasticgraph_details_code_snippet %>
 
 gem "elasticgraph-local", *elasticgraph_details
 gem "elasticgraph-<%= ElasticGraph.setup_env.datastore %>", *elasticgraph_details


### PR DESCRIPTION
We can instead expose a way to control `elasticgraph_details` via our `setup_env`, and override that.