### PR TITLE
Use new `resolver` metadata for pagination type resolvers.

### DIFF
--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -2707,12 +2707,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: Address
   AddressAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   AddressAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   AddressConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   AddressEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   AddressGroupedBy:
     default_graphql_resolver: object
@@ -2814,12 +2818,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: Component
   ComponentAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   ComponentAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   ComponentConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   ComponentEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   ComponentFilterInput:
     graphql_fields_by_name:
@@ -2938,12 +2946,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: ElectricalPart
   ElectricalPartAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   ElectricalPartAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   ElectricalPartConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   ElectricalPartEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   ElectricalPartGroupedBy:
     default_graphql_resolver: object
@@ -3141,12 +3153,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: Manufacturer
   ManufacturerAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   ManufacturerAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   ManufacturerConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   ManufacturerEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   ManufacturerGroupedBy:
     default_graphql_resolver: object
@@ -3202,12 +3218,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: MechanicalPart
   MechanicalPartAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   MechanicalPartAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   MechanicalPartConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   MechanicalPartEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   MechanicalPartGroupedBy:
     default_graphql_resolver: object
@@ -3339,12 +3359,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: NamedEntity
   NamedEntityAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   NamedEntityAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   NamedEntityConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   NamedEntityEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   NamedEntityFilterInput:
     graphql_fields_by_name:
@@ -3407,6 +3431,7 @@ object_types_by_name:
           function: cardinality
     graphql_only_return_type: true
   PageInfo:
+    default_graphql_resolver: object
     graphql_only_return_type: true
   Part:
     graphql_fields_by_name:
@@ -3432,12 +3457,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: Part
   PartAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   PartAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   PartConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   PartEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   PartGroupedBy:
     default_graphql_resolver: object
@@ -3530,12 +3559,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: Sponsor
   SponsorAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   SponsorAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   SponsorConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   SponsorEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   SponsorGroupedBy:
     default_graphql_resolver: object
@@ -3552,8 +3585,10 @@ object_types_by_name:
       count:
         name_in_index: __counts
   StringConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   StringEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   StringListFilterInput:
     graphql_fields_by_name:
@@ -3625,12 +3660,14 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: Team
   TeamAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   TeamAggregationCurrentPlayersObjectAffiliationsSubAggregations:
     default_graphql_resolver: object
   TeamAggregationCurrentPlayersObjectSubAggregations:
     default_graphql_resolver: object
   TeamAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   TeamAggregationNestedFields2SubAggregations:
     default_graphql_resolver: object
@@ -3654,12 +3691,14 @@ object_types_by_name:
       nested_fields:
         name_in_index: the_nested_fields
   TeamConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   TeamDetailsAggregatedValues:
     default_graphql_resolver: object
   TeamDetailsGroupedBy:
     default_graphql_resolver: object
   TeamEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   TeamFilterInput:
     graphql_fields_by_name:
@@ -3670,6 +3709,7 @@ object_types_by_name:
   TeamMoneySubAggregation:
     default_graphql_resolver: object
   TeamMoneySubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamNestedFields:
     graphql_fields_by_name:
@@ -3682,20 +3722,24 @@ object_types_by_name:
   TeamPlayerPlayerSeasonSubAggregation:
     default_graphql_resolver: object
   TeamPlayerPlayerSeasonSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamPlayerSeasonSubAggregation:
     default_graphql_resolver: object
   TeamPlayerSeasonSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamPlayerSponsorshipSubAggregation:
     default_graphql_resolver: object
   TeamPlayerSponsorshipSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamPlayerSubAggregation:
     default_graphql_resolver: object
   TeamPlayerSubAggregationAffiliationsSubAggregations:
     default_graphql_resolver: object
   TeamPlayerSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamPlayerSubAggregationSubAggregations:
     default_graphql_resolver: object
@@ -3816,34 +3860,41 @@ object_types_by_name:
   TeamSponsorshipSubAggregation:
     default_graphql_resolver: object
   TeamSponsorshipSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamTeamSeasonPlayerPlayerSeasonSubAggregation:
     default_graphql_resolver: object
   TeamTeamSeasonPlayerPlayerSeasonSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamTeamSeasonPlayerSeasonSubAggregation:
     default_graphql_resolver: object
   TeamTeamSeasonPlayerSeasonSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamTeamSeasonPlayerSponsorshipSubAggregation:
     default_graphql_resolver: object
   TeamTeamSeasonPlayerSponsorshipSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamTeamSeasonPlayerSubAggregation:
     default_graphql_resolver: object
   TeamTeamSeasonPlayerSubAggregationAffiliationsSubAggregations:
     default_graphql_resolver: object
   TeamTeamSeasonPlayerSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamTeamSeasonPlayerSubAggregationSubAggregations:
     default_graphql_resolver: object
   TeamTeamSeasonSponsorshipSubAggregation:
     default_graphql_resolver: object
   TeamTeamSeasonSponsorshipSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamTeamSeasonSubAggregation:
     default_graphql_resolver: object
   TeamTeamSeasonSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamTeamSeasonSubAggregationPlayersObjectAffiliationsSubAggregations:
     default_graphql_resolver: object
@@ -4042,10 +4093,13 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: Widget
   WidgetAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   WidgetAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   WidgetConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   WidgetCurrency:
     graphql_fields_by_name:
@@ -4102,12 +4156,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: WidgetCurrency
   WidgetCurrencyAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   WidgetCurrencyAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   WidgetCurrencyConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   WidgetCurrencyEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   WidgetCurrencyFilterInput:
     graphql_fields_by_name:
@@ -4123,6 +4181,7 @@ object_types_by_name:
   WidgetCurrencyNestedFieldsGroupedBy:
     default_graphql_resolver: object
   WidgetEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   WidgetFilterInput:
     graphql_fields_by_name:
@@ -4249,12 +4308,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: WidgetOrAddress
   WidgetOrAddressAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   WidgetOrAddressAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   WidgetOrAddressConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   WidgetOrAddressEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   WidgetOrAddressFilterInput:
     graphql_fields_by_name:
@@ -4352,12 +4415,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: WidgetWorkspace
   WidgetWorkspaceAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   WidgetWorkspaceAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   WidgetWorkspaceConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   WidgetWorkspaceEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   WidgetWorkspaceGroupedBy:
     default_graphql_resolver: object

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -2710,12 +2710,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: Address
   AddressAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   AddressAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   AddressConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   AddressEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   AddressGroupedBy:
     default_graphql_resolver: object
@@ -2817,12 +2821,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: Component
   ComponentAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   ComponentAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   ComponentConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   ComponentEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   ComponentFilterInput:
     graphql_fields_by_name:
@@ -2953,12 +2961,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: ElectricalPart
   ElectricalPartAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   ElectricalPartAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   ElectricalPartConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   ElectricalPartEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   ElectricalPartGroupedBy:
     default_graphql_resolver: object
@@ -3156,12 +3168,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: Manufacturer
   ManufacturerAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   ManufacturerAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   ManufacturerConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   ManufacturerEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   ManufacturerGroupedBy:
     default_graphql_resolver: object
@@ -3217,12 +3233,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: MechanicalPart
   MechanicalPartAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   MechanicalPartAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   MechanicalPartConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   MechanicalPartEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   MechanicalPartGroupedBy:
     default_graphql_resolver: object
@@ -3354,12 +3374,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: NamedEntity
   NamedEntityAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   NamedEntityAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   NamedEntityConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   NamedEntityEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   NamedEntityFilterInput:
     graphql_fields_by_name:
@@ -3422,6 +3446,7 @@ object_types_by_name:
           function: cardinality
     graphql_only_return_type: true
   PageInfo:
+    default_graphql_resolver: object
     graphql_only_return_type: true
   Part:
     graphql_fields_by_name:
@@ -3447,12 +3472,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: Part
   PartAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   PartAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   PartConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   PartEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   PartGroupedBy:
     default_graphql_resolver: object
@@ -3545,12 +3574,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: Sponsor
   SponsorAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   SponsorAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   SponsorConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   SponsorEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   SponsorGroupedBy:
     default_graphql_resolver: object
@@ -3567,8 +3600,10 @@ object_types_by_name:
       count:
         name_in_index: __counts
   StringConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   StringEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   StringListFilterInput:
     graphql_fields_by_name:
@@ -3640,12 +3675,14 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: Team
   TeamAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   TeamAggregationCurrentPlayersObjectAffiliationsSubAggregations:
     default_graphql_resolver: object
   TeamAggregationCurrentPlayersObjectSubAggregations:
     default_graphql_resolver: object
   TeamAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   TeamAggregationNestedFields2SubAggregations:
     default_graphql_resolver: object
@@ -3669,12 +3706,14 @@ object_types_by_name:
       nested_fields:
         name_in_index: the_nested_fields
   TeamConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   TeamDetailsAggregatedValues:
     default_graphql_resolver: object
   TeamDetailsGroupedBy:
     default_graphql_resolver: object
   TeamEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   TeamFilterInput:
     graphql_fields_by_name:
@@ -3685,6 +3724,7 @@ object_types_by_name:
   TeamMoneySubAggregation:
     default_graphql_resolver: object
   TeamMoneySubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamNestedFields:
     graphql_fields_by_name:
@@ -3697,20 +3737,24 @@ object_types_by_name:
   TeamPlayerPlayerSeasonSubAggregation:
     default_graphql_resolver: object
   TeamPlayerPlayerSeasonSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamPlayerSeasonSubAggregation:
     default_graphql_resolver: object
   TeamPlayerSeasonSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamPlayerSponsorshipSubAggregation:
     default_graphql_resolver: object
   TeamPlayerSponsorshipSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamPlayerSubAggregation:
     default_graphql_resolver: object
   TeamPlayerSubAggregationAffiliationsSubAggregations:
     default_graphql_resolver: object
   TeamPlayerSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamPlayerSubAggregationSubAggregations:
     default_graphql_resolver: object
@@ -3831,34 +3875,41 @@ object_types_by_name:
   TeamSponsorshipSubAggregation:
     default_graphql_resolver: object
   TeamSponsorshipSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamTeamSeasonPlayerPlayerSeasonSubAggregation:
     default_graphql_resolver: object
   TeamTeamSeasonPlayerPlayerSeasonSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamTeamSeasonPlayerSeasonSubAggregation:
     default_graphql_resolver: object
   TeamTeamSeasonPlayerSeasonSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamTeamSeasonPlayerSponsorshipSubAggregation:
     default_graphql_resolver: object
   TeamTeamSeasonPlayerSponsorshipSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamTeamSeasonPlayerSubAggregation:
     default_graphql_resolver: object
   TeamTeamSeasonPlayerSubAggregationAffiliationsSubAggregations:
     default_graphql_resolver: object
   TeamTeamSeasonPlayerSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamTeamSeasonPlayerSubAggregationSubAggregations:
     default_graphql_resolver: object
   TeamTeamSeasonSponsorshipSubAggregation:
     default_graphql_resolver: object
   TeamTeamSeasonSponsorshipSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamTeamSeasonSubAggregation:
     default_graphql_resolver: object
   TeamTeamSeasonSubAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: nested_sub_aggregation_connection
   TeamTeamSeasonSubAggregationPlayersObjectAffiliationsSubAggregations:
     default_graphql_resolver: object
@@ -4057,10 +4108,13 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: Widget
   WidgetAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   WidgetAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   WidgetConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   WidgetCurrency:
     graphql_fields_by_name:
@@ -4117,12 +4171,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: WidgetCurrency
   WidgetCurrencyAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   WidgetCurrencyAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   WidgetCurrencyConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   WidgetCurrencyEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   WidgetCurrencyFilterInput:
     graphql_fields_by_name:
@@ -4138,6 +4196,7 @@ object_types_by_name:
   WidgetCurrencyNestedFieldsGroupedBy:
     default_graphql_resolver: object
   WidgetEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   WidgetFilterInput:
     graphql_fields_by_name:
@@ -4264,12 +4323,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: WidgetOrAddress
   WidgetOrAddressAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   WidgetOrAddressAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   WidgetOrAddressConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   WidgetOrAddressEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   WidgetOrAddressFilterInput:
     graphql_fields_by_name:
@@ -4367,12 +4430,16 @@ object_types_by_name:
     elasticgraph_category: indexed_aggregation
     source_type: WidgetWorkspace
   WidgetWorkspaceAggregationConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   WidgetWorkspaceAggregationEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   WidgetWorkspaceConnection:
+    default_graphql_resolver: object
     elasticgraph_category: relay_connection
   WidgetWorkspaceEdge:
+    default_graphql_resolver: object
     elasticgraph_category: relay_edge
   WidgetWorkspaceGroupedBy:
     default_graphql_resolver: object

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter.rb
@@ -71,7 +71,6 @@ module ElasticGraph
             return @named_resolvers.fetch(resolver_name)
           end
 
-          return object if object.respond_to?(:can_resolve?) && object.can_resolve?(field: field, object: object)
           resolver = @resolvers.find { |r| r.can_resolve?(field: field, object: object) }
           resolver || yield
         end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/resolvable_value.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/resolvable_value.rb
@@ -34,11 +34,6 @@ module ElasticGraph
           public_send(method_name, **args_to_canonical_form(args))
         end
 
-        def can_resolve?(field:, object:)
-          method_name = schema_element_names.canonical_name_for(field.name)
-          !!method_name && respond_to?(method_name)
-        end
-
         private
 
         def args_to_canonical_form(args)

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
@@ -143,30 +143,6 @@ module ElasticGraph
             end
           end
 
-          describe "#can_resolve?" do
-            it "returns `false` if the field name is not defined in the schema elements" do
-              expect(can_resolve?(field: :last_name)).to be false
-            end
-
-            it "returns `false` if no method matching the field name is defined on the object" do
-              expect(can_resolve?(field: :age)).to be false
-            end
-
-            it "returns `true` if the field name is a defined schema element and the object has a matching method" do
-              expect(can_resolve?(field: :name)).to be true
-              expect(can_resolve?(field: :first_name)).to be true
-            end
-
-            it "considers if the method is defined using the canonical form of the field name" do
-              expect(can_resolve?(name_form: :camelCase, field: :firstName)).to be true
-            end
-
-            def can_resolve?(**options)
-              person, field = person_object_and_schema_field(**options)
-              person.can_resolve?(field: field, object: person)
-            end
-          end
-
           define_method :person_object_and_schema_field do |
             field:, name_form: :snake_case, overrides: {},
             name: "John", birth_date: "2002-09-01", quote: "To be, or not to be, that is the question."

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
@@ -436,7 +436,10 @@ module ElasticGraph
         type_ref = @state.type_ref(type_name)
         new_object_type type_ref.as_edge.name do |t|
           t.relay_pagination_type = true
-          t.runtime_metadata_overrides = {elasticgraph_category: :relay_edge}
+          t.runtime_metadata_overrides = {
+            elasticgraph_category: :relay_edge,
+            default_graphql_resolver: :object
+          }
 
           t.documentation <<~EOS
             Represents a specific `#{type_name}` in the context of a `#{type_ref.as_connection.name}`,
@@ -463,7 +466,10 @@ module ElasticGraph
         type_ref = @state.type_ref(type_name)
         new_object_type type_ref.as_connection.name do |t|
           t.relay_pagination_type = true
-          t.runtime_metadata_overrides = {elasticgraph_category: :relay_connection}
+          t.runtime_metadata_overrides = {
+            elasticgraph_category: :relay_connection,
+            default_graphql_resolver: :object
+          }
 
           if support_pagination
             t.documentation <<~EOS

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_filtering_and_aggregation.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_filtering_and_aggregation.rb
@@ -45,7 +45,10 @@ module ElasticGraph
             [type] + schema_def_state.factory.build_relay_pagination_types(type.name, support_pagination: false) do |t|
               # Record metadata that is necessary for elasticgraph-graphql to correctly recognize and handle
               # this sub-aggregation correctly.
-              t.runtime_metadata_overrides = {elasticgraph_category: :nested_sub_aggregation_connection}
+              t.runtime_metadata_overrides = {
+                elasticgraph_category: :nested_sub_aggregation_connection,
+                default_graphql_resolver: :object
+              }
             end
           end
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
@@ -393,6 +393,8 @@ module ElasticGraph
           # to go from non-null to null, but is not a breaking change to make it non-null
           # in the future.
           register_framework_object_type "PageInfo" do |t|
+            t.runtime_metadata_overrides = {default_graphql_resolver: :object}
+
             t.documentation <<~EOS
               Provides information about the specific fetched page. This implements the `PageInfo`
               specification from the [Relay GraphQL Cursor Connections


### PR DESCRIPTION
This will allow us to make further refactorings to improve performance by relying upon the GraphQL gem's internal dispatch system.