### PR TITLE
Update gemspec and Gemfile version constraints to match `Gemfile.lock`.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,19 +11,19 @@ source "https://rubygems.org"
 # Gems needed by the test suite and other CI checks.
 group :development do
   gem "aws_lambda_ric", "~> 2.0"
-  gem "coderay", "~> 1.1"
-  gem "factory_bot", "~> 6.5"
-  gem "faker", "~> 3.5"
+  gem "coderay", "~> 1.1", ">= 1.1.3"
+  gem "factory_bot", "~> 6.5", ">= 6.5.1"
+  gem "faker", "~> 3.5", ">= 3.5.1"
   gem "flatware-rspec", "~> 2.3", ">= 2.3.4"
-  gem "httpx", "~> 1.3"
+  gem "httpx", "~> 1.4"
   gem "method_source", "~> 1.1"
-  gem "rubocop-factory_bot", "~> 2.26"
+  gem "rubocop-factory_bot", "~> 2.26", ">= 2.26.1"
   gem "rubocop-rake", "~> 0.6"
   gem "rubocop-rspec", "~> 3.4"
   gem "rspec", "~> 3.13"
-  gem "rspec-retry", "~> 0.6"
+  gem "rspec-retry", "~> 0.6", ">= 0.6.2"
   gem "simplecov", "~> 0.22"
-  gem "simplecov-console", "~> 0.9"
+  gem "simplecov-console", "~> 0.9", ">= 0.9.3"
   gem "standard", "~> 1.45.0"
   gem "steep", "~> 1.9.4"
   gem "super_diff", "~> 0.15"
@@ -33,8 +33,8 @@ end
 # Documentation generation gems
 group :site do
   gem "filewatcher", "~> 2.1"
-  gem "jekyll", "~> 4.4"
-  gem "yard", "~> 0.9", ">= 0.9.36"
+  gem "jekyll", "~> 4.4", ">= 4.4.1"
+  gem "yard", "~> 0.9", ">= 0.9.37"
   gem "yard-doctest", "~> 0.1", ">= 0.1.17"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     elasticgraph-admin_lambda (0.19.1.1)
       elasticgraph-admin (= 0.19.1.1)
       elasticgraph-lambda_support (= 0.19.1.1)
-      rake (~> 13.2)
+      rake (~> 13.2, >= 13.2.1)
 
 PATH
   remote: elasticgraph-admin
@@ -14,16 +14,16 @@ PATH
       elasticgraph-indexer (= 0.19.1.1)
       elasticgraph-schema_artifacts (= 0.19.1.1)
       elasticgraph-support (= 0.19.1.1)
-      rake (~> 13.2)
+      rake (~> 13.2, >= 13.2.1)
 
 PATH
   remote: elasticgraph-apollo
   specs:
     elasticgraph-apollo (0.19.1.1)
-      apollo-federation (~> 3.8)
+      apollo-federation (~> 3.10)
       elasticgraph-graphql (= 0.19.1.1)
       elasticgraph-support (= 0.19.1.1)
-      graphql (~> 2.4.8)
+      graphql (~> 2.4.10)
 
 PATH
   remote: elasticgraph-datastore_core
@@ -37,9 +37,9 @@ PATH
   specs:
     elasticgraph-elasticsearch (0.19.1.1)
       elasticgraph-support (= 0.19.1.1)
-      elasticsearch (~> 8.16)
-      faraday (~> 2.12)
-      faraday-retry (~> 2.2)
+      elasticsearch (~> 8.17, >= 8.17.1)
+      faraday (~> 2.12, >= 2.12.2)
+      faraday-retry (~> 2.2, >= 2.2.1)
 
 PATH
   remote: elasticgraph-graphql_lambda
@@ -54,7 +54,7 @@ PATH
     elasticgraph-graphql (0.19.1.1)
       elasticgraph-datastore_core (= 0.19.1.1)
       elasticgraph-schema_artifacts (= 0.19.1.1)
-      graphql (~> 2.4.8)
+      graphql (~> 2.4.10)
 
 PATH
   remote: elasticgraph-health_check
@@ -68,21 +68,21 @@ PATH
   remote: elasticgraph-indexer_autoscaler_lambda
   specs:
     elasticgraph-indexer_autoscaler_lambda (0.19.1.1)
-      aws-sdk-cloudwatch (~> 1.108)
-      aws-sdk-lambda (~> 1.144)
-      aws-sdk-sqs (~> 1.89)
+      aws-sdk-cloudwatch (~> 1.111)
+      aws-sdk-lambda (~> 1.147)
+      aws-sdk-sqs (~> 1.92)
       elasticgraph-datastore_core (= 0.19.1.1)
       elasticgraph-lambda_support (= 0.19.1.1)
-      ox (~> 2.14, >= 2.14.18)
+      ox (~> 2.14, >= 2.14.22)
 
 PATH
   remote: elasticgraph-indexer_lambda
   specs:
     elasticgraph-indexer_lambda (0.19.1.1)
-      aws-sdk-s3 (~> 1.176)
+      aws-sdk-s3 (~> 1.182)
       elasticgraph-indexer (= 0.19.1.1)
       elasticgraph-lambda_support (= 0.19.1.1)
-      ox (~> 2.14)
+      ox (~> 2.14, >= 2.14.22)
 
 PATH
   remote: elasticgraph-indexer
@@ -92,7 +92,7 @@ PATH
       elasticgraph-json_schema (= 0.19.1.1)
       elasticgraph-schema_artifacts (= 0.19.1.1)
       elasticgraph-support (= 0.19.1.1)
-      hashdiff (~> 1.1)
+      hashdiff (~> 1.1, >= 1.1.2)
 
 PATH
   remote: elasticgraph-json_schema
@@ -106,7 +106,7 @@ PATH
   specs:
     elasticgraph-lambda_support (0.19.1.1)
       elasticgraph-opensearch (= 0.19.1.1)
-      faraday_middleware-aws-sigv4 (~> 1.0)
+      faraday_middleware-aws-sigv4 (~> 1.0, >= 1.0.1)
 
 PATH
   remote: elasticgraph-local
@@ -117,17 +117,17 @@ PATH
       elasticgraph-indexer (= 0.19.1.1)
       elasticgraph-rack (= 0.19.1.1)
       elasticgraph-schema_definition (= 0.19.1.1)
-      rackup (~> 2.2)
-      rake (~> 13.2)
-      webrick (~> 1.9)
+      rackup (~> 2.2, >= 2.2.1)
+      rake (~> 13.2, >= 13.2.1)
+      webrick (~> 1.9, >= 1.9.1)
 
 PATH
   remote: elasticgraph-opensearch
   specs:
     elasticgraph-opensearch (0.19.1.1)
       elasticgraph-support (= 0.19.1.1)
-      faraday (~> 2.12)
-      faraday-retry (~> 2.2)
+      faraday (~> 2.12, >= 2.12.2)
+      faraday-retry (~> 2.2, >= 2.2.1)
       opensearch-ruby (~> 3.4)
 
 PATH
@@ -143,15 +143,15 @@ PATH
     elasticgraph-query_registry (0.19.1.1)
       elasticgraph-graphql (= 0.19.1.1)
       elasticgraph-support (= 0.19.1.1)
-      graphql (~> 2.4.8)
-      rake (~> 13.2)
+      graphql (~> 2.4.10)
+      rake (~> 13.2, >= 13.2.1)
 
 PATH
   remote: elasticgraph-rack
   specs:
     elasticgraph-rack (0.19.1.1)
       elasticgraph-graphql (= 0.19.1.1)
-      rack (~> 3.1)
+      rack (~> 3.1, >= 3.1.10)
 
 PATH
   remote: elasticgraph-schema_artifacts
@@ -168,21 +168,21 @@ PATH
       elasticgraph-json_schema (= 0.19.1.1)
       elasticgraph-schema_artifacts (= 0.19.1.1)
       elasticgraph-support (= 0.19.1.1)
-      graphql (~> 2.4.8)
-      rake (~> 13.2)
+      graphql (~> 2.4.10)
+      rake (~> 13.2, >= 13.2.1)
 
 PATH
   remote: elasticgraph-support
   specs:
     elasticgraph-support (0.19.1.1)
-      logger (~> 1.6, >= 1.6.2)
+      logger (~> 1.6, >= 1.6.6)
 
 PATH
   remote: elasticgraph
   specs:
     elasticgraph (0.19.1.1)
       elasticgraph-support (= 0.19.1.1)
-      thor (~> 1.3)
+      thor (~> 1.3, >= 1.3.2)
 
 GEM
   remote: https://rubygems.org/
@@ -535,7 +535,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws_lambda_ric (~> 2.0)
-  coderay (~> 1.1)
+  coderay (~> 1.1, >= 1.1.3)
   elasticgraph (= 0.19.1.1)!
   elasticgraph-admin (= 0.19.1.1)!
   elasticgraph-admin_lambda (= 0.19.1.1)!
@@ -558,28 +558,28 @@ DEPENDENCIES
   elasticgraph-schema_artifacts (= 0.19.1.1)!
   elasticgraph-schema_definition (= 0.19.1.1)!
   elasticgraph-support (= 0.19.1.1)!
-  factory_bot (~> 6.5)
-  faker (~> 3.5)
-  faraday (~> 2.12)
+  factory_bot (~> 6.5, >= 6.5.1)
+  faker (~> 3.5, >= 3.5.1)
+  faraday (~> 2.12, >= 2.12.2)
   filewatcher (~> 2.1)
   flatware-rspec (~> 2.3, >= 2.3.4)
-  httpx (~> 1.3)
-  jekyll (~> 4.4)
+  httpx (~> 1.4)
+  jekyll (~> 4.4, >= 4.4.1)
   method_source (~> 1.1)
-  rack-test (~> 2.1)
-  rake (~> 13.2)
+  rack-test (~> 2.2)
+  rake (~> 13.2, >= 13.2.1)
   rspec (~> 3.13)
-  rspec-retry (~> 0.6)
-  rubocop-factory_bot (~> 2.26)
+  rspec-retry (~> 0.6, >= 0.6.2)
+  rubocop-factory_bot (~> 2.26, >= 2.26.1)
   rubocop-rake (~> 0.6)
   rubocop-rspec (~> 3.4)
   simplecov (~> 0.22)
-  simplecov-console (~> 0.9)
+  simplecov-console (~> 0.9, >= 0.9.3)
   standard (~> 1.45.0)
   steep (~> 1.9.4)
   super_diff (~> 0.15)
   vcr (~> 6.3, >= 6.3.1)
-  yard (~> 0.9, >= 0.9.36)
+  yard (~> 0.9, >= 0.9.37)
   yard-doctest (~> 0.1, >= 0.1.17)
 
 BUNDLED WITH

--- a/elasticgraph-admin/elasticgraph-admin.gemspec
+++ b/elasticgraph-admin/elasticgraph-admin.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "elasticgraph-indexer", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-schema_artifacts", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "rake", "~> 13.2"
+  spec.add_dependency "rake", "~> 13.2", ">= 13.2.1"
 
   spec.add_development_dependency "elasticgraph-elasticsearch", ElasticGraph::VERSION
   spec.add_development_dependency "elasticgraph-opensearch", ElasticGraph::VERSION

--- a/elasticgraph-admin_lambda/elasticgraph-admin_lambda.gemspec
+++ b/elasticgraph-admin_lambda/elasticgraph-admin_lambda.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
-  spec.add_dependency "rake", "~> 13.2"
+  spec.add_dependency "rake", "~> 13.2", ">= 13.2.1"
   spec.add_dependency "elasticgraph-admin", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-lambda_support", ElasticGraph::VERSION
 end

--- a/elasticgraph-apollo/elasticgraph-apollo.gemspec
+++ b/elasticgraph-apollo/elasticgraph-apollo.gemspec
@@ -43,8 +43,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "graphql", "~> 2.4.8"
-  spec.add_dependency "apollo-federation", "~> 3.8"
+  spec.add_dependency "graphql", "~> 2.4.10"
+  spec.add_dependency "apollo-federation", "~> 3.10"
 
   # Note: technically, this is not purely a development dependency, but since `eg-schema_def`
   # isn't intended to be used in production (or even included in a deployed bundle) we don't

--- a/elasticgraph-elasticsearch/elasticgraph-elasticsearch.gemspec
+++ b/elasticgraph-elasticsearch/elasticgraph-elasticsearch.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "elasticsearch", "~> 8.16"
-  spec.add_dependency "faraday", "~> 2.12"
-  spec.add_dependency "faraday-retry", "~> 2.2"
+  spec.add_dependency "elasticsearch", "~> 8.17", ">= 8.17.1"
+  spec.add_dependency "faraday", "~> 2.12", ">= 2.12.2"
+  spec.add_dependency "faraday-retry", "~> 2.2", ">= 2.2.1"
 end

--- a/elasticgraph-graphql/elasticgraph-graphql.gemspec
+++ b/elasticgraph-graphql/elasticgraph-graphql.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "elasticgraph-datastore_core", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-schema_artifacts", ElasticGraph::VERSION
-  spec.add_dependency "graphql", "~> 2.4.8"
+  spec.add_dependency "graphql", "~> 2.4.10"
 
   spec.add_development_dependency "elasticgraph-admin", ElasticGraph::VERSION
   spec.add_development_dependency "elasticgraph-elasticsearch", ElasticGraph::VERSION

--- a/elasticgraph-indexer/elasticgraph-indexer.gemspec
+++ b/elasticgraph-indexer/elasticgraph-indexer.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "elasticgraph-json_schema", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-schema_artifacts", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "hashdiff", "~> 1.1"
+  spec.add_dependency "hashdiff", "~> 1.1", ">= 1.1.2"
 
   spec.add_development_dependency "elasticgraph-admin", ElasticGraph::VERSION
   spec.add_development_dependency "elasticgraph-elasticsearch", ElasticGraph::VERSION

--- a/elasticgraph-indexer_autoscaler_lambda/elasticgraph-indexer_autoscaler_lambda.gemspec
+++ b/elasticgraph-indexer_autoscaler_lambda/elasticgraph-indexer_autoscaler_lambda.gemspec
@@ -43,13 +43,13 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "elasticgraph-datastore_core", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-lambda_support", ElasticGraph::VERSION
-  spec.add_dependency "aws-sdk-lambda", "~> 1.144"
-  spec.add_dependency "aws-sdk-sqs", "~> 1.89"
-  spec.add_dependency "aws-sdk-cloudwatch", "~> 1.108"
+  spec.add_dependency "aws-sdk-lambda", "~> 1.147"
+  spec.add_dependency "aws-sdk-sqs", "~> 1.92"
+  spec.add_dependency "aws-sdk-cloudwatch", "~> 1.111"
   # aws-sdk-sqs requires an XML library be available. On Ruby < 3 it'll use rexml from the standard library but on Ruby 3.0+
   # we have to add an explicit dependency. It supports ox, oga, libxml, nokogiri or rexml, and of those, ox seems to be the
   # best choice: it leads benchmarks, is well-maintained, has no dependencies, and is MIT-licensed.
-  spec.add_dependency "ox", "~> 2.14", ">= 2.14.18"
+  spec.add_dependency "ox", "~> 2.14", ">= 2.14.22"
 
   spec.add_development_dependency "elasticgraph-elasticsearch", ElasticGraph::VERSION
   spec.add_development_dependency "elasticgraph-opensearch", ElasticGraph::VERSION

--- a/elasticgraph-indexer_lambda/elasticgraph-indexer_lambda.gemspec
+++ b/elasticgraph-indexer_lambda/elasticgraph-indexer_lambda.gemspec
@@ -43,10 +43,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "elasticgraph-indexer", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-lambda_support", ElasticGraph::VERSION
-  spec.add_dependency "aws-sdk-s3", "~> 1.176"
+  spec.add_dependency "aws-sdk-s3", "~> 1.182"
 
   # aws-sdk-s3 requires an XML library be available. On Ruby < 3 it'll use rexml from the standard library but on Ruby 3.0+
   # we have to add an explicit dependency. It supports ox, oga, libxml, nokogiri or rexml, and of those, ox seems to be the
   # best choice: it leads benchmarks, is well-maintained, has no dependencies, and is MIT-licensed.
-  spec.add_dependency "ox", "~> 2.14"
+  spec.add_dependency "ox", "~> 2.14", ">= 2.14.22"
 end

--- a/elasticgraph-lambda_support/elasticgraph-lambda_support.gemspec
+++ b/elasticgraph-lambda_support/elasticgraph-lambda_support.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-opensearch", ElasticGraph::VERSION
-  spec.add_dependency "faraday_middleware-aws-sigv4", "~> 1.0"
+  spec.add_dependency "faraday_middleware-aws-sigv4", "~> 1.0", ">= 1.0.1"
 
   spec.add_development_dependency "elasticgraph-admin", ElasticGraph::VERSION
   spec.add_development_dependency "elasticgraph-graphql", ElasticGraph::VERSION

--- a/elasticgraph-local/elasticgraph-local.gemspec
+++ b/elasticgraph-local/elasticgraph-local.gemspec
@@ -46,9 +46,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "elasticgraph-indexer", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-rack", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-schema_definition", ElasticGraph::VERSION
-  spec.add_dependency "rackup", "~> 2.2"
-  spec.add_dependency "rake", "~> 13.2"
-  spec.add_dependency "webrick", "~> 1.9"
+  spec.add_dependency "rackup", "~> 2.2", ">= 2.2.1"
+  spec.add_dependency "rake", "~> 13.2", ">= 13.2.1"
+  spec.add_dependency "webrick", "~> 1.9", ">= 1.9.1"
 
   spec.add_development_dependency "elasticgraph-apollo", ElasticGraph::VERSION
   spec.add_development_dependency "elasticgraph-elasticsearch", ElasticGraph::VERSION

--- a/elasticgraph-opensearch/elasticgraph-opensearch.gemspec
+++ b/elasticgraph-opensearch/elasticgraph-opensearch.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "faraday", "~> 2.12"
-  spec.add_dependency "faraday-retry", "~> 2.2"
+  spec.add_dependency "faraday", "~> 2.12", ">= 2.12.2"
+  spec.add_dependency "faraday-retry", "~> 2.2", ">= 2.2.1"
   spec.add_dependency "opensearch-ruby", "~> 3.4"
 end

--- a/elasticgraph-query_registry/elasticgraph-query_registry.gemspec
+++ b/elasticgraph-query_registry/elasticgraph-query_registry.gemspec
@@ -44,8 +44,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "graphql", "~> 2.4.8"
-  spec.add_dependency "rake", "~> 13.2"
+  spec.add_dependency "graphql", "~> 2.4.10"
+  spec.add_dependency "rake", "~> 13.2", ">= 13.2.1"
 
   spec.add_development_dependency "elasticgraph-elasticsearch", ElasticGraph::VERSION
   spec.add_development_dependency "elasticgraph-opensearch", ElasticGraph::VERSION

--- a/elasticgraph-rack/elasticgraph-rack.gemspec
+++ b/elasticgraph-rack/elasticgraph-rack.gemspec
@@ -42,11 +42,11 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION
-  spec.add_dependency "rack", "~> 3.1"
+  spec.add_dependency "rack", "~> 3.1", ">= 3.1.10"
 
   spec.add_development_dependency "elasticgraph-admin", ElasticGraph::VERSION
   spec.add_development_dependency "elasticgraph-elasticsearch", ElasticGraph::VERSION
   spec.add_development_dependency "elasticgraph-opensearch", ElasticGraph::VERSION
   spec.add_development_dependency "elasticgraph-indexer", ElasticGraph::VERSION
-  spec.add_development_dependency "rack-test", "~> 2.1"
+  spec.add_development_dependency "rack-test", "~> 2.2"
 end

--- a/elasticgraph-schema_definition/elasticgraph-schema_definition.gemspec
+++ b/elasticgraph-schema_definition/elasticgraph-schema_definition.gemspec
@@ -46,8 +46,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "elasticgraph-json_schema", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-schema_artifacts", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "graphql", "~> 2.4.8"
-  spec.add_dependency "rake", "~> 13.2"
+  spec.add_dependency "graphql", "~> 2.4.10"
+  spec.add_dependency "rake", "~> 13.2", ">= 13.2.1"
 
   spec.add_development_dependency "elasticgraph-admin", ElasticGraph::VERSION
   spec.add_development_dependency "elasticgraph-datastore_core", ElasticGraph::VERSION

--- a/elasticgraph-support/elasticgraph-support.gemspec
+++ b/elasticgraph-support/elasticgraph-support.gemspec
@@ -46,8 +46,8 @@ Gem::Specification.new do |spec|
   #
   # Note: Logger 1.6.0 has an issue that impacts our ElasticGraph lambdas, but 1.6.1 avoids the issue:
   # https://github.com/aws/aws-lambda-ruby-runtime-interface-client/issues/33
-  spec.add_dependency "logger", "~> 1.6", ">= 1.6.2"
+  spec.add_dependency "logger", "~> 1.6", ">= 1.6.6"
 
-  spec.add_development_dependency "faraday", "~> 2.12"
-  spec.add_development_dependency "rake", "~> 13.2"
+  spec.add_development_dependency "faraday", "~> 2.12", ">= 2.12.2"
+  spec.add_development_dependency "rake", "~> 13.2", ">= 13.2.1"
 end

--- a/elasticgraph/elasticgraph.gemspec
+++ b/elasticgraph/elasticgraph.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "thor", "~> 1.3"
+  spec.add_dependency "thor", "~> 1.3", ">= 1.3.2"
 
   # Expose 'elasticgraph' as a binary
   spec.bindir = "exe"

--- a/script/update_gem_constraints
+++ b/script/update_gem_constraints
@@ -1,0 +1,141 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler"
+require "rubygems/version"
+
+# This script updates version constraints in Gemfile and gemspec files to match
+# the versions in Gemfile.lock, while preserving the specificity level of the
+# version constraints.
+#
+# For example:
+# - "~> 1.2" with version 1.2.3 becomes "~> 1.2", ">= 1.2.3"
+# - "~> 1.2.3" with version 1.2.3 becomes "~> 1.2.3"
+# - "~> 1.2.3" with version 1.2.4 becomes "~> 1.2.3", ">= 1.2.4"
+#
+# After updating version constraints, it runs bundle install to update Gemfile.lock.
+#
+# This script was created by Goose (https://block.github.io/goose/) and can be updated using Goose.
+class DependencyUpdater
+  def initialize
+    @changes = Hash.new do |hash, key|
+      hash[key] = []
+    end
+  end
+
+  def run
+    update_gemfile
+    update_gemspecs
+    run_bundle_install if @changes.any?
+    display_changes
+  end
+
+  private
+
+  def update_gemfile
+    content = versions.reduce(File.read("Gemfile")) do |gemfile, (gem_name, version)|
+      # Look for gem lines with version constraints
+      gemfile.gsub(/^(\s*gem\s+['"]#{gem_name}['"])\s*,\s*((?:['"][~><=\s\d.]+['"](?:\s*,\s*['"][~><=\s\d.]+['"])*))/) do |match|
+        old_constraint = $2.strip
+        new_constraint = format_version_constraint(version, old_constraint)
+        record_change("Gemfile", gem_name, old_constraint, new_constraint) if old_constraint != new_constraint
+        "#{$1}, #{new_constraint}"
+      end
+    end
+
+    File.write("Gemfile", content)
+  end
+
+  def update_gemspecs
+    `git ls-files "*.gemspec"`.split("\n").each do |gemspec_path|
+      content = versions.reduce(File.read(gemspec_path)) do |gemspec, (gem_name, version)|
+        # Look for add_dependency lines with version constraints
+        gemspec.gsub(/^(\s*spec\.add(?:_development)?_dependency\s+['"]#{gem_name}['"])\s*,\s*((?:['"][~><=\s\d.]+['"](?:\s*,\s*['"][~><=\s\d.]+['"])*))/) do |match|
+          old_constraint = $2.strip
+          new_constraint = format_version_constraint(version, old_constraint)
+          record_change(gemspec_path, gem_name, old_constraint, new_constraint) if old_constraint != new_constraint
+          "#{$1}, #{new_constraint}"
+        end
+      end
+
+      File.write(gemspec_path, content)
+    end
+  end
+
+  def run_bundle_install
+    puts "\nRunning bundle install..."
+    system("bundle install")
+    puts # Add a blank line after bundle install output
+  end
+
+  def display_changes
+    if @changes.empty?
+      puts "\nNo version constraint changes were needed."
+      return
+    end
+
+    puts "Updated version constraints in #{@changes.size} #{pluralize("file", @changes.size)}:"
+    @changes.each do |file, changes|
+      puts "\n\e[1m#{file}:\e[0m"
+      changes.each do |change|
+        puts "  \e[32m#{change[:gem].ljust(30)}\e[0m \e[31m#{change[:old]}\e[0m → \e[32m#{change[:new]}\e[0m"
+      end
+    end
+  end
+
+  def versions
+    @versions ||= Bundler::LockfileParser.new(File.read("Gemfile.lock")).specs.to_h do |spec|
+      [spec.name, spec.version.to_s]
+    end
+  end
+
+  def format_version_constraint(version, original_constraint)
+    # Extract the original ~> version and any >= version if present
+    tilde_match = original_constraint.match(/["']~>\s*(\d+\.\d+(?:\.\d+)?)["']/)
+    return "\"~> #{version}\"" unless tilde_match # fallback if no ~> found
+
+    original_tilde_version = tilde_match[1]
+    dots = original_tilde_version.count(".")
+
+    # Extract the same level of specificity from the new version
+    parts = version.split(".")
+    new_tilde_version = case dots
+    when 1 # major.minor
+      parts[0..1].join(".")
+    when 2 # major.minor.patch
+      parts[0..2].join(".")
+    else # fallback to major.minor
+      parts[0..1].join(".")
+    end
+
+    # For ~> major.minor.patch, the >= constraint is redundant if it's the same version
+    # For ~> major.minor, we need the >= constraint if it's not just major.minor.0
+    if dots == 2
+      # Using patch-level specificity, only need >= if it's a different version
+      if new_tilde_version == version
+        "\"~> #{new_tilde_version}\""
+      else
+        "\"~> #{new_tilde_version}\", \">= #{version}\""
+      end
+    elsif version.end_with?(".0")
+      # Using major.minor specificity, need >= unless it's major.minor.0
+      "\"~> #{new_tilde_version}\""
+    else
+      "\"~> #{new_tilde_version}\", \">= #{version}\""
+    end
+  end
+
+  def record_change(file, gem_name, old_constraint, new_constraint)
+    @changes[file] << {
+      gem: gem_name,
+      old: old_constraint,
+      new: new_constraint
+    }
+  end
+
+  def pluralize(word, count)
+    (count == 1) ? word : "#{word}s"
+  end
+end
+
+DependencyUpdater.new.run


### PR DESCRIPTION
Dependabot regularly updates gem versions in `Gemfile.lock`, which ensures that our CI build runs against the latest versions of gems. However, the version constraints in `Gemfile` and our gemspecs don't get updated by dependabot. That means that users of ElasticGraph may wind up installing and using older versions of gems. While that is usually OK, it's not the verisons of gems that our CI build runs against, which we are confident work with ElasticGraph (and all the other gem versions...). It's best to keep the version constraints up-to-date with our `Gemfile.lock`.

To automate this process, I've used [Goose](https://block.github.io/goose/) to create a script that updates the version constraints. The changes in this commit to `Gemfile`, `Gemfile.lock` and the gemspecs were all made by the new script!