### PR TITLE
Refactor: merge multiple runtime metadata overrides.

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
@@ -272,10 +272,10 @@ module ElasticGraph
         new_object_type @state.type_ref(index_leaf_type).as_aggregated_values.name do |type|
           type.graphql_only true
           type.documentation "A return type used from aggregations to provided aggregated values over `#{index_leaf_type}` fields."
-          type.runtime_metadata_overrides = {
+          type.override_runtime_metadata(
             elasticgraph_category: :scalar_aggregated_values,
             default_graphql_resolver: :object
-          }
+          )
 
           type.field @state.schema_elements.approximate_distinct_value_count, "JsonSafeLong", graphql_only: true do |f|
             # Note: the 1-6% accuracy figure comes from the Elasticsearch docs:
@@ -436,10 +436,10 @@ module ElasticGraph
         type_ref = @state.type_ref(type_name)
         new_object_type type_ref.as_edge.name do |t|
           t.relay_pagination_type = true
-          t.runtime_metadata_overrides = {
+          t.override_runtime_metadata(
             elasticgraph_category: :relay_edge,
             default_graphql_resolver: :object
-          }
+          )
 
           t.documentation <<~EOS
             Represents a specific `#{type_name}` in the context of a `#{type_ref.as_connection.name}`,
@@ -466,10 +466,10 @@ module ElasticGraph
         type_ref = @state.type_ref(type_name)
         new_object_type type_ref.as_connection.name do |t|
           t.relay_pagination_type = true
-          t.runtime_metadata_overrides = {
+          t.override_runtime_metadata(
             elasticgraph_category: :relay_connection,
             default_graphql_resolver: :object
-          }
+          )
 
           if support_pagination
             t.documentation <<~EOS

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
@@ -16,12 +16,12 @@ module ElasticGraph
       module HasIndices
         # @dynamic runtime_metadata_overrides
         # @private
-        attr_accessor :runtime_metadata_overrides
+        attr_reader :runtime_metadata_overrides
 
         # @private
         def initialize(*args, **options)
           super(*args, **options)
-          self.runtime_metadata_overrides = {}
+          @runtime_metadata_overrides = {}
           yield self
 
           # Freeze `indices` so that the indexable status of a type does not change after instantiation.
@@ -148,6 +148,22 @@ module ElasticGraph
         # @return [Array<Indexing::DerivedIndexedType>] list of derived types for this source type
         def derived_indexed_types
           @derived_indexed_types ||= []
+        end
+
+        # Configures overrides for runtime metadata. The provided runtime metadata values will be persisted in the
+        # `runtime_metadata.yaml` schema artifact and made available at runtime to `elasticgraph-graphql` and
+        # `elasticgraph-indexer`.
+        #
+        # @example Configure the `default_graphql_resolver` to use for a type
+        #   ElasticGraph.define_schema do |schema|
+        #     schema.object_type "Person" do |t|
+        #       t.override_runtime_metadata default_graphql_resolver: :object
+        #     end
+        #   end
+        #
+        # @return [void]
+        def override_runtime_metadata(**overrides)
+          @runtime_metadata_overrides.merge!(overrides)
         end
 
         # @private

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_filtering_and_aggregation.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_filtering_and_aggregation.rb
@@ -45,10 +45,7 @@ module ElasticGraph
             [type] + schema_def_state.factory.build_relay_pagination_types(type.name, support_pagination: false) do |t|
               # Record metadata that is necessary for elasticgraph-graphql to correctly recognize and handle
               # this sub-aggregation correctly.
-              t.runtime_metadata_overrides = {
-                elasticgraph_category: :nested_sub_aggregation_connection,
-                default_graphql_resolver: :object
-              }
+              t.override_runtime_metadata elasticgraph_category: :nested_sub_aggregation_connection
             end
           end
 
@@ -119,7 +116,7 @@ module ElasticGraph
             schema_def_state.sub_aggregation_paths_for(nested_field_ref.parent_type).map do |path|
               schema_def_state.factory.new_object_type type_ref.as_sub_aggregation(parent_doc_types: path.parent_doc_types).name do |t|
                 t.documentation "Return type representing a bucket of `#{name}` objects for a sub-aggregation within each `#{type_ref.as_parent_aggregation(parent_doc_types: path.parent_doc_types).name}`."
-                t.runtime_metadata_overrides = {default_graphql_resolver: :object}
+                t.override_runtime_metadata default_graphql_resolver: :object
 
                 t.field schema_def_state.schema_elements.count_detail, "AggregationCountDetail", graphql_only: true do |f|
                   f.documentation "Details of the count of `#{name}` documents in a sub-aggregation bucket."
@@ -167,7 +164,7 @@ module ElasticGraph
             schema_def_state.factory.new_object_type agg_sub_aggs_type_ref.name do |t|
               under_field_description = "under `#{path.field_path_string}` " unless path.field_path.empty?
               t.documentation "Provides access to the `#{schema_def_state.schema_elements.sub_aggregations}` #{under_field_description}within each `#{type_ref.as_parent_aggregation(parent_doc_types: path.parent_doc_types).name}`."
-              t.runtime_metadata_overrides = {default_graphql_resolver: :object}
+              t.override_runtime_metadata default_graphql_resolver: :object
 
               sub_aggregatable_fields.each do |field|
                 if field.nested?
@@ -230,11 +227,11 @@ module ElasticGraph
 
             # Record metadata that is necessary for elasticgraph-graphql to correctly recognize and handle
             # this indexed aggregation type correctly.
-            t.runtime_metadata_overrides = {
+            t.override_runtime_metadata(
               source_type: name,
               elasticgraph_category: :indexed_aggregation,
               default_graphql_resolver: :object
-            }
+            )
           end
         end
 
@@ -245,7 +242,7 @@ module ElasticGraph
 
           new_non_empty_object_type type_ref.as_grouped_by.name do |t|
             t.documentation "Type used to specify the `#{name}` fields to group by for aggregations."
-            t.runtime_metadata_overrides = {default_graphql_resolver: :object}
+            t.override_runtime_metadata default_graphql_resolver: :object
 
             graphql_fields_by_name.values.each do |field|
               field.define_grouped_by_field(t)
@@ -260,7 +257,7 @@ module ElasticGraph
 
           new_non_empty_object_type type_ref.as_aggregated_values.name do |t|
             t.documentation "Type used to perform aggregation computations on `#{name}` fields."
-            t.runtime_metadata_overrides = {default_graphql_resolver: :object}
+            t.override_runtime_metadata default_graphql_resolver: :object
 
             graphql_fields_by_name.values.each do |field|
               field.define_aggregated_values_field(t)

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
@@ -393,7 +393,7 @@ module ElasticGraph
           # to go from non-null to null, but is not a breaking change to make it non-null
           # in the future.
           register_framework_object_type "PageInfo" do |t|
-            t.runtime_metadata_overrides = {default_graphql_resolver: :object}
+            t.override_runtime_metadata default_graphql_resolver: :object
 
             t.documentation <<~EOS
               Provides information about the specific fetched page. This implements the `PageInfo`
@@ -511,7 +511,7 @@ module ElasticGraph
 
           register_framework_object_type "AggregationCountDetail" do |t|
             t.documentation "Provides detail about an aggregation `#{names.count}`."
-            t.runtime_metadata_overrides = {default_graphql_resolver: :object}
+            t.override_runtime_metadata default_graphql_resolver: :object
 
             t.field names.approximate_value, "JsonSafeLong!", graphql_only: true do |f|
               f.documentation <<~EOS
@@ -1293,10 +1293,10 @@ module ElasticGraph
           date = schema_def_state.type_ref("Date")
           register_framework_object_type date.as_grouped_by.name do |t|
             t.documentation "Allows for grouping `Date` values based on the desired return type."
-            t.runtime_metadata_overrides = {
+            t.override_runtime_metadata(
               elasticgraph_category: :date_grouped_by_object,
               default_graphql_resolver: :object
-            }
+            )
 
             t.field names.as_date, "Date", graphql_only: true do |f|
               f.documentation "Used when grouping on the full `Date` value."
@@ -1313,10 +1313,10 @@ module ElasticGraph
           date_time = schema_def_state.type_ref("DateTime")
           register_framework_object_type date_time.as_grouped_by.name do |t|
             t.documentation "Allows for grouping `DateTime` values based on the desired return type."
-            t.runtime_metadata_overrides = {
+            t.override_runtime_metadata(
               elasticgraph_category: :date_grouped_by_object,
               default_graphql_resolver: :object
-            }
+            )
 
             t.field names.as_date_time, "DateTime", graphql_only: true do |f|
               f.documentation "Used when grouping on the full `DateTime` value."

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/mixins/has_indices.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/mixins/has_indices.rbs
@@ -3,9 +3,10 @@ module ElasticGraph
     module Mixins
       module HasIndices
         attr_reader indices: ::Array[Indexing::Index]
-        attr_accessor runtime_metadata_overrides: ::Hash[::Symbol, untyped]
+        attr_reader runtime_metadata_overrides: ::Hash[::Symbol, untyped]
         def index: (::String, ::Hash[::Symbol, ::String | ::Integer]) ?{ (Indexing::Index) -> void } -> ::Array[Indexing::Index]
         def indexed?: () -> bool
+        def override_runtime_metadata: (**untyped) -> void
         def runtime_metadata: (::Array[SchemaArtifacts::RuntimeMetadata::UpdateTarget]) -> SchemaArtifacts::RuntimeMetadata::ObjectType
         def derived_indexed_types: () -> ::Array[Indexing::DerivedIndexedType]
         def derive_indexed_type_fields: (


### PR DESCRIPTION
This allows us to set runtime metadata overrides in multiple spots and trust that the merged result will be used.