### PR TITLE
Refactor: merge multiple runtime metadata overrides.

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
@@ -272,7 +272,7 @@ module ElasticGraph
         new_object_type @state.type_ref(index_leaf_type).as_aggregated_values.name do |type|
           type.graphql_only true
           type.documentation "A return type used from aggregations to provided aggregated values over `#{index_leaf_type}` fields."
-          type.runtime_metadata_overrides = {elasticgraph_category: :scalar_aggregated_values}
+          type.override_runtime_metadata(elasticgraph_category: :scalar_aggregated_values)
 
           type.field @state.schema_elements.approximate_distinct_value_count, "JsonSafeLong", graphql_only: true do |f|
             # Note: the 1-6% accuracy figure comes from the Elasticsearch docs:
@@ -433,7 +433,7 @@ module ElasticGraph
         type_ref = @state.type_ref(type_name)
         new_object_type type_ref.as_edge.name do |t|
           t.relay_pagination_type = true
-          t.runtime_metadata_overrides = {elasticgraph_category: :relay_edge}
+          t.override_runtime_metadata(elasticgraph_category: :relay_edge)
 
           t.documentation <<~EOS
             Represents a specific `#{type_name}` in the context of a `#{type_ref.as_connection.name}`,
@@ -460,7 +460,7 @@ module ElasticGraph
         type_ref = @state.type_ref(type_name)
         new_object_type type_ref.as_connection.name do |t|
           t.relay_pagination_type = true
-          t.runtime_metadata_overrides = {elasticgraph_category: :relay_connection}
+          t.override_runtime_metadata(elasticgraph_category: :relay_connection)
 
           if support_pagination
             t.documentation <<~EOS

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
@@ -16,12 +16,12 @@ module ElasticGraph
       module HasIndices
         # @dynamic runtime_metadata_overrides
         # @private
-        attr_accessor :runtime_metadata_overrides
+        attr_reader :runtime_metadata_overrides
 
         # @private
         def initialize(*args, **options)
           super(*args, **options)
-          self.runtime_metadata_overrides = {}
+          @runtime_metadata_overrides = {}
           yield self
 
           # Freeze `indices` so that the indexable status of a type does not change after instantiation.
@@ -148,6 +148,15 @@ module ElasticGraph
         # @return [Array<Indexing::DerivedIndexedType>] list of derived types for this source type
         def derived_indexed_types
           @derived_indexed_types ||= []
+        end
+
+        # Configures overrides for runtime metadata. The provided runtime metadata values will be persisted in the
+        # `runtime_metadata.yaml` schema artifact and made available at runtime to `elasticgraph-graphql` and
+        # `elasticgraph-indexer`.
+        #
+        # @return [void]
+        def override_runtime_metadata(**overrides)
+          @runtime_metadata_overrides.merge!(overrides)
         end
 
         # @private

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_filtering_and_aggregation.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_filtering_and_aggregation.rb
@@ -45,7 +45,7 @@ module ElasticGraph
             [type] + schema_def_state.factory.build_relay_pagination_types(type.name, support_pagination: false) do |t|
               # Record metadata that is necessary for elasticgraph-graphql to correctly recognize and handle
               # this sub-aggregation correctly.
-              t.runtime_metadata_overrides = {elasticgraph_category: :nested_sub_aggregation_connection}
+              t.override_runtime_metadata(elasticgraph_category: :nested_sub_aggregation_connection)
             end
           end
 
@@ -225,7 +225,7 @@ module ElasticGraph
 
             # Record metadata that is necessary for elasticgraph-graphql to correctly recognize and handle
             # this indexed aggregation type correctly.
-            t.runtime_metadata_overrides = {source_type: name, elasticgraph_category: :indexed_aggregation}
+            t.override_runtime_metadata(source_type: name, elasticgraph_category: :indexed_aggregation)
           end
         end
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
@@ -1290,7 +1290,7 @@ module ElasticGraph
           date = schema_def_state.type_ref("Date")
           register_framework_object_type date.as_grouped_by.name do |t|
             t.documentation "Allows for grouping `Date` values based on the desired return type."
-            t.runtime_metadata_overrides = {elasticgraph_category: :date_grouped_by_object}
+            t.override_runtime_metadata(elasticgraph_category: :date_grouped_by_object)
 
             t.field names.as_date, "Date", graphql_only: true do |f|
               f.documentation "Used when grouping on the full `Date` value."
@@ -1307,7 +1307,7 @@ module ElasticGraph
           date_time = schema_def_state.type_ref("DateTime")
           register_framework_object_type date_time.as_grouped_by.name do |t|
             t.documentation "Allows for grouping `DateTime` values based on the desired return type."
-            t.runtime_metadata_overrides = {elasticgraph_category: :date_grouped_by_object}
+            t.override_runtime_metadata(elasticgraph_category: :date_grouped_by_object)
 
             t.field names.as_date_time, "DateTime", graphql_only: true do |f|
               f.documentation "Used when grouping on the full `DateTime` value."

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/mixins/has_indices.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/mixins/has_indices.rbs
@@ -3,9 +3,10 @@ module ElasticGraph
     module Mixins
       module HasIndices
         attr_reader indices: ::Array[Indexing::Index]
-        attr_accessor runtime_metadata_overrides: ::Hash[::Symbol, untyped]
+        attr_reader runtime_metadata_overrides: ::Hash[::Symbol, untyped]
         def index: (::String, ::Hash[::Symbol, ::String | ::Integer]) ?{ (Indexing::Index) -> void } -> ::Array[Indexing::Index]
         def indexed?: () -> bool
+        def override_runtime_metadata: (**untyped) -> void
         def runtime_metadata: (::Array[SchemaArtifacts::RuntimeMetadata::UpdateTarget]) -> SchemaArtifacts::RuntimeMetadata::ObjectType
         def derived_indexed_types: () -> ::Array[Indexing::DerivedIndexedType]
         def derive_indexed_type_fields: (


### PR DESCRIPTION
This allows us to set runtime metadata overrides in multiple spots and trust that the merged result will be used.