### PR TITLE
Remove a confusing TODO comment from bootstrapped projects.

### DIFF
--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -1946,7 +1946,7 @@ scripts:
 
         // No timestamp values matched the params, so return `false`.
         return false;
-  update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413:
+  update_index_data_38ea36e5b48fc1566d4142e9fc44b12e:
     context: update
     script:
       lang: painless
@@ -1991,7 +1991,6 @@ scripts:
         // clusters, we need to keep using it.
         //
         // Later, after the old script is no longer used by any clusters, we'll stop using `__sourceVersions`.
-        // TODO: switch to `__versions` when we no longer need to maintain compatibility with the old version of the script.
         Number _versionForSourceType = source.get("__sourceVersions")?.get(params.sourceType)?.get(sourceId);
         Number _versionForRelationship = relationshipVersionsMap.get(sourceId);
 

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -2697,7 +2697,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Address
   AddressAggregation:
     elasticgraph_category: indexed_aggregation
@@ -2781,7 +2781,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Component
   ComponentAggregatedValues:
     graphql_fields_by_name:
@@ -2894,7 +2894,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: ElectricalPart
   ElectricalPartAggregation:
     elasticgraph_category: indexed_aggregation
@@ -3080,7 +3080,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Manufacturer
   ManufacturerAggregation:
     elasticgraph_category: indexed_aggregation
@@ -3133,7 +3133,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: MechanicalPart
   MechanicalPartAggregation:
     elasticgraph_category: indexed_aggregation
@@ -3407,7 +3407,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Sponsor
   SponsorAggregation:
     elasticgraph_category: indexed_aggregation
@@ -3493,7 +3493,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: formed_on
       routing_value_source: league
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Team
   TeamAggregation:
     elasticgraph_category: indexed_aggregation
@@ -3795,7 +3795,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: created_at
       routing_value_source: workspace_id2
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Widget
     - data_params:
         widget_cost:
@@ -3826,7 +3826,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: widget
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Component
   WidgetAggregatedValues:
     graphql_fields_by_name:
@@ -3898,7 +3898,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: introduced_on
       routing_value_source: primary_continent
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: WidgetCurrency
   WidgetCurrencyAggregatedValues:
     graphql_fields_by_name:
@@ -4111,7 +4111,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: WidgetWorkspace
     - data_params:
         workspace_name:
@@ -4132,7 +4132,7 @@ object_types_by_name:
       relationship: workspace
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Widget
   WidgetWorkspaceAggregation:
     elasticgraph_category: indexed_aggregation
@@ -4243,4 +4243,4 @@ static_script_ids_by_scoped_name:
   field/as_day_of_week: field_as_day_of_week_f2b5c7d9e8f75bf2457b52412bfb6537
   field/as_time_of_day: field_as_time_of_day_ed82aba44fc66bff5635bec4305c1c66
   filter/by_time_of_day: filter_by_time_of_day_ea12d0561b24961789ab68ed38435612
-  update/index_data: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+  update/index_data: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -1946,7 +1946,7 @@ scripts:
 
         // No timestamp values matched the params, so return `false`.
         return false;
-  update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413:
+  update_index_data_38ea36e5b48fc1566d4142e9fc44b12e:
     context: update
     script:
       lang: painless
@@ -1991,7 +1991,6 @@ scripts:
         // clusters, we need to keep using it.
         //
         // Later, after the old script is no longer used by any clusters, we'll stop using `__sourceVersions`.
-        // TODO: switch to `__versions` when we no longer need to maintain compatibility with the old version of the script.
         Number _versionForSourceType = source.get("__sourceVersions")?.get(params.sourceType)?.get(sourceId);
         Number _versionForRelationship = relationshipVersionsMap.get(sourceId);
 

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -2700,7 +2700,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Address
   AddressAggregation:
     elasticgraph_category: indexed_aggregation
@@ -2784,7 +2784,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Component
   ComponentAggregatedValues:
     graphql_fields_by_name:
@@ -2907,7 +2907,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: ElectricalPart
   ElectricalPartAggregation:
     elasticgraph_category: indexed_aggregation
@@ -3093,7 +3093,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Manufacturer
   ManufacturerAggregation:
     elasticgraph_category: indexed_aggregation
@@ -3146,7 +3146,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: MechanicalPart
   MechanicalPartAggregation:
     elasticgraph_category: indexed_aggregation
@@ -3420,7 +3420,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Sponsor
   SponsorAggregation:
     elasticgraph_category: indexed_aggregation
@@ -3506,7 +3506,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: formed_on
       routing_value_source: league
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Team
   TeamAggregation:
     elasticgraph_category: indexed_aggregation
@@ -3808,7 +3808,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: created_at
       routing_value_source: workspace_id2
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Widget
     - data_params:
         widget_cost:
@@ -3839,7 +3839,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: widget
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Component
   WidgetAggregatedValues:
     graphql_fields_by_name:
@@ -3911,7 +3911,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: introduced_on
       routing_value_source: primary_continent
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: WidgetCurrency
   WidgetCurrencyAggregatedValues:
     graphql_fields_by_name:
@@ -4124,7 +4124,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: WidgetWorkspace
     - data_params:
         workspace_name:
@@ -4145,7 +4145,7 @@ object_types_by_name:
       relationship: workspace
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
-      script_id: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Widget
   WidgetWorkspaceAggregation:
     elasticgraph_category: indexed_aggregation
@@ -4295,4 +4295,4 @@ static_script_ids_by_scoped_name:
   field/as_day_of_week: field_as_day_of_week_f2b5c7d9e8f75bf2457b52412bfb6537
   field/as_time_of_day: field_as_time_of_day_ed82aba44fc66bff5635bec4305c1c66
   filter/by_time_of_day: filter_by_time_of_day_ea12d0561b24961789ab68ed38435612
-  update/index_data: update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413
+  update/index_data: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/scripts/update/index_data.painless
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/scripts/update/index_data.painless
@@ -38,7 +38,6 @@ if (previousSourceIdsForRelationship.size() > 0) {
 // clusters, we need to keep using it.
 //
 // Later, after the old script is no longer used by any clusters, we'll stop using `__sourceVersions`.
-// TODO: switch to `__versions` when we no longer need to maintain compatibility with the old version of the script.
 Number _versionForSourceType = source.get("__sourceVersions")?.get(params.sourceType)?.get(sourceId);
 Number _versionForRelationship = relationshipVersionsMap.get(sourceId);
 

--- a/elasticgraph-support/lib/elastic_graph/constants.rb
+++ b/elasticgraph-support/lib/elastic_graph/constants.rb
@@ -125,7 +125,7 @@ module ElasticGraph
   #
   # Note: this constant is automatically kept up-to-date by our `schema_artifacts:dump` rake task.
   # @private
-  INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_d577eb4b07ee3c53b59f2f6d6c7b2413"
+  INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_38ea36e5b48fc1566d4142e9fc44b12e"
 
   # The id of the old version of the update data script before ElasticGraph v0.9. For now, we are maintaining
   # backwards compatibility with how it recorded event versions, and we have test coverage for that which relies

--- a/elasticgraph/spec/acceptance/cli_new_spec.rb
+++ b/elasticgraph/spec/acceptance/cli_new_spec.rb
@@ -71,6 +71,9 @@ module ElasticGraph
       # but were not named with the proper `.tt` file extension, then thor would copy them without rendering them
       # as ERB. This would catch it.
       expect(all_committed_code_in("musical_artists")).to exclude("<%", "%>")
+
+      # Verify that the only TODO comments in the project comte from our template, not from our generated artifacts.
+      expect(todo_comments_in("musical_artists").join("\n")).to eq(todo_comments_in(CLI.source_root).join("\n"))
     end
 
     it "aborts if given an invalid datastore option" do
@@ -165,6 +168,14 @@ module ElasticGraph
 
     def all_committed_code_in(dir)
       ::Dir.chdir(dir) { `git ls-files -z | xargs -0 cat` }
+    end
+
+    def todo_comments_in(dir)
+      ::Dir.chdir(dir) do
+        `git grep TODO`.split("\n").map do |match|
+          match.sub(/^[^:]+:\s*/, "")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
When bootstrapping a project, the output recommends using TODO comments to identify all the places that need further updates. It was confusing that one would show up in the generated `datastore_config.yaml` file.