### PR TITLE
Specify the Ruby version in `update-gem-version-artifacts.yaml`.

### DIFF
--- a/.github/workflows/update-gem-version-artifacts.yaml
+++ b/.github/workflows/update-gem-version-artifacts.yaml
@@ -30,6 +30,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@2a18b06812b0e15bb916e1df298d3e740422c47e # v1.203.0
         with:
+          ruby-version: "3.4"
           bundler-cache: true
 
       - name: Update RBS collection


### PR DESCRIPTION
This should fix an error we got[^1]:

```
Error: Error: input ruby-version needs to be specified if no .ruby-version or .tool-versions file exists
```

[^1]: https://github.com/block/elasticgraph/actions/runs/13509716554/job/37747282106?pr=226