### PR TITLE
Use strings instead of symbols for type names.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_adapter.rb
@@ -213,7 +213,7 @@ module ElasticGraph
             elsif !field.type.object?
               case field.type.name
               # Legacy date grouping API
-              when :Date
+              when "Date"
                 legacy_date_histogram_groupings_from(
                   field_path: field_path,
                   node: node,
@@ -221,7 +221,7 @@ module ElasticGraph
                   get_offset: ->(args) { args[element_names.offset_days]&.then { |days| "#{days}d" } }
                 )
               # Legacy datetime grouping API
-              when :DateTime
+              when "DateTime"
                 legacy_date_histogram_groupings_from(
                   field_path: field_path,
                   node: node,

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
@@ -74,7 +74,7 @@ module ElasticGraph
       # get type objects for wrapped types, but you need to get it from a field object of that
       # type.
       def type_named(type_name)
-        @types_by_name.fetch(type_name.to_s)
+        @types_by_name.fetch(type_name)
       rescue KeyError => e
         msg = "No type named #{type_name} could be found"
         msg += "; Possible alternatives: [#{e.corrections.join(", ").delete('"')}]." if e.corrections.any?
@@ -109,7 +109,7 @@ module ElasticGraph
       end
 
       def to_s
-        "#<#{self.class.name} 0x#{__id__.to_s(16)} indexed_document_types=#{indexed_document_types.map(&:name).sort.to_s.delete(":")}>"
+        "#<#{self.class.name} 0x#{__id__.to_s(16)} indexed_document_types=[#{indexed_document_types.map(&:name).sort.join(", ")}]>"
       end
       alias_method :inspect, :to_s
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/field.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/field.rb
@@ -47,7 +47,7 @@ module ElasticGraph
           # when those types are accessed in a Query. We don't really want to mutate the fields on the
           # built-in types by adding `:lookahead` so it's best to avoid setting that extra on the built
           # in types.
-          if @graphql_field.respond_to?(:extras) && !BUILT_IN_TYPE_NAMES.include?(parent_type.name.to_s)
+          if @graphql_field.respond_to?(:extras) && !BUILT_IN_TYPE_NAMES.include?(parent_type.name)
             @graphql_field.extras([:lookahead])
           end
         end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/type.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/type.rb
@@ -45,7 +45,7 @@ module ElasticGraph
         end
 
         def name
-          @name ||= @graphql_type.to_type_signature.to_sym
+          @name ||= @graphql_type.to_type_signature
         end
 
         # List of index definitions that should be searched for this type.

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/schema.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/schema.rbs
@@ -15,8 +15,8 @@ module ElasticGraph
       ) -> void
 
       def type_from: (::GraphQL::Schema::_Type) -> Type
-      def type_named: (::String | ::Symbol) -> Type
-      def field_named: (::String | ::Symbol, ::String | ::Symbol) -> Field
+      def type_named: (::String) -> Type
+      def field_named: (::String, ::String | ::Symbol) -> Field
       def indexed_document_types: () -> ::Array[Type]
     end
   end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/schema/type.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/schema/type.rbs
@@ -3,7 +3,7 @@ module ElasticGraph
     class Schema
       # Note: this is a partial signature definition (`type.rb` is ignored in `Steepfile`)
       class Type
-        attr_reader name: ::Symbol
+        attr_reader name: ::String
         attr_reader fields_by_name: ::Hash[::String, Field]
         attr_reader elasticgraph_category: SchemaArtifacts::RuntimeMetadata::elasticGraphCategory?
         attr_reader graphql_type: ::GraphQL::Schema::_Type

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/list_records_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/list_records_spec.rb
@@ -16,7 +16,7 @@ module ElasticGraph
           let(:graphql) { build_graphql }
 
           it "wraps the datastore response in a relay connection adapter when the field is a relay connection field" do
-            expect(resolve(:Query, :widgets)).to be_a RelayConnection::GenericAdapter
+            expect(resolve("Query", :widgets)).to be_a RelayConnection::GenericAdapter
           end
         end
 
@@ -32,10 +32,10 @@ module ElasticGraph
           end
 
           it "respects a list of `order_by` options, supporting ascending and descending sorts" do
-            results = resolve_nodes(:Query, :widgets, order_by: ["amount_cents_DESC", "created_at_ASC"])
+            results = resolve_nodes("Query", :widgets, order_by: ["amount_cents_DESC", "created_at_ASC"])
             expect(results.map { |r| r.fetch("id") }).to eq ["w2", "w3", "w1"]
 
-            results = resolve_nodes(:Query, :widgets, order_by: ["amount_cents_ASC", "created_at_DESC"])
+            results = resolve_nodes("Query", :widgets, order_by: ["amount_cents_ASC", "created_at_DESC"])
             expect(results.map { |r| r.fetch("id") }).to eq ["w1", "w3", "w2"]
           end
         end
@@ -53,28 +53,28 @@ module ElasticGraph
           end
 
           it "supports filtering by a list of one value" do
-            results = resolve_nodes(:Query, :widgets, filter: {id: {equal_to_any_of: [widget1.fetch(:id)]}})
+            results = resolve_nodes("Query", :widgets, filter: {id: {equal_to_any_of: [widget1.fetch(:id)]}})
             expect(results.map { |r| r.fetch("id") }).to contain_exactly(widget1.fetch(:id))
 
-            results = resolve_nodes(:Query, :widgets, filter: {name: {equal_to_any_of: ["w2"]}})
+            results = resolve_nodes("Query", :widgets, filter: {name: {equal_to_any_of: ["w2"]}})
             expect(results.map { |r| r.fetch("id") }).to contain_exactly(widget2a.fetch(:id), widget2b.fetch(:id))
           end
 
           it "supports filtering by a list of multiple values" do
-            results = resolve_nodes(:Query, :widgets, filter: {id: {equal_to_any_of: [widget1.fetch(:id), widget3.fetch(:id)]}})
+            results = resolve_nodes("Query", :widgets, filter: {id: {equal_to_any_of: [widget1.fetch(:id), widget3.fetch(:id)]}})
             expect(results.map { |r| r.fetch("id") }).to contain_exactly(widget1.fetch(:id), widget3.fetch(:id))
 
-            results = resolve_nodes(:Query, :widgets, filter: {name: {equal_to_any_of: ["w2", "w1"]}})
+            results = resolve_nodes("Query", :widgets, filter: {name: {equal_to_any_of: ["w2", "w1"]}})
             expect(results.map { |r| r.fetch("id") }).to contain_exactly(widget1.fetch(:id), widget2a.fetch(:id), widget2b.fetch(:id))
           end
 
           it "supports default sort" do
-            results = resolve_nodes(:Query, :widgets, filter: {id: {equal_to_any_of: ["w3", "w2b", "w1"]}})
+            results = resolve_nodes("Query", :widgets, filter: {id: {equal_to_any_of: ["w3", "w2b", "w1"]}})
             expect(results.map { |r| r.fetch("id") }).to eq([widget3.fetch(:id), widget2b.fetch(:id), widget1.fetch(:id)])
           end
 
           it "supports combining filters on more than one field" do
-            results = resolve_nodes(:Query, :widgets, filter: {
+            results = resolve_nodes("Query", :widgets, filter: {
               name: {equal_to_any_of: ["w2", "w3"]},
               amount_cents: {equal_to_any_of: [100, 400]}
             })

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_spec.rb
@@ -45,14 +45,14 @@ module ElasticGraph
           let(:component1) { build(:component) }
 
           it "wraps the datastore response in a relay connection adapter when the field is a relay connection field" do
-            result = resolve(:Widget, :components, {"component_ids" => [component1.fetch(:id)]})
+            result = resolve("Widget", :components, {"component_ids" => [component1.fetch(:id)]})
 
             expect(result).to be_a RelayConnection::GenericAdapter
           end
 
           it "wraps the datastore response in a relay connection adapter when the foreign key field is missing" do
             expect {
-              result = resolve(:Widget, :components, {"name" => "a"})
+              result = resolve("Widget", :components, {"name" => "a"})
 
               expect(result).to be_a(RelayConnection::GenericAdapter)
               expect(result.edges).to be_empty
@@ -115,38 +115,38 @@ module ElasticGraph
             end
 
             it "loads the relationship and respects defaultSort" do
-              result = resolve_nodes(:Widget, :components, {"component_ids" => [component1.fetch(:id), component2.fetch(:id)]})
+              result = resolve_nodes("Widget", :components, {"component_ids" => [component1.fetch(:id), component2.fetch(:id)]})
 
               expect(result.map { |c| c.fetch("id") }).to eq([component2.fetch(:id), component1.fetch(:id)])
             end
 
             it "respects a list of `order_by` options, supporting ascending and descending sorts" do
-              result = resolve_nodes(:Widget, :components,
+              result = resolve_nodes("Widget", :components,
                 {"component_ids" => [component2.fetch(:id), component3.fetch(:id), component1.fetch(:id)]},
                 order_by: ["created_at_ASC"])
               expect(result.map { |c| c.fetch("id") }).to eq([component1.fetch(:id), component2.fetch(:id), component3.fetch(:id)])
 
-              result = resolve_nodes(:Widget, :components,
+              result = resolve_nodes("Widget", :components,
                 {"component_ids" => [component2.fetch(:id), component3.fetch(:id), component1.fetch(:id)]},
                 order_by: ["created_at_DESC"])
               expect(result.map { |c| c.fetch("id") }).to eq([component3.fetch(:id), component2.fetch(:id), component1.fetch(:id)])
             end
 
             it "tolerates not finding some ids" do
-              result = resolve_nodes(:Widget, :components, {"component_ids" => [component1.fetch(:id), build(:component).fetch(:id)]})
+              result = resolve_nodes("Widget", :components, {"component_ids" => [component1.fetch(:id), build(:component).fetch(:id)]})
 
               expect(result.map { |c| c.fetch("id") }).to contain_exactly(component1.fetch(:id))
             end
 
             it "returns an empty list when given a blank list of ids" do
-              result = resolve_nodes(:Widget, :components, {"component_ids" => []})
+              result = resolve_nodes("Widget", :components, {"component_ids" => []})
 
               expect(result).to be_empty
             end
 
             it "returns a list of a single record (and logs a warning) when the foreign key field is a scalar instead of a list" do
               expect {
-                result = resolve_nodes(:Widget, :components, {"component_ids" => component1.fetch(:id), "id" => "123"})
+                result = resolve_nodes("Widget", :components, {"component_ids" => component1.fetch(:id), "id" => "123"})
 
                 expect(result.map { |c| c.fetch("id") }).to contain_exactly(component1.fetch(:id))
               }.to log a_string_including("Widget(id: 123).components", "component_ids: scalar instead of a list")
@@ -154,21 +154,21 @@ module ElasticGraph
 
             it "returns an empty list (and logs a warning) when the foreign key field is missing" do
               expect {
-                result = resolve_nodes(:Widget, :components, {"name" => "a"})
+                result = resolve_nodes("Widget", :components, {"name" => "a"})
 
                 expect(result).to be_empty
               }.to log a_string_including("Widget(id: <no id>).components", "component_ids is missing from the document")
             end
 
             it "returns a list of records matching additional filter conditions" do
-              result = resolve_nodes(:Component, :dollar_widgets, {"id" => component1.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
+              result = resolve_nodes("Component", :dollar_widgets, {"id" => component1.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
 
               expect(result.map { |c| c.fetch("id") }).to contain_exactly(widget1.fetch(:id))
               expect(result.map { |c| c.fetch("cost").fetch("amount_cents") }).to contain_exactly(100)
             end
 
             it "returns an empty list when records with matching conditions are not found" do
-              result = resolve_nodes(:Component, :dollar_widgets, {"id" => component3.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
+              result = resolve_nodes("Component", :dollar_widgets, {"id" => component3.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
 
               expect(result).to be_empty
             end
@@ -180,19 +180,19 @@ module ElasticGraph
             end
 
             it "loads the relationship" do
-              result = resolve(:Component, :widget, {"id" => component1.fetch(:id)})
+              result = resolve("Component", :widget, {"id" => component1.fetch(:id)})
 
               expect(result.fetch("id")).to eq widget1.fetch(:id)
             end
 
             it "tolerates not finding the id" do
-              result = resolve(:Component, :widget, {"id" => build(:component).fetch(:id)})
+              result = resolve("Component", :widget, {"id" => build(:component).fetch(:id)})
 
               expect(result).to eq nil
             end
 
             it "returns nil when given a nil id" do
-              result = resolve(:Component, :widget, {"id" => nil})
+              result = resolve("Component", :widget, {"id" => nil})
 
               expect(result).to eq nil
             end
@@ -200,7 +200,7 @@ module ElasticGraph
             it "returns one record (and logs a warning) when querying the datastore produces a list of records instead of a single one" do
               expect {
                 # Note: inclusion of nested field `cost.amount_cents` is necessary to exercise an edge case that originally resulted in an exception.
-                result = resolve(:Component, :widget, {"id" => component2.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
+                result = resolve("Component", :widget, {"id" => component2.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
 
                 expect(result.fetch("id")).to eq(widget1.fetch(:id)).or eq(widget2.fetch(:id))
                 expect(result.fetch("cost").fetch("amount_cents")).to eq(widget1.fetch(:cost).fetch(:amount_cents)).or eq(widget2.fetch(:cost).fetch(:amount_cents))
@@ -210,7 +210,7 @@ module ElasticGraph
             it "returns one record (and logs a warning) when the id field is a list instead of a scalar" do
               ids = [component1.fetch(:id), component3.fetch(:id)]
               expect {
-                result = resolve(:Component, :widget, {"id" => ids})
+                result = resolve("Component", :widget, {"id" => ids})
 
                 expect(result.fetch("id")).to eq(widget1.fetch(:id)).or eq(widget3.fetch(:id))
               }.to log a_string_including("Component(id: #{ids}).widget", "id: list of more than one item instead of a scalar")
@@ -218,21 +218,21 @@ module ElasticGraph
 
             it "returns nil (and logs a warning) when the id field is missing" do
               expect {
-                result = resolve(:Component, :widget, {"name" => "foo"})
+                result = resolve("Component", :widget, {"name" => "foo"})
 
                 expect(result).to eq nil
               }.to log a_string_including("Component(id: <no id>).widget", "id is missing from the document")
             end
 
             it "returns one record matching additional filter conditions" do
-              result = resolve(:Component, :dollar_widget, {"id" => component1.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
+              result = resolve("Component", :dollar_widget, {"id" => component1.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
 
               expect(result.fetch("id")).to eq(widget1.fetch(:id))
               expect(result.fetch("cost").fetch("amount_cents")).to eq(widget1.fetch(:cost).fetch(:amount_cents))
             end
 
             it "returns nil when a record with matching conditions is not found" do
-              result = resolve(:Component, :dollar_widget, {"id" => component3.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
+              result = resolve("Component", :dollar_widget, {"id" => component3.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
 
               expect(result).to eq nil
             end
@@ -288,31 +288,31 @@ module ElasticGraph
             end
 
             it "loads the relationship and respects defaultSort" do
-              result = resolve_nodes(:Manufacturer, :manufactured_parts, {"id" => manufacturer1.fetch(:id)})
+              result = resolve_nodes("Manufacturer", :manufactured_parts, {"id" => manufacturer1.fetch(:id)})
 
               expect(result.map { |c| c.fetch("id") }).to eq([part2.fetch(:id), part1.fetch(:id)])
             end
 
             it "respects a list of `order_by` options, supporting ascending and descending sorts" do
-              result = resolve_nodes(:Manufacturer, :manufactured_parts,
+              result = resolve_nodes("Manufacturer", :manufactured_parts,
                 {"id" => manufacturer1.fetch(:id)},
                 order_by: ["created_at_ASC"])
               expect(result.map { |c| c.fetch("id") }).to eq([part1.fetch(:id), part2.fetch(:id)])
 
-              result = resolve_nodes(:Manufacturer, :manufactured_parts,
+              result = resolve_nodes("Manufacturer", :manufactured_parts,
                 {"id" => manufacturer1.fetch(:id)},
                 order_by: ["created_at_DESC"])
               expect(result.map { |c| c.fetch("id") }).to eq([part2.fetch(:id), part1.fetch(:id)])
             end
 
             it "tolerates not finding records for the given id" do
-              result = resolve_nodes(:Manufacturer, :manufactured_parts, {"id" => build(:manufacturer).fetch(:id)})
+              result = resolve_nodes("Manufacturer", :manufactured_parts, {"id" => build(:manufacturer).fetch(:id)})
 
               expect(result).to be_empty
             end
 
             it "returns an empty list when given a nil id" do
-              result = resolve_nodes(:Manufacturer, :manufactured_parts, {"id" => nil})
+              result = resolve_nodes("Manufacturer", :manufactured_parts, {"id" => nil})
 
               expect(result).to be_empty
             end
@@ -320,7 +320,7 @@ module ElasticGraph
             it "returns one of the two lists of matches (and logs a warning) when the id field is a list instead of a scalar" do
               ids = [manufacturer1.fetch(:id), manufacturer2.fetch(:id)]
               expect {
-                result = resolve_nodes(:Manufacturer, :manufactured_parts, {"id" => ids})
+                result = resolve_nodes("Manufacturer", :manufactured_parts, {"id" => ids})
 
                 expect(result.map { |c| c.fetch("id") }).to contain_exactly(part1.fetch(:id), part2.fetch(:id)).or eq([part3.fetch(:id)])
               }.to log a_string_including("Manufacturer(id: #{ids}).manufactured_parts", "id: list of more than one item instead of a scalar")
@@ -328,7 +328,7 @@ module ElasticGraph
 
             it "returns an empty list (and logs a warning) when the id field is missing" do
               expect {
-                result = resolve_nodes(:Manufacturer, :manufactured_parts, {"name" => "foo"})
+                result = resolve_nodes("Manufacturer", :manufactured_parts, {"name" => "foo"})
 
                 expect(result).to be_empty
               }.to log a_string_including("Manufacturer(id: <no id>).manufactured_parts", "id is missing from the document")
@@ -343,19 +343,19 @@ module ElasticGraph
             end
 
             it "loads the relationship" do
-              result = resolve(:ElectricalPart, :manufacturer, {"manufacturer_id" => manufacturer1.fetch(:id)})
+              result = resolve("ElectricalPart", :manufacturer, {"manufacturer_id" => manufacturer1.fetch(:id)})
 
               expect(result.fetch("id")).to eq manufacturer1.fetch(:id)
             end
 
             it "tolerates not finding a record the given id" do
-              result = resolve(:ElectricalPart, :manufacturer, {"manufacturer_id" => build(:manufacturer).fetch(:id)})
+              result = resolve("ElectricalPart", :manufacturer, {"manufacturer_id" => build(:manufacturer).fetch(:id)})
 
               expect(result).to eq nil
             end
 
             it "returns nil when given a nil id" do
-              result = resolve(:ElectricalPart, :manufacturer, {"manufacturer_id" => nil})
+              result = resolve("ElectricalPart", :manufacturer, {"manufacturer_id" => nil})
 
               expect(result).to eq nil
             end
@@ -363,7 +363,7 @@ module ElasticGraph
             it "returns one of the referenced documents (and logs a warning) when the foreign key field is a list instead of a scalar" do
               expect {
                 manufacturer_ids = [manufacturer1.fetch(:id), manufacturer2.fetch(:id)]
-                result = resolve(:ElectricalPart, :manufacturer, {"id" => "123", "manufacturer_id" => manufacturer_ids})
+                result = resolve("ElectricalPart", :manufacturer, {"id" => "123", "manufacturer_id" => manufacturer_ids})
 
                 expect(result.fetch("id")).to eq(manufacturer1.fetch(:id)).or eq(manufacturer2.fetch(:id))
               }.to log a_string_including("Part(id: 123).manufacturer", "manufacturer_id: list of more than one item instead of a scalar")
@@ -371,7 +371,7 @@ module ElasticGraph
 
             it "returns nil (and logs a warning) when the foreign key field is missing" do
               expect {
-                result = resolve(:ElectricalPart, :manufacturer, {"id" => "123"})
+                result = resolve("ElectricalPart", :manufacturer, {"id" => "123"})
 
                 expect(result).to eq nil
               }.to log a_string_including("Part(id: 123).manufacturer", "manufacturer_id is missing from the document")
@@ -442,38 +442,38 @@ module ElasticGraph
             end
 
             it "loads the relationship and respects defaultSort" do
-              result = resolve_nodes(:Component, :parts, {"part_ids" => [part1.fetch(:id), part2.fetch(:id)]})
+              result = resolve_nodes("Component", :parts, {"part_ids" => [part1.fetch(:id), part2.fetch(:id)]})
 
               expect(result.map { |c| c.fetch("id") }).to eq([part2.fetch(:id), part1.fetch(:id)])
             end
 
             it "respects a list of `order_by` options, supporting ascending and descending sorts" do
-              result = resolve_nodes(:Component, :parts,
+              result = resolve_nodes("Component", :parts,
                 {"part_ids" => [part1.fetch(:id), part2.fetch(:id)]},
                 order_by: ["created_at_ASC"])
               expect(result.map { |c| c.fetch("id") }).to eq([part1.fetch(:id), part2.fetch(:id)])
 
-              result = resolve_nodes(:Component, :parts,
+              result = resolve_nodes("Component", :parts,
                 {"part_ids" => [part1.fetch(:id), part2.fetch(:id)]},
                 order_by: ["created_at_DESC"])
               expect(result.map { |c| c.fetch("id") }).to eq([part2.fetch(:id), part1.fetch(:id)])
             end
 
             it "tolerates not finding some ids" do
-              result = resolve_nodes(:Component, :parts, {"part_ids" => [part1.fetch(:id), build(:part).fetch(:id)]})
+              result = resolve_nodes("Component", :parts, {"part_ids" => [part1.fetch(:id), build(:part).fetch(:id)]})
 
               expect(result.map { |c| c.fetch("id") }).to contain_exactly(part1.fetch(:id))
             end
 
             it "returns an empty list when given a blank list of ids" do
-              result = resolve_nodes(:Component, :parts, {"part_ids" => []})
+              result = resolve_nodes("Component", :parts, {"part_ids" => []})
 
               expect(result).to be_empty
             end
 
             it "returns a list of the matching document (and logs a warning) when the foreign key field is a scalar instead of a list" do
               expect {
-                result = resolve_nodes(:Component, :parts, {"id" => "123", "part_ids" => part1.fetch(:id)})
+                result = resolve_nodes("Component", :parts, {"id" => "123", "part_ids" => part1.fetch(:id)})
 
                 expect(result.map { |p| p.fetch("id") }).to eq [part1.fetch(:id)]
               }.to log a_string_including("Component(id: 123).parts", "part_ids: scalar instead of a list")
@@ -481,21 +481,21 @@ module ElasticGraph
 
             it "returns an empty list" do
               expect {
-                result = resolve_nodes(:Component, :parts, {"id" => "123"})
+                result = resolve_nodes("Component", :parts, {"id" => "123"})
 
                 expect(result).to be_empty
               }.to log a_string_including("Component(id: 123).parts", "part_ids is missing from the document")
             end
 
             it "supports filtering on a non-id field" do
-              results = resolve_nodes(:Component, :parts, {"part_ids" => [part1.fetch(:id), part2.fetch(:id)]},
+              results = resolve_nodes("Component", :parts, {"part_ids" => [part1.fetch(:id), part2.fetch(:id)]},
                 filter: {name: {equal_to_any_of: ["p1", "p4"]}})
 
               expect(results.map { |c| c.fetch("id") }).to contain_exactly(part1.fetch(:id))
             end
 
             it "supports filtering on id" do
-              results = resolve_nodes(:Component, :parts, {"part_ids" => [part1.fetch(:id), part2.fetch(:id)]},
+              results = resolve_nodes("Component", :parts, {"part_ids" => [part1.fetch(:id), part2.fetch(:id)]},
                 filter: {id: {equal_to_any_of: [part1.fetch(:id), part4.fetch(:id)]}})
 
               expect(results.map { |c| c.fetch("id") }).to contain_exactly(part1.fetch(:id))
@@ -508,27 +508,27 @@ module ElasticGraph
             end
 
             it "loads the relationship and supports defaultSort" do
-              result = resolve_nodes(:ElectricalPart, :components, {"id" => part1.fetch(:id)})
+              result = resolve_nodes("ElectricalPart", :components, {"id" => part1.fetch(:id)})
 
               expect(result.map { |c| c.fetch("id") }).to eq([component2.fetch(:id), component1.fetch(:id)])
             end
 
             it "respects a list of `order_by` options, supporting ascending and descending sorts" do
-              result = resolve_nodes(:ElectricalPart, :components, {"id" => part1.fetch(:id)}, order_by: ["created_at_ASC"])
+              result = resolve_nodes("ElectricalPart", :components, {"id" => part1.fetch(:id)}, order_by: ["created_at_ASC"])
               expect(result.map { |c| c.fetch("id") }).to eq([component1.fetch(:id), component2.fetch(:id)])
 
-              result = resolve_nodes(:ElectricalPart, :components, {"id" => part1.fetch(:id)}, order_by: ["created_at_DESC"])
+              result = resolve_nodes("ElectricalPart", :components, {"id" => part1.fetch(:id)}, order_by: ["created_at_DESC"])
               expect(result.map { |c| c.fetch("id") }).to eq([component2.fetch(:id), component1.fetch(:id)])
             end
 
             it "tolerates not finding records for the given id" do
-              result = resolve_nodes(:ElectricalPart, :components, {"id" => build(:part).fetch(:id)})
+              result = resolve_nodes("ElectricalPart", :components, {"id" => build(:part).fetch(:id)})
 
               expect(result).to be_empty
             end
 
             it "returns an empty list when given a nil id" do
-              result = resolve_nodes(:ElectricalPart, :components, {"id" => nil})
+              result = resolve_nodes("ElectricalPart", :components, {"id" => nil})
 
               expect(result).to be_empty
             end
@@ -536,7 +536,7 @@ module ElasticGraph
             it "returns one of the two lists of matches (and logs a warning) when the id field is a list instead of a scalar" do
               ids = [part1.fetch(:id), part2.fetch(:id)]
               expect {
-                result = resolve_nodes(:ElectricalPart, :components, {"id" => ids})
+                result = resolve_nodes("ElectricalPart", :components, {"id" => ids})
 
                 expect(result.map { |c| c.fetch("id") }).to \
                   contain_exactly(component1.fetch(:id), component2.fetch(:id)).or \
@@ -546,14 +546,14 @@ module ElasticGraph
 
             it "returns an empty list (and logs a warning) when the id field is missing" do
               expect {
-                result = resolve_nodes(:ElectricalPart, :components, {"name" => "foo"})
+                result = resolve_nodes("ElectricalPart", :components, {"name" => "foo"})
 
                 expect(result).to be_empty
               }.to log a_string_including("ElectricalPart(id: <no id>).components", "id is missing from the document")
             end
 
             it "supports filtering on a non-id field" do
-              results = resolve_nodes(:ElectricalPart, :components, {"id" => part1.fetch(:id)},
+              results = resolve_nodes("ElectricalPart", :components, {"id" => part1.fetch(:id)},
                 filter: {name: {equal_to_any_of: ["c1", "c4"]}})
 
               expect(results.map { |c| c.fetch("id") }).to contain_exactly(component1.fetch(:id))
@@ -562,7 +562,7 @@ module ElasticGraph
             it "supports filtering on id", :expect_search_routing do
               component_ids = [component1.fetch(:id), component4.fetch(:id)]
 
-              results = resolve_nodes(:ElectricalPart, :components, {"id" => part1.fetch(:id)},
+              results = resolve_nodes("ElectricalPart", :components, {"id" => part1.fetch(:id)},
                 filter: {id: {equal_to_any_of: component_ids}})
 
               expect(results.map { |c| c.fetch("id") }).to contain_exactly(component1.fetch(:id))
@@ -607,19 +607,19 @@ module ElasticGraph
             end
 
             it "loads the relationship" do
-              result = resolve(:Address, :manufacturer, {"manufacturer_id" => manufacturer1.fetch(:id)})
+              result = resolve("Address", :manufacturer, {"manufacturer_id" => manufacturer1.fetch(:id)})
 
               expect(result.fetch("id")).to eq manufacturer1.fetch(:id)
             end
 
             it "tolerates not finding a record for the given id" do
-              result = resolve(:Address, :manufacturer, {"manufacturer_id" => build(:manufacturer).fetch(:id)})
+              result = resolve("Address", :manufacturer, {"manufacturer_id" => build(:manufacturer).fetch(:id)})
 
               expect(result).to eq nil
             end
 
             it "returns nil when given a nil id" do
-              result = resolve(:Address, :manufacturer, {"manufacturer_id" => nil})
+              result = resolve("Address", :manufacturer, {"manufacturer_id" => nil})
 
               expect(result).to eq nil
             end
@@ -627,7 +627,7 @@ module ElasticGraph
             it "returns one of the referenced documents (and logs a warning) when the foreign key field is a list instead of a scalar" do
               expect {
                 manufacturer_ids = [manufacturer1.fetch(:id), manufacturer2.fetch(:id)]
-                result = resolve(:Address, :manufacturer, {"id" => "123", "manufacturer_id" => manufacturer_ids})
+                result = resolve("Address", :manufacturer, {"id" => "123", "manufacturer_id" => manufacturer_ids})
 
                 expect(result.fetch("id")).to eq(manufacturer1.fetch(:id)).or eq(manufacturer2.fetch(:id))
               }.to log a_string_including("Address(id: 123).manufacturer", "manufacturer_id: list of more than one item instead of a scalar")
@@ -635,7 +635,7 @@ module ElasticGraph
 
             it "returns nil (and logs a warning) when the foreign key field is missing" do
               expect {
-                result = resolve(:Address, :manufacturer, {"id" => "123"})
+                result = resolve("Address", :manufacturer, {"id" => "123"})
 
                 expect(result).to eq nil
               }.to log a_string_including("Address(id: 123).manufacturer", "manufacturer_id is missing from the document")
@@ -648,26 +648,26 @@ module ElasticGraph
             end
 
             it "loads the relationship" do
-              result = resolve(:Manufacturer, :address, {"id" => manufacturer1.fetch(:id)})
+              result = resolve("Manufacturer", :address, {"id" => manufacturer1.fetch(:id)})
 
               expect(result.fetch("id")).to eq address1.fetch(:id)
             end
 
             it "tolerates not finding a record for the given id" do
-              result = resolve(:Manufacturer, :address, {"id" => build(:manufacturer).fetch(:id)})
+              result = resolve("Manufacturer", :address, {"id" => build(:manufacturer).fetch(:id)})
 
               expect(result).to eq nil
             end
 
             it "returns nil when given a nil id" do
-              result = resolve(:Manufacturer, :address, {"id" => nil})
+              result = resolve("Manufacturer", :address, {"id" => nil})
 
               expect(result).to eq nil
             end
 
             it "returns one of the matching records (and logs a warning) when querying the datastore produces a list of records instead of a single one" do
               expect {
-                result = resolve(:Manufacturer, :address, {"id" => manufacturer2.fetch(:id)})
+                result = resolve("Manufacturer", :address, {"id" => manufacturer2.fetch(:id)})
 
                 expect(result.fetch("id")).to eq(address2.fetch(:id)).or eq(address3.fetch(:id))
               }.to log a_string_including("Manufacturer(id: #{manufacturer2.fetch(:id)}).address", "got list of more than one item instead of a scalar from the datastore search query")
@@ -676,7 +676,7 @@ module ElasticGraph
             it "returns one of the matching records (and logs a warning) when the id field is a list instead of a scalar" do
               ids = [manufacturer1.fetch(:id), manufacturer3.fetch(:id)]
               expect {
-                result = resolve(:Manufacturer, :address, {"id" => ids})
+                result = resolve("Manufacturer", :address, {"id" => ids})
 
                 expect(result.fetch("id")).to eq(address1.fetch(:id)).or eq(address4.fetch(:id))
               }.to log a_string_including("Manufacturer(id: #{ids}).address", "id: list of more than one item instead of a scalar")
@@ -684,7 +684,7 @@ module ElasticGraph
 
             it "returns nil (and logs a warning) when the id field is missing" do
               expect {
-                result = resolve(:Manufacturer, :address, {"name" => "foo"})
+                result = resolve("Manufacturer", :address, {"name" => "foo"})
 
                 expect(result).to eq nil
               }.to log a_string_including("Manufacturer(id: <no id>).address", "id is missing from the document")
@@ -707,13 +707,13 @@ module ElasticGraph
             end
 
             it "loads the relationship from a nested field in an object list" do
-              result = resolve_nodes(:Sponsor, :affiliated_teams_from_object, {"id" => sponsor1.fetch(:id)}, requested_fields: ["id"])
+              result = resolve_nodes("Sponsor", :affiliated_teams_from_object, {"id" => sponsor1.fetch(:id)}, requested_fields: ["id"])
 
               expect(result.map { |t| t.fetch("id") }).to contain_exactly(team1.fetch(:id), team2.fetch(:id))
             end
 
             it "loads the relationship from a nested field in a nested list" do
-              result = resolve_nodes(:Sponsor, :affiliated_teams_from_nested, {"id" => sponsor1.fetch(:id)}, requested_fields: ["id"])
+              result = resolve_nodes("Sponsor", :affiliated_teams_from_nested, {"id" => sponsor1.fetch(:id)}, requested_fields: ["id"])
 
               expect(result.map { |t| t.fetch("id") }).to contain_exactly(team1.fetch(:id), team2.fetch(:id))
             end

--- a/elasticgraph-graphql/spec/support/query_adapter.rb
+++ b/elasticgraph-graphql/spec/support/query_adapter.rb
@@ -113,18 +113,18 @@ module QueryAdapterSpecSupport
     end
 
     DEFAULT_SCALAR_VALUES = {
-      Int: 37,
-      Float: 37.0,
-      String: "37",
-      ID: "37",
-      Cursor: "37",
-      JsonSafeLong: 37,
-      LongString: "37",
-      Boolean: false,
-      Date: "2021-08-23",
-      DateTime: "2021-08-23T12:00:00Z",
-      DayOfWeek: "MONDAY",
-      LocalTime: "12:00:00"
+      "Int" => 37,
+      "Float" => 37.0,
+      "String" => "37",
+      "ID" => "37",
+      "Cursor" => "37",
+      "JsonSafeLong" => 37,
+      "LongString" => "37",
+      "Boolean" => false,
+      "Date" => "2021-08-23",
+      "DateTime" => "2021-08-23T12:00:00Z",
+      "DayOfWeek" => "MONDAY",
+      "LocalTime" => "12:00:00"
     }
 
     def default_scalar_value_for(type)

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_adapter_spec.rb
@@ -24,7 +24,7 @@ module ElasticGraph
 
         shared_examples_for "a query selecting nodes under aggregations" do |before_nodes:, after_nodes:|
           it "can build an aggregations object with 2 computations and no groupings" do
-            aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+            aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
               query {
                 widget_aggregations {
                   #{before_nodes}
@@ -53,7 +53,7 @@ module ElasticGraph
             end
 
             it "respects the override in the generated aggregation hash" do
-              aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
                 query {
                   widget_aggregations {
                     #{before_nodes}
@@ -76,7 +76,7 @@ module ElasticGraph
           end
 
           it "can build an ungrouped aggregation hash from nested query fields" do
-            aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+            aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
               query {
                 widget_aggregations {
                   #{before_nodes}
@@ -105,7 +105,7 @@ module ElasticGraph
             end
 
             it "respects the override in the generated aggregation hash" do
-              aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
                 query {
                   widget_aggregations {
                     #{before_nodes}
@@ -135,7 +135,7 @@ module ElasticGraph
             end
 
             it "can build sub-aggregations" do
-              aggregations = aggregations_from_datastore_query(:Query, :team_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :team_aggregations, <<~QUERY)
                 query {
                   team_aggregations {
                     #{before_nodes}
@@ -169,7 +169,7 @@ module ElasticGraph
 
             it "uses the injected grouping adapter on sub-aggregations" do
               build_sub_agg = lambda do |adapter|
-                aggregations = aggregations_from_datastore_query(:Query, :team_aggregations, <<~QUERY, sub_aggregation_grouping_adapter: adapter)
+                aggregations = aggregations_from_datastore_query("Query", :team_aggregations, <<~QUERY, sub_aggregation_grouping_adapter: adapter)
                   query {
                     team_aggregations {
                       #{before_nodes}
@@ -204,7 +204,7 @@ module ElasticGraph
 
             it "determines it needs the doc count error if `upper_bound` or `exact_value` are requested, but not if `approximate_value` is requested" do
               needs_doc_count_error_by_count_field = %w[exact_value approximate_value upper_bound].to_h do |count_field|
-                aggs = aggregations_from_datastore_query(:Query, :team_aggregations, <<~QUERY)
+                aggs = aggregations_from_datastore_query("Query", :team_aggregations, <<~QUERY)
                   query {
                     team_aggregations {
                       #{before_nodes}
@@ -233,7 +233,7 @@ module ElasticGraph
             end
 
             it "builds a multi-part nested `path` for a `nested` field under extra object layers" do
-              aggregations = aggregations_from_datastore_query(:Query, :team_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :team_aggregations, <<~QUERY)
                 query {
                   team_aggregations {
                     #{before_nodes}
@@ -263,7 +263,7 @@ module ElasticGraph
             end
 
             it "supports sub-aggregation fields having an alternate `name_in_index`" do
-              aggregations = aggregations_from_datastore_query(:Query, :team_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :team_aggregations, <<~QUERY)
                 query {
                   team_aggregations {
                     #{before_nodes}
@@ -293,7 +293,7 @@ module ElasticGraph
             end
 
             it "supports sub-aggregations of sub-aggregations" do
-              aggregations = aggregations_from_datastore_query(:Query, :team_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :team_aggregations, <<~QUERY)
                 query {
                   team_aggregations {
                     #{before_nodes}
@@ -333,7 +333,7 @@ module ElasticGraph
             end
 
             it "can handle sub-aggregation fields of the same name under parents of a different name" do
-              aggregations = aggregations_from_datastore_query(:Query, :team_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :team_aggregations, <<~QUERY)
                 query {
                   team_aggregations {
                     #{before_nodes}
@@ -396,7 +396,7 @@ module ElasticGraph
             end
 
             it "allows aliases to be used on a sub-aggregations field to request multiple differing sub-aggregations" do
-              aggregations = aggregations_from_datastore_query(:Query, :team_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :team_aggregations, <<~QUERY)
                 query {
                   team_aggregations {
                     #{before_nodes}
@@ -437,7 +437,7 @@ module ElasticGraph
             end
 
             it "builds a `filter` on a sub-aggregation when present on the GraphQL query" do
-              aggregations = aggregations_from_datastore_query(:Query, :team_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :team_aggregations, <<~QUERY)
                 query {
                   team_aggregations {
                     #{before_nodes}
@@ -465,7 +465,7 @@ module ElasticGraph
             end
 
             it "builds `groupings` at any level of sub-aggregation when `groupedBy` is present in the query at that level" do
-              aggregations = aggregations_from_datastore_query(:Query, :team_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :team_aggregations, <<~QUERY)
                 query {
                   team_aggregations {
                     #{before_nodes}
@@ -516,7 +516,7 @@ module ElasticGraph
             end
 
             it "builds legacy date time `groupings` at any level of sub-aggregation when `groupedBy` is present in the query at that level" do
-              aggregations = aggregations_from_datastore_query(:Query, :team_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :team_aggregations, <<~QUERY)
                 query {
                   team_aggregations {
                     #{before_nodes}
@@ -611,7 +611,7 @@ module ElasticGraph
             end
 
             it "builds `computations` at any level of sub-aggregation when `aggregated_values` is present in the query at that level" do
-              aggregations = aggregations_from_datastore_query(:Query, :team_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :team_aggregations, <<~QUERY)
                 query {
                   team_aggregations {
                     #{before_nodes}
@@ -704,7 +704,7 @@ module ElasticGraph
 
               def build_sub_aggregation_query(args, default_page_size:, max_page_size:)
                 aggregations = aggregations_from_datastore_query(
-                  :Query,
+                  "Query",
                   :team_aggregations,
                   query_for(**args),
                   default_page_size: default_page_size,
@@ -742,7 +742,7 @@ module ElasticGraph
               end
 
               it "respects the `name_in_index` when parsing a filter" do
-                aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+                aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
                   query {
                     widget_aggregations {
                       #{before_nodes}
@@ -776,7 +776,7 @@ module ElasticGraph
               self.schema_artifacts = generate_schema_artifacts { |schema| define_schema(schema, legacy_grouping_schema: true) }
             end
             it "can build an aggregations object with multiple groupings and computations" do
-              aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
                 query {
                   widget_aggregations {
                     #{before_nodes}
@@ -812,7 +812,7 @@ module ElasticGraph
             end
 
             it "respects the `time_zone` option" do
-              aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
                 query {
                   widget_aggregations {
                     #{before_nodes}
@@ -837,7 +837,7 @@ module ElasticGraph
             end
 
             it "respects the `offset` option" do
-              aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
                 query {
                   widget_aggregations {
                     #{before_nodes}
@@ -862,7 +862,7 @@ module ElasticGraph
             end
 
             it "supports `Date` field groupings, allowing them to have no `time_zone` argument" do
-              aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
                 query {
                   widget_aggregations {
                     #{before_nodes}
@@ -887,7 +887,7 @@ module ElasticGraph
             end
 
             it "supports `offsetDays` on `Date` field groupings" do
-              aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
                 query {
                   widget_aggregations {
                     #{before_nodes}
@@ -914,7 +914,7 @@ module ElasticGraph
 
           context "aggregations without `legacy_grouping_schema`" do
             it "can build an aggregations object with multiple groupings and computations" do
-              aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
                 query {
                   widget_aggregations {
                     #{before_nodes}
@@ -955,7 +955,7 @@ module ElasticGraph
               # Verify that the fields we request in the query below are in fact all the subfields
               expect(sub_fields_of("DateTimeGroupedBy")).to contain_exactly("as_date_time", "as_date", "as_time_of_day", "as_day_of_week")
 
-              aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
                 query {
                   widget_aggregations {
                     #{before_nodes}
@@ -988,7 +988,7 @@ module ElasticGraph
             end
 
             it "sets defaults correctly when `as_day_of_week` for time_zone and offset_ms" do
-              aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
                 query {
                   widget_aggregations {
                     #{before_nodes}
@@ -1015,7 +1015,7 @@ module ElasticGraph
             end
 
             it "sets defaults correctly when `as_time_of_day` for time_zone and offset_ms" do
-              aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
                 query {
                   widget_aggregations {
                     #{before_nodes}
@@ -1042,7 +1042,7 @@ module ElasticGraph
             end
 
             it "respects the `time_zone` option" do
-              aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
                 query {
                   widget_aggregations {
                     #{before_nodes}
@@ -1069,7 +1069,7 @@ module ElasticGraph
             end
 
             it "respects the `offset` option" do
-              aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
                 query {
                   widget_aggregations {
                     #{before_nodes}
@@ -1096,7 +1096,7 @@ module ElasticGraph
             end
 
             it "supports `Date` field groupings, allowing them to have no `time_zone` argument" do
-              aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
                 query {
                   widget_aggregations {
                     #{before_nodes}
@@ -1126,7 +1126,7 @@ module ElasticGraph
               # Verify that the fields we request in the query below are in fact all the subfields
               expect(sub_fields_of("DateGroupedBy")).to contain_exactly("as_date", "as_day_of_week")
 
-              aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
                 query {
                   widget_aggregations {
                     #{before_nodes}
@@ -1155,7 +1155,7 @@ module ElasticGraph
             end
 
             it "supports `offset` on `Date` field groupings" do
-              aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+              aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
                 query {
                   widget_aggregations {
                     #{before_nodes}
@@ -1183,7 +1183,7 @@ module ElasticGraph
           end
 
           it "omits grouping fields that have a `@skip(if: true)` directive" do
-            aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+            aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
               query {
                 widget_aggregations {
                   #{before_nodes}
@@ -1218,7 +1218,7 @@ module ElasticGraph
           end
 
           it "omits grouping fields that have an `@include(if: false)` directive" do
-            aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+            aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
               query {
                 widget_aggregations {
                   #{before_nodes}
@@ -1253,7 +1253,7 @@ module ElasticGraph
           end
 
           it "omits computation fields that have a `@skip(if: true)` directive" do
-            aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+            aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
               query {
                 widget_aggregations {
                   #{before_nodes}
@@ -1286,7 +1286,7 @@ module ElasticGraph
           end
 
           it "omits computation fields that have a `@include(if: true)` directive" do
-            aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+            aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
               query {
                 widget_aggregations {
                   #{before_nodes}
@@ -1319,7 +1319,7 @@ module ElasticGraph
           end
 
           it "sets `needs_doc_count` to false if the count field has a `@skip(if: true)` directive" do
-            skip_false = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY).first
+            skip_false = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY).first
               query {
                 widget_aggregations {
                   #{before_nodes}
@@ -1335,7 +1335,7 @@ module ElasticGraph
 
             expect(skip_false.needs_doc_count).to eq true
 
-            skip_true = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY).first
+            skip_true = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY).first
               query {
                 widget_aggregations {
                   #{before_nodes}
@@ -1353,7 +1353,7 @@ module ElasticGraph
           end
 
           it "sets `needs_doc_count` to false if the count field has an `@include(if: false)` directive" do
-            include_false = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY).first
+            include_false = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY).first
               query {
                 widget_aggregations {
                   #{before_nodes}
@@ -1369,7 +1369,7 @@ module ElasticGraph
 
             expect(include_false.needs_doc_count).to eq false
 
-            include_true = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY).first
+            include_true = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY).first
               query {
                 widget_aggregations {
                   #{before_nodes}
@@ -1545,7 +1545,7 @@ module ElasticGraph
           end
 
           it "supports multiple aliases on `count` since that doesn't interfere with grouping" do
-            aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+            aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
               query {
                 widget_aggregations {
                   #{before_nodes}
@@ -1570,7 +1570,7 @@ module ElasticGraph
           end
 
           it "supports multiple aliases on `aggregated_values` since that doesn't interfere with grouping" do
-            aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+            aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
               query {
                 widget_aggregations {
                   #{before_nodes}
@@ -1606,7 +1606,7 @@ module ElasticGraph
           end
 
           it "supports multiple aliases on subfields of `aggregated_values` since that doesn't interfere with grouping" do
-            aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+            aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
               query {
                 widget_aggregations {
                   #{before_nodes}
@@ -1637,7 +1637,7 @@ module ElasticGraph
           end
 
           it "supports multiple aliases on subfields of `grouped_by` since that doesn't interfere with grouping" do
-            aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+            aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
               query {
                 widget_aggregations {
                   #{before_nodes}
@@ -1665,7 +1665,7 @@ module ElasticGraph
           end
 
           it "can build an aggregations object with multiple computations and groupings (including on a nested scalar field)" do
-            aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+            aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
               query {
                 widget_aggregations {
                   #{before_nodes}
@@ -1751,7 +1751,7 @@ module ElasticGraph
           end
 
           it "does not build any groupings or computations for the aggregation `count` field" do
-            aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+            aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
               query {
                 widget_aggregations {
                   #{before_nodes}
@@ -1765,7 +1765,7 @@ module ElasticGraph
           end
 
           it "supports aliases for aggregated_values, grouped_by, and count" do
-            aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+            aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
               query {
                 widget_aggregations {
                   #{before_nodes}
@@ -1799,7 +1799,7 @@ module ElasticGraph
 
           describe "needs_doc_count" do
             it "is true when the count field is requested" do
-              aggs = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY).first
+              aggs = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY).first
                 query {
                   widget_aggregations {
                     #{before_nodes}
@@ -1820,7 +1820,7 @@ module ElasticGraph
             end
 
             it "is false when the count field is not requested" do
-              aggs = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY).first
+              aggs = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY).first
                 query {
                   widget_aggregations {
                     #{before_nodes}
@@ -1841,7 +1841,7 @@ module ElasticGraph
         end
 
         it "works correctly when nothing under `node` is requested (e.g. just `page_info`)" do
-          aggregations = aggregations_from_datastore_query(:Query, :widget_aggregations, <<~QUERY)
+          aggregations = aggregations_from_datastore_query("Query", :widget_aggregations, <<~QUERY)
             query {
               widget_aggregations {
                 page_info {
@@ -1956,7 +1956,7 @@ module ElasticGraph
           end
 
           it "supports a single alias on every layer of nesting of a full query, since that doesn't interfere with grouping" do
-            aggregations = aggregations_from_datastore_query(:Query, :wa, <<~QUERY)
+            aggregations = aggregations_from_datastore_query("Query", :wa, <<~QUERY)
               query {
                 wa: widget_aggregations {
                   e: edges {
@@ -2065,7 +2065,7 @@ module ElasticGraph
           end
 
           it "supports a single alias on every layer of nesting of a full query, since that doesn't interfere with grouping" do
-            aggregations = aggregations_from_datastore_query(:Query, :wa, <<~QUERY)
+            aggregations = aggregations_from_datastore_query("Query", :wa, <<~QUERY)
               query {
                 wa: widget_aggregations {
                   n: nodes {

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/get_record_field_value_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/get_record_field_value_spec.rb
@@ -46,32 +46,32 @@ module ElasticGraph
 
         context "for a field without customizations" do
           it "fetches a requested scalar field from the document" do
-            value = resolve(:Person, :name, {"id" => 1, "name" => "Napoleon"})
+            value = resolve("Person", :name, {"id" => 1, "name" => "Napoleon"})
 
             expect(value).to eq "Napoleon"
           end
 
           it "works with an `DatastoreResponse::Document`" do
             doc = DatastoreResponse::Document.with_payload("id" => 1, "name" => "Napoleon")
-            value = resolve(:Person, :name, doc)
+            value = resolve("Person", :name, doc)
 
             expect(value).to eq "Napoleon"
           end
 
           it "fetches a requested list field from the document" do
-            value = resolve(:Person, :nicknames, {"id" => 1, "nicknames" => %w[Napo Leon]})
+            value = resolve("Person", :nicknames, {"id" => 1, "nicknames" => %w[Napo Leon]})
 
             expect(value).to eq %w[Napo Leon]
           end
 
           it "returns `nil` when a scalar field is missing" do
-            value = resolve(:Person, :name, {"id" => 1})
+            value = resolve("Person", :name, {"id" => 1})
 
             expect(value).to eq nil
           end
 
           it "returns a blank list when a list field is missing" do
-            value = resolve(:Person, :nicknames, {"id" => 2})
+            value = resolve("Person", :nicknames, {"id" => 2})
 
             expect(value).to eq []
           end
@@ -79,26 +79,26 @@ module ElasticGraph
 
         context "for a field with customizations" do
           it "resolves to the field named via the `name_in_index` option instead of the schema field name" do
-            value = resolve(:Person, :alt_name1, {"id" => 1, "name" => "Napoleon"})
+            value = resolve("Person", :alt_name1, {"id" => 1, "name" => "Napoleon"})
 
             expect(value).to eq "Napoleon"
           end
 
           it "can resolve to a child `name_in_index`" do
-            value = resolve(:Person, :ssn, {"id" => 1, "identifiers" => {"ssn" => "123-456-7890"}})
+            value = resolve("Person", :ssn, {"id" => 1, "identifiers" => {"ssn" => "123-456-7890"}})
 
             expect(value).to eq "123-456-7890"
           end
 
           it "can resolve a list field" do
-            value = resolve(:Person, :alt_nicknames, {"id" => 1, "nicknames" => %w[Napo Leon]})
+            value = resolve("Person", :alt_nicknames, {"id" => 1, "nicknames" => %w[Napo Leon]})
 
             expect(value).to eq %w[Napo Leon]
           end
 
           it "allows the `name` arg value to be a string or symbol" do
-            value1 = resolve(:Person, :alt_name1, {"id" => 1, "name" => "Napoleon"})
-            value2 = resolve(:Person, :alt_name2, {"id" => 1, "name" => "Napoleon"})
+            value1 = resolve("Person", :alt_name1, {"id" => 1, "name" => "Napoleon"})
+            value2 = resolve("Person", :alt_name2, {"id" => 1, "name" => "Napoleon"})
 
             expect(value1).to eq "Napoleon"
             expect(value2).to eq "Napoleon"
@@ -106,18 +106,18 @@ module ElasticGraph
 
           it "works with an `DatastoreResponse::Document`" do
             doc = DatastoreResponse::Document.with_payload("id" => 1, "name" => "Napoleon")
-            value = resolve(:Person, :alt_name1, doc)
+            value = resolve("Person", :alt_name1, doc)
 
             expect(value).to eq "Napoleon"
           end
 
           it "returns `nil` for a scalar when the directive field name is missing" do
-            value = resolve(:Person, :alt_name1, {"id" => 1})
+            value = resolve("Person", :alt_name1, {"id" => 1})
             expect(value).to eq nil
           end
 
           it "returns a blank list for a list field when the directive field name is missing" do
-            value = resolve(:Person, :alt_nicknames, {"id" => 2})
+            value = resolve("Person", :alt_nicknames, {"id" => 2})
 
             expect(value).to eq []
           end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/query_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/query_adapter_spec.rb
@@ -51,7 +51,7 @@ module ElasticGraph
         end
 
         let(:graphql) { build_graphql(schema_artifacts: schema_artifacts) }
-        let(:field) { graphql.schema.field_named(:Query, :widgets) }
+        let(:field) { graphql.schema.field_named("Query", :widgets) }
         let(:query_adapter) do
           QueryAdapter.new(
             datastore_query_builder: graphql.datastore_query_builder,
@@ -67,7 +67,7 @@ module ElasticGraph
 
           it "sets the `search_index_definitions` based on the field type" do
             datastore_query = build_query_from({})
-            expect(datastore_query.search_index_definitions).to eq(graphql.schema.type_named(:Widget).search_index_definitions)
+            expect(datastore_query.search_index_definitions).to eq(graphql.schema.type_named("Widget").search_index_definitions)
           end
 
           describe "sort" do
@@ -87,8 +87,8 @@ module ElasticGraph
 
             context "on a union type where the subtypes have different default sorts" do
               it "consistently uses the default sort from the alphabetically first index definition" do
-                field1 = graphql.schema.field_named(:Query, :widgets_or_components)
-                field2 = graphql.schema.field_named(:Query, :components_or_widgets)
+                field1 = graphql.schema.field_named("Query", :widgets_or_components)
+                field2 = graphql.schema.field_named("Query", :components_or_widgets)
 
                 sort1 = build_query_from({}, field: field1).sort
                 sort2 = build_query_from({}, field: field2).sort
@@ -107,7 +107,7 @@ module ElasticGraph
 
           describe "document_pagination" do
             context "on an indexed document field" do
-              let(:field) { graphql.schema.field_named(:Query, :widgets) }
+              let(:field) { graphql.schema.field_named("Query", :widgets) }
 
               it "extracts `after`" do
                 datastore_query = build_query_from({after: "ABC"})
@@ -131,7 +131,7 @@ module ElasticGraph
             end
 
             context "on an indexed aggregation field" do
-              let(:field) { graphql.schema.field_named(:Query, :widget_aggregations) }
+              let(:field) { graphql.schema.field_named("Query", :widget_aggregations) }
 
               it "ignores the pagination arguments since the aggregation adapter handles them for aggregations" do
                 datastore_query = build_query_from({

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection_spec.rb
@@ -63,7 +63,7 @@ module ElasticGraph
             response = DatastoreResponse::SearchResponse.build(build_response_hash([hit_for(300, "w1")]))
 
             graphql = build_graphql(schema_artifacts: schema_artifacts)
-            field = graphql.schema.field_named(:Query, field_name)
+            field = graphql.schema.field_named("Query", field_name)
             context = {schema_element_names: graphql.runtime_metadata.schema_element_names}
 
             lookahead = ::GraphQL::Execution::Lookahead.new(

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
@@ -150,7 +150,7 @@ module ElasticGraph
               birth_date: birth_date
             )
 
-            [person, build_graphql(element_names).schema.field_named(:Person, field)]
+            [person, build_graphql(element_names).schema.field_named("Person", field)]
           end
 
           def build_graphql(element_names)

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/enum_value_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/enum_value_spec.rb
@@ -18,7 +18,7 @@ module ElasticGraph
             s.enum_type "ColorSpace" do |t|
               t.value "rgb"
             end
-          end.enum_value_named(:ColorSpace, :rgb)
+          end.enum_value_named("ColorSpace", :rgb)
 
           expect(enum_value.inspect).to eq "#<ElasticGraph::GraphQL::Schema::EnumValue ColorSpace.rgb>"
         end
@@ -29,7 +29,7 @@ module ElasticGraph
               s.enum_type "ColorSpace" do |t|
                 t.value "rgb"
               end
-            end.enum_value_named(:ColorSpace, :rgb)
+            end.enum_value_named("ColorSpace", :rgb)
 
             expect(enum_value.name).to eq :rgb
           end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/field_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/field_spec.rb
@@ -18,7 +18,7 @@ module ElasticGraph
             schema.object_type "Color" do |t|
               t.field "red", "Int!"
             end
-          end.field_named(:Color, :red)
+          end.field_named("Color", :red)
 
           expect(field.name).to eq :red
         end
@@ -30,8 +30,8 @@ module ElasticGraph
             end
           end
 
-          field = schema.field_named(:Color, :red)
-          expect(field.parent_type).to be schema.type_named(:Color)
+          field = schema.field_named("Color", :red)
+          expect(field.parent_type).to be schema.type_named("Color")
         end
 
         it "inspects well" do
@@ -39,7 +39,7 @@ module ElasticGraph
             schema.object_type "Color" do |t|
               t.field "red", "Int!"
             end
-          end.field_named(:Color, :red)
+          end.field_named("Color", :red)
 
           expect(field.inspect).to eq "#<ElasticGraph::GraphQL::Schema::Field Color.red>"
         end
@@ -52,10 +52,10 @@ module ElasticGraph
               end
             end
 
-            field = schema.field_named(:Color, :red)
+            field = schema.field_named("Color", :red)
 
-            expect(field.type.name).to eq :Int
-            expect(field.type).to be schema.type_named(:Int)
+            expect(field.type.name).to eq "Int"
+            expect(field.type).to be schema.type_named("Int")
           end
 
           it "supports wrapped types" do
@@ -65,9 +65,9 @@ module ElasticGraph
               end
             end
 
-            field = schema.field_named(:Color, :red)
+            field = schema.field_named("Color", :red)
 
-            expect(field.type.name).to eq :"[Int!]!"
+            expect(field.type.name).to eq "[Int!]!"
           end
         end
 
@@ -85,7 +85,7 @@ module ElasticGraph
                 t.relates_to_many "colors", "Color", via: "photo_id", dir: :in, singular: "color"
                 t.index "photos"
               end
-            end.field_named(:Photo, :colors)
+            end.field_named("Photo", :colors)
 
             expect(field.relation_join).to be_a(RelationJoin).and be(field.relation_join)
           end
@@ -97,7 +97,7 @@ module ElasticGraph
               s.object_type "Color" do |t|
                 t.field "red", "Int"
               end
-            end.field_named(:Color, :red)
+            end.field_named("Color", :red)
 
             expect(field.relation_join).to be(nil).and be(field.relation_join)
             expect(RelationJoin).to have_received(:from).once
@@ -110,7 +110,7 @@ module ElasticGraph
               s.object_type "Widget" do |t|
                 t.field "count", "Int"
               end
-            end.field_named(:Widget, :count)
+            end.field_named("Widget", :count)
 
             expect {
               field.sort_clauses_for(:enum_value)
@@ -131,7 +131,7 @@ module ElasticGraph
           end
 
           it "returns a list of datastore sort clauses when passed an array" do
-            field = schema.field_named(:Query, :photos)
+            field = schema.field_named("Query", :photos)
             sort_clauses = field.sort_clauses_for([:pixel_count_DESC, :created_at_ms_DESC])
 
             expect(sort_clauses).to eq([
@@ -141,14 +141,14 @@ module ElasticGraph
           end
 
           it "returns a list of a single datastore sort clause when passed a scalar" do
-            field = schema.field_named(:Query, :photos)
+            field = schema.field_named("Query", :photos)
             sort_clauses = field.sort_clauses_for(:pixel_count_DESC)
 
             expect(sort_clauses).to eq([{"pixel_count" => {"order" => "desc"}}])
           end
 
           it "raises an error if a sort value is undefined" do
-            field = schema.field_named(:Query, :photos)
+            field = schema.field_named("Query", :photos)
 
             expect {
               field.sort_clauses_for(:bogus_DESC)
@@ -173,7 +173,7 @@ module ElasticGraph
               EOS
             end
 
-            field = schema.field_named(:Query, :photos)
+            field = schema.field_named("Query", :photos)
 
             expect {
               field.sort_clauses_for(:invalid_photo_sort_DESC)
@@ -181,7 +181,7 @@ module ElasticGraph
           end
 
           it "returns an empty array when given nil or []" do
-            field = schema.field_named(:Query, :photos)
+            field = schema.field_named("Query", :photos)
 
             expect(field.sort_clauses_for(nil)).to eq []
             expect(field.sort_clauses_for([])).to eq []
@@ -196,7 +196,7 @@ module ElasticGraph
                 t.field "some_field", "Int"
                 t.index "photos"
               end
-            end.field_named(:IntAggregatedValues, :exact_sum)
+            end.field_named("IntAggregatedValues", :exact_sum)
 
             expect(field.computation_detail).to eq(
               SchemaArtifacts::RuntimeMetadata::ComputationDetail.new(
@@ -245,7 +245,7 @@ module ElasticGraph
               schema.object_type "Photo" do |t|
                 t.field "some_field", type_name, filterable: false, aggregatable: false, groupable: false
               end
-            end.field_named(:Photo, :some_field)
+            end.field_named("Photo", :some_field)
           end
         end
 
@@ -261,7 +261,7 @@ module ElasticGraph
 
           context "when a schema field is defined with a `name_in_index`" do
             it "returns the `name_in_index` value" do
-              field = schema.field_named(:Person, :alt_name)
+              field = schema.field_named("Person", :alt_name)
 
               expect(field.name_in_index).to eq(:name)
             end
@@ -269,7 +269,7 @@ module ElasticGraph
 
           context "when a schema field does not have a `name_in_index`" do
             it "returns the field name" do
-              field = schema.field_named(:Person, :first_name)
+              field = schema.field_named("Person", :first_name)
 
               expect(field.name_in_index).to eq(:first_name)
             end
@@ -289,7 +289,7 @@ module ElasticGraph
                   foo(camelCaseField: Int, maybe_set_to_null: String, nested: Nested): Int
                 }
               EOS
-            end.field_named(:Query, :foo)
+            end.field_named("Query", :foo)
           end
 
           it "converts an args hash from the keyword args style provided by graphql gem to their form in the schema" do
@@ -372,10 +372,10 @@ module ElasticGraph
 
             schema = graphql.schema
 
-            expect(schema.field_named(:WidgetConnection, :edges).index_field_names_for_resolution).to eq []
-            expect(schema.field_named(:WidgetConnection, :page_info).index_field_names_for_resolution).to eq []
-            expect(schema.field_named(:WidgetEdge, :node).index_field_names_for_resolution).to eq []
-            expect(schema.field_named(:WidgetEdge, :cursor).index_field_names_for_resolution).to eq []
+            expect(schema.field_named("WidgetConnection", :edges).index_field_names_for_resolution).to eq []
+            expect(schema.field_named("WidgetConnection", :page_info).index_field_names_for_resolution).to eq []
+            expect(schema.field_named("WidgetEdge", :node).index_field_names_for_resolution).to eq []
+            expect(schema.field_named("WidgetEdge", :cursor).index_field_names_for_resolution).to eq []
           end
 
           def index_field_names_for(field_method, field_name, field_type, **field_args)
@@ -389,7 +389,7 @@ module ElasticGraph
               yield s if block_given?
             end)
 
-            graphql.schema.field_named(:Widget, field_name).index_field_names_for_resolution
+            graphql.schema.field_named("Widget", field_name).index_field_names_for_resolution
           end
         end
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/type_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/type_spec.rb
@@ -13,14 +13,14 @@ module ElasticGraph
   class GraphQL
     class Schema
       RSpec.describe Type, :ensure_no_orphaned_types do
-        it "exposes the name as a capitalized symbol" do
+        it "exposes the name as a capitalized string" do
           type = define_schema do |schema|
             schema.object_type "Color" do |t|
               t.field "name", "String"
             end
           end.type_named("Color")
 
-          expect(type.name).to eq :Color
+          expect(type.name).to eq "Color"
         end
 
         it "inspects well" do
@@ -152,223 +152,223 @@ module ElasticGraph
           it "can model a scalar" do
             type = type_for(:int)
 
-            expect(type.name).to eq :Int
+            expect(type.name).to eq "Int"
             expect(type).to only_satisfy_predicates(:nullable?)
-            expect(type.unwrap_fully).to be schema.type_named(:Int)
+            expect(type.unwrap_fully).to be schema.type_named("Int")
             expect(type.unwrap_non_null).to be type
           end
 
           it "can model a non-nullable scalar" do
             type = type_for(:non_null_int)
 
-            expect(type.name).to eq :Int!
+            expect(type.name).to eq "Int!"
             expect(type).to only_satisfy_predicates(:non_null?)
-            expect(type.unwrap_fully).to be schema.type_named(:Int)
-            expect(type.unwrap_non_null).to be schema.type_named(:Int)
+            expect(type.unwrap_fully).to be schema.type_named("Int")
+            expect(type.unwrap_non_null).to be schema.type_named("Int")
           end
 
           it "can model an embedded object" do
             type = type_for(:color)
 
-            expect(type.name).to eq :Color
+            expect(type.name).to eq "Color"
             expect(type).to only_satisfy_predicates(:nullable?, :object?, :embedded_object?)
-            expect(type.unwrap_fully).to be schema.type_named(:Color)
+            expect(type.unwrap_fully).to be schema.type_named("Color")
             expect(type.unwrap_non_null).to be type
           end
 
           it "can model a non-nullable embedded object" do
             type = type_for(:non_null_color)
 
-            expect(type.name).to eq :Color!
+            expect(type.name).to eq "Color!"
             expect(type).to only_satisfy_predicates(:non_null?, :object?, :embedded_object?)
-            expect(type.unwrap_fully).to be schema.type_named(:Color)
-            expect(type.unwrap_non_null).to be schema.type_named(:Color)
+            expect(type.unwrap_fully).to be schema.type_named("Color")
+            expect(type.unwrap_non_null).to be schema.type_named("Color")
           end
 
           it "can model a list" do
             type = type_for(:list_of_int)
 
-            expect(type.name).to eq :"[Int]"
+            expect(type.name).to eq "[Int]"
             expect(type).to only_satisfy_predicates(:nullable?, :list?, :collection?)
-            expect(type.unwrap_fully).to be schema.type_named(:Int)
+            expect(type.unwrap_fully).to be schema.type_named("Int")
             expect(type.unwrap_non_null).to be type
           end
 
           it "can model a relay connection" do
             type = type_for(:relay_connection)
 
-            expect(type.name).to eq :PersonConnection
+            expect(type.name).to eq "PersonConnection"
             expect(type).to only_satisfy_predicates(:nullable?, :object?, :relay_connection?, :collection?)
-            expect(type.unwrap_fully).to be schema.type_named(:Person)
+            expect(type.unwrap_fully).to be schema.type_named("Person")
             expect(type.unwrap_non_null).to be type
           end
 
           it "can model a non-nullable relay connection" do
             type = type_for(:non_null_relay_connection)
 
-            expect(type.name).to eq :PersonConnection!
+            expect(type.name).to eq "PersonConnection!"
             expect(type).to only_satisfy_predicates(:non_null?, :object?, :relay_connection?, :collection?)
-            expect(type.unwrap_fully).to be schema.type_named(:Person)
-            expect(type.unwrap_non_null).to be schema.type_named(:PersonConnection)
+            expect(type.unwrap_fully).to be schema.type_named("Person")
+            expect(type.unwrap_non_null).to be schema.type_named("PersonConnection")
           end
 
           it "can model a relay edge" do
             type = type_for(:relay_edge)
 
-            expect(type.name).to eq :PersonEdge
+            expect(type.name).to eq "PersonEdge"
             expect(type).to only_satisfy_predicates(:nullable?, :object?, :relay_edge?)
-            expect(type.unwrap_fully).to be schema.type_named(:PersonEdge)
+            expect(type.unwrap_fully).to be schema.type_named("PersonEdge")
             expect(type.unwrap_non_null).to be type
           end
 
           it "can model a non-nullable relay edge" do
             type = type_for(:non_null_relay_edge)
 
-            expect(type.name).to eq :PersonEdge!
+            expect(type.name).to eq "PersonEdge!"
             expect(type).to only_satisfy_predicates(:non_null?, :object?, :relay_edge?)
-            expect(type.unwrap_fully).to be schema.type_named(:PersonEdge)
-            expect(type.unwrap_non_null).to be schema.type_named(:PersonEdge)
+            expect(type.unwrap_fully).to be schema.type_named("PersonEdge")
+            expect(type.unwrap_non_null).to be schema.type_named("PersonEdge")
           end
 
           it "can model a list of non-nullable scalars" do
             type = type_for(:list_of_non_null_int)
 
-            expect(type.name).to eq :"[Int!]"
+            expect(type.name).to eq "[Int!]"
             expect(type).to only_satisfy_predicates(:nullable?, :list?, :collection?)
-            expect(type.unwrap_fully).to be schema.type_named(:Int)
+            expect(type.unwrap_fully).to be schema.type_named("Int")
             expect(type.unwrap_non_null).to be type
           end
 
           it "can model a non-nullable list of scalars" do
             type = type_for(:non_null_list_of_int)
 
-            expect(type.name).to eq :"[Int]!"
+            expect(type.name).to eq "[Int]!"
             expect(type).to only_satisfy_predicates(:non_null?, :list?, :collection?)
-            expect(type.unwrap_fully).to be schema.type_named(:Int)
-            expect(type.unwrap_non_null.name).to eq :"[Int]"
+            expect(type.unwrap_fully).to be schema.type_named("Int")
+            expect(type.unwrap_non_null.name).to eq "[Int]"
           end
 
           it "can model a non-nullable list of non-nullable scalars" do
             type = type_for(:non_null_list_of_non_null_int)
 
-            expect(type.name).to eq :"[Int!]!"
+            expect(type.name).to eq "[Int!]!"
             expect(type).to only_satisfy_predicates(:non_null?, :list?, :collection?)
-            expect(type.unwrap_fully).to be schema.type_named(:Int)
-            expect(type.unwrap_non_null.name).to eq :"[Int!]"
+            expect(type.unwrap_fully).to be schema.type_named("Int")
+            expect(type.unwrap_non_null.name).to eq "[Int!]"
           end
 
           it "can model an indexed type" do
             type = type_for(:person)
 
-            expect(type.name).to eq :Person
+            expect(type.name).to eq "Person"
             expect(type).to only_satisfy_predicates(:nullable?, :object?, :indexed_document?)
-            expect(type.unwrap_fully).to be schema.type_named(:Person)
+            expect(type.unwrap_fully).to be schema.type_named("Person")
             expect(type.unwrap_non_null).to be type
           end
 
           it "can model an indexed aggregation type" do
             type = type_for(:indexed_aggregation)
 
-            expect(type.name).to eq :PersonAggregation
+            expect(type.name).to eq "PersonAggregation"
             expect(type).to only_satisfy_predicates(:nullable?, :object?, :indexed_aggregation?)
-            expect(type.unwrap_fully).to be schema.type_named(:PersonAggregation)
+            expect(type.unwrap_fully).to be schema.type_named("PersonAggregation")
             expect(type.unwrap_non_null).to be type
           end
 
           it "can model a non-null indexed aggregation type" do
             type = type_for(:non_null_indexed_aggregation)
 
-            expect(type.name).to eq :PersonAggregation!
+            expect(type.name).to eq "PersonAggregation!"
             expect(type).to only_satisfy_predicates(:non_null?, :object?, :indexed_aggregation?)
-            expect(type.unwrap_fully).to be schema.type_named(:PersonAggregation)
-            expect(type.unwrap_non_null.name).to be :PersonAggregation
+            expect(type.unwrap_fully).to be schema.type_named("PersonAggregation")
+            expect(type.unwrap_non_null.name).to eq "PersonAggregation"
           end
 
           it "can model a list of indexed aggregation type" do
             type = type_for(:list_of_indexed_aggregation)
 
-            expect(type.name).to eq :"[PersonAggregation]"
+            expect(type.name).to eq "[PersonAggregation]"
             expect(type).to only_satisfy_predicates(:nullable?, :list?, :collection?)
-            expect(type.unwrap_fully).to be schema.type_named(:PersonAggregation)
-            expect(type.unwrap_non_null.name).to be :"[PersonAggregation]"
+            expect(type.unwrap_fully).to be schema.type_named("PersonAggregation")
+            expect(type.unwrap_non_null.name).to eq "[PersonAggregation]"
           end
 
           it "can model a non-null list of indexed aggregation type" do
             type = type_for(:non_null_list_of_indexed_aggregation)
 
-            expect(type.name).to eq :"[PersonAggregation]!"
+            expect(type.name).to eq "[PersonAggregation]!"
             expect(type).to only_satisfy_predicates(:non_null?, :list?, :collection?)
-            expect(type.unwrap_fully).to be schema.type_named(:PersonAggregation)
-            expect(type.unwrap_non_null.name).to be :"[PersonAggregation]"
+            expect(type.unwrap_fully).to be schema.type_named("PersonAggregation")
+            expect(type.unwrap_non_null.name).to eq "[PersonAggregation]"
           end
 
           it "can model a list of indexed type" do
             type = type_for(:person_list)
 
-            expect(type.name).to eq :"[Person]"
+            expect(type.name).to eq "[Person]"
             expect(type).to only_satisfy_predicates(:nullable?, :list?, :collection?)
-            expect(type.unwrap_fully).to be schema.type_named(:Person)
+            expect(type.unwrap_fully).to be schema.type_named("Person")
             expect(type.unwrap_non_null).to be type
           end
 
           it "can model a non-nullable indexed type" do
             type = type_for(:non_null_person)
 
-            expect(type.name).to eq :Person!
+            expect(type.name).to eq "Person!"
             expect(type).to only_satisfy_predicates(:non_null?, :object?, :indexed_document?)
-            expect(type.unwrap_fully).to be schema.type_named(:Person)
-            expect(type.unwrap_non_null).to be schema.type_named(:Person)
+            expect(type.unwrap_fully).to be schema.type_named("Person")
+            expect(type.unwrap_non_null).to be schema.type_named("Person")
           end
 
           it "can model a union of embedded object types" do
             type = type_for(:attribute)
 
-            expect(type.name).to eq :Attribute
+            expect(type.name).to eq "Attribute"
             expect(type).to only_satisfy_predicates(:nullable?, :object?, :abstract?, :embedded_object?)
-            expect(type.unwrap_fully).to be schema.type_named(:Attribute)
+            expect(type.unwrap_fully).to be schema.type_named("Attribute")
             expect(type.unwrap_non_null).to be type
           end
 
           it "can model an indexed union of object types" do
             type = type_for(:indexed_attribute)
 
-            expect(type.name).to eq :IndexedAttribute
+            expect(type.name).to eq "IndexedAttribute"
             expect(type).to only_satisfy_predicates(:nullable?, :object?, :abstract?, :indexed_document?)
-            expect(type.unwrap_fully).to be schema.type_named(:IndexedAttribute)
+            expect(type.unwrap_fully).to be schema.type_named("IndexedAttribute")
             expect(type.unwrap_non_null).to be type
           end
 
           it "can model a non-nullable union of embedded object types" do
             type = type_for(:non_null_attribute)
 
-            expect(type.name).to eq :Attribute!
+            expect(type.name).to eq "Attribute!"
             expect(type).to only_satisfy_predicates(:non_null?, :object?, :abstract?, :embedded_object?)
-            expect(type.unwrap_fully).to be schema.type_named(:Attribute)
-            expect(type.unwrap_non_null).to be schema.type_named(:Attribute)
+            expect(type.unwrap_fully).to be schema.type_named("Attribute")
+            expect(type.unwrap_non_null).to be schema.type_named("Attribute")
           end
 
           it "can model a union of indexed object types" do
             type = type_for(:entity)
 
-            expect(type.name).to eq :Entity
+            expect(type.name).to eq "Entity"
             expect(type).to only_satisfy_predicates(:nullable?, :object?, :abstract?, :indexed_document?)
-            expect(type.unwrap_fully).to be schema.type_named(:Entity)
+            expect(type.unwrap_fully).to be schema.type_named("Entity")
             expect(type.unwrap_non_null).to be type
           end
 
           it "can model a non-null union of indexed object types" do
             type = type_for(:non_null_entity)
 
-            expect(type.name).to eq :Entity!
+            expect(type.name).to eq "Entity!"
             expect(type).to only_satisfy_predicates(:non_null?, :object?, :abstract?, :indexed_document?)
-            expect(type.unwrap_fully).to be schema.type_named(:Entity)
-            expect(type.unwrap_non_null).to be schema.type_named(:Entity)
+            expect(type.unwrap_fully).to be schema.type_named("Entity")
+            expect(type.unwrap_non_null).to be schema.type_named("Entity")
           end
 
           it "can model an enum type" do
             type = type_for(:size)
 
-            expect(type.name).to eq :Size
+            expect(type.name).to eq "Size"
             expect(type).to only_satisfy_predicates(:nullable?, :enum?)
             expect(type.unwrap_fully).to be type
             expect(type.unwrap_non_null).to be type
@@ -377,52 +377,52 @@ module ElasticGraph
           it "can model a non-null enum type" do
             type = type_for(:non_null_size)
 
-            expect(type.name).to eq :Size!
+            expect(type.name).to eq "Size!"
             expect(type).to only_satisfy_predicates(:non_null?, :enum?)
-            expect(type.unwrap_fully).to be schema.type_named(:Size)
-            expect(type.unwrap_non_null).to be schema.type_named(:Size)
+            expect(type.unwrap_fully).to be schema.type_named("Size")
+            expect(type.unwrap_non_null).to be schema.type_named("Size")
           end
 
           it "can model a list of enums" do
             type = type_for(:list_of_size)
 
-            expect(type.name).to eq :"[Size]"
+            expect(type.name).to eq "[Size]"
             expect(type).to only_satisfy_predicates(:nullable?, :list?, :collection?)
-            expect(type.unwrap_fully).to be schema.type_named(:Size)
+            expect(type.unwrap_fully).to be schema.type_named("Size")
             expect(type.unwrap_non_null).to be type
           end
 
           it "can model an input type" do
-            type = schema.type_named(:IntFilterInput)
+            type = schema.type_named("IntFilterInput")
 
-            expect(type.name).to eq :IntFilterInput
+            expect(type.name).to eq "IntFilterInput"
             expect(type).to only_satisfy_predicates(:nullable?, :object?)
             expect(type.unwrap_fully).to be type
             expect(type.unwrap_non_null).to be type
           end
 
           it "can model an embedded interface type" do
-            type = schema.type_named(:EmbeddedInterface)
+            type = schema.type_named("EmbeddedInterface")
 
-            expect(type.name).to eq :EmbeddedInterface
+            expect(type.name).to eq "EmbeddedInterface"
             expect(type).to only_satisfy_predicates(:nullable?, :object?, :embedded_object?, :abstract?)
             expect(type.unwrap_fully).to be type
             expect(type.unwrap_non_null).to be type
           end
 
           it "can model a directly indexed interface type" do
-            type = schema.type_named(:DirectlyIndexedInterface)
+            type = schema.type_named("DirectlyIndexedInterface")
 
-            expect(type.name).to eq :DirectlyIndexedInterface
+            expect(type.name).to eq "DirectlyIndexedInterface"
             expect(type).to only_satisfy_predicates(:nullable?, :object?, :indexed_document?, :abstract?)
             expect(type.unwrap_fully).to be type
             expect(type.unwrap_non_null).to be type
           end
 
           it "can model an indirectly indexed interface type" do
-            type = schema.type_named(:IndirectlyIndexedInterface)
+            type = schema.type_named("IndirectlyIndexedInterface")
 
-            expect(type.name).to eq :IndirectlyIndexedInterface
+            expect(type.name).to eq "IndirectlyIndexedInterface"
             expect(type).to only_satisfy_predicates(:nullable?, :object?, :indexed_document?, :abstract?)
             expect(type.unwrap_fully).to be type
             expect(type.unwrap_non_null).to be type
@@ -459,7 +459,7 @@ module ElasticGraph
           end
 
           def type_for(field_name)
-            schema.field_named(:WrappedTypes, field_name).type
+            schema.field_named("WrappedTypes", field_name).type
           end
         end
 
@@ -473,15 +473,15 @@ module ElasticGraph
           end
 
           it "returns the same enum_value object returns by schema's `enum_value_named` method" do
-            from_type = schema.type_named(:ColorSpace).enum_value_named(:rgb)
-            from_schema = schema.enum_value_named(:ColorSpace, :rgb)
+            from_type = schema.type_named("ColorSpace").enum_value_named(:rgb)
+            from_schema = schema.enum_value_named("ColorSpace", :rgb)
 
             expect(from_schema).to be_a(EnumValue).and be(from_type)
           end
 
           it "supports the enum_value being named with a string or symbol" do
-            from_string = schema.type_named(:ColorSpace).enum_value_named("rgb")
-            from_symbol = schema.type_named(:ColorSpace).enum_value_named(:rgb)
+            from_string = schema.type_named("ColorSpace").enum_value_named("rgb")
+            from_symbol = schema.type_named("ColorSpace").enum_value_named(:rgb)
 
             expect(from_symbol).to be_a(EnumValue).and be(from_string)
           end
@@ -497,15 +497,15 @@ module ElasticGraph
           end
 
           it "returns the same field object returned from the schema's `field_named` method" do
-            from_type = schema.type_named(:Color).field_named(:red)
-            from_schema = schema.field_named(:Color, :red)
+            from_type = schema.type_named("Color").field_named(:red)
+            from_schema = schema.field_named("Color", :red)
 
             expect(from_schema).to be_a(Field).and be(from_type)
           end
 
           it "supports the field being named with a string or symbol" do
-            from_string = schema.type_named(:Color).field_named("red")
-            from_symbol = schema.type_named(:Color).field_named(:red)
+            from_string = schema.type_named("Color").field_named("red")
+            from_symbol = schema.type_named("Color").field_named(:red)
 
             expect(from_symbol).to be_a(Field).and be(from_string)
           end
@@ -540,22 +540,22 @@ module ElasticGraph
           end
 
           it "returns true for unions" do
-            type = schema.type_named(:Options)
+            type = schema.type_named("Options")
             expect(type.abstract?).to be true
           end
 
           it "returns true for interfaces" do
-            type = schema.type_named(:Named)
+            type = schema.type_named("Named")
             expect(type.abstract?).to be true
           end
 
           it "returns false for objects" do
-            type = schema.type_named(:Size)
+            type = schema.type_named("Size")
             expect(type.abstract?).to be false
           end
 
           it "returns false for scalars" do
-            type = schema.type_named(:Int)
+            type = schema.type_named("Int")
             expect(type.abstract?).to be false
           end
         end
@@ -589,23 +589,23 @@ module ElasticGraph
           end
 
           it "returns [] for object types" do
-            type = schema.type_named(:Size)
+            type = schema.type_named("Size")
             expect(type.subtypes).to eq []
           end
 
           it "returns [] for scalar types" do
-            type = schema.type_named(:Int)
+            type = schema.type_named("Int")
             expect(type.subtypes).to eq []
           end
 
           it "returns the subtypes of a union" do
-            type = schema.type_named(:Options)
-            expect(type.subtypes).to contain_exactly(schema.type_named(:Color), schema.type_named(:Size))
+            type = schema.type_named("Options")
+            expect(type.subtypes).to contain_exactly(schema.type_named("Color"), schema.type_named("Size"))
           end
 
           it "returns the subtypes of an interface" do
-            type = schema.type_named(:Named)
-            expect(type.subtypes).to contain_exactly(schema.type_named(:Size), schema.type_named(:Person))
+            type = schema.type_named("Named")
+            expect(type.subtypes).to contain_exactly(schema.type_named("Size"), schema.type_named("Person"))
           end
         end
 
@@ -727,7 +727,7 @@ module ElasticGraph
             end
           end
 
-          def search_index_definitions_from(type_name: :TheType)
+          def search_index_definitions_from(type_name: "TheType")
             schema = define_schema do |s|
               yield s, type_name
             end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
@@ -44,14 +44,10 @@ module ElasticGraph
           expect(schema.type_named("Color")).to be_a GraphQL::Schema::Type
         end
 
-        it "finds a type by symbol name" do
-          expect(schema.type_named(:Color)).to be_a GraphQL::Schema::Type
-        end
-
         it "consistently returns the same type object" do
           color1 = schema.type_named("Color")
           color2 = schema.type_named("Color")
-          color3 = schema.type_named(:Color)
+          color3 = schema.type_named("Color")
           query = schema.type_named("Query")
 
           expect(color2).to be(color1)
@@ -85,8 +81,8 @@ module ElasticGraph
           end
 
           expect(schema.defined_types).to all be_a Schema::Type
-          expect(schema.defined_types.map(&:name)).to include(:Options, :Color, :Query)
-            .and exclude(:Int, :Float, :Boolean, :String, :ID)
+          expect(schema.defined_types.map(&:name)).to include("Options", "Color", "Query")
+            .and exclude("Int", "Float", "Boolean", "String", "ID")
         end
       end
 
@@ -99,8 +95,8 @@ module ElasticGraph
           end
 
           expect(schema.indexed_document_types).to contain_exactly(
-            schema.type_named(:Person),
-            schema.type_named(:Widget)
+            schema.type_named("Person"),
+            schema.type_named("Widget")
           )
         end
       end
@@ -109,8 +105,8 @@ module ElasticGraph
         it "returns the type stored in the named index" do
           schema = schema_with_indices("Person" => "people", "Widget" => "widgets")
 
-          expect(schema.document_type_stored_in("people")).to eq(schema.type_named(:Person))
-          expect(schema.document_type_stored_in("widgets")).to eq(schema.type_named(:Widget))
+          expect(schema.document_type_stored_in("people")).to eq(schema.type_named("Person"))
+          expect(schema.document_type_stored_in("widgets")).to eq(schema.type_named("Widget"))
         end
 
         it "raises an exception if given an unrecognizd index name" do
@@ -162,14 +158,14 @@ module ElasticGraph
         end
 
         it "finds an enum_value when given a type and enum_value name symbols" do
-          expect(schema.enum_value_named(:ColorSpace, :rgb)).to be_a GraphQL::Schema::EnumValue
+          expect(schema.enum_value_named("ColorSpace", :rgb)).to be_a GraphQL::Schema::EnumValue
         end
 
         it "consistently returns the same enum_value_object" do
-          enum_value1 = schema.enum_value_named(:ColorSpace, :rgb)
-          enum_value2 = schema.enum_value_named(:ColorSpace, :rgb)
+          enum_value1 = schema.enum_value_named("ColorSpace", :rgb)
+          enum_value2 = schema.enum_value_named("ColorSpace", :rgb)
           enum_value3 = schema.enum_value_named("ColorSpace", "rgb")
-          other_field = schema.enum_value_named(:ColorSpace, :srgb)
+          other_field = schema.enum_value_named("ColorSpace", :srgb)
 
           expect(enum_value2).to be(enum_value1)
           expect(enum_value3).to be(enum_value1)
@@ -178,19 +174,19 @@ module ElasticGraph
 
         it "raises an error when the type cannot be found" do
           expect {
-            schema.enum_value_named(:ColorType, :name)
+            schema.enum_value_named("ColorType", :name)
           }.to raise_error(Errors::NotFoundError, /ColorSpace/)
         end
 
         it "raises an error when the enum value cannot be found, suggesting a correction if it can find one" do
           expect {
-            schema.enum_value_named(:ColorSpace, :srg)
+            schema.enum_value_named("ColorSpace", :srg)
           }.to raise_error(Errors::NotFoundError, a_string_including("ColorSpace", "srg", "Possible alternatives", "srgb"))
         end
 
         it "raises an error when the enum value cannot be found, with no suggestions if not close to any enum value name" do
           expect {
-            schema.enum_value_named(:ColorSpace, :foo)
+            schema.enum_value_named("ColorSpace", :foo)
           }.to raise_error(Errors::NotFoundError, a_string_including("ColorSpace", "foo").and(excluding("Possible alternatives")))
         end
       end
@@ -213,14 +209,14 @@ module ElasticGraph
             end
 
             it "finds a field when given type and field name symbols" do
-              expect(field_named(:Color, :blue)).to be_a GraphQL::Schema::Field
+              expect(field_named("Color", :blue)).to be_a GraphQL::Schema::Field
             end
 
             it "consistently returns the same field object" do
-              field1 = field_named(:Color, :red)
-              field2 = field_named(:Color, :red)
+              field1 = field_named("Color", :red)
+              field2 = field_named("Color", :red)
               field3 = field_named("Color", "red")
-              other_field = field_named(:Color, :blue)
+              other_field = field_named("Color", :blue)
 
               expect(field2).to be(field1)
               expect(field3).to be(field1)
@@ -229,19 +225,19 @@ module ElasticGraph
 
             it "raises an error when the type part of the given field name cannot be found" do
               expect {
-                field_named(:Person, :name)
+                field_named("Person", :name)
               }.to raise_error(Errors::NotFoundError, /Person/)
             end
 
             it "raises an error when the field part of the given field name cannot be found, suggesting a correction if possible" do
               expect {
-                field_named(:Color, :gren)
+                field_named("Color", :gren)
               }.to raise_error(Errors::NotFoundError, a_string_including("Color", "gren", "Possible alternatives", "green"))
             end
 
             it "raises an error when the field part of the given field name cannot be found, with no suggestions if not close to any field names" do
               expect {
-                field_named(:Color, :purple)
+                field_named("Color", :purple)
               }.to raise_error(Errors::NotFoundError, a_string_including("Color", "purple").and(excluding("Possible alternatives")))
             end
 


### PR DESCRIPTION
Previously, we were inconsistent, and had to do some extranous conversions.