### PR TITLE
Omit `name_in_index` from dumped GraphQL fields when it matches GraphQL name.

### DIFF
--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
@@ -59,7 +59,7 @@ module ElasticGraph
                     relation: nil
                   ),
                   "parent" => GraphQLField.new(
-                    name_in_index: nil,
+                    name_in_index: "parent",
                     computation_detail: nil,
                     relation: Relation.new(
                       foreign_key: "grandparents.parents.some_id",
@@ -69,7 +69,7 @@ module ElasticGraph
                     )
                   ),
                   "sum" => GraphQLField.new(
-                    name_in_index: nil,
+                    name_in_index: "sum",
                     computation_detail: ComputationDetail.new(
                       empty_bucket_value: 0,
                       function: :sum

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
@@ -140,7 +140,7 @@ module ElasticGraph
             legacy_grouping_schema: legacy_grouping_schema
           )
 
-          if name != name_in_index && name_in_index&.include?(".") && !graphql_only
+          if name != name_in_index && name_in_index.include?(".") && !graphql_only
             raise Errors::SchemaError, "#{self} has an invalid `name_in_index`: #{name_in_index.inspect}. Only `graphql_only: true` fields can have a `name_in_index` that references a child field."
           end
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_with_subfields.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_with_subfields.rb
@@ -197,8 +197,6 @@ module ElasticGraph
               "configure an alternate name for the `#{name}` operator."
           end
 
-          options = {name_in_index: nil}.merge(options) if graphql_only
-
           field_factory.call(
             name: name,
             type: type,

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/relation_metadata_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/relation_metadata_spec.rb
@@ -24,7 +24,7 @@ module ElasticGraph
 
         expect(metadata.graphql_fields_by_name).to eq({
           "parent" => graphql_field_with(
-            name_in_index: nil,
+            name_in_index: "parent",
             relation: SchemaArtifacts::RuntimeMetadata::Relation.new(
               foreign_key: "parent_id",
               direction: :out,
@@ -45,7 +45,6 @@ module ElasticGraph
         end
 
         expected_relation_field = graphql_field_with(
-          name_in_index: nil,
           relation: SchemaArtifacts::RuntimeMetadata::Relation.new(
             foreign_key: "parent_id",
             direction: :in,
@@ -55,8 +54,8 @@ module ElasticGraph
         )
 
         expect(metadata.graphql_fields_by_name).to eq({
-          "children" => expected_relation_field,
-          "child_aggregations" => expected_relation_field
+          "children" => expected_relation_field.with(name_in_index: "children"),
+          "child_aggregations" => expected_relation_field.with(name_in_index: "child_aggregations")
         })
       end
 
@@ -80,7 +79,6 @@ module ElasticGraph
         end
 
         expected_relation_field = graphql_field_with(
-          name_in_index: nil,
           relation: SchemaArtifacts::RuntimeMetadata::Relation.new(
             foreign_key: "parent_id",
             direction: :in,
@@ -90,9 +88,9 @@ module ElasticGraph
         )
 
         expect(metadata.graphql_fields_by_name).to eq({
-          "children" => expected_relation_field,
-          "child_aggregations" => expected_relation_field,
-          "parent" => expected_relation_field
+          "children" => expected_relation_field.with(name_in_index: "children"),
+          "child_aggregations" => expected_relation_field.with(name_in_index: "child_aggregations"),
+          "parent" => expected_relation_field.with(name_in_index: "parent")
         })
       end
 
@@ -116,7 +114,6 @@ module ElasticGraph
         end
 
         expected_relation_field = graphql_field_with(
-          name_in_index: nil,
           relation: SchemaArtifacts::RuntimeMetadata::Relation.new(
             foreign_key: "parent_id",
             direction: :in,
@@ -126,9 +123,9 @@ module ElasticGraph
         )
 
         expect(metadata.graphql_fields_by_name).to eq({
-          "children" => expected_relation_field,
-          "child_aggregations" => expected_relation_field,
-          "parent" => expected_relation_field
+          "children" => expected_relation_field.with(name_in_index: "children"),
+          "child_aggregations" => expected_relation_field.with(name_in_index: "child_aggregations"),
+          "parent" => expected_relation_field.with(name_in_index: "parent")
         })
       end
 
@@ -161,7 +158,6 @@ module ElasticGraph
         end
 
         expected_relation_field = graphql_field_with(
-          name_in_index: nil,
           relation: SchemaArtifacts::RuntimeMetadata::Relation.new(
             foreign_key: "parent_id",
             direction: :in,
@@ -175,9 +171,9 @@ module ElasticGraph
         )
 
         expect(metadata.graphql_fields_by_name).to eq({
-          "children" => expected_relation_field,
-          "child_aggregations" => expected_relation_field,
-          "parent" => expected_relation_field
+          "children" => expected_relation_field.with(name_in_index: "children"),
+          "child_aggregations" => expected_relation_field.with(name_in_index: "child_aggregations"),
+          "parent" => expected_relation_field.with(name_in_index: "parent")
         })
       end
 
@@ -242,7 +238,6 @@ module ElasticGraph
           end
 
           expected_relation_field = graphql_field_with(
-            name_in_index: nil,
             relation: SchemaArtifacts::RuntimeMetadata::Relation.new(
               foreign_key: "players.affiliations.sponsorships.sponsor_id",
               direction: :in,
@@ -251,8 +246,8 @@ module ElasticGraph
             )
           )
           expect(metadata.graphql_fields_by_name).to eq({
-            "affiliated_teams" => expected_relation_field,
-            "affiliated_team_aggregations" => expected_relation_field
+            "affiliated_teams" => expected_relation_field.with(name_in_index: "affiliated_teams"),
+            "affiliated_team_aggregations" => expected_relation_field.with(name_in_index: "affiliated_team_aggregations")
           })
         end
       end


### PR DESCRIPTION
Previously, if a GraphQL field was dumped, we always included its `name_in_index` even if that duplicated the GraphQL name. To avoid bloat in our `runtime_metadata.yaml`, we can avoid dumping it if it matches. This removes the need to clear `name_in_index` on a `graphql_only` field--the `name_in_index` will naturally not be dumped.