### PR TITLE
Don't require local datastore to be on localhost.

### DIFF
--- a/elasticgraph-local/sig/elastic_graph/local/rake_tasks.rbs
+++ b/elasticgraph-local/sig/elastic_graph/local/rake_tasks.rbs
@@ -34,8 +34,8 @@ module ElasticGraph
       def define_docker_tasks_for_version: (::String, ::Symbol, ::String, port: ::Integer, version: ::String, env: ::String, ready_log_line: ::Regexp) -> void
       def define_other_tasks: () -> void
 
-      @local_datastore_port: ::Integer?
-      def local_datastore_port: () -> ::Integer
+      @local_datastore_url: ::String?
+      def local_datastore_url: () -> ::String
 
       @local_cluster_backends: ::Set[::String]?
       def local_cluster_backends: () -> ::Set[::String]


### PR DESCRIPTION
In order to support running in docker, I'd like to be able to connect to a local datastore that is not running on localhost. This is useful if this rake task runs in one container and wants to connect to a different container running the elasticsearch or opensearch instance.

Since `env_port_mapping` is used to trigger running a docker-compose file, I do not plan on running it from another docker container, so for now I am just leaving it as a port.