### PR TITLE
Allow query adapters to be instantiated without a schema.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -212,14 +212,13 @@ module ElasticGraph
             filter_node_interpreter: filter_node_interpreter
           ),
           GraphQL::QueryAdapter::Sort.new(order_by_arg_name: schema_element_names.order_by),
-          Aggregation::QueryAdapter.new(
-            schema: schema,
+          Aggregation::QueryAdapter::WithoutSchema.new(
             config: config,
             filter_args_translator: filter_args_translator,
             runtime_metadata: runtime_metadata,
             sub_aggregation_grouping_adapter: sub_aggregation_grouping_adapter
           ),
-          GraphQL::QueryAdapter::RequestedFields.new(schema)
+          GraphQL::QueryAdapter::RequestedFields::WithoutSchema.new
         ]
       end
     end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/query_adapter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/query_adapter.rbs
@@ -27,6 +27,19 @@ module ElasticGraph
 
       class QueryAdapter < QueryAdapterSupertype
         include _QueryAdapter
+
+        class WithoutSchema
+          include _QueryAdapter
+          @build_adapter: ^(Schema) -> QueryAdapter
+
+          def initialize: (
+            config: Config,
+            filter_args_translator: Filtering::FilterArgsTranslator,
+            runtime_metadata: SchemaArtifacts::RuntimeMetadata::Schema,
+            sub_aggregation_grouping_adapter: groupingAdapter
+          ) -> void
+        end
+
         attr_reader element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames
 
         private

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/query_adapter/requested_fields.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/query_adapter/requested_fields.rbs
@@ -2,6 +2,10 @@ module ElasticGraph
   class GraphQL
     class QueryAdapter
       class RequestedFields
+        class WithoutSchema
+          include _QueryAdapter
+        end
+
         include _QueryAdapter
         def initialize: (Schema) -> void
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/query_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/query_adapter_spec.rb
@@ -211,7 +211,7 @@ module ElasticGraph
             context = ::GraphQL::Query::Context.new(
               query: nil,
               schema: graphql.schema.graphql_schema,
-              values: context
+              values: context.merge(elastic_graph_schema: graphql.schema)
             )
 
             query_adapter.build_query_from(


### PR DESCRIPTION
The refactoring I'm working on requires that the query adapters be built before the schema instance is available. As such, we won't be able to pass it into the constructors. To allow for this, I've made some simple `WithoutSchema` classes that we instantiate up front, and then defined `call` to build the original classes using the `elastic_graph_schema` available in `context`.