### PR TITLE
Refactor: split `GetRecordFieldValue` resolver.

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -36,7 +36,6 @@ target :elasticgraph_gems do
     elasticgraph-graphql/lib/elastic_graph/graphql/datastore_search_router.rb
     elasticgraph-graphql/lib/elastic_graph/graphql/monkey_patches/schema_field.rb
     elasticgraph-graphql/lib/elastic_graph/graphql/monkey_patches/schema_object.rb
-    elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/get_record_field_value.rb
     elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter.rb
     elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/list_records.rb
     elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships.rb

--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -166,18 +166,15 @@ module ElasticGraph
     # @private
     def graphql_resolvers
       @graphql_resolvers ||= begin
-        require "elastic_graph/graphql/resolvers/get_record_field_value"
+        require "elastic_graph/graphql/resolvers/document"
+        require "elastic_graph/graphql/resolvers/hash"
         require "elastic_graph/graphql/resolvers/list_records"
 
-        list_records = Resolvers::ListRecords.new(
-          resolver_query_adapter: resolver_query_adapter
-        )
+        list_records = Resolvers::ListRecords.new(resolver_query_adapter: resolver_query_adapter)
+        hash = Resolvers::Hash.new(schema_element_names: runtime_metadata.schema_element_names)
+        document = Resolvers::Document.new(hash_resolver: hash)
 
-        get_record_field_value = Resolvers::GetRecordFieldValue.new(
-          schema_element_names: runtime_metadata.schema_element_names
-        )
-
-        [list_records, get_record_field_value]
+        [list_records, hash, document]
       end
     end
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/document.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/document.rb
@@ -1,0 +1,32 @@
+# Copyright 2024 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/graphql/datastore_response/document"
+require "elastic_graph/graphql/resolvers/relay_connection/array_adapter"
+require "elastic_graph/support/hash_util"
+
+module ElasticGraph
+  class GraphQL
+    module Resolvers
+      # Responsible for fetching a single field value from a datastore document.
+      class Document
+        def initialize(hash_resolver:)
+          @hash_resolver = hash_resolver
+        end
+
+        def can_resolve?(field:, object:)
+          object.is_a?(DatastoreResponse::Document)
+        end
+
+        def call(parent_type, graphql_field, object, args, context)
+          @hash_resolver.call(parent_type, graphql_field, object.payload, args, context)
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/hash.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/hash.rb
@@ -13,28 +13,21 @@ require "elastic_graph/support/hash_util"
 module ElasticGraph
   class GraphQL
     module Resolvers
-      # Responsible for fetching a single field value from a document.
-      class GetRecordFieldValue
+      # Responsible for fetching a single field value from a Ruby hash.
+      class Hash
         def initialize(schema_element_names:)
           @schema_element_names = schema_element_names
         end
 
         def can_resolve?(field:, object:)
-          object.is_a?(DatastoreResponse::Document) || object.is_a?(::Hash)
+          object.is_a?(::Hash)
         end
 
         def call(parent_type, graphql_field, object, args, context)
           field = context.fetch(:elastic_graph_schema).field_named(parent_type.graphql_name, graphql_field.name)
           field_name = field.name_in_index.to_s
-          data =
-            case object
-            when DatastoreResponse::Document
-              object.payload
-            else
-              object
-            end
 
-          value = Support::HashUtil.fetch_value_at_path(data, field_name) do
+          value = Support::HashUtil.fetch_value_at_path(object, field_name) do
             field.type.list? ? [] : nil
           end
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/document.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/document.rbs
@@ -1,0 +1,15 @@
+module ElasticGraph
+  class GraphQL
+    module Resolvers
+      class Document
+        include _Resolver
+
+        @hash_resolver: Resolvers::Hash
+
+        def initialize: (
+          hash_resolver: Resolvers::Hash
+        ) -> void
+      end
+    end
+  end
+end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/hash.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/hash.rbs
@@ -1,8 +1,10 @@
 module ElasticGraph
   class GraphQL
     module Resolvers
-      class GetRecordFieldValue
+      class Hash
         include _Resolver
+
+        @schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames
 
         def initialize: (
           schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames

--- a/elasticgraph-graphql/spec/support/resolver.rb
+++ b/elasticgraph-graphql/spec/support/resolver.rb
@@ -82,6 +82,10 @@ RSpec.shared_context "resolver support" do
           graphql.runtime_metadata.schema_element_names
         elsif dep_name == :resolver_query_adapter
           resolver_query_adapter
+        elsif dep_name == :hash_resolver
+          ElasticGraph::GraphQL::Resolvers::Hash.new(
+            schema_element_names: graphql.runtime_metadata.schema_element_names
+          )
         else
           graphql.public_send(dep_name)
         end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/document_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/document_spec.rb
@@ -1,0 +1,25 @@
+# Copyright 2024 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/graphql/resolvers/document"
+require_relative "hash_or_document_shared_examples"
+
+module ElasticGraph
+  class GraphQL
+    module Resolvers
+      RSpec.describe Document, :capture_logs, :resolver do
+        include_examples "Hash or Document resolver"
+
+        def resolve(type_name, field_name, hash, **options)
+          doc = DatastoreResponse::Document.with_payload(hash)
+          super(type_name, field_name, doc, **options)
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/hash_or_document_shared_examples.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/hash_or_document_shared_examples.rb
@@ -6,13 +6,10 @@
 #
 # frozen_string_literal: true
 
-require "elastic_graph/graphql/datastore_response/document"
-require "elastic_graph/graphql/resolvers/get_record_field_value"
-
 module ElasticGraph
   class GraphQL
     module Resolvers
-      RSpec.describe GetRecordFieldValue, :capture_logs, :resolver do
+      RSpec.shared_examples_for "Hash or Document resolver", :capture_logs, :resolver do
         attr_accessor :schema_artifacts
 
         before(:context) do
@@ -47,13 +44,6 @@ module ElasticGraph
         context "for a field without customizations" do
           it "fetches a requested scalar field from the document" do
             value = resolve(:Person, :name, {"id" => 1, "name" => "Napoleon"})
-
-            expect(value).to eq "Napoleon"
-          end
-
-          it "works with an `DatastoreResponse::Document`" do
-            doc = DatastoreResponse::Document.with_payload("id" => 1, "name" => "Napoleon")
-            value = resolve(:Person, :name, doc)
 
             expect(value).to eq "Napoleon"
           end
@@ -102,13 +92,6 @@ module ElasticGraph
 
             expect(value1).to eq "Napoleon"
             expect(value2).to eq "Napoleon"
-          end
-
-          it "works with an `DatastoreResponse::Document`" do
-            doc = DatastoreResponse::Document.with_payload("id" => 1, "name" => "Napoleon")
-            value = resolve(:Person, :alt_name1, doc)
-
-            expect(value).to eq "Napoleon"
           end
 
           it "returns `nil` for a scalar when the directive field name is missing" do

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/hash_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/hash_spec.rb
@@ -1,0 +1,20 @@
+# Copyright 2024 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/graphql/resolvers/hash"
+require_relative "hash_or_document_shared_examples"
+
+module ElasticGraph
+  class GraphQL
+    module Resolvers
+      RSpec.describe Hash, :capture_logs, :resolver do
+        include_examples "Hash or Document resolver"
+      end
+    end
+  end
+end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection/array_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection/array_adapter_spec.rb
@@ -6,19 +6,19 @@
 #
 # frozen_string_literal: true
 
-require "elastic_graph/graphql/resolvers/get_record_field_value"
+require "elastic_graph/graphql/resolvers/hash"
 
 module ElasticGraph
   class GraphQL
     module Resolvers
       module RelayConnection
         # Note: while this file is `array_adapter_spec.rb`, the describe block below
-        # must use `GetRecordFieldValue` so we can leverage the handy `resolver` support
-        # (since `GetRecordFieldValue` is a resolver, but `ArrayAdapter` is not).
+        # must use `Hash` so we can leverage the handy `resolver` support
+        # (since `Hash` is a resolver, but `ArrayAdapter` is not).
         # It still primarily exercises the `ArrayAdapter` class defined in `array_adapter.rb`,
-        # but does so via the `GetRecordFieldValue` resolver, which has the added benefit
-        # of also verifying that `GetRecordFieldValue` builds `ArrayAdapter` properly.
-        RSpec.describe GetRecordFieldValue, "on a paginated collection field", :resolver do
+        # but does so via the `Hash` resolver, which has the added benefit
+        # of also verifying that `Hash` builds `ArrayAdapter` properly.
+        RSpec.describe Hash, "on a paginated collection field", :resolver do
           attr_accessor :schema_artifacts
 
           before(:context) do


### PR DESCRIPTION
Previously, it handled both the `Hash` and `Document` cases, via a `case` statement on `object`. Instead, we can handle it with two separate resolvers. The `Document` resolver simply delegates to the `Hash` resolver after extracting the hash `payload`.

We want to minimize the logic that needs to happen to resolve each field, so it's nice to eliminate this `case` statement.