### PR TITLE
Use new `resolver` metadata for Apollo resolvers.

### DIFF
--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -3548,6 +3548,10 @@ object_types_by_name:
     default_graphql_resolver: object
   Query:
     graphql_fields_by_name:
+      _entities:
+        resolver: apollo_entities
+      _service:
+        resolver: apollo_service
       address_aggregations:
         resolver: list_records
       addresses:

--- a/elasticgraph-apollo/apollo_tests_implementation/config/products_schema.rb
+++ b/elasticgraph-apollo/apollo_tests_implementation/config/products_schema.rb
@@ -49,6 +49,7 @@ module ApolloTestImpl
       if type.name == "Query"
         type.field "product", "Product" do |f|
           f.argument "id", "ID!"
+          f.resolver = :product
         end
 
         type.field "deprecatedProduct", "DeprecatedProduct" do |f|

--- a/elasticgraph-apollo/apollo_tests_implementation/lib/test_implementation_extension.rb
+++ b/elasticgraph-apollo/apollo_tests_implementation/lib/test_implementation_extension.rb
@@ -15,8 +15,8 @@
 # This defines an extension that injects a custom resolver that supports the field.
 # @private
 module ApolloTestImplementationExtension
-  def graphql_resolvers
-    @graphql_resolvers ||= [product_field_resolver] + super
+  def named_graphql_resolvers
+    @named_graphql_resolvers ||= super.merge({product: product_field_resolver})
   end
 
   def product_field_resolver
@@ -33,10 +33,6 @@ module ApolloTestImplementationExtension
       @datastore_query_builder = datastore_query_builder
       @product_index_def = product_index_def
       @datastore_router = datastore_router
-    end
-
-    def can_resolve?(field:, object:)
-      field.parent_type.name == :Query && field.name == :product
     end
 
     def call(parent_type, graphql_field, object, args, context)

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/engine_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/engine_extension.rb
@@ -19,18 +19,19 @@ module ElasticGraph
       # @private
       module EngineExtension
         # @private
-        def graphql_resolvers
-          @graphql_resolvers ||= begin
+        def named_graphql_resolvers
+          @named_graphql_resolvers ||= begin
             require "elastic_graph/apollo/graphql/entities_field_resolver"
             require "elastic_graph/apollo/graphql/service_field_resolver"
 
-            [
-              EntitiesFieldResolver.new(
-                datastore_query_builder: datastore_query_builder,
-                schema_element_names: runtime_metadata.schema_element_names
-              ),
-              ServiceFieldResolver.new
-            ] + super
+            apollo_entities = EntitiesFieldResolver.new(
+              datastore_query_builder: datastore_query_builder,
+              schema_element_names: runtime_metadata.schema_element_names
+            )
+
+            apollo_service = ServiceFieldResolver.new
+
+            super.merge({apollo_entities: apollo_entities, apollo_service: apollo_service})
           end
         end
 

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/entities_field_resolver.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/entities_field_resolver.rb
@@ -24,10 +24,6 @@ module ElasticGraph
           @schema_element_names = schema_element_names
         end
 
-        def can_resolve?(field:, object:)
-          field.parent_type.name == :Query && field.name == :_entities
-        end
-
         def call(parent_type, graphql_field, object, args, context)
           schema = context.fetch(:elastic_graph_schema)
           field = schema.field_named(parent_type.graphql_name, graphql_field.name)

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/service_field_resolver.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/service_field_resolver.rb
@@ -13,10 +13,6 @@ module ElasticGraph
       #
       # @private
       class ServiceFieldResolver
-        def can_resolve?(field:, object:)
-          field.parent_type.name == :Query && field.name == :_service
-        end
-
         def call(parent_type, field, object, args, context)
           {"sdl" => service_sdl(context.fetch(:elastic_graph_schema).graphql_schema)}
         end

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/api_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/api_extension.rb
@@ -452,7 +452,7 @@ module ElasticGraph
 
         private_class_method def self.customize_root_query_type(type)
           if type.schema_def_state.object_types_by_name.values.any?(&:indexed?)
-            type.field "_entities", "[_Entity]!" do |f|
+            type.field "_entities", "[_Entity]!", graphql_only: true do |f|
               f.documentation <<~EOS
                 A field required by the [Apollo Federation subgraph
                 spec](https://www.apollographql.com/docs/federation/subgraph-spec/#query_entities):
@@ -480,10 +480,12 @@ module ElasticGraph
                   spec](https://www.apollographql.com/docs/federation/subgraph-spec/#resolve-requests-for-entities).
                 EOS
               end
+
+              f.resolver = :apollo_entities
             end
           end
 
-          type.field "_service", "_Service!" do |f|
+          type.field "_service", "_Service!", graphql_only: true do |f|
             f.documentation <<~EOS
               A field required by the [Apollo Federation subgraph
               spec](https://www.apollographql.com/docs/federation/subgraph-spec/#query_service):
@@ -494,6 +496,8 @@ module ElasticGraph
 
               Not intended for use by clients other than Apollo.
             EOS
+
+            f.resolver = :apollo_service
           end
         end
       end

--- a/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
+++ b/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
@@ -424,7 +424,15 @@ module ElasticGraph
           with_apollo_runtime_metadata = SchemaArtifacts::RuntimeMetadata::Schema.from_hash(with_apollo_results.runtime_metadata.to_dumpable_hash, for_context: :graphql)
           without_apollo_runtime_metadata = SchemaArtifacts::RuntimeMetadata::Schema.from_hash(without_apollo_results.runtime_metadata.to_dumpable_hash, for_context: :graphql)
           expect(with_apollo_runtime_metadata.enum_types_by_name).to eq(without_apollo_runtime_metadata.enum_types_by_name)
-          expect(with_apollo_runtime_metadata.object_types_by_name.except("_Entity", "_Service")).to eq(without_apollo_runtime_metadata.object_types_by_name)
+          expect(with_apollo_runtime_metadata.object_types_by_name.except("_Entity", "_Service", "Query")).to eq(without_apollo_runtime_metadata.object_types_by_name.except("Query"))
+        end
+
+        it "avoids defining `name_in_index` on the runtime metadata of the Query `_entities` and `_service` fields" do
+          results = define_schema(with_apollo: true) { |s| define_some_types_on(s) }
+          query_type = results.runtime_metadata.object_types_by_name.fetch("Query")
+
+          expect(query_type.graphql_fields_by_name.fetch("_entities").name_in_index).to eq nil
+          expect(query_type.graphql_fields_by_name.fetch("_service").name_in_index).to eq nil
         end
 
         # We use `dont_validate_graphql_schema` here because the validation triggers the example exceptions we assert on from


### PR DESCRIPTION
This moves us one step closer to being able to use the GraphQL gem's native resolver disaptching.