### PR TITLE
Automate maintenance of gem version artifacts.

### DIFF
--- a/.github/workflows/update-gem-version-artifacts.yaml
+++ b/.github/workflows/update-gem-version-artifacts.yaml
@@ -1,0 +1,49 @@
+name: Update Gem Version Artifacts
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  update-dependencies:
+    # Only run on Dependabot PRs
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to push to PR branches
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout Git Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.head_ref }}
+          # Important: fetch with token that can push to PR branches
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@2a18b06812b0e15bb916e1df298d3e740422c47e # v1.203.0
+        with:
+          bundler-cache: true
+
+      - name: Update RBS collection
+        run: bundle exec rbs collection update
+
+      - name: Update gem version constraints
+        run: script/update_gem_constraints
+
+      - name: Commit and push if changed
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git config --local user.name "github-actions[bot]"
+            git add rbs_collection.lock.yaml Gemfile Gemfile.lock *.gemspec
+            git commit -m "Update gem version artifacts."
+            git push
+          fi


### PR DESCRIPTION
Each time dependabot upgrades a gem, we also need to update `rbs_collection.lock.yaml` to match.
In addition, we want to update the version constraints in `Gemfile` and our gemspecs.

This GitHub workflow is intended to automate that.
