### PR TITLE
Limit `update-gem-version-artifacts` to just dependabot PRs.

### DIFF
--- a/.github/workflows/update-gem-version-artifacts.yaml
+++ b/.github/workflows/update-gem-version-artifacts.yaml
@@ -9,6 +9,10 @@ on:
 jobs:
   update-dependencies:
     runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]'
     # The 'permissions' here apply to the GITHUB_TOKEN, but we'll actually be pushing with the PAT
     permissions:
       contents: write
@@ -35,17 +39,12 @@ jobs:
           cache-version: 2
 
       - name: Update RBS collection
-        run: |
-          bundle exec rbs collection update
-          git status
-          git diff
+        run: bundle exec rbs collection update
 
       - name: Update gem version constraints
         run: |
           bundle config --local deployment false
           script/update_gem_constraints
-          git status
-          git diff
 
       - name: Commit and push if changed
         run: |


### PR DESCRIPTION
It was wrongly running on all PRs.

Also, remove the `git status`/`git diff` logging as we no longer need it.