### PR TITLE
Use strings instead of symbols for field names.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/path_segment.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/path_segment.rb
@@ -22,7 +22,7 @@ module ElasticGraph
 
           new(
             name_in_graphql_query: ast_node.alias || ast_node.name,
-            name_in_index: field&.name_in_index&.to_s
+            name_in_index: field&.name_in_index
           )
         end
       end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_adapter.rb
@@ -192,7 +192,7 @@ module ElasticGraph
 
                 Aggregation::Computation.new(
                   source_field_path: field_path,
-                  computed_index_field_name: computed_field.name_in_index.to_s,
+                  computed_index_field_name: computed_field.name_in_index,
                   detail: computation_detail
                 )
               end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rb
@@ -21,7 +21,7 @@ module ElasticGraph
             key = Key::AggregatedValue.new(
               aggregation_name: aggregation_name,
               field_path: field_path.map(&:name_in_graphql_query),
-              function_name: field.name_in_index.to_s
+              function_name: field.name_in_index
             )
 
             result = Support::HashUtil.verbose_fetch(bucket, key.encode)

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_args_translator.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_args_translator.rb
@@ -37,7 +37,7 @@ module ElasticGraph
           when ::Hash
             filter_object.to_h do |key, value|
               field = parent_type.field_named(key)
-              [field.name_in_index.to_s, convert(field.type.unwrap_fully, value)]
+              [field.name_in_index, convert(field.type.unwrap_fully, value)]
             end
           when ::Array
             filter_object.map { |value| convert(parent_type, value) }

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/get_record_field_value.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/get_record_field_value.rb
@@ -20,7 +20,7 @@ module ElasticGraph
         end
 
         def resolve(field:, object:, args:, context:, lookahead:)
-          field_name = field.name_in_index.to_s
+          field_name = field.name_in_index
           data =
             case object
             when DatastoreResponse::Document

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/field.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/field.rb
@@ -28,7 +28,7 @@ module ElasticGraph
           @relation = runtime_metadata&.relation
           @computation_detail = runtime_metadata&.computation_detail
           @resolver = runtime_metadata&.resolver
-          @name_in_index = runtime_metadata&.name_in_index&.to_sym || name
+          @name_in_index = runtime_metadata&.name_in_index || name
 
           # Adds the :extras required by ElasticGraph. For now, this blindly adds `:lookahead`
           # to each field so that we have access to what the child selections are, as described here:
@@ -57,7 +57,7 @@ module ElasticGraph
         end
 
         def name
-          @name ||= @graphql_field.name.to_sym
+          @name ||= @graphql_field.name
         end
 
         # Returns an object that knows how this field joins to its relation.
@@ -94,7 +94,7 @@ module ElasticGraph
           return [] if parent_type.relay_connection? || parent_type.relay_edge?
           return index_id_field_names_for_relation if relation_join
 
-          [name_in_index.to_s]
+          [name_in_index]
         end
 
         # Indicates this field should be hidden in the GraphQL schema so as to not be queryable.

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/type.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/type.rb
@@ -114,7 +114,7 @@ module ElasticGraph
         end
 
         def field_named(field_name)
-          @fields_by_name.fetch(field_name.to_s)
+          @fields_by_name.fetch(field_name)
         rescue KeyError => e
           msg = "No field named #{field_name} (on type #{name}) could be found"
           msg += "; Possible alternatives: [#{e.corrections.join(", ").delete('"')}]." if e.corrections.any?

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/schema.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/schema.rbs
@@ -16,7 +16,7 @@ module ElasticGraph
 
       def type_from: (::GraphQL::Schema::_Type) -> Type
       def type_named: (::String) -> Type
-      def field_named: (::String, ::String | ::Symbol) -> Field
+      def field_named: (::String, ::String) -> Field
       def indexed_document_types: () -> ::Array[Type]
     end
   end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/schema/field.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/schema/field.rbs
@@ -5,8 +5,8 @@ module ElasticGraph
       class Field
         attr_reader description: ::String
         attr_reader schema: Schema
-        attr_reader name: ::Symbol
-        attr_reader name_in_index: ::Symbol
+        attr_reader name: ::String
+        attr_reader name_in_index: ::String
         attr_reader parent_type: Type
         attr_reader type: Type
         attr_reader graphql_field: ::GraphQL::Schema::Field

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/schema/type.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/schema/type.rbs
@@ -9,7 +9,7 @@ module ElasticGraph
         attr_reader graphql_type: ::GraphQL::Schema::_Type
         def search_index_definitions: () -> ::Array[DatastoreCore::_IndexDefinition]
         def unwrap_fully: () -> Type
-        def field_named: (::String | ::Symbol) -> Field
+        def field_named: (::String) -> Field
         def object?: () -> bool
         def relay_connection?: () -> bool
         def abstract?: () -> bool

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/list_records_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/list_records_spec.rb
@@ -16,7 +16,7 @@ module ElasticGraph
           let(:graphql) { build_graphql }
 
           it "wraps the datastore response in a relay connection adapter when the field is a relay connection field" do
-            expect(resolve("Query", :widgets)).to be_a RelayConnection::GenericAdapter
+            expect(resolve("Query", "widgets")).to be_a RelayConnection::GenericAdapter
           end
         end
 
@@ -32,10 +32,10 @@ module ElasticGraph
           end
 
           it "respects a list of `order_by` options, supporting ascending and descending sorts" do
-            results = resolve_nodes("Query", :widgets, order_by: ["amount_cents_DESC", "created_at_ASC"])
+            results = resolve_nodes("Query", "widgets", order_by: ["amount_cents_DESC", "created_at_ASC"])
             expect(results.map { |r| r.fetch("id") }).to eq ["w2", "w3", "w1"]
 
-            results = resolve_nodes("Query", :widgets, order_by: ["amount_cents_ASC", "created_at_DESC"])
+            results = resolve_nodes("Query", "widgets", order_by: ["amount_cents_ASC", "created_at_DESC"])
             expect(results.map { |r| r.fetch("id") }).to eq ["w1", "w3", "w2"]
           end
         end
@@ -53,28 +53,28 @@ module ElasticGraph
           end
 
           it "supports filtering by a list of one value" do
-            results = resolve_nodes("Query", :widgets, filter: {id: {equal_to_any_of: [widget1.fetch(:id)]}})
+            results = resolve_nodes("Query", "widgets", filter: {id: {equal_to_any_of: [widget1.fetch(:id)]}})
             expect(results.map { |r| r.fetch("id") }).to contain_exactly(widget1.fetch(:id))
 
-            results = resolve_nodes("Query", :widgets, filter: {name: {equal_to_any_of: ["w2"]}})
+            results = resolve_nodes("Query", "widgets", filter: {name: {equal_to_any_of: ["w2"]}})
             expect(results.map { |r| r.fetch("id") }).to contain_exactly(widget2a.fetch(:id), widget2b.fetch(:id))
           end
 
           it "supports filtering by a list of multiple values" do
-            results = resolve_nodes("Query", :widgets, filter: {id: {equal_to_any_of: [widget1.fetch(:id), widget3.fetch(:id)]}})
+            results = resolve_nodes("Query", "widgets", filter: {id: {equal_to_any_of: [widget1.fetch(:id), widget3.fetch(:id)]}})
             expect(results.map { |r| r.fetch("id") }).to contain_exactly(widget1.fetch(:id), widget3.fetch(:id))
 
-            results = resolve_nodes("Query", :widgets, filter: {name: {equal_to_any_of: ["w2", "w1"]}})
+            results = resolve_nodes("Query", "widgets", filter: {name: {equal_to_any_of: ["w2", "w1"]}})
             expect(results.map { |r| r.fetch("id") }).to contain_exactly(widget1.fetch(:id), widget2a.fetch(:id), widget2b.fetch(:id))
           end
 
           it "supports default sort" do
-            results = resolve_nodes("Query", :widgets, filter: {id: {equal_to_any_of: ["w3", "w2b", "w1"]}})
+            results = resolve_nodes("Query", "widgets", filter: {id: {equal_to_any_of: ["w3", "w2b", "w1"]}})
             expect(results.map { |r| r.fetch("id") }).to eq([widget3.fetch(:id), widget2b.fetch(:id), widget1.fetch(:id)])
           end
 
           it "supports combining filters on more than one field" do
-            results = resolve_nodes("Query", :widgets, filter: {
+            results = resolve_nodes("Query", "widgets", filter: {
               name: {equal_to_any_of: ["w2", "w3"]},
               amount_cents: {equal_to_any_of: [100, 400]}
             })

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_spec.rb
@@ -45,14 +45,14 @@ module ElasticGraph
           let(:component1) { build(:component) }
 
           it "wraps the datastore response in a relay connection adapter when the field is a relay connection field" do
-            result = resolve("Widget", :components, {"component_ids" => [component1.fetch(:id)]})
+            result = resolve("Widget", "components", {"component_ids" => [component1.fetch(:id)]})
 
             expect(result).to be_a RelayConnection::GenericAdapter
           end
 
           it "wraps the datastore response in a relay connection adapter when the foreign key field is missing" do
             expect {
-              result = resolve("Widget", :components, {"name" => "a"})
+              result = resolve("Widget", "components", {"name" => "a"})
 
               expect(result).to be_a(RelayConnection::GenericAdapter)
               expect(result.edges).to be_empty
@@ -115,38 +115,38 @@ module ElasticGraph
             end
 
             it "loads the relationship and respects defaultSort" do
-              result = resolve_nodes("Widget", :components, {"component_ids" => [component1.fetch(:id), component2.fetch(:id)]})
+              result = resolve_nodes("Widget", "components", {"component_ids" => [component1.fetch(:id), component2.fetch(:id)]})
 
               expect(result.map { |c| c.fetch("id") }).to eq([component2.fetch(:id), component1.fetch(:id)])
             end
 
             it "respects a list of `order_by` options, supporting ascending and descending sorts" do
-              result = resolve_nodes("Widget", :components,
+              result = resolve_nodes("Widget", "components",
                 {"component_ids" => [component2.fetch(:id), component3.fetch(:id), component1.fetch(:id)]},
                 order_by: ["created_at_ASC"])
               expect(result.map { |c| c.fetch("id") }).to eq([component1.fetch(:id), component2.fetch(:id), component3.fetch(:id)])
 
-              result = resolve_nodes("Widget", :components,
+              result = resolve_nodes("Widget", "components",
                 {"component_ids" => [component2.fetch(:id), component3.fetch(:id), component1.fetch(:id)]},
                 order_by: ["created_at_DESC"])
               expect(result.map { |c| c.fetch("id") }).to eq([component3.fetch(:id), component2.fetch(:id), component1.fetch(:id)])
             end
 
             it "tolerates not finding some ids" do
-              result = resolve_nodes("Widget", :components, {"component_ids" => [component1.fetch(:id), build(:component).fetch(:id)]})
+              result = resolve_nodes("Widget", "components", {"component_ids" => [component1.fetch(:id), build(:component).fetch(:id)]})
 
               expect(result.map { |c| c.fetch("id") }).to contain_exactly(component1.fetch(:id))
             end
 
             it "returns an empty list when given a blank list of ids" do
-              result = resolve_nodes("Widget", :components, {"component_ids" => []})
+              result = resolve_nodes("Widget", "components", {"component_ids" => []})
 
               expect(result).to be_empty
             end
 
             it "returns a list of a single record (and logs a warning) when the foreign key field is a scalar instead of a list" do
               expect {
-                result = resolve_nodes("Widget", :components, {"component_ids" => component1.fetch(:id), "id" => "123"})
+                result = resolve_nodes("Widget", "components", {"component_ids" => component1.fetch(:id), "id" => "123"})
 
                 expect(result.map { |c| c.fetch("id") }).to contain_exactly(component1.fetch(:id))
               }.to log a_string_including("Widget(id: 123).components", "component_ids: scalar instead of a list")
@@ -154,21 +154,21 @@ module ElasticGraph
 
             it "returns an empty list (and logs a warning) when the foreign key field is missing" do
               expect {
-                result = resolve_nodes("Widget", :components, {"name" => "a"})
+                result = resolve_nodes("Widget", "components", {"name" => "a"})
 
                 expect(result).to be_empty
               }.to log a_string_including("Widget(id: <no id>).components", "component_ids is missing from the document")
             end
 
             it "returns a list of records matching additional filter conditions" do
-              result = resolve_nodes("Component", :dollar_widgets, {"id" => component1.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
+              result = resolve_nodes("Component", "dollar_widgets", {"id" => component1.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
 
               expect(result.map { |c| c.fetch("id") }).to contain_exactly(widget1.fetch(:id))
               expect(result.map { |c| c.fetch("cost").fetch("amount_cents") }).to contain_exactly(100)
             end
 
             it "returns an empty list when records with matching conditions are not found" do
-              result = resolve_nodes("Component", :dollar_widgets, {"id" => component3.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
+              result = resolve_nodes("Component", "dollar_widgets", {"id" => component3.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
 
               expect(result).to be_empty
             end
@@ -180,19 +180,19 @@ module ElasticGraph
             end
 
             it "loads the relationship" do
-              result = resolve("Component", :widget, {"id" => component1.fetch(:id)})
+              result = resolve("Component", "widget", {"id" => component1.fetch(:id)})
 
               expect(result.fetch("id")).to eq widget1.fetch(:id)
             end
 
             it "tolerates not finding the id" do
-              result = resolve("Component", :widget, {"id" => build(:component).fetch(:id)})
+              result = resolve("Component", "widget", {"id" => build(:component).fetch(:id)})
 
               expect(result).to eq nil
             end
 
             it "returns nil when given a nil id" do
-              result = resolve("Component", :widget, {"id" => nil})
+              result = resolve("Component", "widget", {"id" => nil})
 
               expect(result).to eq nil
             end
@@ -200,7 +200,7 @@ module ElasticGraph
             it "returns one record (and logs a warning) when querying the datastore produces a list of records instead of a single one" do
               expect {
                 # Note: inclusion of nested field `cost.amount_cents` is necessary to exercise an edge case that originally resulted in an exception.
-                result = resolve("Component", :widget, {"id" => component2.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
+                result = resolve("Component", "widget", {"id" => component2.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
 
                 expect(result.fetch("id")).to eq(widget1.fetch(:id)).or eq(widget2.fetch(:id))
                 expect(result.fetch("cost").fetch("amount_cents")).to eq(widget1.fetch(:cost).fetch(:amount_cents)).or eq(widget2.fetch(:cost).fetch(:amount_cents))
@@ -210,7 +210,7 @@ module ElasticGraph
             it "returns one record (and logs a warning) when the id field is a list instead of a scalar" do
               ids = [component1.fetch(:id), component3.fetch(:id)]
               expect {
-                result = resolve("Component", :widget, {"id" => ids})
+                result = resolve("Component", "widget", {"id" => ids})
 
                 expect(result.fetch("id")).to eq(widget1.fetch(:id)).or eq(widget3.fetch(:id))
               }.to log a_string_including("Component(id: #{ids}).widget", "id: list of more than one item instead of a scalar")
@@ -218,21 +218,21 @@ module ElasticGraph
 
             it "returns nil (and logs a warning) when the id field is missing" do
               expect {
-                result = resolve("Component", :widget, {"name" => "foo"})
+                result = resolve("Component", "widget", {"name" => "foo"})
 
                 expect(result).to eq nil
               }.to log a_string_including("Component(id: <no id>).widget", "id is missing from the document")
             end
 
             it "returns one record matching additional filter conditions" do
-              result = resolve("Component", :dollar_widget, {"id" => component1.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
+              result = resolve("Component", "dollar_widget", {"id" => component1.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
 
               expect(result.fetch("id")).to eq(widget1.fetch(:id))
               expect(result.fetch("cost").fetch("amount_cents")).to eq(widget1.fetch(:cost).fetch(:amount_cents))
             end
 
             it "returns nil when a record with matching conditions is not found" do
-              result = resolve("Component", :dollar_widget, {"id" => component3.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
+              result = resolve("Component", "dollar_widget", {"id" => component3.fetch(:id)}, requested_fields: ["id", "cost.amount_cents"])
 
               expect(result).to eq nil
             end
@@ -288,31 +288,31 @@ module ElasticGraph
             end
 
             it "loads the relationship and respects defaultSort" do
-              result = resolve_nodes("Manufacturer", :manufactured_parts, {"id" => manufacturer1.fetch(:id)})
+              result = resolve_nodes("Manufacturer", "manufactured_parts", {"id" => manufacturer1.fetch(:id)})
 
               expect(result.map { |c| c.fetch("id") }).to eq([part2.fetch(:id), part1.fetch(:id)])
             end
 
             it "respects a list of `order_by` options, supporting ascending and descending sorts" do
-              result = resolve_nodes("Manufacturer", :manufactured_parts,
+              result = resolve_nodes("Manufacturer", "manufactured_parts",
                 {"id" => manufacturer1.fetch(:id)},
                 order_by: ["created_at_ASC"])
               expect(result.map { |c| c.fetch("id") }).to eq([part1.fetch(:id), part2.fetch(:id)])
 
-              result = resolve_nodes("Manufacturer", :manufactured_parts,
+              result = resolve_nodes("Manufacturer", "manufactured_parts",
                 {"id" => manufacturer1.fetch(:id)},
                 order_by: ["created_at_DESC"])
               expect(result.map { |c| c.fetch("id") }).to eq([part2.fetch(:id), part1.fetch(:id)])
             end
 
             it "tolerates not finding records for the given id" do
-              result = resolve_nodes("Manufacturer", :manufactured_parts, {"id" => build(:manufacturer).fetch(:id)})
+              result = resolve_nodes("Manufacturer", "manufactured_parts", {"id" => build(:manufacturer).fetch(:id)})
 
               expect(result).to be_empty
             end
 
             it "returns an empty list when given a nil id" do
-              result = resolve_nodes("Manufacturer", :manufactured_parts, {"id" => nil})
+              result = resolve_nodes("Manufacturer", "manufactured_parts", {"id" => nil})
 
               expect(result).to be_empty
             end
@@ -320,7 +320,7 @@ module ElasticGraph
             it "returns one of the two lists of matches (and logs a warning) when the id field is a list instead of a scalar" do
               ids = [manufacturer1.fetch(:id), manufacturer2.fetch(:id)]
               expect {
-                result = resolve_nodes("Manufacturer", :manufactured_parts, {"id" => ids})
+                result = resolve_nodes("Manufacturer", "manufactured_parts", {"id" => ids})
 
                 expect(result.map { |c| c.fetch("id") }).to contain_exactly(part1.fetch(:id), part2.fetch(:id)).or eq([part3.fetch(:id)])
               }.to log a_string_including("Manufacturer(id: #{ids}).manufactured_parts", "id: list of more than one item instead of a scalar")
@@ -328,7 +328,7 @@ module ElasticGraph
 
             it "returns an empty list (and logs a warning) when the id field is missing" do
               expect {
-                result = resolve_nodes("Manufacturer", :manufactured_parts, {"name" => "foo"})
+                result = resolve_nodes("Manufacturer", "manufactured_parts", {"name" => "foo"})
 
                 expect(result).to be_empty
               }.to log a_string_including("Manufacturer(id: <no id>).manufactured_parts", "id is missing from the document")
@@ -343,19 +343,19 @@ module ElasticGraph
             end
 
             it "loads the relationship" do
-              result = resolve("ElectricalPart", :manufacturer, {"manufacturer_id" => manufacturer1.fetch(:id)})
+              result = resolve("ElectricalPart", "manufacturer", {"manufacturer_id" => manufacturer1.fetch(:id)})
 
               expect(result.fetch("id")).to eq manufacturer1.fetch(:id)
             end
 
             it "tolerates not finding a record the given id" do
-              result = resolve("ElectricalPart", :manufacturer, {"manufacturer_id" => build(:manufacturer).fetch(:id)})
+              result = resolve("ElectricalPart", "manufacturer", {"manufacturer_id" => build(:manufacturer).fetch(:id)})
 
               expect(result).to eq nil
             end
 
             it "returns nil when given a nil id" do
-              result = resolve("ElectricalPart", :manufacturer, {"manufacturer_id" => nil})
+              result = resolve("ElectricalPart", "manufacturer", {"manufacturer_id" => nil})
 
               expect(result).to eq nil
             end
@@ -363,7 +363,7 @@ module ElasticGraph
             it "returns one of the referenced documents (and logs a warning) when the foreign key field is a list instead of a scalar" do
               expect {
                 manufacturer_ids = [manufacturer1.fetch(:id), manufacturer2.fetch(:id)]
-                result = resolve("ElectricalPart", :manufacturer, {"id" => "123", "manufacturer_id" => manufacturer_ids})
+                result = resolve("ElectricalPart", "manufacturer", {"id" => "123", "manufacturer_id" => manufacturer_ids})
 
                 expect(result.fetch("id")).to eq(manufacturer1.fetch(:id)).or eq(manufacturer2.fetch(:id))
               }.to log a_string_including("Part(id: 123).manufacturer", "manufacturer_id: list of more than one item instead of a scalar")
@@ -371,7 +371,7 @@ module ElasticGraph
 
             it "returns nil (and logs a warning) when the foreign key field is missing" do
               expect {
-                result = resolve("ElectricalPart", :manufacturer, {"id" => "123"})
+                result = resolve("ElectricalPart", "manufacturer", {"id" => "123"})
 
                 expect(result).to eq nil
               }.to log a_string_including("Part(id: 123).manufacturer", "manufacturer_id is missing from the document")
@@ -442,38 +442,38 @@ module ElasticGraph
             end
 
             it "loads the relationship and respects defaultSort" do
-              result = resolve_nodes("Component", :parts, {"part_ids" => [part1.fetch(:id), part2.fetch(:id)]})
+              result = resolve_nodes("Component", "parts", {"part_ids" => [part1.fetch(:id), part2.fetch(:id)]})
 
               expect(result.map { |c| c.fetch("id") }).to eq([part2.fetch(:id), part1.fetch(:id)])
             end
 
             it "respects a list of `order_by` options, supporting ascending and descending sorts" do
-              result = resolve_nodes("Component", :parts,
+              result = resolve_nodes("Component", "parts",
                 {"part_ids" => [part1.fetch(:id), part2.fetch(:id)]},
                 order_by: ["created_at_ASC"])
               expect(result.map { |c| c.fetch("id") }).to eq([part1.fetch(:id), part2.fetch(:id)])
 
-              result = resolve_nodes("Component", :parts,
+              result = resolve_nodes("Component", "parts",
                 {"part_ids" => [part1.fetch(:id), part2.fetch(:id)]},
                 order_by: ["created_at_DESC"])
               expect(result.map { |c| c.fetch("id") }).to eq([part2.fetch(:id), part1.fetch(:id)])
             end
 
             it "tolerates not finding some ids" do
-              result = resolve_nodes("Component", :parts, {"part_ids" => [part1.fetch(:id), build(:part).fetch(:id)]})
+              result = resolve_nodes("Component", "parts", {"part_ids" => [part1.fetch(:id), build(:part).fetch(:id)]})
 
               expect(result.map { |c| c.fetch("id") }).to contain_exactly(part1.fetch(:id))
             end
 
             it "returns an empty list when given a blank list of ids" do
-              result = resolve_nodes("Component", :parts, {"part_ids" => []})
+              result = resolve_nodes("Component", "parts", {"part_ids" => []})
 
               expect(result).to be_empty
             end
 
             it "returns a list of the matching document (and logs a warning) when the foreign key field is a scalar instead of a list" do
               expect {
-                result = resolve_nodes("Component", :parts, {"id" => "123", "part_ids" => part1.fetch(:id)})
+                result = resolve_nodes("Component", "parts", {"id" => "123", "part_ids" => part1.fetch(:id)})
 
                 expect(result.map { |p| p.fetch("id") }).to eq [part1.fetch(:id)]
               }.to log a_string_including("Component(id: 123).parts", "part_ids: scalar instead of a list")
@@ -481,21 +481,21 @@ module ElasticGraph
 
             it "returns an empty list" do
               expect {
-                result = resolve_nodes("Component", :parts, {"id" => "123"})
+                result = resolve_nodes("Component", "parts", {"id" => "123"})
 
                 expect(result).to be_empty
               }.to log a_string_including("Component(id: 123).parts", "part_ids is missing from the document")
             end
 
             it "supports filtering on a non-id field" do
-              results = resolve_nodes("Component", :parts, {"part_ids" => [part1.fetch(:id), part2.fetch(:id)]},
+              results = resolve_nodes("Component", "parts", {"part_ids" => [part1.fetch(:id), part2.fetch(:id)]},
                 filter: {name: {equal_to_any_of: ["p1", "p4"]}})
 
               expect(results.map { |c| c.fetch("id") }).to contain_exactly(part1.fetch(:id))
             end
 
             it "supports filtering on id" do
-              results = resolve_nodes("Component", :parts, {"part_ids" => [part1.fetch(:id), part2.fetch(:id)]},
+              results = resolve_nodes("Component", "parts", {"part_ids" => [part1.fetch(:id), part2.fetch(:id)]},
                 filter: {id: {equal_to_any_of: [part1.fetch(:id), part4.fetch(:id)]}})
 
               expect(results.map { |c| c.fetch("id") }).to contain_exactly(part1.fetch(:id))
@@ -508,27 +508,27 @@ module ElasticGraph
             end
 
             it "loads the relationship and supports defaultSort" do
-              result = resolve_nodes("ElectricalPart", :components, {"id" => part1.fetch(:id)})
+              result = resolve_nodes("ElectricalPart", "components", {"id" => part1.fetch(:id)})
 
               expect(result.map { |c| c.fetch("id") }).to eq([component2.fetch(:id), component1.fetch(:id)])
             end
 
             it "respects a list of `order_by` options, supporting ascending and descending sorts" do
-              result = resolve_nodes("ElectricalPart", :components, {"id" => part1.fetch(:id)}, order_by: ["created_at_ASC"])
+              result = resolve_nodes("ElectricalPart", "components", {"id" => part1.fetch(:id)}, order_by: ["created_at_ASC"])
               expect(result.map { |c| c.fetch("id") }).to eq([component1.fetch(:id), component2.fetch(:id)])
 
-              result = resolve_nodes("ElectricalPart", :components, {"id" => part1.fetch(:id)}, order_by: ["created_at_DESC"])
+              result = resolve_nodes("ElectricalPart", "components", {"id" => part1.fetch(:id)}, order_by: ["created_at_DESC"])
               expect(result.map { |c| c.fetch("id") }).to eq([component2.fetch(:id), component1.fetch(:id)])
             end
 
             it "tolerates not finding records for the given id" do
-              result = resolve_nodes("ElectricalPart", :components, {"id" => build(:part).fetch(:id)})
+              result = resolve_nodes("ElectricalPart", "components", {"id" => build(:part).fetch(:id)})
 
               expect(result).to be_empty
             end
 
             it "returns an empty list when given a nil id" do
-              result = resolve_nodes("ElectricalPart", :components, {"id" => nil})
+              result = resolve_nodes("ElectricalPart", "components", {"id" => nil})
 
               expect(result).to be_empty
             end
@@ -536,7 +536,7 @@ module ElasticGraph
             it "returns one of the two lists of matches (and logs a warning) when the id field is a list instead of a scalar" do
               ids = [part1.fetch(:id), part2.fetch(:id)]
               expect {
-                result = resolve_nodes("ElectricalPart", :components, {"id" => ids})
+                result = resolve_nodes("ElectricalPart", "components", {"id" => ids})
 
                 expect(result.map { |c| c.fetch("id") }).to \
                   contain_exactly(component1.fetch(:id), component2.fetch(:id)).or \
@@ -546,14 +546,14 @@ module ElasticGraph
 
             it "returns an empty list (and logs a warning) when the id field is missing" do
               expect {
-                result = resolve_nodes("ElectricalPart", :components, {"name" => "foo"})
+                result = resolve_nodes("ElectricalPart", "components", {"name" => "foo"})
 
                 expect(result).to be_empty
               }.to log a_string_including("ElectricalPart(id: <no id>).components", "id is missing from the document")
             end
 
             it "supports filtering on a non-id field" do
-              results = resolve_nodes("ElectricalPart", :components, {"id" => part1.fetch(:id)},
+              results = resolve_nodes("ElectricalPart", "components", {"id" => part1.fetch(:id)},
                 filter: {name: {equal_to_any_of: ["c1", "c4"]}})
 
               expect(results.map { |c| c.fetch("id") }).to contain_exactly(component1.fetch(:id))
@@ -562,7 +562,7 @@ module ElasticGraph
             it "supports filtering on id", :expect_search_routing do
               component_ids = [component1.fetch(:id), component4.fetch(:id)]
 
-              results = resolve_nodes("ElectricalPart", :components, {"id" => part1.fetch(:id)},
+              results = resolve_nodes("ElectricalPart", "components", {"id" => part1.fetch(:id)},
                 filter: {id: {equal_to_any_of: component_ids}})
 
               expect(results.map { |c| c.fetch("id") }).to contain_exactly(component1.fetch(:id))
@@ -607,19 +607,19 @@ module ElasticGraph
             end
 
             it "loads the relationship" do
-              result = resolve("Address", :manufacturer, {"manufacturer_id" => manufacturer1.fetch(:id)})
+              result = resolve("Address", "manufacturer", {"manufacturer_id" => manufacturer1.fetch(:id)})
 
               expect(result.fetch("id")).to eq manufacturer1.fetch(:id)
             end
 
             it "tolerates not finding a record for the given id" do
-              result = resolve("Address", :manufacturer, {"manufacturer_id" => build(:manufacturer).fetch(:id)})
+              result = resolve("Address", "manufacturer", {"manufacturer_id" => build(:manufacturer).fetch(:id)})
 
               expect(result).to eq nil
             end
 
             it "returns nil when given a nil id" do
-              result = resolve("Address", :manufacturer, {"manufacturer_id" => nil})
+              result = resolve("Address", "manufacturer", {"manufacturer_id" => nil})
 
               expect(result).to eq nil
             end
@@ -627,7 +627,7 @@ module ElasticGraph
             it "returns one of the referenced documents (and logs a warning) when the foreign key field is a list instead of a scalar" do
               expect {
                 manufacturer_ids = [manufacturer1.fetch(:id), manufacturer2.fetch(:id)]
-                result = resolve("Address", :manufacturer, {"id" => "123", "manufacturer_id" => manufacturer_ids})
+                result = resolve("Address", "manufacturer", {"id" => "123", "manufacturer_id" => manufacturer_ids})
 
                 expect(result.fetch("id")).to eq(manufacturer1.fetch(:id)).or eq(manufacturer2.fetch(:id))
               }.to log a_string_including("Address(id: 123).manufacturer", "manufacturer_id: list of more than one item instead of a scalar")
@@ -635,7 +635,7 @@ module ElasticGraph
 
             it "returns nil (and logs a warning) when the foreign key field is missing" do
               expect {
-                result = resolve("Address", :manufacturer, {"id" => "123"})
+                result = resolve("Address", "manufacturer", {"id" => "123"})
 
                 expect(result).to eq nil
               }.to log a_string_including("Address(id: 123).manufacturer", "manufacturer_id is missing from the document")
@@ -648,26 +648,26 @@ module ElasticGraph
             end
 
             it "loads the relationship" do
-              result = resolve("Manufacturer", :address, {"id" => manufacturer1.fetch(:id)})
+              result = resolve("Manufacturer", "address", {"id" => manufacturer1.fetch(:id)})
 
               expect(result.fetch("id")).to eq address1.fetch(:id)
             end
 
             it "tolerates not finding a record for the given id" do
-              result = resolve("Manufacturer", :address, {"id" => build(:manufacturer).fetch(:id)})
+              result = resolve("Manufacturer", "address", {"id" => build(:manufacturer).fetch(:id)})
 
               expect(result).to eq nil
             end
 
             it "returns nil when given a nil id" do
-              result = resolve("Manufacturer", :address, {"id" => nil})
+              result = resolve("Manufacturer", "address", {"id" => nil})
 
               expect(result).to eq nil
             end
 
             it "returns one of the matching records (and logs a warning) when querying the datastore produces a list of records instead of a single one" do
               expect {
-                result = resolve("Manufacturer", :address, {"id" => manufacturer2.fetch(:id)})
+                result = resolve("Manufacturer", "address", {"id" => manufacturer2.fetch(:id)})
 
                 expect(result.fetch("id")).to eq(address2.fetch(:id)).or eq(address3.fetch(:id))
               }.to log a_string_including("Manufacturer(id: #{manufacturer2.fetch(:id)}).address", "got list of more than one item instead of a scalar from the datastore search query")
@@ -676,7 +676,7 @@ module ElasticGraph
             it "returns one of the matching records (and logs a warning) when the id field is a list instead of a scalar" do
               ids = [manufacturer1.fetch(:id), manufacturer3.fetch(:id)]
               expect {
-                result = resolve("Manufacturer", :address, {"id" => ids})
+                result = resolve("Manufacturer", "address", {"id" => ids})
 
                 expect(result.fetch("id")).to eq(address1.fetch(:id)).or eq(address4.fetch(:id))
               }.to log a_string_including("Manufacturer(id: #{ids}).address", "id: list of more than one item instead of a scalar")
@@ -684,7 +684,7 @@ module ElasticGraph
 
             it "returns nil (and logs a warning) when the id field is missing" do
               expect {
-                result = resolve("Manufacturer", :address, {"name" => "foo"})
+                result = resolve("Manufacturer", "address", {"name" => "foo"})
 
                 expect(result).to eq nil
               }.to log a_string_including("Manufacturer(id: <no id>).address", "id is missing from the document")
@@ -707,13 +707,13 @@ module ElasticGraph
             end
 
             it "loads the relationship from a nested field in an object list" do
-              result = resolve_nodes("Sponsor", :affiliated_teams_from_object, {"id" => sponsor1.fetch(:id)}, requested_fields: ["id"])
+              result = resolve_nodes("Sponsor", "affiliated_teams_from_object", {"id" => sponsor1.fetch(:id)}, requested_fields: ["id"])
 
               expect(result.map { |t| t.fetch("id") }).to contain_exactly(team1.fetch(:id), team2.fetch(:id))
             end
 
             it "loads the relationship from a nested field in a nested list" do
-              result = resolve_nodes("Sponsor", :affiliated_teams_from_nested, {"id" => sponsor1.fetch(:id)}, requested_fields: ["id"])
+              result = resolve_nodes("Sponsor", "affiliated_teams_from_nested", {"id" => sponsor1.fetch(:id)}, requested_fields: ["id"])
 
               expect(result.map { |t| t.fetch("id") }).to contain_exactly(team1.fetch(:id), team2.fetch(:id))
             end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/get_record_field_value_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/get_record_field_value_spec.rb
@@ -46,32 +46,32 @@ module ElasticGraph
 
         context "for a field without customizations" do
           it "fetches a requested scalar field from the document" do
-            value = resolve("Person", :name, {"id" => 1, "name" => "Napoleon"})
+            value = resolve("Person", "name", {"id" => 1, "name" => "Napoleon"})
 
             expect(value).to eq "Napoleon"
           end
 
           it "works with an `DatastoreResponse::Document`" do
             doc = DatastoreResponse::Document.with_payload("id" => 1, "name" => "Napoleon")
-            value = resolve("Person", :name, doc)
+            value = resolve("Person", "name", doc)
 
             expect(value).to eq "Napoleon"
           end
 
           it "fetches a requested list field from the document" do
-            value = resolve("Person", :nicknames, {"id" => 1, "nicknames" => %w[Napo Leon]})
+            value = resolve("Person", "nicknames", {"id" => 1, "nicknames" => %w[Napo Leon]})
 
             expect(value).to eq %w[Napo Leon]
           end
 
           it "returns `nil` when a scalar field is missing" do
-            value = resolve("Person", :name, {"id" => 1})
+            value = resolve("Person", "name", {"id" => 1})
 
             expect(value).to eq nil
           end
 
           it "returns a blank list when a list field is missing" do
-            value = resolve("Person", :nicknames, {"id" => 2})
+            value = resolve("Person", "nicknames", {"id" => 2})
 
             expect(value).to eq []
           end
@@ -79,45 +79,37 @@ module ElasticGraph
 
         context "for a field with customizations" do
           it "resolves to the field named via the `name_in_index` option instead of the schema field name" do
-            value = resolve("Person", :alt_name1, {"id" => 1, "name" => "Napoleon"})
+            value = resolve("Person", "alt_name1", {"id" => 1, "name" => "Napoleon"})
 
             expect(value).to eq "Napoleon"
           end
 
           it "can resolve to a child `name_in_index`" do
-            value = resolve("Person", :ssn, {"id" => 1, "identifiers" => {"ssn" => "123-456-7890"}})
+            value = resolve("Person", "ssn", {"id" => 1, "identifiers" => {"ssn" => "123-456-7890"}})
 
             expect(value).to eq "123-456-7890"
           end
 
           it "can resolve a list field" do
-            value = resolve("Person", :alt_nicknames, {"id" => 1, "nicknames" => %w[Napo Leon]})
+            value = resolve("Person", "alt_nicknames", {"id" => 1, "nicknames" => %w[Napo Leon]})
 
             expect(value).to eq %w[Napo Leon]
           end
 
-          it "allows the `name` arg value to be a string or symbol" do
-            value1 = resolve("Person", :alt_name1, {"id" => 1, "name" => "Napoleon"})
-            value2 = resolve("Person", :alt_name2, {"id" => 1, "name" => "Napoleon"})
-
-            expect(value1).to eq "Napoleon"
-            expect(value2).to eq "Napoleon"
-          end
-
           it "works with an `DatastoreResponse::Document`" do
             doc = DatastoreResponse::Document.with_payload("id" => 1, "name" => "Napoleon")
-            value = resolve("Person", :alt_name1, doc)
+            value = resolve("Person", "alt_name1", doc)
 
             expect(value).to eq "Napoleon"
           end
 
           it "returns `nil` for a scalar when the directive field name is missing" do
-            value = resolve("Person", :alt_name1, {"id" => 1})
+            value = resolve("Person", "alt_name1", {"id" => 1})
             expect(value).to eq nil
           end
 
           it "returns a blank list for a list field when the directive field name is missing" do
-            value = resolve("Person", :alt_nicknames, {"id" => 2})
+            value = resolve("Person", "alt_nicknames", {"id" => 2})
 
             expect(value).to eq []
           end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/query_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/query_adapter_spec.rb
@@ -51,7 +51,7 @@ module ElasticGraph
         end
 
         let(:graphql) { build_graphql(schema_artifacts: schema_artifacts) }
-        let(:field) { graphql.schema.field_named("Query", :widgets) }
+        let(:field) { graphql.schema.field_named("Query", "widgets") }
         let(:query_adapter) do
           QueryAdapter.new(
             datastore_query_builder: graphql.datastore_query_builder,
@@ -87,8 +87,8 @@ module ElasticGraph
 
             context "on a union type where the subtypes have different default sorts" do
               it "consistently uses the default sort from the alphabetically first index definition" do
-                field1 = graphql.schema.field_named("Query", :widgets_or_components)
-                field2 = graphql.schema.field_named("Query", :components_or_widgets)
+                field1 = graphql.schema.field_named("Query", "widgets_or_components")
+                field2 = graphql.schema.field_named("Query", "components_or_widgets")
 
                 sort1 = build_query_from({}, field: field1).sort
                 sort2 = build_query_from({}, field: field2).sort
@@ -107,7 +107,7 @@ module ElasticGraph
 
           describe "document_pagination" do
             context "on an indexed document field" do
-              let(:field) { graphql.schema.field_named("Query", :widgets) }
+              let(:field) { graphql.schema.field_named("Query", "widgets") }
 
               it "extracts `after`" do
                 datastore_query = build_query_from({after: "ABC"})
@@ -131,7 +131,7 @@ module ElasticGraph
             end
 
             context "on an indexed aggregation field" do
-              let(:field) { graphql.schema.field_named("Query", :widget_aggregations) }
+              let(:field) { graphql.schema.field_named("Query", "widget_aggregations") }
 
               it "ignores the pagination arguments since the aggregation adapter handles them for aggregations" do
                 datastore_query = build_query_from({

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
@@ -47,40 +47,40 @@ module ElasticGraph
         shared_examples_for ResolvableValue do |person_class|
           describe "#resolve" do
             it "delegates to a method of the same name on the object" do
-              value = resolve(name: "Kristin", field: :name)
+              value = resolve(name: "Kristin", field: "name")
 
               expect(value).to eq "Kristin"
             end
 
             it "coerces the field name to its canonical form before calling the method" do
-              value = resolve(name_form: :camelCase, birth_date: "2001-03-01", field: :birthDate)
+              value = resolve(name_form: :camelCase, birth_date: "2001-03-01", field: "birthDate")
 
               expect(value).to eq "2001-03-01"
             end
 
             it "evaluates the block passed to `ResolvableValue.new` just like `Data.define` does" do
-              value = resolve(name: "John Doe", field: :first_name)
+              value = resolve(name: "John Doe", field: "first_name")
               expect(value).to eq "John"
 
-              value = resolve(name_form: :camelCase, name: "John Doe", field: :firstName)
+              value = resolve(name_form: :camelCase, name: "John Doe", field: "firstName")
               expect(value).to eq "John"
             end
 
             it "raises a clear error if the field being resolved was not defined in the schema element names" do
               expect {
-                resolve(name: "John Doe", field: :last_name)
+                resolve(name: "John Doe", field: "last_name")
               }.to raise_error(Errors::SchemaError, /last_name/)
             end
 
             it "raises an error if the field name is not in the form defined by the schema elements" do
               expect {
-                resolve(name_form: :snake_case, birth_date: "2001-03-01", field: :birthDate)
+                resolve(name_form: :snake_case, birth_date: "2001-03-01", field: "birthDate")
               }.to raise_error(Errors::SchemaError, /birthDate/)
             end
 
             it "raises a `NoMethodError` if the field being resolved is not a defined method" do
               expect {
-                resolve(name: "John Doe", field: :age)
+                resolve(name: "John Doe", field: "age")
               }.to raise_error(NoMethodError, /age/)
             end
 
@@ -88,7 +88,7 @@ module ElasticGraph
               value = resolve(
                 name: "John Does",
                 quote: "To be, or not to be",
-                field: :favorite_quote,
+                field: "favorite_quote",
                 args: {truncate_to: 5}
               )
 
@@ -100,7 +100,7 @@ module ElasticGraph
                 overrides: {truncate_to: "trunc_to"},
                 name: "John Does",
                 quote: "To be, or not to be",
-                field: :favorite_quote2,
+                field: "favorite_quote2",
                 args: {trunc_to: 5}
               )
 
@@ -112,7 +112,7 @@ module ElasticGraph
                 resolve(
                   name: "John Does",
                   quote: "To be, or not to be",
-                  field: :favorite_quote,
+                  field: "favorite_quote",
                   args: {truncate_to: 5, foo_bar_bazz: 23}
                 )
               }.to raise_error Errors::SchemaError, a_string_including("foo_bar_bazz")
@@ -123,7 +123,7 @@ module ElasticGraph
                 resolve(
                   name: "John Does",
                   quote: "To be, or not to be",
-                  field: :name,
+                  field: "name",
                   args: {truncate_to: 5}
                 )
               }.to raise_error ArgumentError

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/field_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/field_spec.rb
@@ -13,14 +13,14 @@ module ElasticGraph
   class GraphQL
     class Schema
       RSpec.describe Field, :ensure_no_orphaned_types do
-        it "exposes the name as a lowercase symbol" do
+        it "exposes the name as a lowercase string" do
           field = define_schema do |schema|
             schema.object_type "Color" do |t|
               t.field "red", "Int!"
             end
-          end.field_named("Color", :red)
+          end.field_named("Color", "red")
 
-          expect(field.name).to eq :red
+          expect(field.name).to eq "red"
         end
 
         it "exposes the parent type" do
@@ -30,7 +30,7 @@ module ElasticGraph
             end
           end
 
-          field = schema.field_named("Color", :red)
+          field = schema.field_named("Color", "red")
           expect(field.parent_type).to be schema.type_named("Color")
         end
 
@@ -39,7 +39,7 @@ module ElasticGraph
             schema.object_type "Color" do |t|
               t.field "red", "Int!"
             end
-          end.field_named("Color", :red)
+          end.field_named("Color", "red")
 
           expect(field.inspect).to eq "#<ElasticGraph::GraphQL::Schema::Field Color.red>"
         end
@@ -52,7 +52,7 @@ module ElasticGraph
               end
             end
 
-            field = schema.field_named("Color", :red)
+            field = schema.field_named("Color", "red")
 
             expect(field.type.name).to eq "Int"
             expect(field.type).to be schema.type_named("Int")
@@ -65,7 +65,7 @@ module ElasticGraph
               end
             end
 
-            field = schema.field_named("Color", :red)
+            field = schema.field_named("Color", "red")
 
             expect(field.type.name).to eq "[Int!]!"
           end
@@ -85,7 +85,7 @@ module ElasticGraph
                 t.relates_to_many "colors", "Color", via: "photo_id", dir: :in, singular: "color"
                 t.index "photos"
               end
-            end.field_named("Photo", :colors)
+            end.field_named("Photo", "colors")
 
             expect(field.relation_join).to be_a(RelationJoin).and be(field.relation_join)
           end
@@ -97,7 +97,7 @@ module ElasticGraph
               s.object_type "Color" do |t|
                 t.field "red", "Int"
               end
-            end.field_named("Color", :red)
+            end.field_named("Color", "red")
 
             expect(field.relation_join).to be(nil).and be(field.relation_join)
             expect(RelationJoin).to have_received(:from).once
@@ -110,7 +110,7 @@ module ElasticGraph
               s.object_type "Widget" do |t|
                 t.field "count", "Int"
               end
-            end.field_named("Widget", :count)
+            end.field_named("Widget", "count")
 
             expect {
               field.sort_clauses_for(:enum_value)
@@ -131,7 +131,7 @@ module ElasticGraph
           end
 
           it "returns a list of datastore sort clauses when passed an array" do
-            field = schema.field_named("Query", :photos)
+            field = schema.field_named("Query", "photos")
             sort_clauses = field.sort_clauses_for([:pixel_count_DESC, :created_at_ms_DESC])
 
             expect(sort_clauses).to eq([
@@ -141,14 +141,14 @@ module ElasticGraph
           end
 
           it "returns a list of a single datastore sort clause when passed a scalar" do
-            field = schema.field_named("Query", :photos)
+            field = schema.field_named("Query", "photos")
             sort_clauses = field.sort_clauses_for(:pixel_count_DESC)
 
             expect(sort_clauses).to eq([{"pixel_count" => {"order" => "desc"}}])
           end
 
           it "raises an error if a sort value is undefined" do
-            field = schema.field_named("Query", :photos)
+            field = schema.field_named("Query", "photos")
 
             expect {
               field.sort_clauses_for(:bogus_DESC)
@@ -173,7 +173,7 @@ module ElasticGraph
               EOS
             end
 
-            field = schema.field_named("Query", :photos)
+            field = schema.field_named("Query", "photos")
 
             expect {
               field.sort_clauses_for(:invalid_photo_sort_DESC)
@@ -181,7 +181,7 @@ module ElasticGraph
           end
 
           it "returns an empty array when given nil or []" do
-            field = schema.field_named("Query", :photos)
+            field = schema.field_named("Query", "photos")
 
             expect(field.sort_clauses_for(nil)).to eq []
             expect(field.sort_clauses_for([])).to eq []
@@ -196,7 +196,7 @@ module ElasticGraph
                 t.field "some_field", "Int"
                 t.index "photos"
               end
-            end.field_named("IntAggregatedValues", :exact_sum)
+            end.field_named("IntAggregatedValues", "exact_sum")
 
             expect(field.computation_detail).to eq(
               SchemaArtifacts::RuntimeMetadata::ComputationDetail.new(
@@ -245,7 +245,7 @@ module ElasticGraph
               schema.object_type "Photo" do |t|
                 t.field "some_field", type_name, filterable: false, aggregatable: false, groupable: false
               end
-            end.field_named("Photo", :some_field)
+            end.field_named("Photo", "some_field")
           end
         end
 
@@ -261,17 +261,17 @@ module ElasticGraph
 
           context "when a schema field is defined with a `name_in_index`" do
             it "returns the `name_in_index` value" do
-              field = schema.field_named("Person", :alt_name)
+              field = schema.field_named("Person", "alt_name")
 
-              expect(field.name_in_index).to eq(:name)
+              expect(field.name_in_index).to eq("name")
             end
           end
 
           context "when a schema field does not have a `name_in_index`" do
             it "returns the field name" do
-              field = schema.field_named("Person", :first_name)
+              field = schema.field_named("Person", "first_name")
 
-              expect(field.name_in_index).to eq(:first_name)
+              expect(field.name_in_index).to eq("first_name")
             end
           end
         end
@@ -289,7 +289,7 @@ module ElasticGraph
                   foo(camelCaseField: Int, maybe_set_to_null: String, nested: Nested): Int
                 }
               EOS
-            end.field_named("Query", :foo)
+            end.field_named("Query", "foo")
           end
 
           it "converts an args hash from the keyword args style provided by graphql gem to their form in the schema" do
@@ -372,10 +372,10 @@ module ElasticGraph
 
             schema = graphql.schema
 
-            expect(schema.field_named("WidgetConnection", :edges).index_field_names_for_resolution).to eq []
-            expect(schema.field_named("WidgetConnection", :page_info).index_field_names_for_resolution).to eq []
-            expect(schema.field_named("WidgetEdge", :node).index_field_names_for_resolution).to eq []
-            expect(schema.field_named("WidgetEdge", :cursor).index_field_names_for_resolution).to eq []
+            expect(schema.field_named("WidgetConnection", "edges").index_field_names_for_resolution).to eq []
+            expect(schema.field_named("WidgetConnection", "page_info").index_field_names_for_resolution).to eq []
+            expect(schema.field_named("WidgetEdge", "node").index_field_names_for_resolution).to eq []
+            expect(schema.field_named("WidgetEdge", "cursor").index_field_names_for_resolution).to eq []
           end
 
           def index_field_names_for(field_method, field_name, field_type, **field_args)

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/type_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/type_spec.rb
@@ -150,7 +150,7 @@ module ElasticGraph
           end
 
           it "can model a scalar" do
-            type = type_for(:int)
+            type = type_for("int")
 
             expect(type.name).to eq "Int"
             expect(type).to only_satisfy_predicates(:nullable?)
@@ -159,7 +159,7 @@ module ElasticGraph
           end
 
           it "can model a non-nullable scalar" do
-            type = type_for(:non_null_int)
+            type = type_for("non_null_int")
 
             expect(type.name).to eq "Int!"
             expect(type).to only_satisfy_predicates(:non_null?)
@@ -168,7 +168,7 @@ module ElasticGraph
           end
 
           it "can model an embedded object" do
-            type = type_for(:color)
+            type = type_for("color")
 
             expect(type.name).to eq "Color"
             expect(type).to only_satisfy_predicates(:nullable?, :object?, :embedded_object?)
@@ -177,7 +177,7 @@ module ElasticGraph
           end
 
           it "can model a non-nullable embedded object" do
-            type = type_for(:non_null_color)
+            type = type_for("non_null_color")
 
             expect(type.name).to eq "Color!"
             expect(type).to only_satisfy_predicates(:non_null?, :object?, :embedded_object?)
@@ -186,7 +186,7 @@ module ElasticGraph
           end
 
           it "can model a list" do
-            type = type_for(:list_of_int)
+            type = type_for("list_of_int")
 
             expect(type.name).to eq "[Int]"
             expect(type).to only_satisfy_predicates(:nullable?, :list?, :collection?)
@@ -195,7 +195,7 @@ module ElasticGraph
           end
 
           it "can model a relay connection" do
-            type = type_for(:relay_connection)
+            type = type_for("relay_connection")
 
             expect(type.name).to eq "PersonConnection"
             expect(type).to only_satisfy_predicates(:nullable?, :object?, :relay_connection?, :collection?)
@@ -204,7 +204,7 @@ module ElasticGraph
           end
 
           it "can model a non-nullable relay connection" do
-            type = type_for(:non_null_relay_connection)
+            type = type_for("non_null_relay_connection")
 
             expect(type.name).to eq "PersonConnection!"
             expect(type).to only_satisfy_predicates(:non_null?, :object?, :relay_connection?, :collection?)
@@ -213,7 +213,7 @@ module ElasticGraph
           end
 
           it "can model a relay edge" do
-            type = type_for(:relay_edge)
+            type = type_for("relay_edge")
 
             expect(type.name).to eq "PersonEdge"
             expect(type).to only_satisfy_predicates(:nullable?, :object?, :relay_edge?)
@@ -222,7 +222,7 @@ module ElasticGraph
           end
 
           it "can model a non-nullable relay edge" do
-            type = type_for(:non_null_relay_edge)
+            type = type_for("non_null_relay_edge")
 
             expect(type.name).to eq "PersonEdge!"
             expect(type).to only_satisfy_predicates(:non_null?, :object?, :relay_edge?)
@@ -231,7 +231,7 @@ module ElasticGraph
           end
 
           it "can model a list of non-nullable scalars" do
-            type = type_for(:list_of_non_null_int)
+            type = type_for("list_of_non_null_int")
 
             expect(type.name).to eq "[Int!]"
             expect(type).to only_satisfy_predicates(:nullable?, :list?, :collection?)
@@ -240,7 +240,7 @@ module ElasticGraph
           end
 
           it "can model a non-nullable list of scalars" do
-            type = type_for(:non_null_list_of_int)
+            type = type_for("non_null_list_of_int")
 
             expect(type.name).to eq "[Int]!"
             expect(type).to only_satisfy_predicates(:non_null?, :list?, :collection?)
@@ -249,7 +249,7 @@ module ElasticGraph
           end
 
           it "can model a non-nullable list of non-nullable scalars" do
-            type = type_for(:non_null_list_of_non_null_int)
+            type = type_for("non_null_list_of_non_null_int")
 
             expect(type.name).to eq "[Int!]!"
             expect(type).to only_satisfy_predicates(:non_null?, :list?, :collection?)
@@ -258,7 +258,7 @@ module ElasticGraph
           end
 
           it "can model an indexed type" do
-            type = type_for(:person)
+            type = type_for("person")
 
             expect(type.name).to eq "Person"
             expect(type).to only_satisfy_predicates(:nullable?, :object?, :indexed_document?)
@@ -267,7 +267,7 @@ module ElasticGraph
           end
 
           it "can model an indexed aggregation type" do
-            type = type_for(:indexed_aggregation)
+            type = type_for("indexed_aggregation")
 
             expect(type.name).to eq "PersonAggregation"
             expect(type).to only_satisfy_predicates(:nullable?, :object?, :indexed_aggregation?)
@@ -276,7 +276,7 @@ module ElasticGraph
           end
 
           it "can model a non-null indexed aggregation type" do
-            type = type_for(:non_null_indexed_aggregation)
+            type = type_for("non_null_indexed_aggregation")
 
             expect(type.name).to eq "PersonAggregation!"
             expect(type).to only_satisfy_predicates(:non_null?, :object?, :indexed_aggregation?)
@@ -285,7 +285,7 @@ module ElasticGraph
           end
 
           it "can model a list of indexed aggregation type" do
-            type = type_for(:list_of_indexed_aggregation)
+            type = type_for("list_of_indexed_aggregation")
 
             expect(type.name).to eq "[PersonAggregation]"
             expect(type).to only_satisfy_predicates(:nullable?, :list?, :collection?)
@@ -294,7 +294,7 @@ module ElasticGraph
           end
 
           it "can model a non-null list of indexed aggregation type" do
-            type = type_for(:non_null_list_of_indexed_aggregation)
+            type = type_for("non_null_list_of_indexed_aggregation")
 
             expect(type.name).to eq "[PersonAggregation]!"
             expect(type).to only_satisfy_predicates(:non_null?, :list?, :collection?)
@@ -303,7 +303,7 @@ module ElasticGraph
           end
 
           it "can model a list of indexed type" do
-            type = type_for(:person_list)
+            type = type_for("person_list")
 
             expect(type.name).to eq "[Person]"
             expect(type).to only_satisfy_predicates(:nullable?, :list?, :collection?)
@@ -312,7 +312,7 @@ module ElasticGraph
           end
 
           it "can model a non-nullable indexed type" do
-            type = type_for(:non_null_person)
+            type = type_for("non_null_person")
 
             expect(type.name).to eq "Person!"
             expect(type).to only_satisfy_predicates(:non_null?, :object?, :indexed_document?)
@@ -321,7 +321,7 @@ module ElasticGraph
           end
 
           it "can model a union of embedded object types" do
-            type = type_for(:attribute)
+            type = type_for("attribute")
 
             expect(type.name).to eq "Attribute"
             expect(type).to only_satisfy_predicates(:nullable?, :object?, :abstract?, :embedded_object?)
@@ -330,7 +330,7 @@ module ElasticGraph
           end
 
           it "can model an indexed union of object types" do
-            type = type_for(:indexed_attribute)
+            type = type_for("indexed_attribute")
 
             expect(type.name).to eq "IndexedAttribute"
             expect(type).to only_satisfy_predicates(:nullable?, :object?, :abstract?, :indexed_document?)
@@ -339,7 +339,7 @@ module ElasticGraph
           end
 
           it "can model a non-nullable union of embedded object types" do
-            type = type_for(:non_null_attribute)
+            type = type_for("non_null_attribute")
 
             expect(type.name).to eq "Attribute!"
             expect(type).to only_satisfy_predicates(:non_null?, :object?, :abstract?, :embedded_object?)
@@ -348,7 +348,7 @@ module ElasticGraph
           end
 
           it "can model a union of indexed object types" do
-            type = type_for(:entity)
+            type = type_for("entity")
 
             expect(type.name).to eq "Entity"
             expect(type).to only_satisfy_predicates(:nullable?, :object?, :abstract?, :indexed_document?)
@@ -357,7 +357,7 @@ module ElasticGraph
           end
 
           it "can model a non-null union of indexed object types" do
-            type = type_for(:non_null_entity)
+            type = type_for("non_null_entity")
 
             expect(type.name).to eq "Entity!"
             expect(type).to only_satisfy_predicates(:non_null?, :object?, :abstract?, :indexed_document?)
@@ -366,7 +366,7 @@ module ElasticGraph
           end
 
           it "can model an enum type" do
-            type = type_for(:size)
+            type = type_for("size")
 
             expect(type.name).to eq "Size"
             expect(type).to only_satisfy_predicates(:nullable?, :enum?)
@@ -375,7 +375,7 @@ module ElasticGraph
           end
 
           it "can model a non-null enum type" do
-            type = type_for(:non_null_size)
+            type = type_for("non_null_size")
 
             expect(type.name).to eq "Size!"
             expect(type).to only_satisfy_predicates(:non_null?, :enum?)
@@ -384,7 +384,7 @@ module ElasticGraph
           end
 
           it "can model a list of enums" do
-            type = type_for(:list_of_size)
+            type = type_for("list_of_size")
 
             expect(type.name).to eq "[Size]"
             expect(type).to only_satisfy_predicates(:nullable?, :list?, :collection?)
@@ -497,17 +497,10 @@ module ElasticGraph
           end
 
           it "returns the same field object returned from the schema's `field_named` method" do
-            from_type = schema.type_named("Color").field_named(:red)
-            from_schema = schema.field_named("Color", :red)
+            from_type = schema.type_named("Color").field_named("red")
+            from_schema = schema.field_named("Color", "red")
 
             expect(from_schema).to be_a(Field).and be(from_type)
-          end
-
-          it "supports the field being named with a string or symbol" do
-            from_string = schema.type_named("Color").field_named("red")
-            from_symbol = schema.type_named("Color").field_named(:red)
-
-            expect(from_symbol).to be_a(Field).and be(from_string)
           end
         end
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
@@ -208,15 +208,11 @@ module ElasticGraph
               expect(field_named("Color", "blue")).to be_a GraphQL::Schema::Field
             end
 
-            it "finds a field when given type and field name symbols" do
-              expect(field_named("Color", :blue)).to be_a GraphQL::Schema::Field
-            end
-
             it "consistently returns the same field object" do
-              field1 = field_named("Color", :red)
-              field2 = field_named("Color", :red)
+              field1 = field_named("Color", "red")
+              field2 = field_named("Color", "red")
               field3 = field_named("Color", "red")
-              other_field = field_named("Color", :blue)
+              other_field = field_named("Color", "blue")
 
               expect(field2).to be(field1)
               expect(field3).to be(field1)
@@ -225,19 +221,19 @@ module ElasticGraph
 
             it "raises an error when the type part of the given field name cannot be found" do
               expect {
-                field_named("Person", :name)
+                field_named("Person", "name")
               }.to raise_error(Errors::NotFoundError, /Person/)
             end
 
             it "raises an error when the field part of the given field name cannot be found, suggesting a correction if possible" do
               expect {
-                field_named("Color", :gren)
+                field_named("Color", "gren")
               }.to raise_error(Errors::NotFoundError, a_string_including("Color", "gren", "Possible alternatives", "green"))
             end
 
             it "raises an error when the field part of the given field name cannot be found, with no suggestions if not close to any field names" do
               expect {
-                field_named("Color", :purple)
+                field_named("Color", "purple")
               }.to raise_error(Errors::NotFoundError, a_string_including("Color", "purple").and(excluding("Possible alternatives")))
             end
 


### PR DESCRIPTION
Previously, we were inconsistent, and had to do some extranous conversions. These extranous conversions create extra garbage that needs to be collected and slow things down a bit.