### PR TITLE
Use new `resolver` metadata for aggregation resolvers.

### DIFF
--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -2700,7 +2700,10 @@ object_types_by_name:
       routing_value_source: id
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Address
+  AddressAggregatedValues:
+    default_graphql_resolver: object
   AddressAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: Address
   AddressAggregationConnection:
@@ -2711,11 +2714,22 @@ object_types_by_name:
     elasticgraph_category: relay_connection
   AddressEdge:
     elasticgraph_category: relay_edge
+  AddressGroupedBy:
+    default_graphql_resolver: object
+  AddressTimestampsAggregatedValues:
+    default_graphql_resolver: object
+  AddressTimestampsGroupedBy:
+    default_graphql_resolver: object
+  AffiliationsAggregatedValues:
+    default_graphql_resolver: object
   AffiliationsFieldsListFilterInput:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  AffiliationsGroupedBy:
+    default_graphql_resolver: object
   AggregationCountDetail:
+    default_graphql_resolver: object
     graphql_only_return_type: true
   ColorListFilterInput:
     graphql_fields_by_name:
@@ -2791,10 +2805,12 @@ object_types_by_name:
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Component
   ComponentAggregatedValues:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       widget_workspace_id:
         name_in_index: widget_workspace_id3
   ComponentAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: Component
   ComponentAggregationConnection:
@@ -2810,10 +2826,16 @@ object_types_by_name:
       widget_workspace_id:
         name_in_index: widget_workspace_id3
   ComponentGroupedBy:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       widget_workspace_id:
         name_in_index: widget_workspace_id3
+  CurrencyDetailsAggregatedValues:
+    default_graphql_resolver: object
+  CurrencyDetailsGroupedBy:
+    default_graphql_resolver: object
   DateAggregatedValues:
+    default_graphql_resolver: object
     elasticgraph_category: scalar_aggregated_values
     graphql_fields_by_name:
       approximate_avg:
@@ -2831,6 +2853,7 @@ object_types_by_name:
           function: min
     graphql_only_return_type: true
   DateGroupedBy:
+    default_graphql_resolver: object
     elasticgraph_category: date_grouped_by_object
     graphql_only_return_type: true
   DateListFilterInput:
@@ -2838,6 +2861,7 @@ object_types_by_name:
       count:
         name_in_index: __counts
   DateTimeAggregatedValues:
+    default_graphql_resolver: object
     elasticgraph_category: scalar_aggregated_values
     graphql_fields_by_name:
       approximate_avg:
@@ -2855,6 +2879,7 @@ object_types_by_name:
           function: min
     graphql_only_return_type: true
   DateTimeGroupedBy:
+    default_graphql_resolver: object
     elasticgraph_category: date_grouped_by_object
     graphql_only_return_type: true
   DateTimeListFilterInput:
@@ -2906,7 +2931,10 @@ object_types_by_name:
       routing_value_source: id
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: ElectricalPart
+  ElectricalPartAggregatedValues:
+    default_graphql_resolver: object
   ElectricalPartAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: ElectricalPart
   ElectricalPartAggregationConnection:
@@ -2917,7 +2945,10 @@ object_types_by_name:
     elasticgraph_category: relay_connection
   ElectricalPartEdge:
     elasticgraph_category: relay_edge
+  ElectricalPartGroupedBy:
+    default_graphql_resolver: object
   FloatAggregatedValues:
+    default_graphql_resolver: object
     elasticgraph_category: scalar_aggregated_values
     graphql_fields_by_name:
       approximate_avg:
@@ -2949,6 +2980,7 @@ object_types_by_name:
       count:
         name_in_index: __counts
   IntAggregatedValues:
+    default_graphql_resolver: object
     elasticgraph_category: scalar_aggregated_values
     graphql_fields_by_name:
       approximate_avg:
@@ -2977,7 +3009,12 @@ object_types_by_name:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  InventorAggregatedValues:
+    default_graphql_resolver: object
+  InventorGroupedBy:
+    default_graphql_resolver: object
   JsonSafeLongAggregatedValues:
+    default_graphql_resolver: object
     elasticgraph_category: scalar_aggregated_values
     graphql_fields_by_name:
       approximate_avg:
@@ -3007,6 +3044,7 @@ object_types_by_name:
       count:
         name_in_index: __counts
   LocalTimeAggregatedValues:
+    default_graphql_resolver: object
     elasticgraph_category: scalar_aggregated_values
     graphql_fields_by_name:
       approximate_avg:
@@ -3024,6 +3062,7 @@ object_types_by_name:
           function: min
     graphql_only_return_type: true
   LongStringAggregatedValues:
+    default_graphql_resolver: object
     elasticgraph_category: scalar_aggregated_values
     graphql_fields_by_name:
       approximate_avg:
@@ -3095,7 +3134,10 @@ object_types_by_name:
       routing_value_source: id
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Manufacturer
+  ManufacturerAggregatedValues:
+    default_graphql_resolver: object
   ManufacturerAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: Manufacturer
   ManufacturerAggregationConnection:
@@ -3106,6 +3148,8 @@ object_types_by_name:
     elasticgraph_category: relay_connection
   ManufacturerEdge:
     elasticgraph_category: relay_edge
+  ManufacturerGroupedBy:
+    default_graphql_resolver: object
   MechanicalPart:
     graphql_fields_by_name:
       component_aggregations:
@@ -3151,7 +3195,10 @@ object_types_by_name:
       routing_value_source: id
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: MechanicalPart
+  MechanicalPartAggregatedValues:
+    default_graphql_resolver: object
   MechanicalPartAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: MechanicalPart
   MechanicalPartAggregationConnection:
@@ -3162,10 +3209,16 @@ object_types_by_name:
     elasticgraph_category: relay_connection
   MechanicalPartEdge:
     elasticgraph_category: relay_edge
+  MechanicalPartGroupedBy:
+    default_graphql_resolver: object
+  MoneyAggregatedValues:
+    default_graphql_resolver: object
   MoneyFieldsListFilterInput:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  MoneyGroupedBy:
+    default_graphql_resolver: object
   MoneyListFilterInput:
     graphql_fields_by_name:
       count:
@@ -3261,6 +3314,7 @@ object_types_by_name:
       workspace_id:
         name_in_index: workspace_id2
   NamedEntityAggregatedValues:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       amount_cents2:
         name_in_index: amount_cents
@@ -3281,6 +3335,7 @@ object_types_by_name:
       workspace_id:
         name_in_index: workspace_id2
   NamedEntityAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: NamedEntity
   NamedEntityAggregationConnection:
@@ -3312,6 +3367,7 @@ object_types_by_name:
       workspace_id:
         name_in_index: workspace_id2
   NamedEntityGroupedBy:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       amount_cents2:
         name_in_index: amount_cents
@@ -3337,7 +3393,12 @@ object_types_by_name:
         name_in_index: widget_workspace_id3
       workspace_id:
         name_in_index: workspace_id2
+  NamedInventorAggregatedValues:
+    default_graphql_resolver: object
+  NamedInventorGroupedBy:
+    default_graphql_resolver: object
   NonNumericAggregatedValues:
+    default_graphql_resolver: object
     elasticgraph_category: scalar_aggregated_values
     graphql_fields_by_name:
       approximate_distinct_value_count:
@@ -3364,7 +3425,10 @@ object_types_by_name:
           direction: out
           foreign_key: manufacturer_id
         resolver: nested_relationships
+  PartAggregatedValues:
+    default_graphql_resolver: object
   PartAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: Part
   PartAggregationConnection:
@@ -3375,22 +3439,36 @@ object_types_by_name:
     elasticgraph_category: relay_connection
   PartEdge:
     elasticgraph_category: relay_edge
+  PartGroupedBy:
+    default_graphql_resolver: object
+  PlayerAggregatedValues:
+    default_graphql_resolver: object
   PlayerFieldsListFilterInput:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  PlayerGroupedBy:
+    default_graphql_resolver: object
   PlayerListFilterInput:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  PlayerSeasonAggregatedValues:
+    default_graphql_resolver: object
   PlayerSeasonFieldsListFilterInput:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  PlayerSeasonGroupedBy:
+    default_graphql_resolver: object
   PlayerSeasonListFilterInput:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  PositionAggregatedValues:
+    default_graphql_resolver: object
+  PositionGroupedBy:
+    default_graphql_resolver: object
   SizeListFilterInput:
     graphql_fields_by_name:
       count:
@@ -3445,7 +3523,10 @@ object_types_by_name:
       routing_value_source: id
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Sponsor
+  SponsorAggregatedValues:
+    default_graphql_resolver: object
   SponsorAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: Sponsor
   SponsorAggregationConnection:
@@ -3456,10 +3537,16 @@ object_types_by_name:
     elasticgraph_category: relay_connection
   SponsorEdge:
     elasticgraph_category: relay_edge
+  SponsorGroupedBy:
+    default_graphql_resolver: object
+  SponsorshipAggregatedValues:
+    default_graphql_resolver: object
   SponsorshipFieldsListFilterInput:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  SponsorshipGroupedBy:
+    default_graphql_resolver: object
   SponsorshipListFilterInput:
     graphql_fields_by_name:
       count:
@@ -3531,33 +3618,57 @@ object_types_by_name:
       routing_value_source: league
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Team
+  TeamAggregatedValues:
+    default_graphql_resolver: object
   TeamAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: Team
   TeamAggregationConnection:
     elasticgraph_category: relay_connection
+  TeamAggregationCurrentPlayersObjectAffiliationsSubAggregations:
+    default_graphql_resolver: object
+  TeamAggregationCurrentPlayersObjectSubAggregations:
+    default_graphql_resolver: object
   TeamAggregationEdge:
     elasticgraph_category: relay_edge
   TeamAggregationNestedFields2SubAggregations:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       seasons:
         name_in_index: the_seasons
   TeamAggregationNestedFieldsSubAggregations:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       seasons:
         name_in_index: the_seasons
+  TeamAggregationSeasonsObjectPlayersObjectAffiliationsSubAggregations:
+    default_graphql_resolver: object
+  TeamAggregationSeasonsObjectPlayersObjectSubAggregations:
+    default_graphql_resolver: object
+  TeamAggregationSeasonsObjectSubAggregations:
+    default_graphql_resolver: object
   TeamAggregationSubAggregations:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       nested_fields:
         name_in_index: the_nested_fields
   TeamConnection:
     elasticgraph_category: relay_connection
+  TeamDetailsAggregatedValues:
+    default_graphql_resolver: object
+  TeamDetailsGroupedBy:
+    default_graphql_resolver: object
   TeamEdge:
     elasticgraph_category: relay_edge
   TeamFilterInput:
     graphql_fields_by_name:
       nested_fields:
         name_in_index: the_nested_fields
+  TeamGroupedBy:
+    default_graphql_resolver: object
+  TeamMoneySubAggregation:
+    default_graphql_resolver: object
   TeamMoneySubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
   TeamNestedFields:
@@ -3568,14 +3679,26 @@ object_types_by_name:
     graphql_fields_by_name:
       seasons:
         name_in_index: the_seasons
+  TeamPlayerPlayerSeasonSubAggregation:
+    default_graphql_resolver: object
   TeamPlayerPlayerSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamPlayerSeasonSubAggregation:
+    default_graphql_resolver: object
   TeamPlayerSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamPlayerSponsorshipSubAggregation:
+    default_graphql_resolver: object
   TeamPlayerSponsorshipSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamPlayerSubAggregation:
+    default_graphql_resolver: object
+  TeamPlayerSubAggregationAffiliationsSubAggregations:
+    default_graphql_resolver: object
   TeamPlayerSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamPlayerSubAggregationSubAggregations:
+    default_graphql_resolver: object
   TeamRecord:
     graphql_fields_by_name:
       first_win_on_legacy:
@@ -3589,6 +3712,7 @@ object_types_by_name:
       wins:
         name_in_index: win_count
   TeamRecordAggregatedValues:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       first_win_on_legacy:
         name_in_index: first_win_on
@@ -3627,6 +3751,7 @@ object_types_by_name:
       wins:
         name_in_index: win_count
   TeamRecordGroupedBy:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       first_win_on_legacy:
         name_in_index: first_win_on
@@ -3647,6 +3772,7 @@ object_types_by_name:
       won_games_at_legacy:
         name_in_index: won_games_at
   TeamSeasonAggregatedValues:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       record:
         name_in_index: the_record
@@ -3671,6 +3797,7 @@ object_types_by_name:
       won_games_at_legacy:
         name_in_index: won_games_at
   TeamSeasonGroupedBy:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       note:
         name_in_index: notes
@@ -3686,20 +3813,44 @@ object_types_by_name:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  TeamSponsorshipSubAggregation:
+    default_graphql_resolver: object
   TeamSponsorshipSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamTeamSeasonPlayerPlayerSeasonSubAggregation:
+    default_graphql_resolver: object
   TeamTeamSeasonPlayerPlayerSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamTeamSeasonPlayerSeasonSubAggregation:
+    default_graphql_resolver: object
   TeamTeamSeasonPlayerSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamTeamSeasonPlayerSponsorshipSubAggregation:
+    default_graphql_resolver: object
   TeamTeamSeasonPlayerSponsorshipSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamTeamSeasonPlayerSubAggregation:
+    default_graphql_resolver: object
+  TeamTeamSeasonPlayerSubAggregationAffiliationsSubAggregations:
+    default_graphql_resolver: object
   TeamTeamSeasonPlayerSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamTeamSeasonPlayerSubAggregationSubAggregations:
+    default_graphql_resolver: object
+  TeamTeamSeasonSponsorshipSubAggregation:
+    default_graphql_resolver: object
   TeamTeamSeasonSponsorshipSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamTeamSeasonSubAggregation:
+    default_graphql_resolver: object
   TeamTeamSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamTeamSeasonSubAggregationPlayersObjectAffiliationsSubAggregations:
+    default_graphql_resolver: object
+  TeamTeamSeasonSubAggregationPlayersObjectSubAggregations:
+    default_graphql_resolver: object
+  TeamTeamSeasonSubAggregationSubAggregations:
+    default_graphql_resolver: object
   Widget:
     graphql_fields_by_name:
       amount_cents2:
@@ -3868,6 +4019,7 @@ object_types_by_name:
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Component
   WidgetAggregatedValues:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       amount_cents2:
         name_in_index: amount_cents
@@ -3886,6 +4038,7 @@ object_types_by_name:
       workspace_id:
         name_in_index: workspace_id2
   WidgetAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: Widget
   WidgetAggregationConnection:
@@ -3940,10 +4093,12 @@ object_types_by_name:
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: WidgetCurrency
   WidgetCurrencyAggregatedValues:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       widget_names:
         name_in_index: widget_names2
   WidgetCurrencyAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: WidgetCurrency
   WidgetCurrencyAggregationConnection:
@@ -3959,9 +4114,14 @@ object_types_by_name:
       widget_names:
         name_in_index: widget_names2
   WidgetCurrencyGroupedBy:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       widget_name:
         name_in_index: widget_names2
+  WidgetCurrencyNestedFieldsAggregatedValues:
+    default_graphql_resolver: object
+  WidgetCurrencyNestedFieldsGroupedBy:
+    default_graphql_resolver: object
   WidgetEdge:
     elasticgraph_category: relay_edge
   WidgetFilterInput:
@@ -3983,6 +4143,7 @@ object_types_by_name:
       workspace_id:
         name_in_index: workspace_id2
   WidgetGroupedBy:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       amount_cents2:
         name_in_index: amount_cents
@@ -4006,11 +4167,14 @@ object_types_by_name:
         name_in_index: the_opts
       workspace_id:
         name_in_index: workspace_id2
+  WidgetOptionSetsAggregatedValues:
+    default_graphql_resolver: object
   WidgetOptions:
     graphql_fields_by_name:
       the_size:
         name_in_index: the_sighs
   WidgetOptionsAggregatedValues:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       the_size:
         name_in_index: the_sighs
@@ -4019,6 +4183,7 @@ object_types_by_name:
       the_size:
         name_in_index: the_sighs
   WidgetOptionsGroupedBy:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       the_size:
         name_in_index: the_sighs
@@ -4061,6 +4226,7 @@ object_types_by_name:
       workspace_id:
         name_in_index: workspace_id2
   WidgetOrAddressAggregatedValues:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       amount_cents2:
         name_in_index: amount_cents
@@ -4079,6 +4245,7 @@ object_types_by_name:
       workspace_id:
         name_in_index: workspace_id2
   WidgetOrAddressAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: WidgetOrAddress
   WidgetOrAddressAggregationConnection:
@@ -4108,6 +4275,7 @@ object_types_by_name:
       workspace_id:
         name_in_index: workspace_id2
   WidgetOrAddressGroupedBy:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       amount_cents2:
         name_in_index: amount_cents
@@ -4177,7 +4345,10 @@ object_types_by_name:
       routing_value_source: id
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Widget
+  WidgetWorkspaceAggregatedValues:
+    default_graphql_resolver: object
   WidgetWorkspaceAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: WidgetWorkspace
   WidgetWorkspaceAggregationConnection:
@@ -4188,6 +4359,12 @@ object_types_by_name:
     elasticgraph_category: relay_connection
   WidgetWorkspaceEdge:
     elasticgraph_category: relay_edge
+  WidgetWorkspaceGroupedBy:
+    default_graphql_resolver: object
+  WorkspaceWidgetAggregatedValues:
+    default_graphql_resolver: object
+  WorkspaceWidgetGroupedBy:
+    default_graphql_resolver: object
 scalar_types_by_name:
   Boolean:
     coercion_adapter:

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -2703,7 +2703,10 @@ object_types_by_name:
       routing_value_source: id
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Address
+  AddressAggregatedValues:
+    default_graphql_resolver: object
   AddressAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: Address
   AddressAggregationConnection:
@@ -2714,11 +2717,22 @@ object_types_by_name:
     elasticgraph_category: relay_connection
   AddressEdge:
     elasticgraph_category: relay_edge
+  AddressGroupedBy:
+    default_graphql_resolver: object
+  AddressTimestampsAggregatedValues:
+    default_graphql_resolver: object
+  AddressTimestampsGroupedBy:
+    default_graphql_resolver: object
+  AffiliationsAggregatedValues:
+    default_graphql_resolver: object
   AffiliationsFieldsListFilterInput:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  AffiliationsGroupedBy:
+    default_graphql_resolver: object
   AggregationCountDetail:
+    default_graphql_resolver: object
     graphql_only_return_type: true
   ColorListFilterInput:
     graphql_fields_by_name:
@@ -2794,10 +2808,12 @@ object_types_by_name:
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Component
   ComponentAggregatedValues:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       widget_workspace_id:
         name_in_index: widget_workspace_id3
   ComponentAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: Component
   ComponentAggregationConnection:
@@ -2813,6 +2829,7 @@ object_types_by_name:
       widget_workspace_id:
         name_in_index: widget_workspace_id3
   ComponentGroupedBy:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       widget_workspace_id:
         name_in_index: widget_workspace_id3
@@ -2828,7 +2845,12 @@ object_types_by_name:
           direction: in
           foreign_key: country_code
         resolver: nested_relationships
+  CurrencyDetailsAggregatedValues:
+    default_graphql_resolver: object
+  CurrencyDetailsGroupedBy:
+    default_graphql_resolver: object
   DateAggregatedValues:
+    default_graphql_resolver: object
     elasticgraph_category: scalar_aggregated_values
     graphql_fields_by_name:
       approximate_avg:
@@ -2846,6 +2868,7 @@ object_types_by_name:
           function: min
     graphql_only_return_type: true
   DateGroupedBy:
+    default_graphql_resolver: object
     elasticgraph_category: date_grouped_by_object
     graphql_only_return_type: true
   DateListFilterInput:
@@ -2853,6 +2876,7 @@ object_types_by_name:
       count:
         name_in_index: __counts
   DateTimeAggregatedValues:
+    default_graphql_resolver: object
     elasticgraph_category: scalar_aggregated_values
     graphql_fields_by_name:
       approximate_avg:
@@ -2870,6 +2894,7 @@ object_types_by_name:
           function: min
     graphql_only_return_type: true
   DateTimeGroupedBy:
+    default_graphql_resolver: object
     elasticgraph_category: date_grouped_by_object
     graphql_only_return_type: true
   DateTimeListFilterInput:
@@ -2921,7 +2946,10 @@ object_types_by_name:
       routing_value_source: id
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: ElectricalPart
+  ElectricalPartAggregatedValues:
+    default_graphql_resolver: object
   ElectricalPartAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: ElectricalPart
   ElectricalPartAggregationConnection:
@@ -2932,7 +2960,10 @@ object_types_by_name:
     elasticgraph_category: relay_connection
   ElectricalPartEdge:
     elasticgraph_category: relay_edge
+  ElectricalPartGroupedBy:
+    default_graphql_resolver: object
   FloatAggregatedValues:
+    default_graphql_resolver: object
     elasticgraph_category: scalar_aggregated_values
     graphql_fields_by_name:
       approximate_avg:
@@ -2964,6 +2995,7 @@ object_types_by_name:
       count:
         name_in_index: __counts
   IntAggregatedValues:
+    default_graphql_resolver: object
     elasticgraph_category: scalar_aggregated_values
     graphql_fields_by_name:
       approximate_avg:
@@ -2992,7 +3024,12 @@ object_types_by_name:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  InventorAggregatedValues:
+    default_graphql_resolver: object
+  InventorGroupedBy:
+    default_graphql_resolver: object
   JsonSafeLongAggregatedValues:
+    default_graphql_resolver: object
     elasticgraph_category: scalar_aggregated_values
     graphql_fields_by_name:
       approximate_avg:
@@ -3022,6 +3059,7 @@ object_types_by_name:
       count:
         name_in_index: __counts
   LocalTimeAggregatedValues:
+    default_graphql_resolver: object
     elasticgraph_category: scalar_aggregated_values
     graphql_fields_by_name:
       approximate_avg:
@@ -3039,6 +3077,7 @@ object_types_by_name:
           function: min
     graphql_only_return_type: true
   LongStringAggregatedValues:
+    default_graphql_resolver: object
     elasticgraph_category: scalar_aggregated_values
     graphql_fields_by_name:
       approximate_avg:
@@ -3110,7 +3149,10 @@ object_types_by_name:
       routing_value_source: id
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Manufacturer
+  ManufacturerAggregatedValues:
+    default_graphql_resolver: object
   ManufacturerAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: Manufacturer
   ManufacturerAggregationConnection:
@@ -3121,6 +3163,8 @@ object_types_by_name:
     elasticgraph_category: relay_connection
   ManufacturerEdge:
     elasticgraph_category: relay_edge
+  ManufacturerGroupedBy:
+    default_graphql_resolver: object
   MechanicalPart:
     graphql_fields_by_name:
       component_aggregations:
@@ -3166,7 +3210,10 @@ object_types_by_name:
       routing_value_source: id
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: MechanicalPart
+  MechanicalPartAggregatedValues:
+    default_graphql_resolver: object
   MechanicalPartAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: MechanicalPart
   MechanicalPartAggregationConnection:
@@ -3177,10 +3224,16 @@ object_types_by_name:
     elasticgraph_category: relay_connection
   MechanicalPartEdge:
     elasticgraph_category: relay_edge
+  MechanicalPartGroupedBy:
+    default_graphql_resolver: object
+  MoneyAggregatedValues:
+    default_graphql_resolver: object
   MoneyFieldsListFilterInput:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  MoneyGroupedBy:
+    default_graphql_resolver: object
   MoneyListFilterInput:
     graphql_fields_by_name:
       count:
@@ -3276,6 +3329,7 @@ object_types_by_name:
       workspace_id:
         name_in_index: workspace_id2
   NamedEntityAggregatedValues:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       amount_cents2:
         name_in_index: amount_cents
@@ -3296,6 +3350,7 @@ object_types_by_name:
       workspace_id:
         name_in_index: workspace_id2
   NamedEntityAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: NamedEntity
   NamedEntityAggregationConnection:
@@ -3327,6 +3382,7 @@ object_types_by_name:
       workspace_id:
         name_in_index: workspace_id2
   NamedEntityGroupedBy:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       amount_cents2:
         name_in_index: amount_cents
@@ -3352,7 +3408,12 @@ object_types_by_name:
         name_in_index: widget_workspace_id3
       workspace_id:
         name_in_index: workspace_id2
+  NamedInventorAggregatedValues:
+    default_graphql_resolver: object
+  NamedInventorGroupedBy:
+    default_graphql_resolver: object
   NonNumericAggregatedValues:
+    default_graphql_resolver: object
     elasticgraph_category: scalar_aggregated_values
     graphql_fields_by_name:
       approximate_distinct_value_count:
@@ -3379,7 +3440,10 @@ object_types_by_name:
           direction: out
           foreign_key: manufacturer_id
         resolver: nested_relationships
+  PartAggregatedValues:
+    default_graphql_resolver: object
   PartAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: Part
   PartAggregationConnection:
@@ -3390,22 +3454,36 @@ object_types_by_name:
     elasticgraph_category: relay_connection
   PartEdge:
     elasticgraph_category: relay_edge
+  PartGroupedBy:
+    default_graphql_resolver: object
+  PlayerAggregatedValues:
+    default_graphql_resolver: object
   PlayerFieldsListFilterInput:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  PlayerGroupedBy:
+    default_graphql_resolver: object
   PlayerListFilterInput:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  PlayerSeasonAggregatedValues:
+    default_graphql_resolver: object
   PlayerSeasonFieldsListFilterInput:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  PlayerSeasonGroupedBy:
+    default_graphql_resolver: object
   PlayerSeasonListFilterInput:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  PositionAggregatedValues:
+    default_graphql_resolver: object
+  PositionGroupedBy:
+    default_graphql_resolver: object
   SizeListFilterInput:
     graphql_fields_by_name:
       count:
@@ -3460,7 +3538,10 @@ object_types_by_name:
       routing_value_source: id
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Sponsor
+  SponsorAggregatedValues:
+    default_graphql_resolver: object
   SponsorAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: Sponsor
   SponsorAggregationConnection:
@@ -3471,10 +3552,16 @@ object_types_by_name:
     elasticgraph_category: relay_connection
   SponsorEdge:
     elasticgraph_category: relay_edge
+  SponsorGroupedBy:
+    default_graphql_resolver: object
+  SponsorshipAggregatedValues:
+    default_graphql_resolver: object
   SponsorshipFieldsListFilterInput:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  SponsorshipGroupedBy:
+    default_graphql_resolver: object
   SponsorshipListFilterInput:
     graphql_fields_by_name:
       count:
@@ -3546,33 +3633,57 @@ object_types_by_name:
       routing_value_source: league
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Team
+  TeamAggregatedValues:
+    default_graphql_resolver: object
   TeamAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: Team
   TeamAggregationConnection:
     elasticgraph_category: relay_connection
+  TeamAggregationCurrentPlayersObjectAffiliationsSubAggregations:
+    default_graphql_resolver: object
+  TeamAggregationCurrentPlayersObjectSubAggregations:
+    default_graphql_resolver: object
   TeamAggregationEdge:
     elasticgraph_category: relay_edge
   TeamAggregationNestedFields2SubAggregations:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       seasons:
         name_in_index: the_seasons
   TeamAggregationNestedFieldsSubAggregations:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       seasons:
         name_in_index: the_seasons
+  TeamAggregationSeasonsObjectPlayersObjectAffiliationsSubAggregations:
+    default_graphql_resolver: object
+  TeamAggregationSeasonsObjectPlayersObjectSubAggregations:
+    default_graphql_resolver: object
+  TeamAggregationSeasonsObjectSubAggregations:
+    default_graphql_resolver: object
   TeamAggregationSubAggregations:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       nested_fields:
         name_in_index: the_nested_fields
   TeamConnection:
     elasticgraph_category: relay_connection
+  TeamDetailsAggregatedValues:
+    default_graphql_resolver: object
+  TeamDetailsGroupedBy:
+    default_graphql_resolver: object
   TeamEdge:
     elasticgraph_category: relay_edge
   TeamFilterInput:
     graphql_fields_by_name:
       nested_fields:
         name_in_index: the_nested_fields
+  TeamGroupedBy:
+    default_graphql_resolver: object
+  TeamMoneySubAggregation:
+    default_graphql_resolver: object
   TeamMoneySubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
   TeamNestedFields:
@@ -3583,14 +3694,26 @@ object_types_by_name:
     graphql_fields_by_name:
       seasons:
         name_in_index: the_seasons
+  TeamPlayerPlayerSeasonSubAggregation:
+    default_graphql_resolver: object
   TeamPlayerPlayerSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamPlayerSeasonSubAggregation:
+    default_graphql_resolver: object
   TeamPlayerSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamPlayerSponsorshipSubAggregation:
+    default_graphql_resolver: object
   TeamPlayerSponsorshipSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamPlayerSubAggregation:
+    default_graphql_resolver: object
+  TeamPlayerSubAggregationAffiliationsSubAggregations:
+    default_graphql_resolver: object
   TeamPlayerSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamPlayerSubAggregationSubAggregations:
+    default_graphql_resolver: object
   TeamRecord:
     graphql_fields_by_name:
       first_win_on_legacy:
@@ -3604,6 +3727,7 @@ object_types_by_name:
       wins:
         name_in_index: win_count
   TeamRecordAggregatedValues:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       first_win_on_legacy:
         name_in_index: first_win_on
@@ -3642,6 +3766,7 @@ object_types_by_name:
       wins:
         name_in_index: win_count
   TeamRecordGroupedBy:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       first_win_on_legacy:
         name_in_index: first_win_on
@@ -3662,6 +3787,7 @@ object_types_by_name:
       won_games_at_legacy:
         name_in_index: won_games_at
   TeamSeasonAggregatedValues:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       record:
         name_in_index: the_record
@@ -3686,6 +3812,7 @@ object_types_by_name:
       won_games_at_legacy:
         name_in_index: won_games_at
   TeamSeasonGroupedBy:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       note:
         name_in_index: notes
@@ -3701,20 +3828,44 @@ object_types_by_name:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  TeamSponsorshipSubAggregation:
+    default_graphql_resolver: object
   TeamSponsorshipSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamTeamSeasonPlayerPlayerSeasonSubAggregation:
+    default_graphql_resolver: object
   TeamTeamSeasonPlayerPlayerSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamTeamSeasonPlayerSeasonSubAggregation:
+    default_graphql_resolver: object
   TeamTeamSeasonPlayerSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamTeamSeasonPlayerSponsorshipSubAggregation:
+    default_graphql_resolver: object
   TeamTeamSeasonPlayerSponsorshipSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamTeamSeasonPlayerSubAggregation:
+    default_graphql_resolver: object
+  TeamTeamSeasonPlayerSubAggregationAffiliationsSubAggregations:
+    default_graphql_resolver: object
   TeamTeamSeasonPlayerSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamTeamSeasonPlayerSubAggregationSubAggregations:
+    default_graphql_resolver: object
+  TeamTeamSeasonSponsorshipSubAggregation:
+    default_graphql_resolver: object
   TeamTeamSeasonSponsorshipSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamTeamSeasonSubAggregation:
+    default_graphql_resolver: object
   TeamTeamSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+  TeamTeamSeasonSubAggregationPlayersObjectAffiliationsSubAggregations:
+    default_graphql_resolver: object
+  TeamTeamSeasonSubAggregationPlayersObjectSubAggregations:
+    default_graphql_resolver: object
+  TeamTeamSeasonSubAggregationSubAggregations:
+    default_graphql_resolver: object
   Widget:
     graphql_fields_by_name:
       amount_cents2:
@@ -3883,6 +4034,7 @@ object_types_by_name:
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Component
   WidgetAggregatedValues:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       amount_cents2:
         name_in_index: amount_cents
@@ -3901,6 +4053,7 @@ object_types_by_name:
       workspace_id:
         name_in_index: workspace_id2
   WidgetAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: Widget
   WidgetAggregationConnection:
@@ -3955,10 +4108,12 @@ object_types_by_name:
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: WidgetCurrency
   WidgetCurrencyAggregatedValues:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       widget_names:
         name_in_index: widget_names2
   WidgetCurrencyAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: WidgetCurrency
   WidgetCurrencyAggregationConnection:
@@ -3974,9 +4129,14 @@ object_types_by_name:
       widget_names:
         name_in_index: widget_names2
   WidgetCurrencyGroupedBy:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       widget_name:
         name_in_index: widget_names2
+  WidgetCurrencyNestedFieldsAggregatedValues:
+    default_graphql_resolver: object
+  WidgetCurrencyNestedFieldsGroupedBy:
+    default_graphql_resolver: object
   WidgetEdge:
     elasticgraph_category: relay_edge
   WidgetFilterInput:
@@ -3998,6 +4158,7 @@ object_types_by_name:
       workspace_id:
         name_in_index: workspace_id2
   WidgetGroupedBy:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       amount_cents2:
         name_in_index: amount_cents
@@ -4021,11 +4182,14 @@ object_types_by_name:
         name_in_index: the_opts
       workspace_id:
         name_in_index: workspace_id2
+  WidgetOptionSetsAggregatedValues:
+    default_graphql_resolver: object
   WidgetOptions:
     graphql_fields_by_name:
       the_size:
         name_in_index: the_sighs
   WidgetOptionsAggregatedValues:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       the_size:
         name_in_index: the_sighs
@@ -4034,6 +4198,7 @@ object_types_by_name:
       the_size:
         name_in_index: the_sighs
   WidgetOptionsGroupedBy:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       the_size:
         name_in_index: the_sighs
@@ -4076,6 +4241,7 @@ object_types_by_name:
       workspace_id:
         name_in_index: workspace_id2
   WidgetOrAddressAggregatedValues:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       amount_cents2:
         name_in_index: amount_cents
@@ -4094,6 +4260,7 @@ object_types_by_name:
       workspace_id:
         name_in_index: workspace_id2
   WidgetOrAddressAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: WidgetOrAddress
   WidgetOrAddressAggregationConnection:
@@ -4123,6 +4290,7 @@ object_types_by_name:
       workspace_id:
         name_in_index: workspace_id2
   WidgetOrAddressGroupedBy:
+    default_graphql_resolver: object
     graphql_fields_by_name:
       amount_cents2:
         name_in_index: amount_cents
@@ -4192,7 +4360,10 @@ object_types_by_name:
       routing_value_source: id
       script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
       type: Widget
+  WidgetWorkspaceAggregatedValues:
+    default_graphql_resolver: object
   WidgetWorkspaceAggregation:
+    default_graphql_resolver: object
     elasticgraph_category: indexed_aggregation
     source_type: WidgetWorkspace
   WidgetWorkspaceAggregationConnection:
@@ -4203,6 +4374,12 @@ object_types_by_name:
     elasticgraph_category: relay_connection
   WidgetWorkspaceEdge:
     elasticgraph_category: relay_edge
+  WidgetWorkspaceGroupedBy:
+    default_graphql_resolver: object
+  WorkspaceWidgetAggregatedValues:
+    default_graphql_resolver: object
+  WorkspaceWidgetGroupedBy:
+    default_graphql_resolver: object
   _Entity:
     graphql_only_return_type: true
   _Service:

--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -185,6 +185,7 @@ module ElasticGraph
     def named_graphql_resolvers
       @named_graphql_resolvers ||= begin
         require "elastic_graph/graphql/resolvers/nested_relationships"
+        require "elastic_graph/graphql/resolvers/object"
 
         nested_relationships = Resolvers::NestedRelationships.new(
           resolver_query_adapter: resolver_query_adapter,
@@ -192,7 +193,10 @@ module ElasticGraph
           logger: logger
         )
 
-        {nested_relationships: nested_relationships}
+        {
+          nested_relationships: nested_relationships,
+          object: Resolvers::Object.new
+        }
       end
     end
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rb
@@ -15,10 +15,6 @@ module ElasticGraph
     module Aggregation
       module Resolvers
         class AggregatedValues < ::Data.define(:aggregation_name, :bucket, :field_path)
-          def can_resolve?(field:, object:)
-            true
-          end
-
           def call(parent_type, graphql_field, object, args, context)
             field = context.fetch(:elastic_graph_schema).field_named(parent_type.graphql_name, graphql_field.name)
             return with(field_path: field_path + [PathSegment.for(field: field, lookahead: args.fetch(:lookahead))]) if field.type.object?

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/grouped_by.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/grouped_by.rb
@@ -14,10 +14,6 @@ module ElasticGraph
     module Aggregation
       module Resolvers
         class GroupedBy < ::Data.define(:bucket, :field_path)
-          def can_resolve?(field:, object:)
-            true
-          end
-
           def call(parent_type, graphql_field, object, args, context)
             field = context.fetch(:elastic_graph_schema).field_named(parent_type.graphql_name, graphql_field.name)
             new_field_path = field_path + [PathSegment.for(field: field, lookahead: args.fetch(:lookahead))]

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/sub_aggregations.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/sub_aggregations.rb
@@ -20,10 +20,6 @@ module ElasticGraph
     module Aggregation
       module Resolvers
         class SubAggregations < ::Data.define(:schema_element_names, :sub_aggregations, :parent_queries, :sub_aggs_by_agg_key, :field_path)
-          def can_resolve?(field:, object:)
-            true
-          end
-
           def call(parent_type, graphql_field, object, args, context)
             field = context.fetch(:elastic_graph_schema).field_named(parent_type.graphql_name, graphql_field.name)
             path_segment = PathSegment.for(field: field, lookahead: args.fetch(:lookahead))

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/object.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/object.rb
@@ -1,0 +1,20 @@
+# Copyright 2024 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+module ElasticGraph
+  class GraphQL
+    module Resolvers
+      # Resolver which just delegates to `object` for resolving.
+      class Object
+        def call(parent_type, graphql_field, object, args, context)
+          object.call(parent_type, graphql_field, object, args, context)
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/field.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/field.rb
@@ -27,7 +27,7 @@ module ElasticGraph
           @graphql_field = graphql_field
           @relation = runtime_metadata&.relation
           @computation_detail = runtime_metadata&.computation_detail
-          @resolver = runtime_metadata&.resolver
+          @resolver = runtime_metadata&.resolver || parent_type.default_graphql_resolver
           @name_in_index = runtime_metadata&.name_in_index&.to_sym || name
 
           # Adds the :extras required by ElasticGraph. For now, this blindly adds `:lookahead`

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/type.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/type.rb
@@ -17,7 +17,7 @@ module ElasticGraph
     class Schema
       # Represents a GraphQL type.
       class Type
-        attr_reader :graphql_type, :fields_by_name, :index_definitions, :elasticgraph_category, :graphql_only_return_type
+        attr_reader :graphql_type, :fields_by_name, :index_definitions, :elasticgraph_category, :graphql_only_return_type, :default_graphql_resolver
 
         def initialize(
           schema,
@@ -36,6 +36,7 @@ module ElasticGraph
           @object_runtime_metadata = object_runtime_metadata
           @elasticgraph_category = object_runtime_metadata&.elasticgraph_category
           @graphql_only_return_type = object_runtime_metadata&.graphql_only_return_type
+          @default_graphql_resolver = object_runtime_metadata&.default_graphql_resolver
           @enum_runtime_metadata = enum_runtime_metadata
           @enum_value_names_by_original_name = (enum_runtime_metadata&.values_by_name || {}).to_h do |name, value|
             [value.alternate_original_name || name, name]

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/interfaces.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/interfaces.rbs
@@ -4,7 +4,6 @@ module ElasticGraph
       type fieldArgs = ::Hash[::Symbol, untyped]
 
       interface _Resolver
-        def can_resolve?: (field: Schema::Field, object: untyped) -> bool
         def call: (
           ::GraphQL::Schema::_Type,
           ::GraphQL::Schema::Field,

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/object.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/object.rbs
@@ -1,0 +1,9 @@
+module ElasticGraph
+  class GraphQL
+    module Resolvers
+      class Object
+        include _Resolver
+      end
+    end
+  end
+end

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
@@ -272,7 +272,10 @@ module ElasticGraph
         new_object_type @state.type_ref(index_leaf_type).as_aggregated_values.name do |type|
           type.graphql_only true
           type.documentation "A return type used from aggregations to provided aggregated values over `#{index_leaf_type}` fields."
-          type.runtime_metadata_overrides = {elasticgraph_category: :scalar_aggregated_values}
+          type.runtime_metadata_overrides = {
+            elasticgraph_category: :scalar_aggregated_values,
+            default_graphql_resolver: :object
+          }
 
           type.field @state.schema_elements.approximate_distinct_value_count, "JsonSafeLong", graphql_only: true do |f|
             # Note: the 1-6% accuracy figure comes from the Elasticsearch docs:

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_filtering_and_aggregation.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_filtering_and_aggregation.rb
@@ -116,6 +116,7 @@ module ElasticGraph
             schema_def_state.sub_aggregation_paths_for(nested_field_ref.parent_type).map do |path|
               schema_def_state.factory.new_object_type type_ref.as_sub_aggregation(parent_doc_types: path.parent_doc_types).name do |t|
                 t.documentation "Return type representing a bucket of `#{name}` objects for a sub-aggregation within each `#{type_ref.as_parent_aggregation(parent_doc_types: path.parent_doc_types).name}`."
+                t.runtime_metadata_overrides = {default_graphql_resolver: :object}
 
                 t.field schema_def_state.schema_elements.count_detail, "AggregationCountDetail", graphql_only: true do |f|
                   f.documentation "Details of the count of `#{name}` documents in a sub-aggregation bucket."
@@ -163,6 +164,7 @@ module ElasticGraph
             schema_def_state.factory.new_object_type agg_sub_aggs_type_ref.name do |t|
               under_field_description = "under `#{path.field_path_string}` " unless path.field_path.empty?
               t.documentation "Provides access to the `#{schema_def_state.schema_elements.sub_aggregations}` #{under_field_description}within each `#{type_ref.as_parent_aggregation(parent_doc_types: path.parent_doc_types).name}`."
+              t.runtime_metadata_overrides = {default_graphql_resolver: :object}
 
               sub_aggregatable_fields.each do |field|
                 if field.nested?
@@ -225,7 +227,11 @@ module ElasticGraph
 
             # Record metadata that is necessary for elasticgraph-graphql to correctly recognize and handle
             # this indexed aggregation type correctly.
-            t.runtime_metadata_overrides = {source_type: name, elasticgraph_category: :indexed_aggregation}
+            t.runtime_metadata_overrides = {
+              source_type: name,
+              elasticgraph_category: :indexed_aggregation,
+              default_graphql_resolver: :object
+            }
           end
         end
 
@@ -236,6 +242,7 @@ module ElasticGraph
 
           new_non_empty_object_type type_ref.as_grouped_by.name do |t|
             t.documentation "Type used to specify the `#{name}` fields to group by for aggregations."
+            t.runtime_metadata_overrides = {default_graphql_resolver: :object}
 
             graphql_fields_by_name.values.each do |field|
               field.define_grouped_by_field(t)
@@ -250,6 +257,7 @@ module ElasticGraph
 
           new_non_empty_object_type type_ref.as_aggregated_values.name do |t|
             t.documentation "Type used to perform aggregation computations on `#{name}` fields."
+            t.runtime_metadata_overrides = {default_graphql_resolver: :object}
 
             graphql_fields_by_name.values.each do |field|
               field.define_aggregated_values_field(t)

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
@@ -509,6 +509,7 @@ module ElasticGraph
 
           register_framework_object_type "AggregationCountDetail" do |t|
             t.documentation "Provides detail about an aggregation `#{names.count}`."
+            t.runtime_metadata_overrides = {default_graphql_resolver: :object}
 
             t.field names.approximate_value, "JsonSafeLong!", graphql_only: true do |f|
               f.documentation <<~EOS
@@ -1290,7 +1291,10 @@ module ElasticGraph
           date = schema_def_state.type_ref("Date")
           register_framework_object_type date.as_grouped_by.name do |t|
             t.documentation "Allows for grouping `Date` values based on the desired return type."
-            t.runtime_metadata_overrides = {elasticgraph_category: :date_grouped_by_object}
+            t.runtime_metadata_overrides = {
+              elasticgraph_category: :date_grouped_by_object,
+              default_graphql_resolver: :object
+            }
 
             t.field names.as_date, "Date", graphql_only: true do |f|
               f.documentation "Used when grouping on the full `Date` value."
@@ -1307,7 +1311,10 @@ module ElasticGraph
           date_time = schema_def_state.type_ref("DateTime")
           register_framework_object_type date_time.as_grouped_by.name do |t|
             t.documentation "Allows for grouping `DateTime` values based on the desired return type."
-            t.runtime_metadata_overrides = {elasticgraph_category: :date_grouped_by_object}
+            t.runtime_metadata_overrides = {
+              elasticgraph_category: :date_grouped_by_object,
+              default_graphql_resolver: :object
+            }
 
             t.field names.as_date_time, "DateTime", graphql_only: true do |f|
               f.documentation "Used when grouping on the full `DateTime` value."

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/pruning_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/pruning_spec.rb
@@ -71,7 +71,9 @@ module ElasticGraph
           LongStringAggregatedValues
           LongStringListFilterInput
           MatchesQueryAllowedEditsPerTermListFilterInput
+          NoCustomizationsAggregatedValues
           NoCustomizationsFieldsListFilterInput
+          NoCustomizationsGroupedBy
           NoCustomizationsListFilterInput
           NonNumericAggregatedValues
           PageInfo


### PR DESCRIPTION
This will allow us to make further refactorings to improve performance by relying upon the GraphQL gem's internal dispatch system.