### PR TITLE
Use new `resolver` metadata for `NestedRelationships` resolver.

### DIFF
--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -2669,6 +2669,7 @@ object_types_by_name:
         relation:
           direction: out
           foreign_key: manufacturer_id
+        resolver: nested_relationships
     index_definition_names:
     - addresses
     update_targets:
@@ -2731,28 +2732,34 @@ object_types_by_name:
                 - 100
           direction: in
           foreign_key: component_ids
+        resolver: nested_relationships
       part_aggregations:
         relation:
           direction: out
           foreign_key: part_ids
+        resolver: nested_relationships
       parts:
         relation:
           direction: out
           foreign_key: part_ids
+        resolver: nested_relationships
       widget:
         relation:
           direction: in
           foreign_key: component_ids
+        resolver: nested_relationships
       widget_aggregations:
         relation:
           direction: in
           foreign_key: component_ids
+        resolver: nested_relationships
       widget_workspace_id:
         name_in_index: widget_workspace_id3
       widgets:
         relation:
           direction: in
           foreign_key: component_ids
+        resolver: nested_relationships
     index_definition_names:
     - components
     update_targets:
@@ -2860,14 +2867,17 @@ object_types_by_name:
         relation:
           direction: in
           foreign_key: part_ids
+        resolver: nested_relationships
       components:
         relation:
           direction: in
           foreign_key: part_ids
+        resolver: nested_relationships
       manufacturer:
         relation:
           direction: out
           foreign_key: manufacturer_id
+        resolver: nested_relationships
     index_definition_names:
     - electrical_parts
     update_targets:
@@ -3050,14 +3060,17 @@ object_types_by_name:
         relation:
           direction: in
           foreign_key: manufacturer_id
+        resolver: nested_relationships
       manufactured_part_aggregations:
         relation:
           direction: in
           foreign_key: manufacturer_id
+        resolver: nested_relationships
       manufactured_parts:
         relation:
           direction: in
           foreign_key: manufacturer_id
+        resolver: nested_relationships
     index_definition_names:
     - manufacturers
     update_targets:
@@ -3099,14 +3112,17 @@ object_types_by_name:
         relation:
           direction: in
           foreign_key: part_ids
+        resolver: nested_relationships
       components:
         relation:
           direction: in
           foreign_key: part_ids
+        resolver: nested_relationships
       manufacturer:
         relation:
           direction: out
           foreign_key: manufacturer_id
+        resolver: nested_relationships
     index_definition_names:
     - mechanical_parts
     update_targets:
@@ -3160,16 +3176,19 @@ object_types_by_name:
         relation:
           direction: in
           foreign_key: manufacturer_id
+        resolver: nested_relationships
       amount_cents2:
         name_in_index: amount_cents
       component_aggregations:
         relation:
           direction: out
           foreign_key: component_ids
+        resolver: nested_relationships
       components:
         relation:
           direction: out
           foreign_key: component_ids
+        resolver: nested_relationships
       created_at2:
         name_in_index: created_at
       created_at2_legacy:
@@ -3187,26 +3206,32 @@ object_types_by_name:
                 - 100
           direction: in
           foreign_key: component_ids
+        resolver: nested_relationships
       manufactured_part_aggregations:
         relation:
           direction: in
           foreign_key: manufacturer_id
+        resolver: nested_relationships
       manufactured_parts:
         relation:
           direction: in
           foreign_key: manufacturer_id
+        resolver: nested_relationships
       manufacturer:
         relation:
           direction: out
           foreign_key: manufacturer_id
+        resolver: nested_relationships
       part_aggregations:
         relation:
           direction: out
           foreign_key: part_ids
+        resolver: nested_relationships
       parts:
         relation:
           direction: out
           foreign_key: part_ids
+        resolver: nested_relationships
       size:
         name_in_index: options.size
       the_options:
@@ -3215,20 +3240,24 @@ object_types_by_name:
         relation:
           direction: in
           foreign_key: component_ids
+        resolver: nested_relationships
       widget_aggregations:
         relation:
           direction: in
           foreign_key: component_ids
+        resolver: nested_relationships
       widget_workspace_id:
         name_in_index: widget_workspace_id3
       widgets:
         relation:
           direction: in
           foreign_key: component_ids
+        resolver: nested_relationships
       workspace:
         relation:
           direction: in
           foreign_key: widget.id
+        resolver: nested_relationships
       workspace_id:
         name_in_index: workspace_id2
   NamedEntityAggregatedValues:
@@ -3324,14 +3353,17 @@ object_types_by_name:
         relation:
           direction: in
           foreign_key: part_ids
+        resolver: nested_relationships
       components:
         relation:
           direction: in
           foreign_key: part_ids
+        resolver: nested_relationships
       manufacturer:
         relation:
           direction: out
           foreign_key: manufacturer_id
+        resolver: nested_relationships
   PartAggregation:
     elasticgraph_category: indexed_aggregation
     source_type: Part
@@ -3372,10 +3404,12 @@ object_types_by_name:
           foreign_key_nested_paths:
           - current_players_nested
           - current_players_nested.affiliations.sponsorships_nested
+        resolver: nested_relationships
       affiliated_team_from_object_aggregations:
         relation:
           direction: in
           foreign_key: current_players_object.affiliations.sponsorships_object.sponsor_id
+        resolver: nested_relationships
       affiliated_teams_from_nested:
         relation:
           direction: in
@@ -3383,10 +3417,12 @@ object_types_by_name:
           foreign_key_nested_paths:
           - current_players_nested
           - current_players_nested.affiliations.sponsorships_nested
+        resolver: nested_relationships
       affiliated_teams_from_object:
         relation:
           direction: in
           foreign_key: current_players_object.affiliations.sponsorships_object.sponsor_id
+        resolver: nested_relationships
     index_definition_names:
     - sponsors
     update_targets:
@@ -3672,10 +3708,12 @@ object_types_by_name:
         relation:
           direction: out
           foreign_key: component_ids
+        resolver: nested_relationships
       components:
         relation:
           direction: out
           foreign_key: component_ids
+        resolver: nested_relationships
       created_at2:
         name_in_index: created_at
       created_at2_legacy:
@@ -3692,6 +3730,7 @@ object_types_by_name:
         relation:
           direction: in
           foreign_key: widget.id
+        resolver: nested_relationships
       workspace_id:
         name_in_index: workspace_id2
     index_definition_names:
@@ -3991,10 +4030,12 @@ object_types_by_name:
         relation:
           direction: out
           foreign_key: component_ids
+        resolver: nested_relationships
       components:
         relation:
           direction: out
           foreign_key: component_ids
+        resolver: nested_relationships
       created_at2:
         name_in_index: created_at
       created_at2_legacy:
@@ -4007,6 +4048,7 @@ object_types_by_name:
         relation:
           direction: out
           foreign_key: manufacturer_id
+        resolver: nested_relationships
       size:
         name_in_index: options.size
       the_options:
@@ -4015,6 +4057,7 @@ object_types_by_name:
         relation:
           direction: in
           foreign_key: widget.id
+        resolver: nested_relationships
       workspace_id:
         name_in_index: workspace_id2
   WidgetOrAddressAggregatedValues:

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -2672,6 +2672,7 @@ object_types_by_name:
         relation:
           direction: out
           foreign_key: manufacturer_id
+        resolver: nested_relationships
     index_definition_names:
     - addresses
     update_targets:
@@ -2734,28 +2735,34 @@ object_types_by_name:
                 - 100
           direction: in
           foreign_key: component_ids
+        resolver: nested_relationships
       part_aggregations:
         relation:
           direction: out
           foreign_key: part_ids
+        resolver: nested_relationships
       parts:
         relation:
           direction: out
           foreign_key: part_ids
+        resolver: nested_relationships
       widget:
         relation:
           direction: in
           foreign_key: component_ids
+        resolver: nested_relationships
       widget_aggregations:
         relation:
           direction: in
           foreign_key: component_ids
+        resolver: nested_relationships
       widget_workspace_id:
         name_in_index: widget_workspace_id3
       widgets:
         relation:
           direction: in
           foreign_key: component_ids
+        resolver: nested_relationships
     index_definition_names:
     - components
     update_targets:
@@ -2815,10 +2822,12 @@ object_types_by_name:
         relation:
           direction: in
           foreign_key: country_code
+        resolver: nested_relationships
       teams:
         relation:
           direction: in
           foreign_key: country_code
+        resolver: nested_relationships
   DateAggregatedValues:
     elasticgraph_category: scalar_aggregated_values
     graphql_fields_by_name:
@@ -2873,14 +2882,17 @@ object_types_by_name:
         relation:
           direction: in
           foreign_key: part_ids
+        resolver: nested_relationships
       components:
         relation:
           direction: in
           foreign_key: part_ids
+        resolver: nested_relationships
       manufacturer:
         relation:
           direction: out
           foreign_key: manufacturer_id
+        resolver: nested_relationships
     index_definition_names:
     - electrical_parts
     update_targets:
@@ -3063,14 +3075,17 @@ object_types_by_name:
         relation:
           direction: in
           foreign_key: manufacturer_id
+        resolver: nested_relationships
       manufactured_part_aggregations:
         relation:
           direction: in
           foreign_key: manufacturer_id
+        resolver: nested_relationships
       manufactured_parts:
         relation:
           direction: in
           foreign_key: manufacturer_id
+        resolver: nested_relationships
     index_definition_names:
     - manufacturers
     update_targets:
@@ -3112,14 +3127,17 @@ object_types_by_name:
         relation:
           direction: in
           foreign_key: part_ids
+        resolver: nested_relationships
       components:
         relation:
           direction: in
           foreign_key: part_ids
+        resolver: nested_relationships
       manufacturer:
         relation:
           direction: out
           foreign_key: manufacturer_id
+        resolver: nested_relationships
     index_definition_names:
     - mechanical_parts
     update_targets:
@@ -3173,16 +3191,19 @@ object_types_by_name:
         relation:
           direction: in
           foreign_key: manufacturer_id
+        resolver: nested_relationships
       amount_cents2:
         name_in_index: amount_cents
       component_aggregations:
         relation:
           direction: out
           foreign_key: component_ids
+        resolver: nested_relationships
       components:
         relation:
           direction: out
           foreign_key: component_ids
+        resolver: nested_relationships
       created_at2:
         name_in_index: created_at
       created_at2_legacy:
@@ -3200,26 +3221,32 @@ object_types_by_name:
                 - 100
           direction: in
           foreign_key: component_ids
+        resolver: nested_relationships
       manufactured_part_aggregations:
         relation:
           direction: in
           foreign_key: manufacturer_id
+        resolver: nested_relationships
       manufactured_parts:
         relation:
           direction: in
           foreign_key: manufacturer_id
+        resolver: nested_relationships
       manufacturer:
         relation:
           direction: out
           foreign_key: manufacturer_id
+        resolver: nested_relationships
       part_aggregations:
         relation:
           direction: out
           foreign_key: part_ids
+        resolver: nested_relationships
       parts:
         relation:
           direction: out
           foreign_key: part_ids
+        resolver: nested_relationships
       size:
         name_in_index: options.size
       the_options:
@@ -3228,20 +3255,24 @@ object_types_by_name:
         relation:
           direction: in
           foreign_key: component_ids
+        resolver: nested_relationships
       widget_aggregations:
         relation:
           direction: in
           foreign_key: component_ids
+        resolver: nested_relationships
       widget_workspace_id:
         name_in_index: widget_workspace_id3
       widgets:
         relation:
           direction: in
           foreign_key: component_ids
+        resolver: nested_relationships
       workspace:
         relation:
           direction: in
           foreign_key: widget.id
+        resolver: nested_relationships
       workspace_id:
         name_in_index: workspace_id2
   NamedEntityAggregatedValues:
@@ -3337,14 +3368,17 @@ object_types_by_name:
         relation:
           direction: in
           foreign_key: part_ids
+        resolver: nested_relationships
       components:
         relation:
           direction: in
           foreign_key: part_ids
+        resolver: nested_relationships
       manufacturer:
         relation:
           direction: out
           foreign_key: manufacturer_id
+        resolver: nested_relationships
   PartAggregation:
     elasticgraph_category: indexed_aggregation
     source_type: Part
@@ -3385,10 +3419,12 @@ object_types_by_name:
           foreign_key_nested_paths:
           - current_players_nested
           - current_players_nested.affiliations.sponsorships_nested
+        resolver: nested_relationships
       affiliated_team_from_object_aggregations:
         relation:
           direction: in
           foreign_key: current_players_object.affiliations.sponsorships_object.sponsor_id
+        resolver: nested_relationships
       affiliated_teams_from_nested:
         relation:
           direction: in
@@ -3396,10 +3432,12 @@ object_types_by_name:
           foreign_key_nested_paths:
           - current_players_nested
           - current_players_nested.affiliations.sponsorships_nested
+        resolver: nested_relationships
       affiliated_teams_from_object:
         relation:
           direction: in
           foreign_key: current_players_object.affiliations.sponsorships_object.sponsor_id
+        resolver: nested_relationships
     index_definition_names:
     - sponsors
     update_targets:
@@ -3685,10 +3723,12 @@ object_types_by_name:
         relation:
           direction: out
           foreign_key: component_ids
+        resolver: nested_relationships
       components:
         relation:
           direction: out
           foreign_key: component_ids
+        resolver: nested_relationships
       created_at2:
         name_in_index: created_at
       created_at2_legacy:
@@ -3705,6 +3745,7 @@ object_types_by_name:
         relation:
           direction: in
           foreign_key: widget.id
+        resolver: nested_relationships
       workspace_id:
         name_in_index: workspace_id2
     index_definition_names:
@@ -4004,10 +4045,12 @@ object_types_by_name:
         relation:
           direction: out
           foreign_key: component_ids
+        resolver: nested_relationships
       components:
         relation:
           direction: out
           foreign_key: component_ids
+        resolver: nested_relationships
       created_at2:
         name_in_index: created_at
       created_at2_legacy:
@@ -4020,6 +4063,7 @@ object_types_by_name:
         relation:
           direction: out
           foreign_key: manufacturer_id
+        resolver: nested_relationships
       size:
         name_in_index: options.size
       the_options:
@@ -4028,6 +4072,7 @@ object_types_by_name:
         relation:
           direction: in
           foreign_key: widget.id
+        resolver: nested_relationships
       workspace_id:
         name_in_index: workspace_id2
   WidgetOrAddressAggregatedValues:

--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -102,6 +102,7 @@ module ElasticGraph
             Resolvers::GraphQLAdapter.new(
               schema: schema,
               runtime_metadata: runtime_metadata,
+              named_resolvers: named_graphql_resolvers,
               resolvers: graphql_resolvers
             )
           end
@@ -167,13 +168,6 @@ module ElasticGraph
       @graphql_resolvers ||= begin
         require "elastic_graph/graphql/resolvers/get_record_field_value"
         require "elastic_graph/graphql/resolvers/list_records"
-        require "elastic_graph/graphql/resolvers/nested_relationships"
-
-        nested_relationships = Resolvers::NestedRelationships.new(
-          resolver_query_adapter: resolver_query_adapter,
-          schema_element_names: runtime_metadata.schema_element_names,
-          logger: logger
-        )
 
         list_records = Resolvers::ListRecords.new(
           resolver_query_adapter: resolver_query_adapter
@@ -183,7 +177,22 @@ module ElasticGraph
           schema_element_names: runtime_metadata.schema_element_names
         )
 
-        [nested_relationships, list_records, get_record_field_value]
+        [list_records, get_record_field_value]
+      end
+    end
+
+    # @private
+    def named_graphql_resolvers
+      @named_graphql_resolvers ||= begin
+        require "elastic_graph/graphql/resolvers/nested_relationships"
+
+        nested_relationships = Resolvers::NestedRelationships.new(
+          resolver_query_adapter: resolver_query_adapter,
+          schema_element_names: runtime_metadata.schema_element_names,
+          logger: logger
+        )
+
+        {nested_relationships: nested_relationships}
       end
     end
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb
@@ -227,7 +227,7 @@ module ElasticGraph
     # Steep weirdly expects them here...
     # @dynamic initialize, config, logger, runtime_metadata, graphql_schema_string, datastore_core, clock
     # @dynamic graphql_http_endpoint, graphql_query_executor, schema, datastore_search_router, filter_interpreter, filter_node_interpreter
-    # @dynamic datastore_query_builder, resolver_query_adapter, graphql_gem_plugins, graphql_resolvers, datastore_query_adapters, monotonic_clock
+    # @dynamic datastore_query_builder, resolver_query_adapter, graphql_gem_plugins, graphql_resolvers, named_graphql_resolvers, datastore_query_adapters, monotonic_clock
     # @dynamic load_dependencies_eagerly, self.from_parsed_yaml, filter_args_translator, sub_aggregation_grouping_adapter
   end
 end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships.rb
@@ -23,10 +23,6 @@ module ElasticGraph
           @logger = logger
         end
 
-        def can_resolve?(field:, object:)
-          !!field.relation_join
-        end
-
         def call(parent_type, graphql_field, object, args, context)
           field = context.fetch(:elastic_graph_schema).field_named(parent_type.graphql_name, graphql_field.name)
           log_warning = ->(**options) { log_field_problem_warning(field: field, **options) }

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/field.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/field.rb
@@ -18,7 +18,7 @@ module ElasticGraph
         # The type in which the field resides.
         attr_reader :parent_type
 
-        attr_reader :schema, :schema_element_names, :graphql_field, :name_in_index, :relation, :computation_detail
+        attr_reader :schema, :schema_element_names, :graphql_field, :name_in_index, :relation, :computation_detail, :resolver
 
         def initialize(schema, parent_type, graphql_field, runtime_metadata)
           @schema = schema
@@ -27,6 +27,7 @@ module ElasticGraph
           @graphql_field = graphql_field
           @relation = runtime_metadata&.relation
           @computation_detail = runtime_metadata&.computation_detail
+          @resolver = runtime_metadata&.resolver
           @name_in_index = runtime_metadata&.name_in_index&.to_sym || name
 
           # Adds the :extras required by ElasticGraph. For now, this blindly adds `:lookahead`

--- a/elasticgraph-graphql/sig/elastic_graph/graphql.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql.rbs
@@ -45,6 +45,9 @@ module ElasticGraph
     @graphql_resolvers: ::Array[Resolvers::_Resolver]?
     def graphql_resolvers: () -> ::Array[Resolvers::_Resolver]
 
+    @named_graphql_resolvers: ::Hash[::Symbol, Resolvers::_Resolver]?
+    def named_graphql_resolvers: () -> ::Hash[::Symbol, Resolvers::_Resolver]
+
     @datastore_query_adapters: ::Array[_QueryAdapter]?
     def datastore_query_adapters: () -> ::Array[_QueryAdapter]
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/graphql_adapter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/graphql_adapter.rbs
@@ -5,6 +5,7 @@ module ElasticGraph
         def initialize: (
           schema: Schema,
           runtime_metadata: SchemaArtifacts::RuntimeMetadata::Schema,
+          named_resolvers: ::Hash[::Symbol, Resolvers::_Resolver],
           resolvers: ::Array[Resolvers::_Resolver]
         ) -> void
       end

--- a/elasticgraph-graphql/spec/support/resolver.rb
+++ b/elasticgraph-graphql/spec/support/resolver.rb
@@ -30,8 +30,6 @@ module ResolverHelperMethods
         }
       )
 
-      expect(document).to satisfy { |doc| resolver.can_resolve?(field: field, object: doc) }
-
       begin
         # In the 2.1.0 release of the GraphQL gem, `GraphQL::Pagination::Connection#initialize` expects a particular thread local[^1].
         # Here we initialize the thread local in a similar way to how the GraphQL gem does it[^2].

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/graphql_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/graphql_adapter_spec.rb
@@ -19,6 +19,7 @@ module ElasticGraph
           adapter = GraphQLAdapter.new(
             schema: schema,
             runtime_metadata: graphql.runtime_metadata,
+            named_resolvers: graphql.named_graphql_resolvers,
             resolvers: graphql.graphql_resolvers
           )
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
@@ -92,7 +92,7 @@ module ElasticGraph
         :aggregated_values_customizations, :sort_order_enum_value_customizations,
         :args, :sortable, :filterable, :aggregatable, :groupable, :graphql_only, :source, :runtime_field_script, :relationship, :singular_name,
         :computation_detail, :non_nullable_in_json_schema, :backing_indexing_field, :as_input,
-        :legacy_grouping_schema, :name_in_index
+        :legacy_grouping_schema, :name_in_index, :resolver
       )
         include Mixins::HasDocumentation
         include Mixins::HasDirectives
@@ -106,7 +106,7 @@ module ElasticGraph
           runtime_metadata_graphql_field: SchemaArtifacts::RuntimeMetadata::GraphQLField::EMPTY,
           type_for_derived_types: nil, graphql_only: nil, singular: nil,
           sortable: nil, filterable: nil, aggregatable: nil, groupable: nil,
-          backing_indexing_field: nil, as_input: false, legacy_grouping_schema: false
+          backing_indexing_field: nil, as_input: false, legacy_grouping_schema: false, resolver: nil
         )
           type_ref = schema_def_state.type_ref(type)
           super(
@@ -137,7 +137,8 @@ module ElasticGraph
             non_nullable_in_json_schema: false,
             backing_indexing_field: backing_indexing_field,
             as_input: as_input,
-            legacy_grouping_schema: legacy_grouping_schema
+            legacy_grouping_schema: legacy_grouping_schema,
+            resolver: resolver
           )
 
           if name != name_in_index && name_in_index&.include?(".") && !graphql_only
@@ -926,7 +927,7 @@ module ElasticGraph
             name_in_index: name_in_index,
             computation_detail: computation_detail,
             relation: relationship&.runtime_metadata,
-            resolver: nil
+            resolver: resolver
           )
         end
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_with_subfields.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_with_subfields.rb
@@ -540,6 +540,7 @@ module ElasticGraph
             yield relationship if block_given?
 
             field.relationship = relationship
+            field.resolver = :nested_relationships
 
             if dir == :out
               register_inferred_foreign_key_fields(from_type: [via, foreign_key_type], to_other: ["id", "ID!"], related_type: relationship.related_type)

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/field.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/field.rbs
@@ -25,6 +25,7 @@ module ElasticGraph
         attr_reader non_nullable_in_json_schema: bool
         attr_reader source: FieldSource?
         attr_accessor relationship: Relationship?
+        attr_accessor resolver: ::Symbol?
         attr_reader singular_name: ::String?
         attr_reader as_input: bool
 

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/relation_metadata_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/relation_metadata_spec.rb
@@ -25,6 +25,7 @@ module ElasticGraph
         expect(metadata.graphql_fields_by_name).to eq({
           "parent" => graphql_field_with(
             name_in_index: nil,
+            resolver: :nested_relationships,
             relation: SchemaArtifacts::RuntimeMetadata::Relation.new(
               foreign_key: "parent_id",
               direction: :out,
@@ -46,6 +47,7 @@ module ElasticGraph
 
         expected_relation_field = graphql_field_with(
           name_in_index: nil,
+          resolver: :nested_relationships,
           relation: SchemaArtifacts::RuntimeMetadata::Relation.new(
             foreign_key: "parent_id",
             direction: :in,
@@ -81,6 +83,7 @@ module ElasticGraph
 
         expected_relation_field = graphql_field_with(
           name_in_index: nil,
+          resolver: :nested_relationships,
           relation: SchemaArtifacts::RuntimeMetadata::Relation.new(
             foreign_key: "parent_id",
             direction: :in,
@@ -117,6 +120,7 @@ module ElasticGraph
 
         expected_relation_field = graphql_field_with(
           name_in_index: nil,
+          resolver: :nested_relationships,
           relation: SchemaArtifacts::RuntimeMetadata::Relation.new(
             foreign_key: "parent_id",
             direction: :in,
@@ -162,6 +166,7 @@ module ElasticGraph
 
         expected_relation_field = graphql_field_with(
           name_in_index: nil,
+          resolver: :nested_relationships,
           relation: SchemaArtifacts::RuntimeMetadata::Relation.new(
             foreign_key: "parent_id",
             direction: :in,
@@ -243,6 +248,7 @@ module ElasticGraph
 
           expected_relation_field = graphql_field_with(
             name_in_index: nil,
+            resolver: :nested_relationships,
             relation: SchemaArtifacts::RuntimeMetadata::Relation.new(
               foreign_key: "players.affiliations.sponsorships.sponsor_id",
               direction: :in,


### PR DESCRIPTION
This should help improve performance (at least, once this entire set of refactorings are done) as it allows us to immediately dispatch to the `NestedRelationships` rather than needing to linearly search for the appropriate resolver.