### PR TITLE
Separate the dependabot PR check into its own workflow.

### DIFF
--- a/.github/workflows/dependabot-pr.yaml
+++ b/.github/workflows/dependabot-pr.yaml
@@ -1,0 +1,13 @@
+# This workflow doesn't have access to secrets and has a read-only token
+# It exists to trigger `update-gem-version-artifacts.yaml` in a two-step process,
+# as recommended by https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544
+name: Dependabot PR Check
+on:
+  pull_request
+
+jobs:
+  check-dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - run: echo "PR created by Dependabot"

--- a/.github/workflows/update-gem-version-artifacts.yaml
+++ b/.github/workflows/update-gem-version-artifacts.yaml
@@ -1,13 +1,13 @@
 name: Update Gem Version Artifacts
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  workflow_run:
+    workflows: ["Dependabot PR Check"]
+    types:
+      - completed
 
 jobs:
   update-dependencies:
-    # Only run on Dependabot PRs
-    if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     # The 'permissions' here apply to the GITHUB_TOKEN, but we'll actually be pushing with the PAT
     permissions:


### PR DESCRIPTION
`pull_request` workflows initiated by Dependabot do not have access to secrets, as discussed here:

https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544

Here I've adopted the solution they recommend--splitting into two workflows, where one checks the Dependabot actor, and another updates the artifacts and pushes.