### PR TITLE
Fix initial type of `Index#routing_field_path`.

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/index.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/index.rb
@@ -53,7 +53,7 @@ module ElasticGraph
 
           settings = DEFAULT_SETTINGS.merge(Support::HashUtil.flatten_and_stringify_keys(settings, prefix: "index"))
 
-          super(name, [], settings, schema_def_state, indexed_type, [], nil)
+          super(name, [], settings, schema_def_state, indexed_type, nil, nil)
 
           schema_def_state.after_user_definition_complete do
             # `id` is the field Elasticsearch/OpenSearch use for routing by default:

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/relationship.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/relationship.rb
@@ -140,7 +140,8 @@ module ElasticGraph
         def routing_value_source_for_index(index)
           return nil unless index.uses_custom_routing?
 
-          @equivalent_field_paths_by_local_path.fetch(index.routing_field_path.path) do |local_need|
+          index_routing_field_path = index.routing_field_path # : FieldPath
+          @equivalent_field_paths_by_local_path.fetch(index_routing_field_path.path) do |local_need|
             yield local_need
           end
         end

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/index.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/index.rbs
@@ -4,7 +4,7 @@ module ElasticGraph
       # Note: this is a partial signature definition (`index.rb` is ignored in `Steepfile`)
       class Index
         attr_reader name: ::String
-        attr_reader routing_field_path: SchemaElements::FieldPath
+        attr_reader routing_field_path: SchemaElements::FieldPath?
         attr_reader rollover_config: RolloverConfig?
         def uses_custom_routing?: () -> bool
         def to_index_config: () -> ::Hash[::String, untyped]


### PR DESCRIPTION
This is a followup on #94. For historical/vestigial reasons, we used to set `routing_field_path` to `[]` before immediately updating it to the `FieldPath` object for `id`. With our change in #114 to lazily set `routing_field_path`, it allowed the value of `[]` to persists beyond `initialize`. `[]` isn't a valid value according to the type; instead I've changed the type to allow `nil` which is a more natural value for this case.