### PR TITLE
Optimize: avoid unneeded id-only datastore query.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_response/search_response.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_response/search_response.rb
@@ -57,6 +57,40 @@ module ElasticGraph
           )
         end
 
+        def self.synthesize_from_ids(index, ids, decoded_cursor_factory: DecodedCursor::Factory::Null)
+          hits = ids.map do |id|
+            {
+              "_index" => index,
+              "_type" => "_doc",
+              "_id" => id,
+              "_score" => nil,
+              "_source" => {"id" => id},
+              "sort" => [id]
+            }
+          end
+
+          raw_data = {
+            "took" => 0,
+            "timed_out" => false,
+            "_shards" => {
+              "total" => 0,
+              "successful" => 0,
+              "skipped" => 0,
+              "failed" => 0
+            },
+            "hits" => {
+              "total" => {
+                "value" => ids.size,
+                "relation" => "eq"
+              },
+              "max_score" => nil,
+              "hits" => hits
+            }
+          }
+
+          build(raw_data, decoded_cursor_factory: decoded_cursor_factory)
+        end
+
         # Benign empty response that can be used in place of datastore response errors as needed.
         RAW_EMPTY = {"hits" => {"hits" => [], "total" => {"value" => 0}}}.freeze
         EMPTY = build(RAW_EMPTY)

--- a/elasticgraph-graphql/spec/acceptance/datastore_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/datastore_spec.rb
@@ -142,9 +142,9 @@ module ElasticGraph
 
           call_graphql_query(<<~QUERY, timeout_in_ms: long_timeout_seconds * 1000)
             query {
-              widgets { edges { node {
-                components { edges { node { id } } }
-              } } }
+              widgets { nodes {
+                components { nodes { id name } }
+              } }
             }
           QUERY
 

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_spec.rb
@@ -723,8 +723,12 @@ module ElasticGraph
         # we override `resolve` (defined in the `resolver support` shared context) in order
         # to enforce that no `resolve` call ever queries the datastore more than once, as part
         # of preventing N+1 queries.
-        # Also, we force `id` as a requested field here since the specs rely on it always being requested.
-        def resolve(*args, requested_fields: ["id"], **options)
+        #
+        # Also, we force `id` and `created_at` as requested fields here since:
+        #
+        # * The specs rely on `id` always being requested.
+        # * We need to request more than just `id` to avoid the synthesizing of a datastore response based just on the ids.
+        def resolve(*args, requested_fields: ["id", "created_at"], **options)
           result = nil
 
           # Perform any cached calls to the datastore to happen before our `query_datastore`

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_response/search_response_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_response/search_response_spec.rb
@@ -198,6 +198,56 @@ module ElasticGraph
           expect(response.total_document_count).to eq 0
         end
 
+        describe ".synthesize_from_ids" do
+          it "creates a response matching the structure from the datastore using the given index and ids" do
+            response = SearchResponse.synthesize_from_ids("widgets", %w[abc def ghi])
+
+            expect(response.raw_data).to eq({
+              "took" => 0,
+              "timed_out" => false,
+              "_shards" => {
+                "total" => 0,
+                "successful" => 0,
+                "skipped" => 0,
+                "failed" => 0
+              },
+              "hits" => {
+                "total" => {
+                  "value" => 3,
+                  "relation" => "eq"
+                },
+                "max_score" => nil,
+                "hits" => [
+                  {
+                    "_index" => "widgets",
+                    "_type" => "_doc",
+                    "_id" => "abc",
+                    "_score" => nil,
+                    "_source" => {"id" => "abc"},
+                    "sort" => ["abc"]
+                  },
+                  {
+                    "_index" => "widgets",
+                    "_type" => "_doc",
+                    "_id" => "def",
+                    "_score" => nil,
+                    "_source" => {"id" => "def"},
+                    "sort" => ["def"]
+                  },
+                  {
+                    "_index" => "widgets",
+                    "_type" => "_doc",
+                    "_id" => "ghi",
+                    "_score" => nil,
+                    "_source" => {"id" => "ghi"},
+                    "sort" => ["ghi"]
+                  }
+                ]
+              }
+            })
+          end
+        end
+
         def raw_data_with_docs(count)
           documents = raw_data.fetch("hits").fetch("hits").first(count)
           raw_data.merge("hits" => raw_data.fetch("hits").merge("hits" => documents))


### PR DESCRIPTION
On an nested relationship that uses an outbound foreign key, we already have the `id` values before resolving the nested relationship. While we must resolve the relationship in most cases, we're able to just return the ids we already have so long as the query satisfies the following crtieria:

* The query is only requesting `id`. If any other fields are requested we (obviously) need to execute the datastore query.
* The query is sorting on `id`, if there is more than one. If we have multiple ids and we're sorting on another field, we have to execute the datastore query to get the results in the requested order.

This optimization avoids an unnecessary datastore query for each parent document, and should make a big efficiency/performance difference in this case.

Note: while this should generally have no impact on the response, it will have an impact when we have orphaned foreign keys. For example, if we have 3 ids, and only 2 of them exist in the index for the nested document type, this will cause nodes to be returned containing all 3 ids--whereas the unoptimized logic would only return nodes for the 2 ids that exist in the index. We believe this is an OK tradeoff to make, but if it becomes a problem, we may want to make this behavior configurable.