### PR TITLE
Use new `resolver` metadata for `ListRecords` resolver.

### DIFF
--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -4059,6 +4059,60 @@ object_types_by_name:
         resolver: object
       "y":
         resolver: object
+  Query:
+    graphql_fields_by_name:
+      address_aggregations:
+        resolver: list_records
+      addresses:
+        resolver: list_records
+      component_aggregations:
+        resolver: list_records
+      components:
+        resolver: list_records
+      electrical_part_aggregations:
+        resolver: list_records
+      electrical_parts:
+        resolver: list_records
+      manufacturer_aggregations:
+        resolver: list_records
+      manufacturers:
+        resolver: list_records
+      mechanical_part_aggregations:
+        resolver: list_records
+      mechanical_parts:
+        resolver: list_records
+      named_entities:
+        resolver: list_records
+      named_entity_aggregations:
+        resolver: list_records
+      part_aggregations:
+        resolver: list_records
+      parts:
+        resolver: list_records
+      sponsor_aggregations:
+        resolver: list_records
+      sponsors:
+        resolver: list_records
+      team_aggregations:
+        resolver: list_records
+      teams:
+        resolver: list_records
+      widget_aggregations:
+        resolver: list_records
+      widget_currencies:
+        resolver: list_records
+      widget_currency_aggregations:
+        resolver: list_records
+      widget_or_address_aggregations:
+        resolver: list_records
+      widget_workspace_aggregations:
+        resolver: list_records
+      widget_workspaces:
+        resolver: list_records
+      widgets:
+        resolver: list_records
+      widgets_or_addresses:
+        resolver: list_records
   SizeListFilterInput:
     graphql_fields_by_name:
       count:

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -4074,6 +4074,60 @@ object_types_by_name:
         resolver: object
       "y":
         resolver: object
+  Query:
+    graphql_fields_by_name:
+      address_aggregations:
+        resolver: list_records
+      addresses:
+        resolver: list_records
+      component_aggregations:
+        resolver: list_records
+      components:
+        resolver: list_records
+      electrical_part_aggregations:
+        resolver: list_records
+      electrical_parts:
+        resolver: list_records
+      manufacturer_aggregations:
+        resolver: list_records
+      manufacturers:
+        resolver: list_records
+      mechanical_part_aggregations:
+        resolver: list_records
+      mechanical_parts:
+        resolver: list_records
+      named_entities:
+        resolver: list_records
+      named_entity_aggregations:
+        resolver: list_records
+      part_aggregations:
+        resolver: list_records
+      parts:
+        resolver: list_records
+      sponsor_aggregations:
+        resolver: list_records
+      sponsors:
+        resolver: list_records
+      team_aggregations:
+        resolver: list_records
+      teams:
+        resolver: list_records
+      widget_aggregations:
+        resolver: list_records
+      widget_currencies:
+        resolver: list_records
+      widget_currency_aggregations:
+        resolver: list_records
+      widget_or_address_aggregations:
+        resolver: list_records
+      widget_workspace_aggregations:
+        resolver: list_records
+      widget_workspaces:
+        resolver: list_records
+      widgets:
+        resolver: list_records
+      widgets_or_addresses:
+        resolver: list_records
   SizeListFilterInput:
     graphql_fields_by_name:
       count:

--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -158,21 +158,19 @@ module ElasticGraph
     def graphql_resolvers
       @graphql_resolvers ||= begin
         require "elastic_graph/graphql/resolvers/get_record_field_value"
-        require "elastic_graph/graphql/resolvers/list_records"
-
-        list_records = Resolvers::ListRecords.new
 
         get_record_field_value = Resolvers::GetRecordFieldValue.new(
           schema_element_names: runtime_metadata.schema_element_names
         )
 
-        [list_records, get_record_field_value]
+        [get_record_field_value]
       end
     end
 
     # @private
     def named_graphql_resolvers
       @named_graphql_resolvers ||= begin
+        require "elastic_graph/graphql/resolvers/list_records"
         require "elastic_graph/graphql/resolvers/nested_relationships"
         require "elastic_graph/graphql/resolvers/object"
 
@@ -182,6 +180,7 @@ module ElasticGraph
         )
 
         {
+          list_records: Resolvers::ListRecords.new,
           nested_relationships: nested_relationships,
           object: Resolvers::Object.new
         }

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/list_records.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/list_records.rb
@@ -14,10 +14,6 @@ module ElasticGraph
     module Resolvers
       # Responsible for fetching a a list of records of a particular type
       class ListRecords
-        def can_resolve?(field:, object:)
-          field.parent_type.name == :Query && field.type.collection?
-        end
-
         def resolve(field:, context:, lookahead:, **)
           query = yield
           response = QuerySource.execute_one(query, for_context: context)

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_executor_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_executor_spec.rb
@@ -45,9 +45,11 @@ module ElasticGraph
                 type.field "float", "Float"  # so the Float type exists
                 type.field "colors", "[Color!]!" do |f|
                   f.argument "args", "ColorArgs"
+                  f.resolver = :list_records
                 end
                 type.field "colors2", "[Color2!]!" do |f|
                   f.argument "args", "ColorArgs"
+                  f.resolver = :list_records
                 end
               end
             end

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
@@ -133,7 +133,7 @@ module ElasticGraph
               singular: indexed_type.singular_root_query_field_name
             ) do |f|
               f.documentation "Fetches `#{indexed_type.name}`s based on the provided arguments."
-              f.resolver = nil
+              f.resolver = :list_records
               f.hide_relationship_runtime_metadata = true
               indexed_type.root_query_fields_customizations&.call(f)
             end

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/pruning_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/pruning_spec.rb
@@ -77,6 +77,7 @@ module ElasticGraph
           NoCustomizationsListFilterInput
           NonNumericAggregatedValues
           PageInfo
+          Query
           StringListFilterInput
           TextListFilterInput
           TimeZoneListFilterInput


### PR DESCRIPTION
This moves us one step closer to being able to use the GraphQL gem's native resolver disaptching.