### PR TITLE
Verify that a resolver has been assigned to all output fields.

### DIFF
--- a/elasticgraph-apollo/apollo_tests_implementation/config/products_schema.rb
+++ b/elasticgraph-apollo/apollo_tests_implementation/config/products_schema.rb
@@ -55,6 +55,7 @@ module ApolloTestImpl
         f.argument "sku", "String!"
         f.argument "package", "String!"
         f.directive "deprecated", reason: "Use product query instead"
+        f.resolver = :product
       end
     end
 

--- a/elasticgraph-graphql/spec/support/scalar_coercion_adapter.rb
+++ b/elasticgraph-graphql/spec/support/scalar_coercion_adapter.rb
@@ -35,6 +35,10 @@ RSpec.shared_context "scalar coercion adapter support" do |scalar_type_name, sch
       schema.on_root_query_type do |t|
         t.field "echo", scalar_type_name do |f|
           f.argument "arg", scalar_type_name
+
+          # `resolver` is overridden via our `test_adapter` above, but we still need to assign it to something here to
+          # avoid errors from `elasticgraph-schema_definition`.
+          f.resolver = :get_record_field_value
         end
       end
     end)

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection_spec.rb
@@ -30,7 +30,9 @@ module ElasticGraph
 
               schema.on_root_query_type do |t|
                 # One test relies on `widgets_non_relay`, which isn't defined by default on `Query` so we define it here.
-                t.field "widgets_non_relay", "[Widget!]!"
+                t.field "widgets_non_relay", "[Widget!]!" do |f|
+                  f.resolver = :list_records
+                end
               end
             end
           end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
@@ -43,7 +43,9 @@ module ElasticGraph
               end
 
               schema.on_root_query_type do |t|
-                t.field "person", "Person"
+                t.field "person", "Person" do |f|
+                  f.resolver = :list_records
+                end
               end
             end
           end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/field_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/field_spec.rb
@@ -170,6 +170,7 @@ module ElasticGraph
               s.on_root_query_type do |f|
                 f.field "photos", "[Photo!]!" do |f|
                   f.argument "order_by", "[PhotoSort!]"
+                  f.resolver = :list_records
                 end
               end
             end
@@ -294,6 +295,7 @@ module ElasticGraph
                   f.argument "camelCaseField", "Int"
                   f.argument "maybe_set_to_null", "String"
                   f.argument "nested", "Nested1FilterInput"
+                  f.resolver = :list_records
                 end
               end
             end.field_named("Query", "foo")

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
@@ -116,6 +116,7 @@ module ElasticGraph
       def define_root_graphql_type
         state.api.object_type "Query" do |query_type|
           query_type.documentation "The query entry point for the entire schema."
+          query_type.default_graphql_resolver = nil
 
           state.types_by_name.values.select(&:indexed?).sort_by(&:name).each do |type|
             # @type var indexed_type: Mixins::HasIndices & _Type


### PR DESCRIPTION
As much as possible, we want to surface errors at schema artifact dump time. If a field has no assigned resolver, it will fail at query time for sure, and we can give quicker feedback by providing an error at dump time instead.