### PR TITLE
Standardize site code snippets on jekyll highlighting.

### DIFF
--- a/config/site/Rakefile
+++ b/config/site/Rakefile
@@ -176,8 +176,31 @@ module ElasticGraph
           sh "bundle exec jekyll serve #{common_jekyll_args}"
         end
 
+        desc "Validates the markdown of the website"
+        task :validate_markdown do
+          files_needing_fixes = ::Dir["#{__dir__}/src/**/*.md"].select do |file|
+            ::File.read(file).include?("```")
+          end
+
+          if files_needing_fixes.any?
+            abort <<~EOS
+              Failure: #{files_needing_fixes.size} files have code snippets using triple backticks (```) but we have standardized
+              on Jekyll's code snippet highlight:
+
+              https://jekyllrb.com/docs/liquid/tags/#code-snippet-highlighting
+              {% highlight language %}
+              some code
+              {% endhighlight %}
+
+              To fix, update the following files to use the Jekyll syntax instead of triple backticks:
+
+              #{files_needing_fixes.sort.map { |f| "- #{f}" }.join("\n")}
+            EOS
+          end
+        end
+
         desc "Perform validations of the website, including doc tests and doc coverage"
-        task validate: [:build, :docs_coverage, :doctest]
+        task validate: [:validate_markdown, :build, :docs_coverage, :doctest]
 
         task build_css: :npm_install do
           require "rouge"

--- a/config/site/src/about.md
+++ b/config/site/src/about.md
@@ -25,7 +25,6 @@ The ElasticGraph platform will allow you to query your data in many different co
 
 ## Get started
 
-
-```shell
+{% highlight shell %}
 gem install elasticgraph
-```
+{% endhighlight %}

--- a/config/site/src/getting-started.md
+++ b/config/site/src/getting-started.md
@@ -21,10 +21,10 @@ Before you begin, ensure you have the following installed on your system:
 
 Begin by cloning the ElasticGraph project template from GitHub:
 
-```bash
-git clone <COMING SOON>!
-cd elasticgraph-project-template
-```
+{% highlight bash %}
+$ git clone <COMING SOON>!
+$ cd elasticgraph-project-template
+{% endhighlight %}
 
 ## Step 2: Run the Initialization Script
 
@@ -32,9 +32,9 @@ We have an initialization script that sets up your ElasticGraph project with nec
 
 Run the following command in your terminal:
 
-```bash
-curl -sL https://raw.githubusercontent.com/<COMING-SOON>/elasticgraph-project-template/main/script/init_eg | bash -s
-```
+{% highlight bash %}
+$ curl -sL https://raw.githubusercontent.com/<COMING-SOON>/elasticgraph-project-template/main/script/init_eg | bash -s
+{% endhighlight %}
 
 This script will prompt you for some inputs:
 
@@ -57,9 +57,9 @@ You can skip this part for now if you want to play with the sample schema. Other
 
    Delete the sample schema file:
 
-   ```bash
-   rm config/schema/people.rb
-   ```
+{% highlight shell %}
+$ rm config/schema/people.rb
+{% endhighlight %}
 
 2. **Create Your Schema**:
 
@@ -67,26 +67,26 @@ You can skip this part for now if you want to play with the sample schema. Other
 
    Define your schema in this file. Here's a basic example:
 
-   ```ruby
-    ElasticGraph.define_schema do |schema|
-      schema.json_schema_version 1
+{% highlight ruby %}
+ElasticGraph.define_schema do |schema|
+  schema.json_schema_version 1
 
-      schema.object_type "Artist" do |t|
-        t.field "id", "ID"
-        t.field "name", "String"
-        t.field "lifetimeSales", "Int"
-        t.field "bio", "ArtistBio"
+  schema.object_type "Artist" do |t|
+    t.field "id", "ID"
+    t.field "name", "String"
+    t.field "lifetimeSales", "Int"
+    t.field "bio", "ArtistBio"
 
-        t.field "albums", "[Album!]!" do |f|
-          f.mapping type: "nested"
-        end
-
-        t.index "artists"
-      end
+    t.field "albums", "[Album!]!" do |f|
+      f.mapping type: "nested"
     end
 
-    # ...
-   ```
+    t.index "artists"
+  end
+end
+
+# ...
+{% endhighlight %}
 
 3. **Update Configuration**:
 
@@ -100,17 +100,17 @@ You can skip this part for now if you want to play with the sample schema. Other
 
 1. **Install Dependencies**:
 
-   ```bash
-   bundle install
-   ```
+{% highlight bash %}
+$ bundle install
+{% endhighlight %}
 
 2. **Run Rake Tasks**:
 
    Test your setup by running:
 
-   ```bash
-   bundle exec rake
-   ```
+{% highlight bash %}
+$ bundle exec rake
+{% endhighlight %}
 
    This command runs all the default tasks to ensure everything is configured correctly.
 
@@ -122,9 +122,9 @@ You can skip this part for now if you want to play with the sample schema. Other
 
 With Docker running, start your local ElasticGraph instance:
 
-```bash
-bundle exec rake boot_locally
-```
+{% highlight bash %}
+$ bundle exec rake boot_locally
+{% endhighlight %}
 
 This command will:
 
@@ -143,7 +143,7 @@ Once GraphiQL opens in your browser, you can start running queries against your 
 
 Replace `customers` and fields with those relevant to your schema.
 
-```graphql
+{% highlight graphql %}
 query Test {
   customers {
     totalEdgeCount
@@ -154,7 +154,7 @@ query Test {
     }
   }
 }
-```
+{% endhighlight %}
 
 **Explanation**:
 
@@ -178,22 +178,21 @@ With `bundle exec rake boot_locally` still running:
    - Click on **"Dev Tools"** in the Kibana sidebar.
    - Run the following commands to explore your indices:
 
-     ```elasticsearch
-     GET /_cat/indices?v
-     GET /_cat/shards?v
-     GET /_cat/templates?v
-     ```
+{% highlight elasticsearch %}
+GET /_cat/indices?v
+GET /_cat/shards?v
+GET /_cat/templates?v
+{% endhighlight %}
 
 3. **Search Your Data**:
 
    Replace `your-index-name` with the name of your index (usually your dataset name).
 
-   ```elasticsearch
-   GET /your-index-name/_search
-   ```
+{% highlight elasticsearch %}
+GET /your-index-name/_search
+{% endhighlight %}
 
    This will return all documents in your index. Normally you'll query via GraphiQL, but this is useful for debugging.
-
 
 ## Troubleshooting
 


### PR DESCRIPTION
We can use either standard markdown syntax (with triple backticks) or Jekyll highlighting syntax:

```
{% highlight bash %}
$ git clone <COMING SOON>!
$ cd elasticgraph-project-template
{% endhighlight %}
```

For reasons I don't understand, the syntax highlighting looks quite different (purple vs black background) and I think the Jekyll syntax highlighting looks much better.

To enforce this, I've added a rake task that hooks into `site:validate` (which runs as part of our CI build) to detect if the standard markdown syntax is ever used. In addition, I've updated the couple of spots where we were using the standard markdown syntax. I've also left-aligned the code snippets; I found that Jekyll would render an extra blank line at the end of a snippet if it was indented.

Here's how the markdown syntax looks (what's currently live at https://block.github.io/elasticgraph/):

![image](https://github.com/user-attachments/assets/bcdb3074-4fd3-4048-aef1-c0fe965c444c)

Here's how it looks with this change:

![image](https://github.com/user-attachments/assets/481b89c4-1b99-4a49-9747-d8957f73f361)
