### PR TITLE
Docker file configuration.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Mac OSX file.
+.DS_Store
+/*/.DS_Store
+
+#Git
+/.git/*
+
+# Documentation
+*.md
+
+# Ignore log and temp files.
+/log/*
+/tmp/*
+/*/log/*
+/*/tmp/*

--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+VERSION=8.16.1
+ENV=local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Use Ruby 3.x as the base image
+FROM ruby:3.4
+
+ENV PORT=9393
+
+# Set working directory
+WORKDIR /app
+
+# Copy the entire project
+COPY . .
+
+
+# Retain just the files needed for building
+RUN find . \! -name "Gemfile" \! -name "*.gemspec" -mindepth 2 -maxdepth 2 -print | xargs rm -rf
+RUN find . \! -name "Gemfile*" \! -name "*.gemspec"  -maxdepth 1 -type f | xargs rm
+
+# Also need the version file add it back
+COPY elasticgraph-support/lib/elastic_graph/version.rb ./elasticgraph-support/lib/elastic_graph/version.rb
+
+
+# Use Ruby 3.x as the base image
+FROM ruby:3.4
+
+WORKDIR /app
+
+
+# Copy files from the first build stage.
+COPY --from=0 /app .
+
+# Install Ruby dependencies
+RUN bundle install
+
+# Copy the entire project
+COPY . .
+
+
+CMD ["bundle", "exec", "rake", "boot_in_container[${PORT,--host=0.0.0.0,true]"]

--- a/config/settings/development.yaml
+++ b/config/settings/development.yaml
@@ -4,7 +4,7 @@ datastore:
     require: httpx/adapters/faraday
   clusters:
     main:
-      url: http://localhost:9334
+      url: http://elasticsearch:9200
       backend: elasticsearch
       settings: {}
   index_definitions:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,90 @@
+---
+networks:
+  default:
+    name: elastic
+    external: false
+services:
+  elasticsearch:
+    build:
+      context: ./elasticgraph-local/lib/elastic_graph/local/elasticsearch/.
+      dockerfile: Dockerfile
+      args:
+        VERSION: ${VERSION}
+    container_name: elasticsearch-${VERSION}-${ENV}
+    healthcheck:
+      interval: 10s
+      retries: 80
+      test: curl --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null http://localhost:9200/
+    environment:
+    # Note: we use `discovery.type=single-node` to ensure that the Elasticsearch node does not
+    # try to join a cluster (or let another node join it). This prevents problems when you
+    # have multiple projects using elasticgraph-local at the same time. You do not want
+    # their Elasticsearch nodes to try to join into a single cluster.
+    - discovery.type=single-node
+    # Note: we use `xpack.security.enabled=false` to silence an annoying warning Elasticsearch 7.13 has
+    # started spewing (as in hundreds of times!) as we run our test suite:
+    #
+    # > warning: 299 Elasticsearch-7.13.0-5ca8591c6fcdb1260ce95b08a8e023559635c6f3 "Elasticsearch built-in
+    # > security features are not enabled. Without authentication, your cluster could be accessible to anyone.
+    # > See https://www.elastic.co/guide/en/elasticsearch/reference/7.13/security-minimal-setup.html to enable
+    # > security."
+    #
+    # Since this is only used in local dev/test environments where the added security would make things harder
+    # (we'd have to setup credentials in our tests), it's simpler/better just to explicitly disable the security,
+    # which silences the warning.
+    - xpack.security.enabled=false
+    # We disable `xpack.ml` because it's not compatible with the `darwin-aarch64` distribution we use on M1 Macs.
+    # Without that flag, we get this error:
+    #
+    # > [2022-01-20T10:06:54,582][ERROR][o.e.b.ElasticsearchUncaughtExceptionHandler] [myron-macbookpro.local] uncaught exception in thread [main]
+    # > org.elasticsearch.bootstrap.StartupException: ElasticsearchException[Failure running machine learning native code. This could be due to running
+    # > on an unsupported OS or distribution, missing OS libraries, or a problem with the temp directory. To bypass this problem by running Elasticsearch
+    # > without machine learning functionality set [xpack.ml.enabled: false].]
+    #
+    # See also this github issue: https://github.com/elastic/elasticsearch/pull/68068
+    - xpack.ml.enabled=false
+    # We don't want Elasticsearch to block writes when the disk allocation passes a threshold for our local/test
+    # Elasticsearch we run using this docker setup.
+    # https://stackoverflow.com/a/75962819
+    #
+    # Without this, I frequently get `FORBIDDEN/10/cluster create-index blocked (api)` errors when running tests.
+    - cluster.routing.allocation.disk.threshold_enabled=false
+    # Necessary on Elasticsearch 8 since our test suites indiscriminately deletes all documents
+    # between tests to sandbox the state of each test. Without this setting, we get errors like:
+    #
+    # > illegal_argument_exception: Wildcard expressions or all indices are not allowed
+    - action.destructive_requires_name=false
+    - ES_JAVA_OPTS=-Xms4g -Xmx4g
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+    - elasticsearch:/usr/share/elasticsearch/data
+    ports:
+    - ${PORT:-9200}:9200
+  kibana:
+    build:
+      context: ./elasticgraph-local/lib/elastic_graph/local/elasticsearch/.
+      dockerfile: UI-Dockerfile
+      args:
+        VERSION: ${VERSION}
+    container_name: kibana-${VERSION}-${ENV}
+    environment:
+    - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+    - ${UI_PORT:-5601}:5601
+  elasticgraph:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        VERSION: ${VERSION}
+        container_name: elasticgraph-${ENV}
+    ports:
+    - 9393:9393
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+volumes:
+  elasticsearch:

--- a/elasticgraph-local/lib/elastic_graph/local/rake_tasks.rb
+++ b/elasticgraph-local/lib/elastic_graph/local/rake_tasks.rb
@@ -375,7 +375,8 @@ module ElasticGraph
         yield self if block_given?
 
         # Default the local port from the local_config_yaml file.
-        self.env_port_mapping = {"local" => local_datastore_port}.merge(env_port_mapping || {})
+        local_port = local_datastore_url[/localhost:(\d+)$/, 1].then { |port_str| Integer(port_str) }
+        self.env_port_mapping = {"local" => local_port}.merge(env_port_mapping || {})
         if (invalid_port_mapping = env_port_mapping.reject { |env, port| VALID_PORT_RANGE.cover?(port) }).any?
           raise "`env_port_mapping` has invalid ports: #{invalid_port_mapping.inspect}. Valid ports must be in the #{VALID_PORT_RANGE} range."
         end
@@ -495,7 +496,7 @@ module ElasticGraph
         end
 
         task :ensure_local_datastore_running do
-          unless /200 OK/.match?(`curl -is localhost:#{local_datastore_port}`)
+          unless /200 OK/.match?(`curl -is #{local_datastore_url}`)
             if elasticsearch_versions.empty?
               raise <<~EOS
                 OpenSearch is not running locally. You need to start it in another terminal using this command:
@@ -533,13 +534,12 @@ module ElasticGraph
         end
       end
 
-      def local_datastore_port
-        @local_datastore_port ||= local_config
+      def local_datastore_url
+        @local_datastore_url ||= local_config
           .fetch("datastore")
           .fetch("clusters")
           .fetch("main")
-          .fetch("url")[/localhost:(\d+)$/, 1]
-          .then { |port_str| Integer(port_str) }
+          .fetch("url")
       end
 
       def local_cluster_backends


### PR DESCRIPTION
This PR still needs some cleanup as it breaks the local rake tasks and overrides the development config but it's a proof of concept with a working docker compose file.

- [ ] Update docker compose file to be more general purpose and name variables specific to their container
- [ ] Create new config file and ensure local rake running still works
- [ ] Cleanup the ElasticGraph Dockerfile a bit. (I think maybe allow for any command)


Feel free to try it out. No dependency on local systems ruby.

From the root directory `VERSION=8.16.1 ENV=local docker compose up`

