### PR TITLE
Improve site search implementation a bit.

### DIFF
--- a/config/site/src/search/index.html
+++ b/config/site/src/search/index.html
@@ -14,7 +14,7 @@ title: Search
 window.store = {};
 
 {% for doc in site.data.searchable_content %}
-    window.store["{{ doc.url | slugify }}"] = {
+    window.store["{{ doc.url }}"] = {
         "title": {{ doc.title | jsonify }},
         "content": {{ doc.content | jsonify }},
         "url": "{{ site.baseurl }}{{ doc.url | xml_escape }}"


### PR DESCRIPTION
- Avoid "Warning: Empty `slug` generated for '/'.`"
- Trim YARD UI text (e.g. "is part of a private API") from search index.
- Skip pages that have no searchable content.