### PR TITLE
Fix our gem constraint maintenance tooling.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 1
+          cache-version: 2
 
       - uses: KengoTODA/actions-setup-docker-compose@a25fb82c577d314635e25bac72995718b9296dd2 # main
         env:

--- a/.github/workflows/update-gem-version-artifacts.yaml
+++ b/.github/workflows/update-gem-version-artifacts.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           ruby-version: "3.4"
           bundler-cache: true
-          cache-version: 1
+          cache-version: 2
 
       - name: Update RBS collection
         run: |
@@ -42,6 +42,7 @@ jobs:
 
       - name: Update gem version constraints
         run: |
+          bundle config --local deployment false
           script/update_gem_constraints
           git status
           git diff

--- a/script/update_ci_yaml
+++ b/script/update_ci_yaml
@@ -141,7 +141,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 1
+          cache-version: 2
 
       - uses: KengoTODA/actions-setup-docker-compose@a25fb82c577d314635e25bac72995718b9296dd2 # main
         env:

--- a/script/update_gem_constraints
+++ b/script/update_gem_constraints
@@ -64,8 +64,12 @@ class DependencyUpdater
 
   def run_bundle_install
     puts "\nRunning bundle install..."
-    system("bundle install")
+    success = system("bundle install")
     puts # Add a blank line after bundle install output
+
+    unless success
+      abort "\e[31mError: bundle install failed\e[0m"
+    end
   end
 
   def display_changes


### PR DESCRIPTION
It hasn't been working because the `bundle install` run by `update_gem_constraints` fails due to the bundle being in frozen deployment mode. (That mode is something that `setup_ruby` enables when using the bundler cache).

I've fixed that issue by explicitly disabling the mode. In addition, I've fixed `update_gem_constraints` to fail if `bundle install` fails rather than silently ignoring the failure.

Finally, I've bumped the bundler cache version as the old logic would put it into a corrupted state.