### PR TITLE
Use strings instead of symbols for enum value names.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_node_interpreter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_node_interpreter.rb
@@ -168,7 +168,7 @@ module ElasticGraph
           when ::Array
             value.map { |v| to_datastore_value(v) }
           when Schema::EnumValue
-            value.name.to_s
+            value.name
           else
             value
           end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/type.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/type.rb
@@ -122,7 +122,7 @@ module ElasticGraph
         end
 
         def enum_value_named(enum_value_name)
-          @enum_values_by_name[enum_value_name.to_s]
+          @enum_values_by_name[enum_value_name]
         end
 
         def coerce_result(result)
@@ -226,7 +226,7 @@ module ElasticGraph
           graphql_enum_value = @graphql_type.values.fetch(enum_value_name)
 
           EnumValue.new(
-            name: graphql_enum_value.graphql_name.to_sym,
+            name: graphql_enum_value.graphql_name,
             type: self,
             runtime_metadata: @enum_runtime_metadata&.values_by_name&.dig(enum_value_name)
           )

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/schema/type.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/schema/type.rbs
@@ -17,7 +17,7 @@ module ElasticGraph
         def embedded_object?: () -> bool
         def indexed_document?: () -> bool
         def indexed_aggregation?: () -> bool
-        def enum_value_named: (::String | ::Symbol) -> EnumValue
+        def enum_value_named: (::String) -> EnumValue
       end
     end
   end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/enum_value_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/enum_value_spec.rb
@@ -18,7 +18,7 @@ module ElasticGraph
             s.enum_type "ColorSpace" do |t|
               t.value "rgb"
             end
-          end.enum_value_named("ColorSpace", :rgb)
+          end.enum_value_named("ColorSpace", "rgb")
 
           expect(enum_value.inspect).to eq "#<ElasticGraph::GraphQL::Schema::EnumValue ColorSpace.rgb>"
         end
@@ -29,9 +29,9 @@ module ElasticGraph
               s.enum_type "ColorSpace" do |t|
                 t.value "rgb"
               end
-            end.enum_value_named("ColorSpace", :rgb)
+            end.enum_value_named("ColorSpace", "rgb")
 
-            expect(enum_value.name).to eq :rgb
+            expect(enum_value.name).to eq "rgb"
           end
         end
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/field_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/field_spec.rb
@@ -132,7 +132,7 @@ module ElasticGraph
 
           it "returns a list of datastore sort clauses when passed an array" do
             field = schema.field_named("Query", "photos")
-            sort_clauses = field.sort_clauses_for([:pixel_count_DESC, :created_at_ms_DESC])
+            sort_clauses = field.sort_clauses_for(["pixel_count_DESC", "created_at_ms_DESC"])
 
             expect(sort_clauses).to eq([
               {"pixel_count" => {"order" => "desc"}},
@@ -142,7 +142,7 @@ module ElasticGraph
 
           it "returns a list of a single datastore sort clause when passed a scalar" do
             field = schema.field_named("Query", "photos")
-            sort_clauses = field.sort_clauses_for(:pixel_count_DESC)
+            sort_clauses = field.sort_clauses_for("pixel_count_DESC")
 
             expect(sort_clauses).to eq([{"pixel_count" => {"order" => "desc"}}])
           end
@@ -151,7 +151,7 @@ module ElasticGraph
             field = schema.field_named("Query", "photos")
 
             expect {
-              field.sort_clauses_for(:bogus_DESC)
+              field.sort_clauses_for("bogus_DESC")
             }.to raise_error(Errors::NotFoundError, a_string_including("No enum value named bogus_DESC"))
           end
 
@@ -176,7 +176,7 @@ module ElasticGraph
             field = schema.field_named("Query", "photos")
 
             expect {
-              field.sort_clauses_for(:invalid_photo_sort_DESC)
+              field.sort_clauses_for("invalid_photo_sort_DESC")
             }.to raise_error(Errors::SchemaError, a_string_including("sort_field", "invalid_photo_sort_DESC"))
           end
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/type_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/type_spec.rb
@@ -473,17 +473,10 @@ module ElasticGraph
           end
 
           it "returns the same enum_value object returns by schema's `enum_value_named` method" do
-            from_type = schema.type_named("ColorSpace").enum_value_named(:rgb)
-            from_schema = schema.enum_value_named("ColorSpace", :rgb)
+            from_type = schema.type_named("ColorSpace").enum_value_named("rgb")
+            from_schema = schema.enum_value_named("ColorSpace", "rgb")
 
             expect(from_schema).to be_a(EnumValue).and be(from_type)
-          end
-
-          it "supports the enum_value being named with a string or symbol" do
-            from_string = schema.type_named("ColorSpace").enum_value_named("rgb")
-            from_symbol = schema.type_named("ColorSpace").enum_value_named(:rgb)
-
-            expect(from_symbol).to be_a(EnumValue).and be(from_string)
           end
         end
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
@@ -153,19 +153,15 @@ module ElasticGraph
           end
         end
 
-        it "finds an enum_value when given a type and enum_value name strings" do
+        it "finds an enum_value when given a type and enum_value name" do
           expect(schema.enum_value_named("ColorSpace", "rgb")).to be_a GraphQL::Schema::EnumValue
         end
 
-        it "finds an enum_value when given a type and enum_value name symbols" do
-          expect(schema.enum_value_named("ColorSpace", :rgb)).to be_a GraphQL::Schema::EnumValue
-        end
-
         it "consistently returns the same enum_value_object" do
-          enum_value1 = schema.enum_value_named("ColorSpace", :rgb)
-          enum_value2 = schema.enum_value_named("ColorSpace", :rgb)
+          enum_value1 = schema.enum_value_named("ColorSpace", "rgb")
+          enum_value2 = schema.enum_value_named("ColorSpace", "rgb")
           enum_value3 = schema.enum_value_named("ColorSpace", "rgb")
-          other_field = schema.enum_value_named("ColorSpace", :srgb)
+          other_field = schema.enum_value_named("ColorSpace", "srgb")
 
           expect(enum_value2).to be(enum_value1)
           expect(enum_value3).to be(enum_value1)
@@ -174,19 +170,19 @@ module ElasticGraph
 
         it "raises an error when the type cannot be found" do
           expect {
-            schema.enum_value_named("ColorType", :name)
+            schema.enum_value_named("ColorType", "name")
           }.to raise_error(Errors::NotFoundError, /ColorSpace/)
         end
 
         it "raises an error when the enum value cannot be found, suggesting a correction if it can find one" do
           expect {
-            schema.enum_value_named("ColorSpace", :srg)
+            schema.enum_value_named("ColorSpace", "srg")
           }.to raise_error(Errors::NotFoundError, a_string_including("ColorSpace", "srg", "Possible alternatives", "srgb"))
         end
 
         it "raises an error when the enum value cannot be found, with no suggestions if not close to any enum value name" do
           expect {
-            schema.enum_value_named("ColorSpace", :foo)
+            schema.enum_value_named("ColorSpace", "foo")
           }.to raise_error(Errors::NotFoundError, a_string_including("ColorSpace", "foo").and(excluding("Possible alternatives")))
         end
       end


### PR DESCRIPTION
Previously, we were inconsistent, and had to do some extranous conversions. These extranous conversions create extra garbage that needs to be collected and slow things down a bit.