### PR TITLE
Add anchor links to site headings.

### DIFF
--- a/config/site/src/_layouts/markdown.html
+++ b/config/site/src/_layouts/markdown.html
@@ -7,6 +7,7 @@
   <title>{{ page.title }}</title>
   <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
   <link rel="stylesheet" href="{{ '/assets/css/highlight.css' | relative_url }}">
+  <script src="{{ '/assets/js/anchor-headings.js' | relative_url }}" defer></script>
 </head>
 
 <body class="{{ site.style.body }}">

--- a/config/site/src/assets/css/tailwind.css
+++ b/config/site/src/assets/css/tailwind.css
@@ -63,4 +63,27 @@
   .alert-warning pre {
     @apply bg-white/50 dark:bg-gray-900/50;
   }
+
+  /* Heading anchors */
+  .has-anchor {
+    @apply scroll-mt-20;
+  }
+
+  .heading-anchor {
+    @apply float-left -ml-6 pr-2 opacity-0 transition-opacity no-underline;
+  }
+
+  .heading-anchor svg {
+    @apply inline-block align-middle fill-gray-500 dark:fill-gray-400;
+  }
+
+  .has-anchor:hover .heading-anchor,
+  .heading-anchor:focus {
+    @apply opacity-100;
+  }
+
+  /* When the heading is linked directly, always show the anchor */
+  :target .heading-anchor {
+    @apply opacity-100;
+  }
 }

--- a/config/site/src/assets/js/anchor-headings.js
+++ b/config/site/src/assets/js/anchor-headings.js
@@ -1,0 +1,29 @@
+// Add anchor links to headings
+document.addEventListener('DOMContentLoaded', function() {
+  const headings = document.querySelectorAll('article h2, article h3, article h4');
+
+  headings.forEach(heading => {
+    // Generate ID from heading text
+    if (!heading.id) {
+      heading.id = heading.textContent
+        .toLowerCase()
+        .replace(/[^\w\- ]/g, '') // Remove special characters
+        .replace(/\s+/g, '-'); // Replace spaces with hyphens
+    }
+
+    // Create anchor link
+    const anchor = document.createElement('a');
+    anchor.href = `#${heading.id}`;
+    anchor.className = 'heading-anchor';
+    anchor.setAttribute('aria-hidden', 'true');
+    anchor.innerHTML = `<svg class="octicon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
+      <path d="m7.775 3.275 1.25-1.25a3.5 3.5 0 1 1 4.95 4.95l-2.5 2.5a3.5 3.5 0 0 1-4.95 0 .751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018 1.998 1.998 0 0 0 2.83 0l2.5-2.5a2.002 2.002 0 0 0-2.83-2.83l-1.25 1.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042Zm-4.69 9.64a1.998 1.998 0 0 0 2.83 0l1.25-1.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042l-1.25 1.25a3.5 3.5 0 1 1-4.95-4.95l2.5-2.5a3.5 3.5 0 0 1 4.95 0 .751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018 1.998 1.998 0 0 0-2.83 0l-2.5 2.5a1.998 1.998 0 0 0 0 2.83Z"></path>
+    </svg>`;
+
+    // Add anchor link before heading content
+    heading.insertBefore(anchor, heading.firstChild);
+
+    // Add hover class to show anchor on heading hover
+    heading.classList.add('has-anchor');
+  });
+});


### PR DESCRIPTION
This supports "deep linking" to a particular section of a page.

Example:

![image](https://github.com/user-attachments/assets/c7d8f602-b3da-4dd6-83c1-4d8dd003a011)
