### PR TITLE
    Use a PAT when pushing from `update-gem-version-artifacts.yaml.`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,16 +7,6 @@ on:
     branches:
       - main
   pull_request:
-  # To avoid infinite workflow loops, a PR update triggered by one workflow will not
-  # automatically run other workflows.
-  #
-  # The `Update Gem Version Artifacts` workflow pushes new commits to dependabot PRs,
-  # and we need to run the CI build on those commits so we can judge whether or not it
-  # is safe to merge. To enable that, we have to opt-in to having this CI workflow run
-  # when `Update Gem Version Artifacts` completes.
-  workflow_run:
-    workflows: ["Update Gem Version Artifacts"]
-    types: [completed]
 
 env:
   # It's recommended to run ElasticGraph with this option to get better performance. We want to run

--- a/.github/workflows/update-gem-version-artifacts.yaml
+++ b/.github/workflows/update-gem-version-artifacts.yaml
@@ -9,8 +9,8 @@ jobs:
     # Only run on Dependabot PRs
     if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
+    # The 'permissions' here apply to the GITHUB_TOKEN, but we'll actually be pushing with the PAT
     permissions:
-      # Required to push to PR branches
       contents: write
       pull-requests: write
 
@@ -23,8 +23,9 @@ jobs:
       - name: Checkout Git Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          # We still need to check out using GITHUB_TOKEN so we can make local changes,
+          # but the push will use the personal access token.
           ref: ${{ github.head_ref }}
-          # Important: fetch with token that can push to PR branches
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Ruby
@@ -46,5 +47,9 @@ jobs:
             git config --local user.name "github-actions[bot]"
             git add rbs_collection.lock.yaml Gemfile Gemfile.lock *.gemspec
             git commit -m "Update gem version artifacts."
-            git push
+
+            # Push with PAT so it triggers "on: pull_request" or "on: push" events
+            # Replace "block" with your actual GitHub org/user, if different.
+            git push "https://github-actions[bot]:${{ secrets.PAT_FOR_PUSHING_AND_TRIGGERING_CI }}@github.com/block/elasticgraph.git" HEAD:${{ github.head_ref }}
           fi
+


### PR DESCRIPTION
The `ci.yaml` workflow isn't running when this workflow pushes
to a dependabot PR. GitHub protects against infinite workflow
loops (where 2 workflows infinitely trigger each other to run)
by disabling `pull_request` triggered workflows when an action
bot pushes to a PR from a workflow. To get around this, we can
use a PAT to push.
