### PR TITLE
Update resolver interface: pass a schema field.

### DIFF
--- a/elasticgraph-apollo/apollo_tests_implementation/lib/test_implementation_extension.rb
+++ b/elasticgraph-apollo/apollo_tests_implementation/lib/test_implementation_extension.rb
@@ -35,7 +35,7 @@ module ApolloTestImplementationExtension
       @datastore_router = datastore_router
     end
 
-    def call(parent_type, graphql_field, object, args, context)
+    def call(field, object, args, context)
       query = @datastore_query_builder.new_query(
         search_index_definitions: [@product_index_def],
         monotonic_clock_deadline: context[:monotonic_clock_deadline],

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/entities_field_resolver.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/entities_field_resolver.rb
@@ -24,9 +24,8 @@ module ElasticGraph
           @schema_element_names = schema_element_names
         end
 
-        def call(parent_type, graphql_field, object, args, context)
+        def call(field, object, args, context)
           schema = context.fetch(:elastic_graph_schema)
-          field = schema.field_named(parent_type.graphql_name, graphql_field.name)
 
           representations = args.fetch(:representations).map.with_index do |rep, index|
             try_parse_representation(rep, schema) do |error_description|

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/service_field_resolver.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/service_field_resolver.rb
@@ -13,7 +13,7 @@ module ElasticGraph
       #
       # @private
       class ServiceFieldResolver
-        def call(parent_type, field, object, args, context)
+        def call(field, object, args, context)
           {"sdl" => service_sdl(context.fetch(:elastic_graph_schema).graphql_schema)}
         end
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rb
@@ -15,8 +15,7 @@ module ElasticGraph
     module Aggregation
       module Resolvers
         class AggregatedValues < ::Data.define(:aggregation_name, :bucket, :field_path)
-          def call(parent_type, graphql_field, object, args, context)
-            field = context.fetch(:elastic_graph_schema).field_named(parent_type.graphql_name, graphql_field.name)
+          def call(field, object, args, context)
             return with(field_path: field_path + [PathSegment.for(field: field, lookahead: args.fetch(:lookahead))]) if field.type.object?
 
             key = Key::AggregatedValue.new(

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/grouped_by.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/grouped_by.rb
@@ -14,8 +14,7 @@ module ElasticGraph
     module Aggregation
       module Resolvers
         class GroupedBy < ::Data.define(:bucket, :field_path)
-          def call(parent_type, graphql_field, object, args, context)
-            field = context.fetch(:elastic_graph_schema).field_named(parent_type.graphql_name, graphql_field.name)
+          def call(field, object, args, context)
             new_field_path = field_path + [PathSegment.for(field: field, lookahead: args.fetch(:lookahead))]
             return with(field_path: new_field_path) if field.type.object?
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/sub_aggregations.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/sub_aggregations.rb
@@ -20,8 +20,7 @@ module ElasticGraph
     module Aggregation
       module Resolvers
         class SubAggregations < ::Data.define(:schema_element_names, :sub_aggregations, :parent_queries, :sub_aggs_by_agg_key, :field_path)
-          def call(parent_type, graphql_field, object, args, context)
-            field = context.fetch(:elastic_graph_schema).field_named(parent_type.graphql_name, graphql_field.name)
+          def call(field, object, args, context)
             path_segment = PathSegment.for(field: field, lookahead: args.fetch(:lookahead))
             new_field_path = field_path + [path_segment]
             return with(field_path: new_field_path) unless field.type.elasticgraph_category == :nested_sub_aggregation_connection

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/get_record_field_value.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/get_record_field_value.rb
@@ -19,8 +19,7 @@ module ElasticGraph
           @schema_element_names = schema_element_names
         end
 
-        def call(parent_type, graphql_field, object, args, context)
-          field = context.fetch(:elastic_graph_schema).field_named(parent_type.graphql_name, graphql_field.name)
+        def call(field, object, args, context)
           field_name = field.name_in_index.to_s
           data =
             case object

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter.rb
@@ -34,7 +34,7 @@ module ElasticGraph
             raise "No resolver yet implemented for `#{parent_type.graphql_name}.#{field.name}`."
           end
 
-          resolver.call(parent_type, field, object, args, context)
+          resolver.call(schema_field, object, args, context)
         end
 
         # In order to support unions and interfaces, we must implement `resolve_type`.

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/list_records.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/list_records.rb
@@ -18,8 +18,7 @@ module ElasticGraph
           @resolver_query_adapter = resolver_query_adapter
         end
 
-        def call(parent_type, graphql_field, object, args, context)
-          field = context.fetch(:elastic_graph_schema).field_named(parent_type.graphql_name, graphql_field.name)
+        def call(field, object, args, context)
           lookahead = args.fetch(:lookahead)
           args = field.args_to_schema_form(args.except(:lookahead))
           query = @resolver_query_adapter.build_query_from(field: field, args: args, lookahead: lookahead, context: context)

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships.rb
@@ -23,8 +23,7 @@ module ElasticGraph
           @logger = logger
         end
 
-        def call(parent_type, graphql_field, object, args, context)
-          field = context.fetch(:elastic_graph_schema).field_named(parent_type.graphql_name, graphql_field.name)
+        def call(field, object, args, context)
           log_warning = ->(**options) { log_field_problem_warning(field: field, **options) }
           join = field.relation_join
           id_or_ids = join.extract_id_or_ids_from(object, log_warning)

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/object.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/object.rb
@@ -11,8 +11,8 @@ module ElasticGraph
     module Resolvers
       # Resolver which just delegates to `object` for resolving.
       class Object
-        def call(parent_type, graphql_field, object, args, context)
-          object.call(parent_type, graphql_field, object, args, context)
+        def call(field, object, args, context)
+          object.call(field, object, args, context)
         end
       end
     end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/resolvable_value.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/resolvable_value.rb
@@ -27,8 +27,7 @@ module ElasticGraph
           end
         end
 
-        def call(parent_type, graphql_field, object, args, context)
-          field = context.fetch(:elastic_graph_schema).field_named(parent_type.graphql_name, graphql_field.name)
+        def call(field, object, args, context)
           args = field.args_to_schema_form(args.except(:lookahead))
           method_name = canonical_name_for(field.name, "Field")
           public_send(method_name, **args_to_canonical_form(args))

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/interfaces.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/interfaces.rbs
@@ -5,8 +5,7 @@ module ElasticGraph
 
       interface _Resolver
         def call: (
-          ::GraphQL::Schema::_Type,
-          ::GraphQL::Schema::Field,
+          Schema::Field,
           untyped,
           fieldArgs,
           ::GraphQL::Query::Context

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/schema/field.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/schema/field.rbs
@@ -16,6 +16,7 @@ module ElasticGraph
         def sort_clauses_for: (::Array[::String]) -> ::Array[::Hash[::String, ::Hash[::String, ::String]]]
         def args_to_schema_form: (::Hash[::Symbol, untyped]) -> ::Hash[::String, untyped]
         def index_field_names_for_resolution: () -> ::Array[::String]
+        def coerce_result: (untyped) -> untyped
       end
     end
   end

--- a/elasticgraph-graphql/spec/support/resolver.rb
+++ b/elasticgraph-graphql/spec/support/resolver.rb
@@ -37,7 +37,7 @@ module ResolverHelperMethods
         # [^1]: https://github.com/rmosolgo/graphql-ruby/blob/v2.1.0/lib/graphql/pagination/connection.rb#L94-L96
         # [^2]: https://github.com/rmosolgo/graphql-ruby/blob/v2.1.0/lib/graphql/execution/interpreter/runtime.rb#L935-L941
         ::Thread.current[:__graphql_runtime_info] = ::Hash.new { |h, k| h[k] = ::GraphQL::Execution::Interpreter::Runtime::CurrentState.new }
-        resolver.call(field.parent_type.graphql_type, field.graphql_field, document, args, context)
+        resolver.call(field, document, args, context)
       ensure
         ::Thread.current[:__graphql_runtime_info] = nil
       end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_executor_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_executor_spec.rb
@@ -391,7 +391,7 @@ module ElasticGraph
 
           let(:graphql) do
             multiply_resolver = Class.new do
-              def call(parent_type, field, object, args, context)
+              def call(field, object, args, context)
                 [
                   args.dig(:operands, "x"),
                   args.dig(:operands, "y"),

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
@@ -134,8 +134,7 @@ module ElasticGraph
               lookahead = instance_double("GraphQL::Execution::Lookahead")
 
               person.call(
-                schema_field.parent_type.graphql_type,
-                schema_field.graphql_field,
+                schema_field,
                 person,
                 args.merge(lookahead: lookahead),
                 {elastic_graph_schema: schema_field.schema}


### PR DESCRIPTION
Previously, we passed separate `parent_type` and `graphql_field` arguments. This was done to align our resolver `#call` interface with the resolver interface of the GraphQL gem. However, as per the docs[^1], when we switch to providing an an implementation hash for `default_resolve`, the interface is different--each resolver is a lambda that accepts 3 arguments `(obj, args, ctx)`. Our resolvers need to know what the field is, an we'll need to adapt the 3-arg interface to our own resolver interface. As part of that, we'll provide an `ElasticGraph::GraphQL::Schema::Field` object to each resolver as the first argument.

[^1] https://graphql-ruby.org/schema/sdl.html