### PR TITLE
Refactor: move where we call `field.coerce_result`.

### DIFF
--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_executor_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_executor_spec.rb
@@ -189,11 +189,11 @@ module ElasticGraph
 
           expect {
             execute_expecting_no_errors(query_string)
-          }.to raise_error(a_string_including("No resolver yet implemented for this case"))
+          }.to raise_error(a_string_including("No resolver yet implemented for `Query.foo`."))
             .and log a_string_including(
               "Query Foo[1] for client (anonymous) failed with an exception[2]",
               query_string.to_s,
-              "RuntimeError: No resolver yet implemented for this case"
+              "RuntimeError: No resolver yet implemented for `Query.foo`."
             )
         end
 


### PR DESCRIPTION
Previously, we called it from `GarphQLAdapter#call`, applying it to all resolved fields. However, we only need to use it in the aggregation `GroupedBy` resolver, where we get `DayOfWeek` enum values that we may need to coerce. There are no other cases where it is needed.

This allows us to simplify `GarphQLAdapter#call` so that it now only does two things:

* Identifies the resolver to dispatch to.
* Dispatches to that resolver.

This will allow us to further optimize by leveraging built-in functionality of the GraphQL gem to have it dispatch to the appropriate resolver in a more performant manner.