### PR TITLE
Refactor: allow extensions to be verified without `ExtensionLoader`.

### DIFF
--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/extension_loader.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/extension_loader.rb
@@ -8,6 +8,7 @@
 
 require "elastic_graph/errors"
 require "elastic_graph/schema_artifacts/runtime_metadata/extension"
+require "elastic_graph/schema_artifacts/runtime_metadata/interface_verifier"
 
 module ElasticGraph
   module SchemaArtifacts
@@ -42,82 +43,10 @@ module ElasticGraph
 
         def load_extension(constant_name, require_path)
           require require_path
-          extension_class = ::Object.const_get(constant_name).tap { |ext| verify_interface(constant_name, ext) }
-          Extension.new(extension_class, require_path, {})
-        end
-
-        def verify_interface(constant_name, extension)
-          # @type var problems: ::Array[::String]
-          problems = []
-          problems.concat(verify_methods("class", extension.singleton_class, @interface_def.singleton_class))
-
-          if extension.is_a?(::Module)
-            problems.concat(verify_methods("instance", extension, @interface_def))
-
-            # We care about the name exactly matching so that we can dump the extension name in a schema
-            # artifact w/o having to pass around the original constant name.
-            if extension.name != constant_name.delete_prefix("::")
-              problems << "- Exposes a name (`#{extension.name}`) that differs from the provided extension name (`#{constant_name}`)"
-            end
-          else
-            problems << "- Is not a class or module as expected"
+          extension_class = ::Object.const_get(constant_name)
+          Extension.new(extension_class, require_path, {}, constant_name.delete_prefix("::")).tap do |ext|
+            ext.verify_against(@interface_def)
           end
-
-          if problems.any?
-            raise Errors::InvalidExtensionError,
-              "Extension `#{constant_name}` does not implement the expected interface correctly. Problems:\n\n" \
-              "#{problems.join("\n")}"
-          end
-        end
-
-        def verify_methods(type, extension, interface)
-          interface_methods = list_instance_interface_methods(interface)
-          extension_methods = list_instance_interface_methods(extension)
-
-          # @type var problems: ::Array[::String]
-          problems = []
-
-          if (missing_methods = interface_methods - extension_methods).any?
-            problems << "- Missing #{type} methods: #{missing_methods.map { |m| "`#{m}`" }.join(", ")}"
-          end
-
-          interface_methods.intersection(extension_methods).each do |method_name|
-            unless parameters_match?(extension, interface, method_name)
-              interface_signature = signature_code_for(interface, method_name)
-              extension_signature = signature_code_for(extension, method_name)
-
-              problems << "- Method signature for #{type} method `#{method_name}` (`#{extension_signature}`) does not match interface (`#{interface_signature}`)"
-            end
-          end
-
-          problems
-        end
-
-        def list_instance_interface_methods(klass)
-          # Here we look at more than just the public methods. This is necessary for `initialize`.
-          # If it's defined on the interface definition, we want to verify it on the extension,
-          # but Ruby makes `initialize` private by default.
-          klass.instance_methods(false) +
-            klass.protected_instance_methods(false) +
-            klass.private_instance_methods(false)
-        end
-
-        def parameters_match?(extension, interface, method_name)
-          interface_parameters = interface.instance_method(method_name).parameters
-          extension_parameters = extension.instance_method(method_name).parameters
-
-          # Here we compare the parameters for exact equality. This is stricter than we need it
-          # to be (it doesn't allow the parameters to have different names, for example) but it's
-          # considerably simpler than us trying to determine what is truly required. For example,
-          # the name doesn't matter on a positional arg, but would matter on a keyword arg.
-          interface_parameters == extension_parameters
-        end
-
-        def signature_code_for(object, method_name)
-          # @type var file_name: ::String?
-          # @type var line_number: ::Integer?
-          file_name, line_number = object.instance_method(method_name).source_location
-          ::File.read(file_name.to_s).split("\n").fetch(line_number.to_i - 1).strip
         end
       end
     end

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/interface_verifier.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/interface_verifier.rb
@@ -1,0 +1,104 @@
+# Copyright 2024 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/errors"
+
+module ElasticGraph
+  module SchemaArtifacts
+    module RuntimeMetadata
+      # Responsible for verifying extensions. This requires an interface definition
+      # (a class or module with empty method definitions that just serves to define what
+      # loaded extensions must implement). That allows us to verify the extension implements
+      # the interface correctly ahead of time, rather than deferring exceptions to when the
+      # extension is later used.
+      #
+      # Note, however, that this does not guarantee no runtime exceptions from the use of the
+      # extension: the extension may return invalid return values, or throw exceptions when
+      # called. But this verifies the interface to the extent that we can.
+      module InterfaceVerifier
+        class << self
+          def verify(extension, against:, constant_name:)
+            # @type var problems: ::Array[::String]
+            problems = []
+            problems.concat(verify_methods("class", extension.singleton_class, against.singleton_class))
+
+            if extension.is_a?(::Module)
+              problems.concat(verify_methods("instance", extension, against))
+
+              # We care about the name exactly matching so that we can dump the extension name in a schema
+              # artifact w/o having to pass around the original constant name.
+              if extension.name != constant_name.delete_prefix("::")
+                problems << "- Exposes a name (`#{extension.name}`) that differs from the provided extension name (`#{constant_name}`)"
+              end
+            else
+              problems << "- Is not a class or module as expected"
+            end
+
+            if problems.any?
+              raise Errors::InvalidExtensionError,
+                "Extension `#{constant_name}` does not implement the expected interface correctly. Problems:\n\n" \
+                "#{problems.join("\n")}"
+            end
+          end
+
+          private
+
+          def verify_methods(type, extension, interface)
+            interface_methods = list_instance_interface_methods(interface)
+            extension_methods = list_instance_interface_methods(extension)
+
+            # @type var problems: ::Array[::String]
+            problems = []
+
+            if (missing_methods = interface_methods - extension_methods).any?
+              problems << "- Missing #{type} methods: #{missing_methods.map { |m| "`#{m}`" }.join(", ")}"
+            end
+
+            interface_methods.intersection(extension_methods).each do |method_name|
+              unless parameters_match?(extension, interface, method_name)
+                interface_signature = signature_code_for(interface, method_name)
+                extension_signature = signature_code_for(extension, method_name)
+
+                problems << "- Method signature for #{type} method `#{method_name}` (`#{extension_signature}`) does not match interface (`#{interface_signature}`)"
+              end
+            end
+
+            problems
+          end
+
+          def list_instance_interface_methods(klass)
+            # Here we look at more than just the public methods. This is necessary for `initialize`.
+            # If it's defined on the interface definition, we want to verify it on the extension,
+            # but Ruby makes `initialize` private by default.
+            klass.instance_methods(false) +
+              klass.protected_instance_methods(false) +
+              klass.private_instance_methods(false)
+          end
+
+          def parameters_match?(extension, interface, method_name)
+            interface_parameters = interface.instance_method(method_name).parameters
+            extension_parameters = extension.instance_method(method_name).parameters
+
+            # Here we compare the parameters for exact equality. This is stricter than we need it
+            # to be (it doesn't allow the parameters to have different names, for example) but it's
+            # considerably simpler than us trying to determine what is truly required. For example,
+            # the name doesn't matter on a positional arg, but would matter on a keyword arg.
+            interface_parameters == extension_parameters
+          end
+
+          def signature_code_for(object, method_name)
+            # @type var file_name: ::String?
+            # @type var line_number: ::Integer?
+            file_name, line_number = object.instance_method(method_name).source_location
+            ::File.read(file_name.to_s).split("\n").fetch(line_number.to_i - 1).strip
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/extension.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/extension.rbs
@@ -3,30 +3,43 @@ module ElasticGraph
     module RuntimeMetadata
       type extensionClass = ::Module | ::Class
 
-      class Extension
+      class ExtensionSupertype
         attr_reader extension_class: extensionClass
         attr_reader require_path: ::String
         attr_reader extension_config: ::Hash[::Symbol, untyped]
+        attr_reader extension_name: ::String
 
         def initialize: (
           extension_class: extensionClass,
           require_path: ::String,
-          extension_config: ::Hash[::Symbol, untyped]
+          extension_config: ::Hash[::Symbol, untyped],
+          extension_name: ::String
         ) -> void
-
-        def self.new:
-          (extension_class: extensionClass, require_path: ::String, extension_config: ::Hash[::Symbol, untyped]) -> Extension
-          | (extensionClass, ::String, ::Hash[::Symbol, untyped]) -> Extension
-
-        def self.load_from_hash: (::Hash[::String, untyped], via: ExtensionLoader) -> Extension
-        def extension_name: () -> ::String
-        def to_dumpable_hash: () -> ::Hash[::String, untyped]
 
         def with: (
           ?extension_class: extensionClass,
           ?require_path: ::String,
-          ?extension_config: ::Hash[::Symbol, untyped]
+          ?extension_config: ::Hash[::Symbol, untyped],
+          ?extension_name: ::String
         ) -> Extension
+      end
+
+      class Extension < ExtensionSupertype
+        def initialize: (
+          extension_class: extensionClass,
+          require_path: ::String,
+          extension_config: ::Hash[::Symbol, untyped],
+          ?extension_name: ::String
+        ) -> void
+
+        def self.new:
+          (extension_class: extensionClass, require_path: ::String, extension_config: ::Hash[::Symbol, untyped], ?extension_name: ::String) -> Extension
+          | (extensionClass, ::String, ::Hash[::Symbol, untyped], ?::String) -> Extension
+
+        def self.load_from_hash: (::Hash[::String, untyped], via: ExtensionLoader) -> Extension
+        def to_dumpable_hash: () -> ::Hash[::String, untyped]
+
+        def verify_against: (extensionClass) -> void
       end
     end
   end

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/extension_loader.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/extension_loader.rbs
@@ -11,15 +11,7 @@ module ElasticGraph
         @interface_def: extensionClass
         @loaded_by_name: ::Hash[::String, Extension]
 
-        type method = ::Method | ::UnboundMethod
-        type methodFetcher = ^(::Module, ::Symbol) -> method
-
         def load_extension: (::String, ::String) -> Extension
-        def verify_interface: (::String, extensionClass) -> void
-        def verify_methods: (::String, extensionClass, extensionClass) -> ::Array[::String]
-        def list_instance_interface_methods: (extensionClass) -> ::Array[::Symbol]
-        def parameters_match?: (extensionClass, extensionClass, ::Symbol) -> bool
-        def signature_code_for: (extensionClass, ::Symbol) -> ::String
       end
     end
   end

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/interface_verifier.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/interface_verifier.rbs
@@ -1,0 +1,16 @@
+module ElasticGraph
+  module SchemaArtifacts
+    module RuntimeMetadata
+      module InterfaceVerifier
+        def self.verify: (extensionClass, against: extensionClass, constant_name: ::String) -> void
+
+        private
+
+        def self.verify_methods: (::String, extensionClass, extensionClass) -> ::Array[::String]
+        def self.list_instance_interface_methods: (extensionClass) -> ::Array[::Symbol]
+        def self.parameters_match?: (extensionClass, extensionClass, ::Symbol) -> bool
+        def self.signature_code_for: (extensionClass, ::Symbol) -> ::String
+      end
+    end
+  end
+end

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/extension_loader_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/extension_loader_spec.rb
@@ -72,30 +72,12 @@ module ElasticGraph
           }.to raise_error NameError, a_string_including("ElasticGraph::Extensions::Typo")
         end
 
-        it "verifies the extension matches the interface definition, notifying of missing instance methods" do
+        it "verifies the extension matches the interface definition" do
           expect {
             loader.load("ElasticGraph::Extensions::MissingInstanceMethod", from: "support/example_extensions/missing_instance_method", config: {})
           }.to raise_error Errors::InvalidExtensionError, a_string_including(
             "ElasticGraph::Extensions::MissingInstanceMethod",
             "Missing instance methods", "instance_method1"
-          )
-        end
-
-        it "verifies the extension matches the interface definition, notifying of missing class methods" do
-          expect {
-            loader.load("ElasticGraph::Extensions::MissingClassMethod", from: "support/example_extensions/missing_class_method", config: {})
-          }.to raise_error Errors::InvalidExtensionError, a_string_including(
-            "ElasticGraph::Extensions::MissingClassMethod",
-            "Missing class methods", "class_method"
-          )
-        end
-
-        it "verifies the extension matches the interface definition, notifying of argument mis-matches" do
-          expect {
-            loader.load("ElasticGraph::Extensions::ArgsMismatch", from: "support/example_extensions/args_mismatch", config: {})
-          }.to raise_error Errors::InvalidExtensionError, a_string_including(
-            "ElasticGraph::Extensions::ArgsMismatch",
-            "Method signature", "def self.class_method", "def instance_method1", "def instance_method2"
           )
         end
 
@@ -117,32 +99,8 @@ module ElasticGraph
           )
         end
 
-        it "ignores extra methods defined on the extension beyond what the interface requires" do
-          extension = loader.load("ElasticGraph::Extensions::AdditionalMethods", from: "support/example_extensions/additional_methods", config: {})
-
-          expect(extension).to eq_extension(ElasticGraph::Extensions::AdditionalMethods, from: "support/example_extensions/additional_methods", config: {})
-        end
-
         context "with an instantiable extension interface" do
           let(:loader) { ExtensionLoader.new(ExampleInstantiableExtension) }
-
-          it "raises an exception if the extension is missing the required `initialize` method" do
-            expect {
-              loader.load("ElasticGraph::Extensions::InitializeMissing", from: "support/example_extensions/initialize_missing", config: {})
-            }.to raise_error Errors::InvalidExtensionError, a_string_including(
-              "ElasticGraph::Extensions::InitializeMissing",
-              "Missing instance methods: `initialize`"
-            )
-          end
-
-          it "raises an exception if the extension's `initialize` accepts different arguments" do
-            expect {
-              loader.load("ElasticGraph::Extensions::InitializeDoesntMatch", from: "support/example_extensions/initialize_doesnt_match", config: {})
-            }.to raise_error Errors::InvalidExtensionError, a_string_including(
-              "ElasticGraph::Extensions::InitializeDoesntMatch",
-              "Method signature for instance method `initialize` (`def initialize(some_arg:, another_arg:)`) does not match interface (`def initialize(some_arg:)`)"
-            )
-          end
 
           it "returns a valid implementation" do
             extension = loader.load("ElasticGraph::Extensions::ValidInstantiable", from: "support/example_extensions/valid_instantiable", config: {})

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/extension_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/extension_spec.rb
@@ -8,6 +8,8 @@
 
 require "elastic_graph/schema_artifacts/runtime_metadata/extension"
 require "elastic_graph/schema_artifacts/runtime_metadata/extension_loader"
+require "support/example_extensions/missing_instance_method"
+require "support/example_extensions/valid"
 
 module ElasticGraph
   module SchemaArtifacts
@@ -28,6 +30,39 @@ module ElasticGraph
           reloaded_extension = Extension.load_from_hash(hash, via: loader)
 
           expect(reloaded_extension).to eq(extension)
+        end
+
+        it "supports verification against an interface definition" do
+          valid_extension = Extension.new(
+            extension_class: Extensions::Valid,
+            require_path: "support/example_extensions/valid",
+            extension_config: {}
+          )
+
+          expect {
+            valid_extension.verify_against(ExampleInterfaceDef)
+          }.not_to raise_error
+
+          invalid_extension = Extension.new(
+            extension_class: Extensions::MissingInstanceMethod,
+            require_path: "support/example_extensions/missing_instance_method",
+            extension_config: {}
+          )
+
+          expect {
+            invalid_extension.verify_against(ExampleInterfaceDef)
+          }.to raise_error Errors::InvalidExtensionError, a_string_including("instance_method1")
+        end
+      end
+
+      class ExampleInterfaceDef
+        def self.class_method(a, b)
+        end
+
+        def instance_method1
+        end
+
+        def instance_method2(foo:)
         end
       end
     end

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/interface_verifier_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/interface_verifier_spec.rb
@@ -1,0 +1,131 @@
+# Copyright 2024 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/errors"
+require "elastic_graph/schema_artifacts/runtime_metadata/interface_verifier"
+
+module ElasticGraph
+  module SchemaArtifacts
+    module RuntimeMetadata
+      RSpec.describe InterfaceVerifier do
+        let(:interface_def) { ExampleExtension }
+
+        it "allows a valid implementation" do
+          expect {
+            verify("ElasticGraph::Extensions::Valid", from: "support/example_extensions/valid")
+          }.not_to raise_error
+        end
+
+        it "verifies the extension matches the interface definition, notifying of missing instance methods" do
+          expect {
+            verify("ElasticGraph::Extensions::MissingInstanceMethod", from: "support/example_extensions/missing_instance_method")
+          }.to raise_error Errors::InvalidExtensionError, a_string_including(
+            "ElasticGraph::Extensions::MissingInstanceMethod",
+            "Missing instance methods", "instance_method1"
+          )
+        end
+
+        it "verifies the extension matches the interface definition, notifying of missing class methods" do
+          expect {
+            verify("ElasticGraph::Extensions::MissingClassMethod", from: "support/example_extensions/missing_class_method")
+          }.to raise_error Errors::InvalidExtensionError, a_string_including(
+            "ElasticGraph::Extensions::MissingClassMethod",
+            "Missing class methods", "class_method"
+          )
+        end
+
+        it "verifies the extension matches the interface definition, notifying of argument mis-matches" do
+          expect {
+            verify("ElasticGraph::Extensions::ArgsMismatch", from: "support/example_extensions/args_mismatch")
+          }.to raise_error Errors::InvalidExtensionError, a_string_including(
+            "ElasticGraph::Extensions::ArgsMismatch",
+            "Method signature", "def self.class_method", "def instance_method1", "def instance_method2"
+          )
+        end
+
+        it "verifies that the extension is a class or module" do
+          expect {
+            verify("ElasticGraph::Extensions::NotAClassOrModule", from: "support/example_extensions/not_a_class_or_module")
+          }.to raise_error Errors::InvalidExtensionError, a_string_including(
+            "ElasticGraph::Extensions::NotAClassOrModule", "not a class or module"
+          ).and(excluding("class_method", "instance_method1", "instance_method2"))
+        end
+
+        it "verifies that the extension name matches the provided name" do
+          expect {
+            verify("ElasticGraph::Extensions::NameMismatch", from: "support/example_extensions/name_mismatch")
+          }.to raise_error Errors::InvalidExtensionError, a_string_including(
+            "ElasticGraph::Extensions::NameMismatch",
+            "differs from the provided extension name",
+            "ElasticGraph::Extensions::ModuleWithWrongName"
+          )
+        end
+
+        it "ignores extra methods defined on the extension beyond what the interface requires" do
+          expect {
+            verify("ElasticGraph::Extensions::AdditionalMethods", from: "support/example_extensions/additional_methods")
+          }.not_to raise_error
+        end
+
+        context "with an instantiable extension interface" do
+          let(:interface_def) { ExampleInstantiableExtension }
+
+          it "raises an exception if the extension is missing the required `initialize` method" do
+            expect {
+              verify("ElasticGraph::Extensions::InitializeMissing", from: "support/example_extensions/initialize_missing")
+            }.to raise_error Errors::InvalidExtensionError, a_string_including(
+              "ElasticGraph::Extensions::InitializeMissing",
+              "Missing instance methods: `initialize`"
+            )
+          end
+
+          it "raises an exception if the extension's `initialize` accepts different arguments" do
+            expect {
+              verify("ElasticGraph::Extensions::InitializeDoesntMatch", from: "support/example_extensions/initialize_doesnt_match")
+            }.to raise_error Errors::InvalidExtensionError, a_string_including(
+              "ElasticGraph::Extensions::InitializeDoesntMatch",
+              "Method signature for instance method `initialize` (`def initialize(some_arg:, another_arg:)`) does not match interface (`def initialize(some_arg:)`)"
+            )
+          end
+
+          it "allows a valid implementation" do
+            expect {
+              verify("ElasticGraph::Extensions::ValidInstantiable", from: "support/example_extensions/valid_instantiable")
+            }.not_to raise_error
+          end
+        end
+
+        def verify(constant_name, from:)
+          require from
+          extension = ::Object.const_get(constant_name)
+          InterfaceVerifier.verify(extension, against: interface_def, constant_name: constant_name)
+        end
+      end
+
+      class ExampleExtension
+        def self.class_method(a, b)
+        end
+
+        def instance_method1
+        end
+
+        def instance_method2(foo:)
+        end
+      end
+
+      class ExampleInstantiableExtension
+        def initialize(some_arg:)
+          # No body needed
+        end
+
+        def do_it
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I plan to use this to verify the registered resolvers.