### PR TITLE
Refactor: move where datastore queries get built.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -101,7 +101,6 @@ module ElasticGraph
             require "elastic_graph/graphql/resolvers/graphql_adapter"
             Resolvers::GraphQLAdapter.new(
               schema: schema,
-              query_adapter: resolver_query_adapter,
               runtime_metadata: runtime_metadata,
               resolvers: graphql_resolvers
             )
@@ -171,11 +170,14 @@ module ElasticGraph
         require "elastic_graph/graphql/resolvers/nested_relationships"
 
         nested_relationships = Resolvers::NestedRelationships.new(
+          resolver_query_adapter: resolver_query_adapter,
           schema_element_names: runtime_metadata.schema_element_names,
           logger: logger
         )
 
-        list_records = Resolvers::ListRecords.new
+        list_records = Resolvers::ListRecords.new(
+          resolver_query_adapter: resolver_query_adapter
+        )
 
         get_record_field_value = Resolvers::GetRecordFieldValue.new(
           schema_element_names: runtime_metadata.schema_element_names

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter.rb
@@ -13,9 +13,8 @@ module ElasticGraph
       # our resolvers. Responsible for routing a resolution request to the appropriate
       # resolver.
       class GraphQLAdapter
-        def initialize(schema:, query_adapter:, runtime_metadata:, resolvers:)
+        def initialize(schema:, runtime_metadata:, resolvers:)
           @schema = schema
-          @query_adapter = query_adapter
           @resolvers = resolvers
 
           scalar_types_by_name = runtime_metadata.scalar_types_by_name
@@ -56,9 +55,7 @@ module ElasticGraph
             ERROR
           end
 
-          result = resolver.resolve(field: schema_field, object: object, args: args, context: context, lookahead: lookahead) do
-            @query_adapter.build_query_from(field: schema_field, args: args, lookahead: lookahead, context: context)
-          end
+          result = resolver.resolve(field: schema_field, object: object, args: args, context: context, lookahead: lookahead)
 
           # Give the field a chance to coerce the result before returning it. Initially, this is only used to deal with
           # enum value overrides (e.g. so that if `DayOfWeek.MONDAY` has been overridden to `DayOfWeek.MON`, we can coerce

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/list_records.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/list_records.rb
@@ -14,12 +14,16 @@ module ElasticGraph
     module Resolvers
       # Responsible for fetching a a list of records of a particular type
       class ListRecords
+        def initialize(resolver_query_adapter:)
+          @resolver_query_adapter = resolver_query_adapter
+        end
+
         def can_resolve?(field:, object:)
           field.parent_type.name == :Query && field.type.collection?
         end
 
-        def resolve(field:, context:, lookahead:, **)
-          query = yield
+        def resolve(field:, context:, lookahead:, args:, object:)
+          query = @resolver_query_adapter.build_query_from(field: field, args: args, lookahead: lookahead, context: context)
           response = QuerySource.execute_one(query, for_context: context)
           RelayConnection.maybe_wrap(response, field: field, context: context, lookahead: lookahead, query: query)
         end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships.rb
@@ -18,7 +18,8 @@ module ElasticGraph
       #
       # Most of the logic for this lives in ElasticGraph::Schema::RelationJoin.
       class NestedRelationships
-        def initialize(schema_element_names:, logger:)
+        def initialize(resolver_query_adapter:, schema_element_names:, logger:)
+          @resolver_query_adapter = resolver_query_adapter
           @schema_element_names = schema_element_names
           @logger = logger
         end
@@ -27,7 +28,7 @@ module ElasticGraph
           !!field.relation_join
         end
 
-        def resolve(object:, field:, context:, lookahead:, **)
+        def resolve(object:, field:, context:, lookahead:, args:)
           log_warning = ->(**options) { log_field_problem_warning(field: field, **options) }
           join = field.relation_join
           id_or_ids = join.extract_id_or_ids_from(object, log_warning)
@@ -36,7 +37,9 @@ module ElasticGraph
             build_filter(join.filter_id_field_name, nil, join.foreign_key_nested_paths, Array(id_or_ids)),
             join.additional_filter
           ].reject(&:empty?)
-          query = yield.merge_with(filters: filters)
+          query = @resolver_query_adapter
+            .build_query_from(field: field, args: args, lookahead: lookahead, context: context)
+            .merge_with(filters: filters)
 
           response =
             case id_or_ids

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/graphql_adapter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/graphql_adapter.rbs
@@ -4,7 +4,6 @@ module ElasticGraph
       class GraphQLAdapter
         def initialize: (
           schema: Schema,
-          query_adapter: Resolvers::QueryAdapter,
           runtime_metadata: SchemaArtifacts::RuntimeMetadata::Schema,
           resolvers: ::Array[Resolvers::_Resolver]
         ) -> void

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/list_records.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/list_records.rbs
@@ -3,6 +3,8 @@ module ElasticGraph
     module Resolvers
       class ListRecords
         include _Resolver
+
+        def initialize: (resolver_query_adapter: Resolvers::QueryAdapter) -> void
       end
     end
   end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/nested_relationships.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/nested_relationships.rbs
@@ -5,6 +5,7 @@ module ElasticGraph
         include _Resolver
 
         def initialize: (
+          resolver_query_adapter: Resolvers::QueryAdapter,
           schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
           logger: ::Logger
         ) -> void

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/graphql_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/graphql_adapter_spec.rb
@@ -18,7 +18,6 @@ module ElasticGraph
         it "raises a clear error when no resolver can be found" do
           adapter = GraphQLAdapter.new(
             schema: schema,
-            query_adapter: graphql.resolver_query_adapter,
             runtime_metadata: graphql.runtime_metadata,
             resolvers: graphql.graphql_resolvers
           )


### PR DESCRIPTION
Rather than building them in `GraphQLAdapter` when a resolver yields, build them in the resolvers that need it.

This paves the way for a larger refactoring I'm working on.