### PR TITLE
Use new `resolver` metadata for pagination type resolvers.

### DIFF
--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -2722,12 +2722,38 @@ object_types_by_name:
     source_type: Address
   AddressAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   AddressAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   AddressConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   AddressEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   AddressGroupedBy:
     graphql_fields_by_name:
       full_address:
@@ -2871,12 +2897,38 @@ object_types_by_name:
     source_type: Component
   ComponentAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   ComponentAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   ComponentConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   ComponentEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   ComponentFilterInput:
     graphql_fields_by_name:
       widget_workspace_id:
@@ -3047,12 +3099,38 @@ object_types_by_name:
     source_type: ElectricalPart
   ElectricalPartAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   ElectricalPartAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   ElectricalPartConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   ElectricalPartEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   ElectricalPartGroupedBy:
     graphql_fields_by_name:
       created_at:
@@ -3304,12 +3382,38 @@ object_types_by_name:
     source_type: Manufacturer
   ManufacturerAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   ManufacturerAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   ManufacturerConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   ManufacturerEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   ManufacturerGroupedBy:
     graphql_fields_by_name:
       created_at:
@@ -3383,12 +3487,38 @@ object_types_by_name:
     source_type: MechanicalPart
   MechanicalPartAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   MechanicalPartAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   MechanicalPartConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   MechanicalPartEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   MechanicalPartGroupedBy:
     graphql_fields_by_name:
       created_at:
@@ -3610,12 +3740,38 @@ object_types_by_name:
     source_type: NamedEntity
   NamedEntityAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   NamedEntityAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   NamedEntityConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   NamedEntityEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   NamedEntityFilterInput:
     graphql_fields_by_name:
       amount_cents2:
@@ -3750,6 +3906,15 @@ object_types_by_name:
         resolver: object
     graphql_only_return_type: true
   PageInfo:
+    graphql_fields_by_name:
+      end_cursor:
+        resolver: object
+      has_next_page:
+        resolver: object
+      has_previous_page:
+        resolver: object
+      start_cursor:
+        resolver: object
     graphql_only_return_type: true
   Part:
     graphql_fields_by_name:
@@ -3792,12 +3957,38 @@ object_types_by_name:
     source_type: Part
   PartAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   PartAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   PartConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   PartEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   PartGroupedBy:
     graphql_fields_by_name:
       created_at:
@@ -3940,12 +4131,38 @@ object_types_by_name:
     source_type: Sponsor
   SponsorAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   SponsorAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   SponsorConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   SponsorEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   SponsorGroupedBy:
     graphql_fields_by_name:
       name:
@@ -3972,8 +4189,22 @@ object_types_by_name:
         name_in_index: __counts
   StringConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   StringEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   StringListFilterInput:
     graphql_fields_by_name:
       count:
@@ -4079,6 +4310,13 @@ object_types_by_name:
     source_type: Team
   TeamAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   TeamAggregationCurrentPlayersObjectAffiliationsSubAggregations:
     graphql_fields_by_name:
       sponsorships_nested:
@@ -4091,6 +4329,11 @@ object_types_by_name:
         resolver: object
   TeamAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   TeamAggregationNestedFields2SubAggregations:
     graphql_fields_by_name:
       current_players:
@@ -4144,6 +4387,15 @@ object_types_by_name:
         resolver: object
   TeamConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   TeamDetailsAggregatedValues:
     graphql_fields_by_name:
       count:
@@ -4156,6 +4408,11 @@ object_types_by_name:
         resolver: object
   TeamEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   TeamFilterInput:
     graphql_fields_by_name:
       nested_fields:
@@ -4188,6 +4445,9 @@ object_types_by_name:
         resolver: object
   TeamMoneySubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamNestedFields:
     graphql_fields_by_name:
       seasons:
@@ -4206,6 +4466,9 @@ object_types_by_name:
         resolver: object
   TeamPlayerPlayerSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamPlayerSeasonSubAggregation:
     graphql_fields_by_name:
       aggregated_values:
@@ -4216,6 +4479,9 @@ object_types_by_name:
         resolver: object
   TeamPlayerSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamPlayerSponsorshipSubAggregation:
     graphql_fields_by_name:
       aggregated_values:
@@ -4226,6 +4492,9 @@ object_types_by_name:
         resolver: object
   TeamPlayerSponsorshipSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamPlayerSubAggregation:
     graphql_fields_by_name:
       aggregated_values:
@@ -4242,6 +4511,9 @@ object_types_by_name:
         resolver: object
   TeamPlayerSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamPlayerSubAggregationSubAggregations:
     graphql_fields_by_name:
       affiliations:
@@ -4410,6 +4682,9 @@ object_types_by_name:
         resolver: object
   TeamSponsorshipSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamTeamSeasonPlayerPlayerSeasonSubAggregation:
     graphql_fields_by_name:
       aggregated_values:
@@ -4420,6 +4695,9 @@ object_types_by_name:
         resolver: object
   TeamTeamSeasonPlayerPlayerSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamTeamSeasonPlayerSeasonSubAggregation:
     graphql_fields_by_name:
       aggregated_values:
@@ -4430,6 +4708,9 @@ object_types_by_name:
         resolver: object
   TeamTeamSeasonPlayerSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamTeamSeasonPlayerSponsorshipSubAggregation:
     graphql_fields_by_name:
       aggregated_values:
@@ -4440,6 +4721,9 @@ object_types_by_name:
         resolver: object
   TeamTeamSeasonPlayerSponsorshipSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamTeamSeasonPlayerSubAggregation:
     graphql_fields_by_name:
       aggregated_values:
@@ -4456,6 +4740,9 @@ object_types_by_name:
         resolver: object
   TeamTeamSeasonPlayerSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamTeamSeasonPlayerSubAggregationSubAggregations:
     graphql_fields_by_name:
       affiliations:
@@ -4472,6 +4759,9 @@ object_types_by_name:
         resolver: object
   TeamTeamSeasonSponsorshipSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamTeamSeasonSubAggregation:
     graphql_fields_by_name:
       aggregated_values:
@@ -4484,6 +4774,9 @@ object_types_by_name:
         resolver: object
   TeamTeamSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamTeamSeasonSubAggregationPlayersObjectAffiliationsSubAggregations:
     graphql_fields_by_name:
       sponsorships_nested:
@@ -4753,10 +5046,31 @@ object_types_by_name:
     source_type: Widget
   WidgetAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   WidgetAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   WidgetConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   WidgetCurrency:
     graphql_fields_by_name:
       widget_names:
@@ -4839,12 +5153,38 @@ object_types_by_name:
     source_type: WidgetCurrency
   WidgetCurrencyAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   WidgetCurrencyAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   WidgetCurrencyConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   WidgetCurrencyEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   WidgetCurrencyFilterInput:
     graphql_fields_by_name:
       widget_names:
@@ -4876,6 +5216,11 @@ object_types_by_name:
         resolver: object
   WidgetEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   WidgetFilterInput:
     graphql_fields_by_name:
       amount_cents2:
@@ -5131,12 +5476,38 @@ object_types_by_name:
     source_type: WidgetOrAddress
   WidgetOrAddressAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   WidgetOrAddressAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   WidgetOrAddressConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   WidgetOrAddressEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   WidgetOrAddressFilterInput:
     graphql_fields_by_name:
       amount_cents2:
@@ -5298,12 +5669,38 @@ object_types_by_name:
     source_type: WidgetWorkspace
   WidgetWorkspaceAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   WidgetWorkspaceAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   WidgetWorkspaceConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   WidgetWorkspaceEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   WidgetWorkspaceGroupedBy:
     graphql_fields_by_name:
       name:

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -2725,12 +2725,38 @@ object_types_by_name:
     source_type: Address
   AddressAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   AddressAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   AddressConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   AddressEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   AddressGroupedBy:
     graphql_fields_by_name:
       full_address:
@@ -2874,12 +2900,38 @@ object_types_by_name:
     source_type: Component
   ComponentAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   ComponentAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   ComponentConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   ComponentEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   ComponentFilterInput:
     graphql_fields_by_name:
       widget_workspace_id:
@@ -3062,12 +3114,38 @@ object_types_by_name:
     source_type: ElectricalPart
   ElectricalPartAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   ElectricalPartAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   ElectricalPartConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   ElectricalPartEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   ElectricalPartGroupedBy:
     graphql_fields_by_name:
       created_at:
@@ -3319,12 +3397,38 @@ object_types_by_name:
     source_type: Manufacturer
   ManufacturerAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   ManufacturerAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   ManufacturerConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   ManufacturerEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   ManufacturerGroupedBy:
     graphql_fields_by_name:
       created_at:
@@ -3398,12 +3502,38 @@ object_types_by_name:
     source_type: MechanicalPart
   MechanicalPartAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   MechanicalPartAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   MechanicalPartConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   MechanicalPartEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   MechanicalPartGroupedBy:
     graphql_fields_by_name:
       created_at:
@@ -3625,12 +3755,38 @@ object_types_by_name:
     source_type: NamedEntity
   NamedEntityAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   NamedEntityAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   NamedEntityConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   NamedEntityEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   NamedEntityFilterInput:
     graphql_fields_by_name:
       amount_cents2:
@@ -3765,6 +3921,15 @@ object_types_by_name:
         resolver: object
     graphql_only_return_type: true
   PageInfo:
+    graphql_fields_by_name:
+      end_cursor:
+        resolver: object
+      has_next_page:
+        resolver: object
+      has_previous_page:
+        resolver: object
+      start_cursor:
+        resolver: object
     graphql_only_return_type: true
   Part:
     graphql_fields_by_name:
@@ -3807,12 +3972,38 @@ object_types_by_name:
     source_type: Part
   PartAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   PartAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   PartConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   PartEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   PartGroupedBy:
     graphql_fields_by_name:
       created_at:
@@ -3955,12 +4146,38 @@ object_types_by_name:
     source_type: Sponsor
   SponsorAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   SponsorAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   SponsorConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   SponsorEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   SponsorGroupedBy:
     graphql_fields_by_name:
       name:
@@ -3987,8 +4204,22 @@ object_types_by_name:
         name_in_index: __counts
   StringConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   StringEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   StringListFilterInput:
     graphql_fields_by_name:
       count:
@@ -4094,6 +4325,13 @@ object_types_by_name:
     source_type: Team
   TeamAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   TeamAggregationCurrentPlayersObjectAffiliationsSubAggregations:
     graphql_fields_by_name:
       sponsorships_nested:
@@ -4106,6 +4344,11 @@ object_types_by_name:
         resolver: object
   TeamAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   TeamAggregationNestedFields2SubAggregations:
     graphql_fields_by_name:
       current_players:
@@ -4159,6 +4402,15 @@ object_types_by_name:
         resolver: object
   TeamConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   TeamDetailsAggregatedValues:
     graphql_fields_by_name:
       count:
@@ -4171,6 +4423,11 @@ object_types_by_name:
         resolver: object
   TeamEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   TeamFilterInput:
     graphql_fields_by_name:
       nested_fields:
@@ -4203,6 +4460,9 @@ object_types_by_name:
         resolver: object
   TeamMoneySubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamNestedFields:
     graphql_fields_by_name:
       seasons:
@@ -4221,6 +4481,9 @@ object_types_by_name:
         resolver: object
   TeamPlayerPlayerSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamPlayerSeasonSubAggregation:
     graphql_fields_by_name:
       aggregated_values:
@@ -4231,6 +4494,9 @@ object_types_by_name:
         resolver: object
   TeamPlayerSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamPlayerSponsorshipSubAggregation:
     graphql_fields_by_name:
       aggregated_values:
@@ -4241,6 +4507,9 @@ object_types_by_name:
         resolver: object
   TeamPlayerSponsorshipSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamPlayerSubAggregation:
     graphql_fields_by_name:
       aggregated_values:
@@ -4257,6 +4526,9 @@ object_types_by_name:
         resolver: object
   TeamPlayerSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamPlayerSubAggregationSubAggregations:
     graphql_fields_by_name:
       affiliations:
@@ -4425,6 +4697,9 @@ object_types_by_name:
         resolver: object
   TeamSponsorshipSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamTeamSeasonPlayerPlayerSeasonSubAggregation:
     graphql_fields_by_name:
       aggregated_values:
@@ -4435,6 +4710,9 @@ object_types_by_name:
         resolver: object
   TeamTeamSeasonPlayerPlayerSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamTeamSeasonPlayerSeasonSubAggregation:
     graphql_fields_by_name:
       aggregated_values:
@@ -4445,6 +4723,9 @@ object_types_by_name:
         resolver: object
   TeamTeamSeasonPlayerSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamTeamSeasonPlayerSponsorshipSubAggregation:
     graphql_fields_by_name:
       aggregated_values:
@@ -4455,6 +4736,9 @@ object_types_by_name:
         resolver: object
   TeamTeamSeasonPlayerSponsorshipSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamTeamSeasonPlayerSubAggregation:
     graphql_fields_by_name:
       aggregated_values:
@@ -4471,6 +4755,9 @@ object_types_by_name:
         resolver: object
   TeamTeamSeasonPlayerSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamTeamSeasonPlayerSubAggregationSubAggregations:
     graphql_fields_by_name:
       affiliations:
@@ -4487,6 +4774,9 @@ object_types_by_name:
         resolver: object
   TeamTeamSeasonSponsorshipSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamTeamSeasonSubAggregation:
     graphql_fields_by_name:
       aggregated_values:
@@ -4499,6 +4789,9 @@ object_types_by_name:
         resolver: object
   TeamTeamSeasonSubAggregationConnection:
     elasticgraph_category: nested_sub_aggregation_connection
+    graphql_fields_by_name:
+      nodes:
+        resolver: object
   TeamTeamSeasonSubAggregationPlayersObjectAffiliationsSubAggregations:
     graphql_fields_by_name:
       sponsorships_nested:
@@ -4768,10 +5061,31 @@ object_types_by_name:
     source_type: Widget
   WidgetAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   WidgetAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   WidgetConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   WidgetCurrency:
     graphql_fields_by_name:
       widget_names:
@@ -4854,12 +5168,38 @@ object_types_by_name:
     source_type: WidgetCurrency
   WidgetCurrencyAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   WidgetCurrencyAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   WidgetCurrencyConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   WidgetCurrencyEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   WidgetCurrencyFilterInput:
     graphql_fields_by_name:
       widget_names:
@@ -4891,6 +5231,11 @@ object_types_by_name:
         resolver: object
   WidgetEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   WidgetFilterInput:
     graphql_fields_by_name:
       amount_cents2:
@@ -5146,12 +5491,38 @@ object_types_by_name:
     source_type: WidgetOrAddress
   WidgetOrAddressAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   WidgetOrAddressAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   WidgetOrAddressConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   WidgetOrAddressEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   WidgetOrAddressFilterInput:
     graphql_fields_by_name:
       amount_cents2:
@@ -5313,12 +5684,38 @@ object_types_by_name:
     source_type: WidgetWorkspace
   WidgetWorkspaceAggregationConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
   WidgetWorkspaceAggregationEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   WidgetWorkspaceConnection:
     elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver: object
+      nodes:
+        resolver: object
+      page_info:
+        resolver: object
+      total_edge_count:
+        resolver: object
   WidgetWorkspaceEdge:
     elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver: object
+      node:
+        resolver: object
   WidgetWorkspaceGroupedBy:
     graphql_fields_by_name:
       name:

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter.rb
@@ -109,7 +109,6 @@ module ElasticGraph
             return @named_resolvers.fetch(resolver_name)
           end
 
-          return object if object.respond_to?(:can_resolve?) && object.can_resolve?(field: field, object: object)
           resolver = @resolvers.find { |r| r.can_resolve?(field: field, object: object) }
           resolver || yield
         end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/resolvable_value.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/resolvable_value.rb
@@ -32,11 +32,6 @@ module ElasticGraph
           public_send(method_name, **args_to_canonical_form(args))
         end
 
-        def can_resolve?(field:, object:)
-          method_name = schema_element_names.canonical_name_for(field.name)
-          !!method_name && respond_to?(method_name)
-        end
-
         private
 
         def args_to_canonical_form(args)

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
@@ -137,30 +137,6 @@ module ElasticGraph
             end
           end
 
-          describe "#can_resolve?" do
-            it "returns `false` if the field name is not defined in the schema elements" do
-              expect(can_resolve?(field: :last_name)).to be false
-            end
-
-            it "returns `false` if no method matching the field name is defined on the object" do
-              expect(can_resolve?(field: :age)).to be false
-            end
-
-            it "returns `true` if the field name is a defined schema element and the object has a matching method" do
-              expect(can_resolve?(field: :name)).to be true
-              expect(can_resolve?(field: :first_name)).to be true
-            end
-
-            it "considers if the method is defined using the canonical form of the field name" do
-              expect(can_resolve?(name_form: :camelCase, field: :firstName)).to be true
-            end
-
-            def can_resolve?(**options)
-              person, field = person_object_and_schema_field(**options)
-              person.can_resolve?(field: field, object: person)
-            end
-          end
-
           define_method :person_object_and_schema_field do |
             field:, name_form: :snake_case, overrides: {},
             name: "John", birth_date: "2002-09-01", quote: "To be, or not to be, that is the question."

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
@@ -434,6 +434,7 @@ module ElasticGraph
         type_ref = @state.type_ref(type_name)
         new_object_type type_ref.as_edge.name do |t|
           t.relay_pagination_type = true
+          t.default_graphql_resolver = :object
           t.override_runtime_metadata(elasticgraph_category: :relay_edge)
 
           t.documentation <<~EOS
@@ -461,6 +462,7 @@ module ElasticGraph
         type_ref = @state.type_ref(type_name)
         new_object_type type_ref.as_connection.name do |t|
           t.relay_pagination_type = true
+          t.default_graphql_resolver = :object
           t.override_runtime_metadata(elasticgraph_category: :relay_connection)
 
           if support_pagination

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_filtering_and_aggregation.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_filtering_and_aggregation.rb
@@ -46,6 +46,7 @@ module ElasticGraph
               # Record metadata that is necessary for elasticgraph-graphql to correctly recognize and handle
               # this sub-aggregation correctly.
               t.override_runtime_metadata(elasticgraph_category: :nested_sub_aggregation_connection)
+              t.default_graphql_resolver = :object
             end
           end
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
@@ -393,6 +393,8 @@ module ElasticGraph
           # to go from non-null to null, but is not a breaking change to make it non-null
           # in the future.
           register_framework_object_type "PageInfo" do |t|
+            t.default_graphql_resolver = :object
+
             t.documentation <<~EOS
               Provides information about the specific fetched page. This implements the `PageInfo`
               specification from the [Relay GraphQL Cursor Connections


### PR DESCRIPTION
This will allow us to make further refactorings to improve performance by relying upon the GraphQL gem's internal dispatch system.