### PR TITLE
Bugfix: avoid `TypeError` on `not: {not: {anyOf: [...]}}`.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_interpreter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_interpreter.rb
@@ -118,7 +118,12 @@ module ElasticGraph
           if sub_filter[:bool].key?(:must_not)
             # Pull clauses up to current bool_node to remove negation
             sub_filter[:bool][:must_not].each do |negated_clause|
-              negated_clause[:bool].each { |k, v| bool_node[k].concat(v) }
+              negated_clause_bool = negated_clause[:bool]
+              # `minimum_should_match` is not a list like the other clauses, and needs to be handled separately.
+              negated_clause_bool.except(:minimum_should_match).each { |k, v| bool_node[k].concat(v) }
+              if (min_should_match = negated_clause_bool[:minimum_should_match])
+                bool_node[:minimum_should_match] = min_should_match
+              end
             end
           end
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/filtering_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/filtering_spec.rb
@@ -1340,6 +1340,20 @@ module ElasticGraph
 
           expect(body_for_inner_not).to eq(body_for_outer_not).and query_datastore_with(always_false_condition)
         end
+
+        it "can double negate an `any_of`" do
+          inner_filter = {
+            "any_of" => [
+              {"age" => {"equal_to_any_of" => [25, 30]}},
+              {"height" => {"gt" => 10}}
+            ]
+          }
+
+          query1 = new_query(filter: {"not" => {"not" => inner_filter}})
+          query2 = new_query(filter: inner_filter)
+
+          expect(datastore_body_of(query1)).to eq(datastore_body_of(query2))
+        end
       end
 
       describe "behavior of empty/null filter values" do


### PR DESCRIPTION
We have special handling for double nots to "pull up" the filter clauses for greater efficiency. That handling didn't work right when an `anyOf` was under the double `not`, and we got a `TypeError`:

```
TypeError: no implicit conversion of Integer into Array
  from elastic_graph/graphql/filtering/filter_interpreter.rb:121:in `concat'
  from elastic_graph/graphql/filtering/filter_interpreter.rb:121:in `block (2 levels) in process_not_expression'
  from elastic_graph/graphql/filtering/filter_interpreter.rb:121:in `each'
  from elastic_graph/graphql/filtering/filter_interpreter.rb:121:in `block in process_not_expression'
  from elastic_graph/graphql/filtering/filter_interpreter.rb:120:in `each'
  from elastic_graph/graphql/filtering/filter_interpreter.rb:120:in `process_not_expression'
  from elastic_graph/graphql/filtering/filter_interpreter.rb:66:in `block in process_filter_hash'
  from elastic_graph/graphql/filtering/filter_interpreter.rb:61:in `each'
  from elastic_graph/graphql/filtering/filter_interpreter.rb:61:in `process_filter_hash'
  from elastic_graph/graphql/filtering/filter_interpreter.rb:43:in `block (2 levels) in build_query'
  from set.rb:511:in `each_key'
  from set.rb:511:in `each'
  from elastic_graph/graphql/filtering/filter_interpreter.rb:42:in `block in build_query'
  from <internal:kernel>:90:in `tap'
  from elastic_graph/graphql/filtering/filter_interpreter.rb:337:in `build_bool_hash'
  from elastic_graph/graphql/filtering/filter_interpreter.rb:41:in `build_query'
  from elastic_graph/graphql/datastore_query.rb:318:in `to_datastore_body'
  from elastic_graph/graphql/datastore_query.rb:229:in `empty?'
  from elastic_graph/graphql/datastore_query.rb:94:in `each'
  from elastic_graph/graphql/datastore_query.rb:94:in `partition'
  from elastic_graph/graphql/datastore_query.rb:94:in `perform'
  from elastic_graph/graphql/datastore_search_router.rb:34:in `msearch'
  from elastic_graph/graphql/resolvers/query_source.rb:26:in `fetch'
  from graphql/dataloader/source.rb:136:in `run_pending_keys'
  from graphql/dataloader.rb:294:in `block (2 levels) in spawn_source_fiber'
  from graphql/dataloader.rb:292:in `each'
  from graphql/dataloader.rb:292:in `block in spawn_source_fiber'
  from graphql/dataloader.rb:245:in `block in spawn_fiber'
```

This fixes that case.