### PR TITLE
Fix elasticgraph-apollo to make it safe to call `results` multiple times.

### DIFF
--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/api_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/api_extension.rb
@@ -59,14 +59,6 @@ module ElasticGraph
       #     tasks.schema_definition_extension_modules = [ElasticGraph::Apollo::SchemaDefinition::APIExtension]
       #   end
       module APIExtension
-        # @private
-        def results
-          register_graphql_extension GraphQL::EngineExtension, defined_at: "elastic_graph/apollo/graphql/engine_extension"
-          define_apollo_schema_elements
-
-          super
-        end
-
         # Applies an apollo tag to built-in types so that they are included in the Apollo contract schema.
         #
         # @param name [String] tag name
@@ -126,6 +118,11 @@ module ElasticGraph
             # Built-in types like `PageInfo` need to be tagged with `@shareable` on Federation V2 since other subgraphs may
             # have them and they aren't entity types. `Query`, as the root, is a special case that must be skipped.
             (_ = type).apollo_shareable if type.respond_to?(:apollo_shareable) && type.name != "Query"
+          end
+
+          api.register_graphql_extension GraphQL::EngineExtension, defined_at: "elastic_graph/apollo/graphql/engine_extension"
+          api.state.after_user_definition_complete do
+            api.send(:define_apollo_schema_elements)
           end
         end
 

--- a/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
+++ b/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
@@ -31,7 +31,15 @@ module ElasticGraph
         let(:schema_elements) { SchemaArtifacts::RuntimeMetadata::SchemaElementNames.new(form: schema_element_name_form) }
 
         it "defines the static schema elements that must be present in every apollo subgraph schema" do
-          schema_string = graphql_schema_string { |s| define_some_types_on(s) }
+          schema_string = graphql_schema_string do |s|
+            define_some_types_on(s)
+
+            # Verify that calling `results` multiple times does not trigger duplicate definition errors.
+            # (at one point it did).
+            s.results
+            s.results
+          end
+
           expect(schema_string).to include(*SchemaDefinition::APIExtension::DIRECTIVE_DEFINITIONS_BY_FEDERATION_VERSION.fetch("2.6"))
 
           # Verify the 2.6 vs 2.0 differences.


### PR DESCRIPTION
Previously, each time it was called, we defined the apollo schema elements, which could lead to duplicate element errors. Instead, we can use the new `after_user_definition_complete` callback.