### PR TITLE
Refactor: move where args are converted to their schema form.

### DIFF
--- a/elasticgraph-apollo/apollo_tests_implementation/lib/test_implementation_extension.rb
+++ b/elasticgraph-apollo/apollo_tests_implementation/lib/test_implementation_extension.rb
@@ -43,7 +43,7 @@ module ApolloTestImplementationExtension
       query = @datastore_query_builder.new_query(
         search_index_definitions: [@product_index_def],
         monotonic_clock_deadline: context[:monotonic_clock_deadline],
-        filter: {"id" => {"equalToAnyOf" => [args.fetch("id")]}},
+        filter: {"id" => {"equalToAnyOf" => [args.fetch(:id)]}},
         individual_docs_needed: true,
         requested_fields: %w[
           id sku package notes

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/entities_field_resolver.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/entities_field_resolver.rb
@@ -31,7 +31,7 @@ module ElasticGraph
         def resolve(field:, object:, args:, context:, lookahead:)
           schema = context.fetch(:elastic_graph_schema)
 
-          representations = args.fetch("representations").map.with_index do |rep, index|
+          representations = args.fetch(:representations).map.with_index do |rep, index|
             try_parse_representation(rep, schema) do |error_description|
               context.add_error(::GraphQL::ExecutionError.new("Representation at index #{index} #{error_description}."))
             end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -101,7 +101,6 @@ module ElasticGraph
             require "elastic_graph/graphql/resolvers/graphql_adapter"
             Resolvers::GraphQLAdapter.new(
               schema: schema,
-              query_adapter: resolver_query_adapter,
               runtime_metadata: runtime_metadata,
               resolvers: graphql_resolvers
             )
@@ -171,11 +170,14 @@ module ElasticGraph
         require "elastic_graph/graphql/resolvers/nested_relationships"
 
         nested_relationships = Resolvers::NestedRelationships.new(
+          resolver_query_adapter: resolver_query_adapter,
           schema_element_names: runtime_metadata.schema_element_names,
           logger: logger
         )
 
-        list_records = Resolvers::ListRecords.new
+        list_records = Resolvers::ListRecords.new(
+          resolver_query_adapter: resolver_query_adapter
+        )
 
         get_record_field_value = Resolvers::GetRecordFieldValue.new(
           schema_element_names: runtime_metadata.schema_element_names

--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -101,8 +101,7 @@ module ElasticGraph
             require "elastic_graph/graphql/resolvers/graphql_adapter"
             Resolvers::GraphQLAdapter.new(
               schema: schema,
-              datastore_query_builder: datastore_query_builder,
-              datastore_query_adapters: datastore_query_adapters,
+              query_adapter: resolver_query_adapter,
               runtime_metadata: runtime_metadata,
               resolvers: graphql_resolvers
             )
@@ -120,6 +119,17 @@ module ElasticGraph
           logger: logger,
           monotonic_clock: monotonic_clock,
           config: @config
+        )
+      end
+    end
+
+    # @private
+    def resolver_query_adapter
+      @resolver_query_adapter ||= begin
+        require "elastic_graph/graphql/resolvers/query_adapter"
+        Resolvers::QueryAdapter.new(
+          datastore_query_builder: datastore_query_builder,
+          datastore_query_adapters: datastore_query_adapters
         )
       end
     end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/sub_aggregations.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/sub_aggregations.rb
@@ -29,6 +29,7 @@ module ElasticGraph
             new_field_path = field_path + [path_segment]
             return with(field_path: new_field_path) unless field.type.elasticgraph_category == :nested_sub_aggregation_connection
 
+            args = field.args_to_schema_form(args.except(:lookahead))
             sub_agg_key = FieldPathEncoder.encode(new_field_path.map(&:name_in_graphql_query))
             sub_agg_query = Support::HashUtil.verbose_fetch(sub_aggregations, sub_agg_key).query
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb
@@ -227,7 +227,7 @@ module ElasticGraph
     # Steep weirdly expects them here...
     # @dynamic initialize, config, logger, runtime_metadata, graphql_schema_string, datastore_core, clock
     # @dynamic graphql_http_endpoint, graphql_query_executor, schema, datastore_search_router, filter_interpreter, filter_node_interpreter
-    # @dynamic datastore_query_builder, graphql_gem_plugins, graphql_resolvers, datastore_query_adapters, monotonic_clock
+    # @dynamic datastore_query_builder, resolver_query_adapter, graphql_gem_plugins, graphql_resolvers, datastore_query_adapters, monotonic_clock
     # @dynamic load_dependencies_eagerly, self.from_parsed_yaml, filter_args_translator, sub_aggregation_grouping_adapter
   end
 end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/get_record_field_value.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/get_record_field_value.rb
@@ -38,6 +38,7 @@ module ElasticGraph
           end
 
           if field.type.relay_connection?
+            args = field.args_to_schema_form(args.except(:lookahead))
             RelayConnection::ArrayAdapter.build(value, args, @schema_element_names, context)
           else
             value

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter.rb
@@ -6,8 +6,6 @@
 #
 # frozen_string_literal: true
 
-require "elastic_graph/graphql/resolvers/query_adapter"
-
 module ElasticGraph
   class GraphQL
     module Resolvers
@@ -15,13 +13,9 @@ module ElasticGraph
       # our resolvers. Responsible for routing a resolution request to the appropriate
       # resolver.
       class GraphQLAdapter
-        def initialize(schema:, datastore_query_builder:, datastore_query_adapters:, runtime_metadata:, resolvers:)
+        def initialize(schema:, query_adapter:, runtime_metadata:, resolvers:)
           @schema = schema
-          @query_adapter = QueryAdapter.new(
-            datastore_query_builder: datastore_query_builder,
-            datastore_query_adapters: datastore_query_adapters
-          )
-
+          @query_adapter = query_adapter
           @resolvers = resolvers
 
           scalar_types_by_name = runtime_metadata.scalar_types_by_name

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter.rb
@@ -13,9 +13,8 @@ module ElasticGraph
       # our resolvers. Responsible for routing a resolution request to the appropriate
       # resolver.
       class GraphQLAdapter
-        def initialize(schema:, query_adapter:, runtime_metadata:, resolvers:)
+        def initialize(schema:, runtime_metadata:, resolvers:)
           @schema = schema
-          @query_adapter = query_adapter
           @resolvers = resolvers
 
           scalar_types_by_name = runtime_metadata.scalar_types_by_name
@@ -56,9 +55,7 @@ module ElasticGraph
             ERROR
           end
 
-          result = resolver.resolve(field: schema_field, object: object, args: args, context: context, lookahead: lookahead) do
-            @query_adapter.build_query_from(field: schema_field, args: args, lookahead: lookahead, context: context)
-          end
+          result = resolver.resolve(field: schema_field, object: object, args: args, context: context, lookahead: lookahead)
 
           # Give the field a chance to coerce the result before returning it. Initially, this is only used to deal with
           # enum value overrides (e.g. so that if `DayOfWeek.MONDAY` has been overridden to `DayOfWeek.MON`, we can coerce

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter.rb
@@ -35,9 +35,6 @@ module ElasticGraph
           # It is not a "real" arg in the schema and breaks `args_to_schema_form` when we call that
           # so we need to peel it off here.
           lookahead = args[:lookahead]
-          # Convert args to the form they were defined in the schema, undoing the normalization
-          # the GraphQL gem does to convert them to Ruby keyword args form.
-          args = schema_field.args_to_schema_form(args.except(:lookahead))
 
           resolver = resolver_for(schema_field, object) do
             raise <<~ERROR

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/list_records.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/list_records.rb
@@ -14,12 +14,16 @@ module ElasticGraph
     module Resolvers
       # Responsible for fetching a a list of records of a particular type
       class ListRecords
+        def initialize(resolver_query_adapter:)
+          @resolver_query_adapter = resolver_query_adapter
+        end
+
         def can_resolve?(field:, object:)
           field.parent_type.name == :Query && field.type.collection?
         end
 
-        def resolve(field:, context:, lookahead:, **)
-          query = yield
+        def resolve(field:, context:, lookahead:, args:, object:)
+          query = @resolver_query_adapter.build_query_from(field: field, args: args, lookahead: lookahead, context: context)
           response = QuerySource.execute_one(query, for_context: context)
           RelayConnection.maybe_wrap(response, field: field, context: context, lookahead: lookahead, query: query)
         end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/list_records.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/list_records.rb
@@ -23,6 +23,7 @@ module ElasticGraph
         end
 
         def resolve(field:, context:, lookahead:, args:, object:)
+          args = field.args_to_schema_form(args.except(:lookahead))
           query = @resolver_query_adapter.build_query_from(field: field, args: args, lookahead: lookahead, context: context)
           response = QuerySource.execute_one(query, for_context: context)
           RelayConnection.maybe_wrap(response, field: field, context: context, lookahead: lookahead, query: query)

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships.rb
@@ -35,6 +35,8 @@ module ElasticGraph
             build_filter(join.filter_id_field_name, nil, join.foreign_key_nested_paths, Array(id_or_ids)),
             join.additional_filter
           ].reject(&:empty?)
+
+          args = field.args_to_schema_form(args.except(:lookahead))
           query = @resolver_query_adapter
             .build_query_from(field: field, args: args, lookahead: lookahead, context: context)
             .merge_with(filters: filters)

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/resolvable_value.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/resolvable_value.rb
@@ -28,6 +28,7 @@ module ElasticGraph
         end
 
         def resolve(field:, object:, context:, args:, lookahead:)
+          args = field.args_to_schema_form(args.except(:lookahead))
           method_name = canonical_name_for(field.name, "Field")
           public_send(method_name, **args_to_canonical_form(args))
         end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/arguments.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/arguments.rb
@@ -42,7 +42,7 @@ module ElasticGraph
         def self.to_schema_form(args_value, args_owner)
           # For custom scalar types (such as `_Any` for apollo federation), `args_owner` won't
           # response to `arguments`.
-          return args_value unless args_owner.respond_to?(:arguments)
+          return (_ = args_value) unless args_owner.respond_to?(:arguments)
 
           __skip__ = case args_value
           when Hash, ::GraphQL::Schema::InputObject

--- a/elasticgraph-graphql/sig/elastic_graph/graphql.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql.rbs
@@ -33,6 +33,9 @@ module ElasticGraph
     @datastore_search_router: DatastoreSearchRouter?
     def datastore_search_router: () -> DatastoreSearchRouter
 
+    @resolver_query_adapter: Resolvers::QueryAdapter?
+    def resolver_query_adapter: () -> Resolvers::QueryAdapter
+
     @datastore_query_builder: DatastoreQuery::Builder?
     def datastore_query_builder: () -> DatastoreQuery::Builder
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/graphql_adapter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/graphql_adapter.rbs
@@ -4,8 +4,7 @@ module ElasticGraph
       class GraphQLAdapter
         def initialize: (
           schema: Schema,
-          datastore_query_builder: DatastoreQuery::Builder,
-          datastore_query_adapters: ::Array[_QueryAdapter],
+          query_adapter: Resolvers::QueryAdapter,
           runtime_metadata: SchemaArtifacts::RuntimeMetadata::Schema,
           resolvers: ::Array[Resolvers::_Resolver]
         ) -> void

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/graphql_adapter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/graphql_adapter.rbs
@@ -4,7 +4,6 @@ module ElasticGraph
       class GraphQLAdapter
         def initialize: (
           schema: Schema,
-          query_adapter: Resolvers::QueryAdapter,
           runtime_metadata: SchemaArtifacts::RuntimeMetadata::Schema,
           resolvers: ::Array[Resolvers::_Resolver]
         ) -> void

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/interfaces.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/interfaces.rbs
@@ -1,7 +1,7 @@
 module ElasticGraph
   class GraphQL
     module Resolvers
-      type fieldArgs = ::Hash[::String, untyped]
+      type fieldArgs = ::Hash[::Symbol, untyped]
 
       interface _Resolver
         def can_resolve?: (field: Schema::Field, object: untyped) -> bool

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/list_records.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/list_records.rbs
@@ -3,6 +3,8 @@ module ElasticGraph
     module Resolvers
       class ListRecords
         include _Resolver
+
+        def initialize: (resolver_query_adapter: Resolvers::QueryAdapter) -> void
       end
     end
   end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/nested_relationships.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/nested_relationships.rbs
@@ -5,6 +5,7 @@ module ElasticGraph
         include _Resolver
 
         def initialize: (
+          resolver_query_adapter: Resolvers::QueryAdapter,
           schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
           logger: ::Logger
         ) -> void

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/query_adapter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/query_adapter.rbs
@@ -1,0 +1,12 @@
+module ElasticGraph
+  class GraphQL
+    module Resolvers
+      class QueryAdapter
+        def initialize: (
+          datastore_query_builder: DatastoreQuery::Builder,
+          datastore_query_adapters: ::Array[_QueryAdapter]
+        ) -> void
+      end
+    end
+  end
+end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/resolvable_value.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/resolvable_value.rbs
@@ -9,7 +9,7 @@ module ElasticGraph
 
         private
 
-        def args_to_canonical_form: (fieldArgs) -> ::Hash[::Symbol, untyped]
+        def args_to_canonical_form: (::Hash[::String, untyped]) -> ::Hash[::Symbol, untyped]
         def canonical_name_for: (::String | ::Symbol, ::String) -> ::Symbol
       end
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/schema/arguments.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/schema/arguments.rbs
@@ -3,7 +3,7 @@ module ElasticGraph
     class Schema
       module Arguments
         def self.to_schema_form: (
-          ::Hash[::String, untyped],
+          ::Hash[::Symbol, untyped],
           untyped
         ) -> ::Hash[::String, untyped]
       end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/schema/field.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/schema/field.rbs
@@ -14,7 +14,7 @@ module ElasticGraph
 
         def aggregated?: () -> bool
         def sort_clauses_for: (::Array[::String]) -> ::Array[::Hash[::String, ::Hash[::String, ::String]]]
-        def args_to_schema_form: (::Hash[::String, untyped]) -> ::Hash[::String, untyped]
+        def args_to_schema_form: (::Hash[::Symbol, untyped]) -> ::Hash[::String, untyped]
         def index_field_names_for_resolution: () -> ::Array[::String]
       end
     end

--- a/elasticgraph-graphql/sig/graphql_gem.rbs
+++ b/elasticgraph-graphql/sig/graphql_gem.rbs
@@ -18,7 +18,7 @@ module GraphQL
       attr_reader name: ::String
       attr_reader field: Schema::Field
       attr_reader owner_type: Schema::_Type
-      attr_reader arguments: ::Hash[::String, untyped]
+      attr_reader arguments: ::Hash[::Symbol, untyped]
 
       def initialize: (
         query: Query,

--- a/elasticgraph-graphql/spec/support/resolver.rb
+++ b/elasticgraph-graphql/spec/support/resolver.rb
@@ -11,10 +11,9 @@ require "elastic_graph/graphql/resolvers/query_source"
 require "graphql"
 
 module ResolverHelperMethods
-  def resolve(type_name, field_name, document = nil, lookahead: nil, query_overrides: {}, **options)
+  def resolve(type_name, field_name, document = nil, lookahead: nil, query_overrides: {}, **args)
     query_override_adapter.query_overrides = query_overrides
     field = graphql.schema.field_named(type_name, field_name)
-    args = field.args_to_schema_form(options)
     lookahead ||= GraphQL::Execution::Lookahead::NULL_LOOKAHEAD
     query_details_tracker = ElasticGraph::GraphQL::QueryDetailsTracker.empty
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_executor_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_executor_spec.rb
@@ -400,8 +400,8 @@ module ElasticGraph
 
               def resolve(field:, object:, args:, context:, lookahead:)
                 [
-                  args.dig("operands", "x"),
-                  args.dig("operands", "y"),
+                  args.dig(:operands, "x"),
+                  args.dig(:operands, "y"),
                   context[:additional_operand]
                 ].compact.reduce(:*)
               end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/graphql_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/graphql_adapter_spec.rb
@@ -18,7 +18,6 @@ module ElasticGraph
         it "raises a clear error when no resolver can be found" do
           adapter = GraphQLAdapter.new(
             schema: schema,
-            query_adapter: graphql.resolver_query_adapter,
             runtime_metadata: graphql.runtime_metadata,
             resolvers: graphql.graphql_resolvers
           )

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/graphql_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/graphql_adapter_spec.rb
@@ -18,8 +18,7 @@ module ElasticGraph
         it "raises a clear error when no resolver can be found" do
           adapter = GraphQLAdapter.new(
             schema: schema,
-            datastore_query_builder: graphql.datastore_query_builder,
-            datastore_query_adapters: graphql.datastore_query_adapters,
+            query_adapter: graphql.resolver_query_adapter,
             runtime_metadata: graphql.runtime_metadata,
             resolvers: graphql.graphql_resolvers
           )

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
@@ -131,7 +131,6 @@ module ElasticGraph
 
             def resolve(args: {}, **options)
               person, field = person_object_and_schema_field(**options)
-              args = field.args_to_schema_form(args)
               lookahead = instance_double("GraphQL::Execution::Lookahead")
               person.resolve(field: field, object: person, context: {}, args: args, lookahead: lookahead)
             end


### PR DESCRIPTION
Previously, we did it in `GraphQLResolver#call`, which gets invoked as part of resolving _every_ GraphQL field at every level of the response structure. We don't want to convert args to their schema form if we're not going to do anything with the args so it's better to defer it until it's needed.