### PR TITLE
Introduce `default_graphql_resolver` at the type level.

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
@@ -18,6 +18,10 @@ module ElasticGraph
         # @private
         attr_reader :runtime_metadata_overrides
 
+        # @return [::Symbol, nil] the default GraphQL resolver to use for fields on this type
+        attr_accessor :default_graphql_resolver
+        # @dynamic default_graphql_resolver, default_graphql_resolver=
+
         # @private
         def initialize(*args, **options)
           super(*args, **options)
@@ -264,7 +268,15 @@ module ElasticGraph
         end
 
         def runtime_metadata_graphql_fields_by_name
-          graphql_fields_by_name.transform_values(&:runtime_metadata_graphql_field)
+          graphql_fields_by_name.transform_values do |field|
+            field_metadata = field.runtime_metadata_graphql_field
+
+            if default_graphql_resolver && !field_metadata.resolver
+              field_metadata.with(resolver: default_graphql_resolver)
+            else
+              field_metadata
+            end
+          end
         end
 
         # Provides a "best effort" conversion of a type name to the plural form.

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
@@ -92,7 +92,7 @@ module ElasticGraph
         :aggregated_values_customizations, :sort_order_enum_value_customizations,
         :args, :sortable, :filterable, :aggregatable, :groupable, :graphql_only, :source, :runtime_field_script, :relationship, :singular_name,
         :computation_detail, :non_nullable_in_json_schema, :backing_indexing_field, :as_input,
-        :legacy_grouping_schema, :name_in_index
+        :legacy_grouping_schema, :name_in_index, :resolver
       )
         include Mixins::HasDocumentation
         include Mixins::HasDirectives
@@ -106,7 +106,7 @@ module ElasticGraph
           runtime_metadata_graphql_field: SchemaArtifacts::RuntimeMetadata::GraphQLField::EMPTY,
           type_for_derived_types: nil, graphql_only: nil, singular: nil,
           sortable: nil, filterable: nil, aggregatable: nil, groupable: nil,
-          backing_indexing_field: nil, as_input: false, legacy_grouping_schema: false
+          backing_indexing_field: nil, as_input: false, legacy_grouping_schema: false, resolver: nil
         )
           type_ref = schema_def_state.type_ref(type)
           super(
@@ -137,7 +137,8 @@ module ElasticGraph
             non_nullable_in_json_schema: false,
             backing_indexing_field: backing_indexing_field,
             as_input: as_input,
-            legacy_grouping_schema: legacy_grouping_schema
+            legacy_grouping_schema: legacy_grouping_schema,
+            resolver: resolver
           )
 
           if name != name_in_index && name_in_index.include?(".") && !graphql_only
@@ -926,7 +927,7 @@ module ElasticGraph
             name_in_index: name_in_index,
             computation_detail: computation_detail,
             relation: relationship&.runtime_metadata,
-            resolver: nil
+            resolver: resolver
           )
         end
 

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/mixins/has_indices.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/mixins/has_indices.rbs
@@ -4,6 +4,7 @@ module ElasticGraph
       module HasIndices
         attr_reader indices: ::Array[Indexing::Index]
         attr_reader runtime_metadata_overrides: ::Hash[::Symbol, untyped]
+        attr_accessor default_graphql_resolver: ::Symbol?
         def index: (::String, ::Hash[::Symbol, ::String | ::Integer]) ?{ (Indexing::Index) -> void } -> ::Array[Indexing::Index]
         def indexed?: () -> bool
         def override_runtime_metadata: (**untyped) -> void

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/field.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/field.rbs
@@ -25,6 +25,7 @@ module ElasticGraph
         attr_reader non_nullable_in_json_schema: bool
         attr_reader source: FieldSource?
         attr_accessor relationship: Relationship?
+        attr_accessor resolver: ::Symbol?
         attr_reader singular_name: ::String?
         attr_reader as_input: bool
 


### PR DESCRIPTION
This provides a more convenient way to configure the GraphQL resolver on fields when it's the same for all fields of a type.