### PR TITLE
Update project template: add TODO comments.

### DIFF
--- a/elasticgraph/lib/elastic_graph/cli.rb
+++ b/elasticgraph/lib/elastic_graph/cli.rb
@@ -72,7 +72,7 @@ module ElasticGraph
           1. cd #{app_path}
           2. Run `bundle exec rake boot_locally` to try it out in your browser.
           3. Run `bundle exec rake -T` to view other available tasks.
-          4. Customize your new project as needed.
+          4. Customize your new project as needed. (Search for `TODO` to find things that need updating.)
       INSTRUCTIONS
     end
   end

--- a/elasticgraph/lib/elastic_graph/project_template/Rakefile.tt
+++ b/elasticgraph/lib/elastic_graph/project_template/Rakefile.tt
@@ -41,6 +41,7 @@ ElasticGraph::Local::RakeTasks.new(
     # IDFilterInput: "IDFilter"
   }
 
+  # TODO: replace this with a fake data generator for your own dataset.
   tasks.define_fake_data_batch_for :artists do
     <%= ElasticGraph.setup_env.app_module %>::FakeDataBatchGenerator.generate(artists: 100, venues: 10)
   end

--- a/elasticgraph/lib/elastic_graph/project_template/config/queries/example_client/FindArtist.graphql
+++ b/elasticgraph/lib/elastic_graph/project_template/config/queries/example_client/FindArtist.graphql
@@ -1,3 +1,4 @@
+# TODO: remove or replace this query when you replace the artist schema.
 query FindArtist {
   byName: artists(filter: {
     name: {equalToAnyOf: ["U2"]}

--- a/elasticgraph/lib/elastic_graph/project_template/config/queries/example_client/ListArtistAlbums.graphql
+++ b/elasticgraph/lib/elastic_graph/project_template/config/queries/example_client/ListArtistAlbums.graphql
@@ -1,3 +1,4 @@
+# TODO: remove or replace this query when you replace the artist schema.
 query ListArtistAlbums {
   artists {
     nodes {

--- a/elasticgraph/lib/elastic_graph/project_template/config/schema/artists.rb.tt
+++ b/elasticgraph/lib/elastic_graph/project_template/config/schema/artists.rb.tt
@@ -1,3 +1,4 @@
+# TODO: replace this file with one that defines the schema for your own dataset.
 ElasticGraph.define_schema do |schema|
   schema.object_type "Artist" do |t|
     t.field "id", "ID"

--- a/elasticgraph/lib/elastic_graph/project_template/config/settings/local.yaml.tt
+++ b/elasticgraph/lib/elastic_graph/project_template/config/settings/local.yaml.tt
@@ -8,7 +8,7 @@ datastore:
       url: http://localhost:9293
       settings: {}
   index_definitions:
-    # TODO: replace this `artists:` key with your dataset's name (e.g. `customers:`)
+    # TODO: replace the `artists:` and `venues:` keys with the indices from your dataset
     artists: &main_index_settings
       # elasticgraph-local relies on the cluster being named "main".
       query_cluster: "main"

--- a/elasticgraph/lib/elastic_graph/project_template/lib/app_name/factories.rb
+++ b/elasticgraph/lib/elastic_graph/project_template/lib/app_name/factories.rb
@@ -2,6 +2,7 @@ require "factory_bot"
 require "faker"
 require_relative "shared_factories"
 
+# TODO: replace the artist/album/tour/venue factories with your own.
 FactoryBot.define do
   factory :artist, parent: :indexed_type_base do
     __typename { "Artist" }

--- a/elasticgraph/lib/elastic_graph/project_template/spec/project_spec.rb.tt
+++ b/elasticgraph/lib/elastic_graph/project_template/spec/project_spec.rb.tt
@@ -11,6 +11,7 @@ RSpec.describe "ElasticGraph project" do
     use_settings_yaml: "local.yaml",
     ignored_factories: ignored_factories
 
+  # TODO: update this spec as needed to generate example fake data for your dataset.
   it "generates a batch of valid records from `FakeDataBatchGenerator`" do
     batch = <%= ElasticGraph.setup_env.app_module %>::FakeDataBatchGenerator.generate(artists: 20, venues: 5)
     expect(batch.size).to eq(25)

--- a/elasticgraph/spec/acceptance/cli_new_spec.rb
+++ b/elasticgraph/spec/acceptance/cli_new_spec.rb
@@ -64,7 +64,7 @@ module ElasticGraph
           1. cd musical_artists
           2. Run `bundle exec rake boot_locally` to try it out in your browser.
           3. Run `bundle exec rake -T` to view other available tasks.
-          4. Customize your new project as needed.
+          4. Customize your new project as needed. (Search for `TODO` to find things that need updating.)
       EOS
 
       # Verify that all ERB templates rendered properly. If any files had ERB template tags (e.g. `<%= foo %>`)
@@ -158,7 +158,7 @@ module ElasticGraph
     def override_gemfile_to_use_local_elasticgraph_gems
       allow(::ElasticGraph).to receive(:setup_env).and_wrap_original do |original|
         original.call&.with(
-          gemfile_elasticgraph_details_code_snippet: %([git: "file://#{CommonSpecHelpers::REPO_ROOT}"])
+          gemfile_elasticgraph_details_code_snippet: %([path: "#{CommonSpecHelpers::REPO_ROOT}"])
         )
       end
     end


### PR DESCRIPTION
This clearly labels all the things that need changes after the project template has been generated.

I also updated the spec to use a `path` instead of a `git` source for the `Gemfile`. I was getting odd errors from the `git` source:

```
Git error: command `git fetch --force --quiet --no-tags --depth 1 -- file:///Users/myron/Development/elasticgraph refs/heads/project_template:refs/heads/project_template` in directory /Users/myron/.rvm/gems/ruby-3.3.4/cache/bundler/git/elasticgraph-3c5d4d4f32023ab2bbd274f7df56f75f91a0e70e has failed.
Revision  does not exist in the repository file:///Users/myron/Development/elasticgraph. Maybe you misspelled it?
```

I don't know why it's looking for a `project_template` revision. Using a `path` source avoids the problem and ensures that the running spec uses the local code for the other gems even if they have uncommitted changes.