### PR TITLE
Introduce GraphQL resolver runtime metadata.

### DIFF
--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/graphql_field.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/graphql_field.rbs
@@ -5,22 +5,25 @@ module ElasticGraph
         attr_reader name_in_index: ::String?
         attr_reader relation: Relation?
         attr_reader computation_detail: ComputationDetail?
+        attr_reader resolver: ::Symbol?
 
         def initialize: (
           name_in_index: ::String?,
           relation: Relation?,
-          computation_detail: ComputationDetail?
+          computation_detail: ComputationDetail?,
+          resolver: ::Symbol?
         ) -> void
 
         def with: (
           ?name_in_index: ::String?,
           ?relation: Relation?,
-          ?computation_detail: ComputationDetail?
+          ?computation_detail: ComputationDetail?,
+          ?resolver: ::Symbol?
         ) -> instance
 
         def self.new:
-          (name_in_index: ::String?, relation: Relation?, computation_detail: ComputationDetail?) -> instance
-          | (::String?, Relation?, ::Symbol?) -> instance
+          (name_in_index: ::String?, relation: Relation?, computation_detail: ComputationDetail?, resolver: ::Symbol?) -> instance
+          | (::String?, Relation?, ComputationDetail?, ::Symbol?) -> instance
       end
 
       class GraphQLField < GraphQLFieldSupertype
@@ -28,6 +31,8 @@ module ElasticGraph
         NAME_IN_INDEX: "name_in_index"
         RELATION: "relation"
         AGGREGATION_DETAIL: "computation_detail"
+        RESOLVER: "resolver"
+
         def self.from_hash: (::Hash[::String, untyped]) -> GraphQLField
         def to_dumpable_hash: () -> ::Hash[::String, untyped]
         def needed?: (::String) -> bool

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/graphql_field_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/graphql_field_spec.rb
@@ -19,17 +19,19 @@ module ElasticGraph
           field = GraphQLField.from_hash({})
 
           expect(field).to eq GraphQLField.new(
+            computation_detail: nil,
             name_in_index: nil,
             relation: nil,
-            computation_detail: nil
+            resolver: nil
           )
         end
 
         it "offers `with_computation_detail` updating aggregation detail" do
           field = GraphQLField.new(
+            computation_detail: nil,
             name_in_index: nil,
             relation: nil,
-            computation_detail: nil
+            resolver: :self
           )
 
           updated = field.with_computation_detail(
@@ -41,6 +43,20 @@ module ElasticGraph
             empty_bucket_value: 0,
             function: :sum
           ))
+        end
+
+        it "exposes `resolver` as a symbol while keeping it as a string in dumped form" do
+          field = GraphQLField.from_hash({"resolver" => "self"})
+
+          expect(field.resolver).to eq :self
+          expect(field.to_dumpable_hash).to include("resolver" => "self")
+        end
+
+        it "exposes `resolver` as nil when it is unset" do
+          field = GraphQLField.from_hash({})
+
+          expect(field.resolver).to eq nil
+          expect(field.to_dumpable_hash).to include("resolver" => nil)
         end
       end
     end

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/object_type_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/object_type_spec.rb
@@ -15,22 +15,6 @@ module ElasticGraph
       RSpec.describe ObjectType do
         include RuntimeMetadataSupport
 
-        it "ignores fields that have no meaningful runtime metadata" do
-          object_type = object_type_with(graphql_fields_by_name: {
-            "has_relation" => graphql_field_with(name_in_index: nil, relation: relation_with),
-            "has_computation_detail" => graphql_field_with(computation_detail: :sum),
-            "has_alternate_index_name" => graphql_field_with(name_in_index: "alternate"),
-            "has_nil_index_name" => graphql_field_with(name_in_index: nil),
-            "has_same_index_name" => graphql_field_with(name_in_index: "has_same_index_name")
-          })
-
-          expect(object_type.graphql_fields_by_name.keys).to contain_exactly(
-            "has_relation",
-            "has_computation_detail",
-            "has_alternate_index_name"
-          )
-        end
-
         it "builds from a minimal hash" do
           type = ObjectType.from_hash({})
 
@@ -80,6 +64,21 @@ module ElasticGraph
           })
 
           expect(ObjectType.from_hash(dumped)).to eq(type)
+        end
+
+        it "omits GraphQL fields that have no meaningful metadata" do
+          type = object_type_with(
+            graphql_fields_by_name: {
+              "foo1" => graphql_field_with(name_in_index: "foo1"),
+              "foo2" => graphql_field_with(name_in_index: "foo2_in_index"),
+              "foo3" => graphql_field_with(name_in_index: "foo3", relation: relation_with),
+              "foo4" => graphql_field_with(name_in_index: "foo4", computation_detail: computation_detail_with),
+              "foo5" => graphql_field_with(resolver: :other, name_in_index: "foo5"),
+              "foo6" => graphql_field_with(name_in_index: nil)
+            }
+          )
+
+          expect(type.graphql_fields_by_name.keys).to contain_exactly("foo2", "foo3", "foo4", "foo5")
         end
       end
     end

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
@@ -54,27 +54,30 @@ module ElasticGraph
                 ],
                 graphql_fields_by_name: {
                   "name_graphql" => GraphQLField.new(
-                    name_in_index: "name_index",
                     computation_detail: nil,
-                    relation: nil
+                    name_in_index: "name_index",
+                    relation: nil,
+                    resolver: :self
                   ),
                   "parent" => GraphQLField.new(
-                    name_in_index: "parent",
                     computation_detail: nil,
+                    name_in_index: "parent",
                     relation: Relation.new(
                       foreign_key: "grandparents.parents.some_id",
                       direction: :out,
                       additional_filter: {"flag_field" => {"equalToAnyOf" => [true]}},
                       foreign_key_nested_paths: ["grandparents", "grandparents.parents"]
-                    )
+                    ),
+                    resolver: :self
                   ),
                   "sum" => GraphQLField.new(
-                    name_in_index: "sum",
                     computation_detail: ComputationDetail.new(
                       empty_bucket_value: 0,
                       function: :sum
                     ),
-                    relation: nil
+                    name_in_index: "sum",
+                    relation: nil,
+                    resolver: :self
                   )
                 },
                 elasticgraph_category: :some_category,
@@ -167,7 +170,8 @@ module ElasticGraph
                 ],
                 "graphql_fields_by_name" => {
                   "name_graphql" => {
-                    "name_in_index" => "name_index"
+                    "name_in_index" => "name_index",
+                    "resolver" => "self"
                   },
                   "parent" => {
                     "relation" => {
@@ -175,13 +179,15 @@ module ElasticGraph
                       "direction" => "out",
                       "additional_filter" => {"flag_field" => {"equalToAnyOf" => [true]}},
                       "foreign_key_nested_paths" => ["grandparents", "grandparents.parents"]
-                    }
+                    },
+                    "resolver" => "self"
                   },
                   "sum" => {
                     "computation_detail" => {
                       "empty_bucket_value" => 0,
                       "function" => "sum"
-                    }
+                    },
+                    "resolver" => "self"
                   }
                 },
                 "elasticgraph_category" => "some_category",
@@ -293,7 +299,8 @@ module ElasticGraph
               "name_graphql" => GraphQLField.new(
                 name_in_index: "name_index",
                 computation_detail: nil,
-                relation: nil
+                relation: nil,
+                resolver: :self
               )
             }),
             "NoMetadata" => object_type_with

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
@@ -925,7 +925,8 @@ module ElasticGraph
           SchemaArtifacts::RuntimeMetadata::GraphQLField.new(
             name_in_index: name_in_index,
             computation_detail: computation_detail,
-            relation: relationship&.runtime_metadata
+            relation: relationship&.runtime_metadata,
+            resolver: nil
           )
         end
 

--- a/spec_support/lib/elastic_graph/spec_support/runtime_metadata_support.rb
+++ b/spec_support/lib/elastic_graph/spec_support/runtime_metadata_support.rb
@@ -93,6 +93,13 @@ module ElasticGraph
           )
         end
 
+        def computation_detail_with(empty_bucket_value: 0, function: :sum)
+          ComputationDetail.new(
+            empty_bucket_value: empty_bucket_value,
+            function: function
+          )
+        end
+
         def dynamic_param_with(source_path: "some_field", cardinality: :one)
           DynamicParam.new(source_path: source_path, cardinality: cardinality)
         end
@@ -130,11 +137,12 @@ module ElasticGraph
           Relation.new(foreign_key: foreign_key, direction: direction, additional_filter: additional_filter, foreign_key_nested_paths: foreign_key_nested_paths)
         end
 
-        def graphql_field_with(name_in_index: "name_index", relation: nil, computation_detail: nil)
+        def graphql_field_with(name_in_index: "name_index", relation: nil, computation_detail: nil, resolver: nil)
           GraphQLField.new(
+            computation_detail: computation_detail,
             name_in_index: name_in_index,
             relation: relation,
-            computation_detail: computation_detail
+            resolver: resolver
           )
         end
 


### PR DESCRIPTION
I plan to use this to optimize our current GraphQL resolver so that instead of doing computation to figure out which resolver to use, it is told up front which resolver to use.