### PR TITLE
Simplify `define_fake_data_batch_for`.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -50,7 +50,7 @@ configure_local_rake_tasks = ->(tasks) do
   tasks.env_port_mapping = {test: test_port}
   tasks.output = schema_def_output
 
-  tasks.define_fake_data_batch_for(:widgets) do |batch|
+  tasks.define_fake_data_batch_for(:widgets) do
     require "rspec/core" # the factories file expects RSpec to be loaded, so load it.
 
     # spec_support is not a full-fledged gem and is not on the load path, so we have to
@@ -58,6 +58,7 @@ configure_local_rake_tasks = ->(tasks) do
     $LOAD_PATH.unshift ::File.join(__dir__, "spec_support", "lib")
     require "elastic_graph/spec_support/factories"
 
+    batch = []
     batch.concat(manufacturers = Array.new(10) { FactoryBot.build(:manufacturer) })
     batch.concat(electrical_parts = Array.new(10) { FactoryBot.build(:electrical_part, manufacturer: manufacturers.sample) })
     batch.concat(mechanical_parts = Array.new(10) { FactoryBot.build(:mechanical_part, manufacturer: manufacturers.sample) })
@@ -76,6 +77,7 @@ configure_local_rake_tasks = ->(tasks) do
 
     batch.concat(sponsors = Array.new(10) { FactoryBot.build(:sponsor) })
     batch.concat(Array.new(10) { FactoryBot.build(:team, sponsors: sponsors.sample(rand(3))) })
+    batch
   end
 
   tested_datastore_versions = ::YAML.load_file(::File.expand_path("config/tested_datastore_versions.yaml", __dir__))

--- a/elasticgraph-local/lib/elastic_graph/local/indexing_coordinator.rb
+++ b/elasticgraph-local/lib/elastic_graph/local/indexing_coordinator.rb
@@ -29,8 +29,7 @@ module ElasticGraph
         publishing_threads = Array.new(PARALLELISM) { new_publishing_thread(batch_queue) }
 
         num_batches.times do
-          batch = [] # : ::Array[::Hash[::String, untyped]]
-          @fake_data_batch_generator.call(batch)
+          batch = @fake_data_batch_generator.call
           @output.puts "Generated batch of #{batch.size} documents..."
           batch_queue << batch
         end

--- a/elasticgraph-local/lib/elastic_graph/local/rake_tasks.rb
+++ b/elasticgraph-local/lib/elastic_graph/local/rake_tasks.rb
@@ -336,8 +336,8 @@ module ElasticGraph
       #     local_config_yaml: "config/settings/local.yaml",
       #     path_to_schema: "config/schema.rb"
       #   ) do |tasks|
-      #     tasks.define_fake_data_batch_for :campaigns do |batch|
-      #       batch.concat(FactoryBot.build_list(:campaigns))
+      #     tasks.define_fake_data_batch_for :campaigns do
+      #       FactoryBot.build_list(:campaigns)
       #     end
       #   end
       def define_fake_data_batch_for(type, &block)

--- a/elasticgraph-local/sig/elastic_graph/local/rake_tasks.rbs
+++ b/elasticgraph-local/sig/elastic_graph/local/rake_tasks.rbs
@@ -18,7 +18,7 @@ module ElasticGraph
       UI_PORT_OFFSET: ::Integer
       VALID_PORT_RANGE: ::Range[::Integer]
 
-      def define_fake_data_batch_for: (::Symbol) { (::Array[::Hash[::String, untyped]]) -> void } -> void
+      def define_fake_data_batch_for: (::Symbol) { () -> ::Array[::Hash[::String, untyped]] } -> void
 
       def initialize: (
         local_config_yaml: ::String | ::Pathname,
@@ -26,7 +26,7 @@ module ElasticGraph
       ) ?{ (RakeTasks) -> void } -> void
 
       @local_config_yaml: ::String
-      @fake_data_batch_generator_by_type: ::Hash[::Symbol, ^(::Array[::Hash[::String, untyped]]) -> void]
+      @fake_data_batch_generator_by_type: ::Hash[::Symbol, ^() -> ::Array[::Hash[::String, untyped]]]
 
       private
 

--- a/elasticgraph-local/sig/elastic_graph/local/types.rbs
+++ b/elasticgraph-local/sig/elastic_graph/local/types.rbs
@@ -1,5 +1,5 @@
 module ElasticGraph
   module Local
-    type fakeDataBatchGenerator =  ^(::Array[::Hash[::String, untyped]]) -> void
+    type fakeDataBatchGenerator =  ^() -> ::Array[::Hash[::String, untyped]]
   end
 end

--- a/elasticgraph-local/spec/acceptance/rake_tasks_spec.rb
+++ b/elasticgraph-local/spec/acceptance/rake_tasks_spec.rb
@@ -130,8 +130,8 @@ module ElasticGraph
 
               yield t if block_given?
 
-              t.define_fake_data_batch_for(:widgets) do |batch|
-                batch.concat(Array.new(batch_size) { build(:widget) })
+              t.define_fake_data_batch_for(:widgets) do
+                Array.new(batch_size) { build(:widget) }
               end
             end
           end

--- a/elasticgraph/lib/elastic_graph/project_template/Rakefile.tt
+++ b/elasticgraph/lib/elastic_graph/project_template/Rakefile.tt
@@ -41,8 +41,8 @@ ElasticGraph::Local::RakeTasks.new(
     # IDFilterInput: "IDFilter"
   }
 
-  tasks.define_fake_data_batch_for :artists do |batch|
-    batch.concat(<%= ElasticGraph.setup_env.app_module %>::FakeDataBatchGenerator.generate(artists: 100, venues: 10))
+  tasks.define_fake_data_batch_for :artists do
+    <%= ElasticGraph.setup_env.app_module %>::FakeDataBatchGenerator.generate(artists: 100, venues: 10)
   end
 end
 


### PR DESCRIPTION
The old interface was odd; we passed the block an empty array
and it would be populated within the block. It's a simpler,
cleaner interface (no mutation!) to have the block return
the batch of data.
