### PR TITLE
Add `Boolean` fields to our test schema.

### DIFF
--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -208,6 +208,8 @@ index_templates:
               won_games_at:
                 type: date
                 format: strict_date_time
+              was_shortened:
+                type: boolean
               players_nested:
                 properties:
                   name:
@@ -405,6 +407,8 @@ index_templates:
               won_games_at:
                 type: date
                 format: strict_date_time
+              was_shortened:
+                type: boolean
               players_nested:
                 properties:
                   name:
@@ -652,6 +656,8 @@ index_templates:
                   won_games_at:
                     type: date
                     format: strict_date_time
+                  was_shortened:
+                    type: boolean
                   players_nested:
                     properties:
                       name:
@@ -937,6 +943,8 @@ index_templates:
                   won_games_at:
                     type: date
                     format: strict_date_time
+                  was_shortened:
+                    type: boolean
                   players_nested:
                     properties:
                       name:
@@ -1182,6 +1190,8 @@ index_templates:
                 type: integer
               seasons_object|won_games_at:
                 type: integer
+              seasons_object|was_shortened:
+                type: integer
               seasons_object|players_nested:
                 type: integer
               seasons_object|players_object:
@@ -1368,6 +1378,8 @@ index_templates:
                 type: keyword
               color:
                 type: keyword
+              is_draft:
+                type: boolean
           the_opts:
             properties:
               size:
@@ -1376,6 +1388,8 @@ index_templates:
                 type: keyword
               color:
                 type: keyword
+              is_draft:
+                type: boolean
           inventor:
             properties:
               name:

--- a/config/schema/artifacts/json_schemas.yaml
+++ b/config/schema/artifacts/json_schemas.yaml
@@ -134,6 +134,8 @@ json_schema_version: 1
     required:
     - sponsorships_nested
     - sponsorships_object
+  Boolean:
+    type: boolean
   Color:
     type: string
     enum:
@@ -734,6 +736,10 @@ json_schema_version: 1
         type: array
         items:
           "$ref": "#/$defs/DateTime"
+      was_shortened:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
       players_nested:
         type: array
         items:
@@ -753,6 +759,7 @@ json_schema_version: 1
     - count
     - started_at
     - won_games_at
+    - was_shortened
     - players_nested
     - players_object
   Untyped:
@@ -932,6 +939,10 @@ json_schema_version: 1
         anyOf:
         - "$ref": "#/$defs/Color"
         - type: 'null'
+      is_draft:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
       __typename:
         type: string
         const: WidgetOptions
@@ -940,6 +951,7 @@ json_schema_version: 1
     - size
     - the_size
     - color
+    - is_draft
   WidgetWorkspace:
     type: object
     properties:

--- a/config/schema/artifacts/json_schemas_by_version/v1.yaml
+++ b/config/schema/artifacts/json_schemas_by_version/v1.yaml
@@ -161,6 +161,8 @@ json_schema_version: 1
     required:
     - sponsorships_nested
     - sponsorships_object
+  Boolean:
+    type: boolean
   Color:
     type: string
     enum:
@@ -989,6 +991,13 @@ json_schema_version: 1
         ElasticGraph:
           type: "[DateTime!]!"
           nameInIndex: won_games_at
+      was_shortened:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: was_shortened
       players_nested:
         type: array
         items:
@@ -1014,6 +1023,7 @@ json_schema_version: 1
     - count
     - started_at
     - won_games_at
+    - was_shortened
     - players_nested
     - players_object
   Untyped:
@@ -1283,6 +1293,13 @@ json_schema_version: 1
         ElasticGraph:
           type: Color
           nameInIndex: color
+      is_draft:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: is_draft
       __typename:
         type: string
         const: WidgetOptions
@@ -1291,6 +1308,7 @@ json_schema_version: 1
     - size
     - the_size
     - color
+    - is_draft
   WidgetWorkspace:
     type: object
     properties:

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -1750,6 +1750,8 @@ index_definitions_by_name:
         source: __self
       __counts.seasons_object|the_record|win_count:
         source: __self
+      __counts.seasons_object|was_shortened:
+        source: __self
       __counts.seasons_object|won_games_at:
         source: __self
       __counts.seasons_object|year:
@@ -2062,6 +2064,8 @@ index_definitions_by_name:
         source: __self
       nested_fields2.the_seasons.the_record.win_count:
         source: __self
+      nested_fields2.the_seasons.was_shortened:
+        source: __self
       nested_fields2.the_seasons.won_games_at:
         source: __self
       nested_fields2.the_seasons.year:
@@ -2202,6 +2206,8 @@ index_definitions_by_name:
         source: __self
       seasons_nested.the_record.win_count:
         source: __self
+      seasons_nested.was_shortened:
+        source: __self
       seasons_nested.won_games_at:
         source: __self
       seasons_nested.year:
@@ -2303,6 +2309,8 @@ index_definitions_by_name:
       seasons_object.the_record.loss_count:
         source: __self
       seasons_object.the_record.win_count:
+        source: __self
+      seasons_object.was_shortened:
         source: __self
       seasons_object.won_games_at:
         source: __self
@@ -2504,6 +2512,8 @@ index_definitions_by_name:
         source: __self
       the_nested_fields.the_seasons.the_record.win_count:
         source: __self
+      the_nested_fields.the_seasons.was_shortened:
+        source: __self
       the_nested_fields.the_seasons.won_games_at:
         source: __self
       the_nested_fields.the_seasons.year:
@@ -2647,6 +2657,8 @@ index_definitions_by_name:
         source: __self
       options.color:
         source: __self
+      options.is_draft:
+        source: __self
       options.size:
         source: __self
       options.the_sighs:
@@ -2658,6 +2670,8 @@ index_definitions_by_name:
       tags:
         source: __self
       the_opts.color:
+        source: __self
+      the_opts.is_draft:
         source: __self
       the_opts.size:
         source: __self
@@ -2820,6 +2834,10 @@ object_types_by_name:
       upper_bound:
         resolver: object
     graphql_only_return_type: true
+  BooleanListFilterInput:
+    graphql_fields_by_name:
+      count:
+        name_in_index: __counts
   ColorListFilterInput:
     graphql_fields_by_name:
       count:
@@ -4960,6 +4978,8 @@ object_types_by_name:
       started_at_legacy:
         name_in_index: started_at
         resolver: get_record_field_value
+      was_shortened:
+        resolver: get_record_field_value
       won_games_at:
         resolver: get_record_field_value
       won_games_at_legacy:
@@ -4982,6 +5002,8 @@ object_types_by_name:
         resolver: object
       started_at_legacy:
         name_in_index: started_at
+        resolver: object
+      was_shortened:
         resolver: object
       won_games_at:
         resolver: object
@@ -5022,6 +5044,8 @@ object_types_by_name:
         resolver: object
       started_at_legacy:
         name_in_index: started_at
+        resolver: object
+      was_shortened:
         resolver: object
       won_game_at:
         name_in_index: won_games_at
@@ -5774,6 +5798,8 @@ object_types_by_name:
     graphql_fields_by_name:
       color:
         resolver: get_record_field_value
+      is_draft:
+        resolver: get_record_field_value
       size:
         resolver: get_record_field_value
       the_size:
@@ -5782,6 +5808,8 @@ object_types_by_name:
   WidgetOptionsAggregatedValues:
     graphql_fields_by_name:
       color:
+        resolver: object
+      is_draft:
         resolver: object
       size:
         resolver: object
@@ -5795,6 +5823,8 @@ object_types_by_name:
   WidgetOptionsGroupedBy:
     graphql_fields_by_name:
       color:
+        resolver: object
+      is_draft:
         resolver: object
       size:
         resolver: object

--- a/config/schema/artifacts/schema.graphql
+++ b/config/schema/artifacts/schema.graphql
@@ -451,6 +451,116 @@ type AggregationCountDetail {
   upper_bound: JsonSafeLong!
 }
 
+"""
+Input type used to specify filters on `Boolean` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input BooleanFilterInput {
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [BooleanFilterInput!]
+
+  """
+  Matches records where the field value is equal to any of the provided values.
+  This works just like an IN operator in SQL.
+
+  When `null` is passed, matches all documents. When an empty list is passed,
+  this part of the filter matches no documents. When `null` is passed in the
+  list, this part of the filter matches records where the field value is `null`.
+  """
+  equal_to_any_of: [Boolean]
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: BooleanFilterInput
+}
+
+"""
+Input type used to specify filters on elements of a `[Boolean]` field.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input BooleanListElementFilterInput {
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [BooleanListElementFilterInput!]
+
+  """
+  Matches records where the field value is equal to any of the provided values.
+  This works just like an IN operator in SQL.
+
+  When `null` is passed, matches all documents. When an empty list is passed,
+  this part of the filter matches no documents. When `null` is passed in the
+  list, this part of the filter matches records where the field value is `null`.
+  """
+  equal_to_any_of: [Boolean!]
+}
+
+"""
+Input type used to specify filters on `[Boolean]` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input BooleanListFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `BooleanListFilterInput` input because of collisions
+  between key names. For example, if you want to provide
+  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [BooleanListFilterInput!]
+
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [BooleanListFilterInput!]
+
+  """
+  Matches records where any of the list elements match the provided sub-filter.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  any_satisfy: BooleanListElementFilterInput
+
+  """
+  Used to filter on the number of non-null elements in this list field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  count: IntFilterInput
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: BooleanListFilterInput
+}
+
 enum Color {
   BLUE
   GREEN
@@ -10529,6 +10639,7 @@ type TeamSeason {
   record: TeamRecord
   started_at: DateTime
   started_at_legacy: DateTime
+  was_shortened: Boolean
   won_games_at: [DateTime!]!
   won_games_at_legacy: [DateTime!]!
   year: Int
@@ -10567,6 +10678,11 @@ type TeamSeasonAggregatedValues {
   Computed aggregate values for the `started_at_legacy` field.
   """
   started_at_legacy: DateTimeAggregatedValues
+
+  """
+  Computed aggregate values for the `was_shortened` field.
+  """
+  was_shortened: NonNumericAggregatedValues
 
   """
   Computed aggregate values for the `won_games_at` field.
@@ -10657,6 +10773,13 @@ input TeamSeasonFieldsListFilterInput {
   When `null` or an empty object is passed, matches all documents.
   """
   started_at_legacy: DateTimeListFilterInput
+
+  """
+  Used to filter on the `was_shortened` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  was_shortened: BooleanListFilterInput
 
   """
   Used to filter on the `won_games_at` field.
@@ -10753,6 +10876,13 @@ input TeamSeasonFilterInput {
   started_at_legacy: DateTimeFilterInput
 
   """
+  Used to filter on the `was_shortened` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  was_shortened: BooleanFilterInput
+
+  """
   Used to filter on the `won_games_at` field.
 
   When `null` or an empty object is passed, matches all documents.
@@ -10838,6 +10968,11 @@ type TeamSeasonGroupedBy {
     """
     time_zone: TimeZone = "UTC"
   ): DateTime
+
+  """
+  The `was_shortened` field value for this group.
+  """
+  was_shortened: Boolean
 
   """
   The individual value from `won_games_at` for this group.
@@ -12924,6 +13059,7 @@ input WidgetOptionSetsFilterInput {
 
 type WidgetOptions {
   color: Color
+  is_draft: Boolean
   size: Size
   the_size: Size
 }
@@ -12936,6 +13072,11 @@ type WidgetOptionsAggregatedValues {
   Computed aggregate values for the `color` field.
   """
   color: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `is_draft` field.
+  """
+  is_draft: NonNumericAggregatedValues
 
   """
   Computed aggregate values for the `size` field.
@@ -12971,6 +13112,13 @@ input WidgetOptionsFilterInput {
   color: ColorFilterInput
 
   """
+  Used to filter on the `is_draft` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  is_draft: BooleanFilterInput
+
+  """
   Matches records where the provided sub-filter evaluates to false.
   This works just like a NOT operator in SQL.
 
@@ -13001,6 +13149,11 @@ type WidgetOptionsGroupedBy {
   The `color` field value for this group.
   """
   color: Color
+
+  """
+  The `is_draft` field value for this group.
+  """
+  is_draft: Boolean
 
   """
   The `size` field value for this group.

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -208,6 +208,8 @@ index_templates:
               won_games_at:
                 type: date
                 format: strict_date_time
+              was_shortened:
+                type: boolean
               players_nested:
                 properties:
                   name:
@@ -405,6 +407,8 @@ index_templates:
               won_games_at:
                 type: date
                 format: strict_date_time
+              was_shortened:
+                type: boolean
               players_nested:
                 properties:
                   name:
@@ -652,6 +656,8 @@ index_templates:
                   won_games_at:
                     type: date
                     format: strict_date_time
+                  was_shortened:
+                    type: boolean
                   players_nested:
                     properties:
                       name:
@@ -937,6 +943,8 @@ index_templates:
                   won_games_at:
                     type: date
                     format: strict_date_time
+                  was_shortened:
+                    type: boolean
                   players_nested:
                     properties:
                       name:
@@ -1182,6 +1190,8 @@ index_templates:
                 type: integer
               seasons_object|won_games_at:
                 type: integer
+              seasons_object|was_shortened:
+                type: integer
               seasons_object|players_nested:
                 type: integer
               seasons_object|players_object:
@@ -1368,6 +1378,8 @@ index_templates:
                 type: keyword
               color:
                 type: keyword
+              is_draft:
+                type: boolean
           the_opts:
             properties:
               size:
@@ -1376,6 +1388,8 @@ index_templates:
                 type: keyword
               color:
                 type: keyword
+              is_draft:
+                type: boolean
           inventor:
             properties:
               name:

--- a/config/schema/artifacts_with_apollo/json_schemas.yaml
+++ b/config/schema/artifacts_with_apollo/json_schemas.yaml
@@ -134,6 +134,8 @@ json_schema_version: 1
     required:
     - sponsorships_nested
     - sponsorships_object
+  Boolean:
+    type: boolean
   Color:
     type: string
     enum:
@@ -734,6 +736,10 @@ json_schema_version: 1
         type: array
         items:
           "$ref": "#/$defs/DateTime"
+      was_shortened:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
       players_nested:
         type: array
         items:
@@ -753,6 +759,7 @@ json_schema_version: 1
     - count
     - started_at
     - won_games_at
+    - was_shortened
     - players_nested
     - players_object
   Untyped:
@@ -932,6 +939,10 @@ json_schema_version: 1
         anyOf:
         - "$ref": "#/$defs/Color"
         - type: 'null'
+      is_draft:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
       __typename:
         type: string
         const: WidgetOptions
@@ -940,6 +951,7 @@ json_schema_version: 1
     - size
     - the_size
     - color
+    - is_draft
   WidgetWorkspace:
     type: object
     properties:

--- a/config/schema/artifacts_with_apollo/json_schemas_by_version/v1.yaml
+++ b/config/schema/artifacts_with_apollo/json_schemas_by_version/v1.yaml
@@ -161,6 +161,8 @@ json_schema_version: 1
     required:
     - sponsorships_nested
     - sponsorships_object
+  Boolean:
+    type: boolean
   Color:
     type: string
     enum:
@@ -989,6 +991,13 @@ json_schema_version: 1
         ElasticGraph:
           type: "[DateTime!]!"
           nameInIndex: won_games_at
+      was_shortened:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: was_shortened
       players_nested:
         type: array
         items:
@@ -1014,6 +1023,7 @@ json_schema_version: 1
     - count
     - started_at
     - won_games_at
+    - was_shortened
     - players_nested
     - players_object
   Untyped:
@@ -1283,6 +1293,13 @@ json_schema_version: 1
         ElasticGraph:
           type: Color
           nameInIndex: color
+      is_draft:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: is_draft
       __typename:
         type: string
         const: WidgetOptions
@@ -1291,6 +1308,7 @@ json_schema_version: 1
     - size
     - the_size
     - color
+    - is_draft
   WidgetWorkspace:
     type: object
     properties:

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -1759,6 +1759,8 @@ index_definitions_by_name:
         source: __self
       __counts.seasons_object|the_record|win_count:
         source: __self
+      __counts.seasons_object|was_shortened:
+        source: __self
       __counts.seasons_object|won_games_at:
         source: __self
       __counts.seasons_object|year:
@@ -2071,6 +2073,8 @@ index_definitions_by_name:
         source: __self
       nested_fields2.the_seasons.the_record.win_count:
         source: __self
+      nested_fields2.the_seasons.was_shortened:
+        source: __self
       nested_fields2.the_seasons.won_games_at:
         source: __self
       nested_fields2.the_seasons.year:
@@ -2211,6 +2215,8 @@ index_definitions_by_name:
         source: __self
       seasons_nested.the_record.win_count:
         source: __self
+      seasons_nested.was_shortened:
+        source: __self
       seasons_nested.won_games_at:
         source: __self
       seasons_nested.year:
@@ -2312,6 +2318,8 @@ index_definitions_by_name:
       seasons_object.the_record.loss_count:
         source: __self
       seasons_object.the_record.win_count:
+        source: __self
+      seasons_object.was_shortened:
         source: __self
       seasons_object.won_games_at:
         source: __self
@@ -2513,6 +2521,8 @@ index_definitions_by_name:
         source: __self
       the_nested_fields.the_seasons.the_record.win_count:
         source: __self
+      the_nested_fields.the_seasons.was_shortened:
+        source: __self
       the_nested_fields.the_seasons.won_games_at:
         source: __self
       the_nested_fields.the_seasons.year:
@@ -2656,6 +2666,8 @@ index_definitions_by_name:
         source: __self
       options.color:
         source: __self
+      options.is_draft:
+        source: __self
       options.size:
         source: __self
       options.the_sighs:
@@ -2667,6 +2679,8 @@ index_definitions_by_name:
       tags:
         source: __self
       the_opts.color:
+        source: __self
+      the_opts.is_draft:
         source: __self
       the_opts.size:
         source: __self
@@ -2829,6 +2843,10 @@ object_types_by_name:
       upper_bound:
         resolver: object
     graphql_only_return_type: true
+  BooleanListFilterInput:
+    graphql_fields_by_name:
+      count:
+        name_in_index: __counts
   ColorListFilterInput:
     graphql_fields_by_name:
       count:
@@ -4991,6 +5009,8 @@ object_types_by_name:
       started_at_legacy:
         name_in_index: started_at
         resolver: get_record_field_value
+      was_shortened:
+        resolver: get_record_field_value
       won_games_at:
         resolver: get_record_field_value
       won_games_at_legacy:
@@ -5013,6 +5033,8 @@ object_types_by_name:
         resolver: object
       started_at_legacy:
         name_in_index: started_at
+        resolver: object
+      was_shortened:
         resolver: object
       won_games_at:
         resolver: object
@@ -5053,6 +5075,8 @@ object_types_by_name:
         resolver: object
       started_at_legacy:
         name_in_index: started_at
+        resolver: object
+      was_shortened:
         resolver: object
       won_game_at:
         name_in_index: won_games_at
@@ -5805,6 +5829,8 @@ object_types_by_name:
     graphql_fields_by_name:
       color:
         resolver: get_record_field_value
+      is_draft:
+        resolver: get_record_field_value
       size:
         resolver: get_record_field_value
       the_size:
@@ -5813,6 +5839,8 @@ object_types_by_name:
   WidgetOptionsAggregatedValues:
     graphql_fields_by_name:
       color:
+        resolver: object
+      is_draft:
         resolver: object
       size:
         resolver: object
@@ -5826,6 +5854,8 @@ object_types_by_name:
   WidgetOptionsGroupedBy:
     graphql_fields_by_name:
       color:
+        resolver: object
+      is_draft:
         resolver: object
       size:
         resolver: object

--- a/config/schema/artifacts_with_apollo/schema.graphql
+++ b/config/schema/artifacts_with_apollo/schema.graphql
@@ -484,6 +484,116 @@ type AggregationCountDetail @shareable {
   upper_bound: JsonSafeLong!
 }
 
+"""
+Input type used to specify filters on `Boolean` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input BooleanFilterInput {
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [BooleanFilterInput!]
+
+  """
+  Matches records where the field value is equal to any of the provided values.
+  This works just like an IN operator in SQL.
+
+  When `null` is passed, matches all documents. When an empty list is passed,
+  this part of the filter matches no documents. When `null` is passed in the
+  list, this part of the filter matches records where the field value is `null`.
+  """
+  equal_to_any_of: [Boolean]
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: BooleanFilterInput
+}
+
+"""
+Input type used to specify filters on elements of a `[Boolean]` field.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input BooleanListElementFilterInput {
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [BooleanListElementFilterInput!]
+
+  """
+  Matches records where the field value is equal to any of the provided values.
+  This works just like an IN operator in SQL.
+
+  When `null` is passed, matches all documents. When an empty list is passed,
+  this part of the filter matches no documents. When `null` is passed in the
+  list, this part of the filter matches records where the field value is `null`.
+  """
+  equal_to_any_of: [Boolean!]
+}
+
+"""
+Input type used to specify filters on `[Boolean]` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input BooleanListFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `BooleanListFilterInput` input because of collisions
+  between key names. For example, if you want to provide
+  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [BooleanListFilterInput!]
+
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [BooleanListFilterInput!]
+
+  """
+  Matches records where any of the list elements match the provided sub-filter.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  any_satisfy: BooleanListElementFilterInput
+
+  """
+  Used to filter on the number of non-null elements in this list field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  count: IntFilterInput
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: BooleanListFilterInput
+}
+
 enum Color {
   BLUE
   GREEN
@@ -10759,6 +10869,7 @@ type TeamSeason {
   record: TeamRecord
   started_at: DateTime
   started_at_legacy: DateTime
+  was_shortened: Boolean
   won_games_at: [DateTime!]!
   won_games_at_legacy: [DateTime!]!
   year: Int
@@ -10797,6 +10908,11 @@ type TeamSeasonAggregatedValues {
   Computed aggregate values for the `started_at_legacy` field.
   """
   started_at_legacy: DateTimeAggregatedValues
+
+  """
+  Computed aggregate values for the `was_shortened` field.
+  """
+  was_shortened: NonNumericAggregatedValues
 
   """
   Computed aggregate values for the `won_games_at` field.
@@ -10887,6 +11003,13 @@ input TeamSeasonFieldsListFilterInput {
   When `null` or an empty object is passed, matches all documents.
   """
   started_at_legacy: DateTimeListFilterInput
+
+  """
+  Used to filter on the `was_shortened` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  was_shortened: BooleanListFilterInput
 
   """
   Used to filter on the `won_games_at` field.
@@ -10983,6 +11106,13 @@ input TeamSeasonFilterInput {
   started_at_legacy: DateTimeFilterInput
 
   """
+  Used to filter on the `was_shortened` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  was_shortened: BooleanFilterInput
+
+  """
   Used to filter on the `won_games_at` field.
 
   When `null` or an empty object is passed, matches all documents.
@@ -11068,6 +11198,11 @@ type TeamSeasonGroupedBy {
     """
     time_zone: TimeZone = "UTC"
   ): DateTime
+
+  """
+  The `was_shortened` field value for this group.
+  """
+  was_shortened: Boolean
 
   """
   The individual value from `won_games_at` for this group.
@@ -13154,6 +13289,7 @@ input WidgetOptionSetsFilterInput {
 
 type WidgetOptions {
   color: Color
+  is_draft: Boolean
   size: Size
   the_size: Size
 }
@@ -13166,6 +13302,11 @@ type WidgetOptionsAggregatedValues {
   Computed aggregate values for the `color` field.
   """
   color: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `is_draft` field.
+  """
+  is_draft: NonNumericAggregatedValues
 
   """
   Computed aggregate values for the `size` field.
@@ -13201,6 +13342,13 @@ input WidgetOptionsFilterInput {
   color: ColorFilterInput
 
   """
+  Used to filter on the `is_draft` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  is_draft: BooleanFilterInput
+
+  """
   Matches records where the provided sub-filter evaluates to false.
   This works just like a NOT operator in SQL.
 
@@ -13231,6 +13379,11 @@ type WidgetOptionsGroupedBy {
   The `color` field value for this group.
   """
   color: Color
+
+  """
+  The `is_draft` field value for this group.
+  """
+  is_draft: Boolean
 
   """
   The `size` field value for this group.

--- a/config/schema/teams.rb
+++ b/config/schema/teams.rb
@@ -121,6 +121,7 @@ ElasticGraph.define_schema do |schema|
     t.field "started_at_legacy", "DateTime", name_in_index: "started_at", graphql_only: true, legacy_grouping_schema: true
     t.field "won_games_at", "[DateTime!]!", singular: "won_game_at"
     t.field "won_games_at_legacy", "[DateTime!]!", singular: "won_game_at_legacy", name_in_index: "won_games_at", graphql_only: true, legacy_grouping_schema: true
+    t.field "was_shortened", "Boolean"
 
     t.field "players_nested", "[Player!]!" do |f|
       f.mapping type: "nested"

--- a/config/schema/widgets.rb
+++ b/config/schema/widgets.rb
@@ -26,6 +26,7 @@ ElasticGraph.define_schema do |schema|
     # when a selected `group_by` option has a different name in the index vs GraphQL.
     t.field "the_size", "Size", name_in_index: "the_sighs"
     t.field "color", "Color"
+    t.field "is_draft", "Boolean"
   end
 
   schema.object_type "Person" do |t|

--- a/elasticgraph-graphql/spec/acceptance/hidden_types_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/hidden_types_spec.rb
@@ -73,6 +73,7 @@ module ElasticGraph
             all_types_related_to("Team") +
             all_types_related_to("Sponsor") +
             relay_types_related_to("String", include_list_filter: true) - ["StringSortOrderInput"] +
+            type_and_filters_for("Boolean", include_list: true) +
             type_and_filters_for("Color", include_list: true, as_input_enum: true) +
             type_and_filters_for("Date", include_list: true) +
             type_and_filters_for("DateTime", include_list: true) +
@@ -102,7 +103,7 @@ module ElasticGraph
             type_filter_and_non_indexed_aggregation_types_for("WidgetCurrencyNestedFields") +
             type_filter_and_non_indexed_aggregation_types_for("WorkspaceWidget") +
             type_filter_and_non_indexed_aggregation_types_for("Sponsorship", include_list_filter: true, include_fields_list_filter: true) - ["SponsorshipListElementFilterInput"] +
-            ::GraphQL::Schema::BUILT_IN_TYPES.keys.flat_map { |k| type_and_filters_for(k) } - ["BooleanFilterInput"] +
+            ::GraphQL::Schema::BUILT_IN_TYPES.keys.flat_map { |k| type_and_filters_for(k) } +
             %w[
               FloatAggregatedValues IntAggregatedValues JsonSafeLongAggregatedValues LongStringAggregatedValues NonNumericAggregatedValues
               DateAggregatedValues DateTimeAggregatedValues LocalTimeAggregatedValues

--- a/elasticgraph-indexer/spec/acceptance/list_fields_spec.rb
+++ b/elasticgraph-indexer/spec/acceptance/list_fields_spec.rb
@@ -108,6 +108,7 @@ module ElasticGraph
         "seasons_object|the_record|last_win_date" => 2,
         "seasons_object|the_record|loss_count" => 2,
         "seasons_object|the_record|win_count" => 2,
+        "seasons_object|was_shortened" => 2,
         "seasons_object|won_games_at" => 0,
         "seasons_object|year" => 2,
         "the_nested_fields|current_players" => 2,

--- a/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/variable_dumper_spec.rb
+++ b/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/variable_dumper_spec.rb
@@ -152,6 +152,11 @@ module ElasticGraph
                 "not" => "ColorFilterInput",
                 "equal_to_any_of" => {"type" => "[ColorInput]", "values" => ["BLUE", "GREEN", "RED"]}
               }},
+              "is_draft" => {"type" => "BooleanFilterInput", "fields" => {
+                "any_of" => "[BooleanFilterInput!]",
+                "not" => "BooleanFilterInput",
+                "equal_to_any_of" => "[Boolean]"
+              }},
               "size" => {"type" => "SizeFilterInput", "fields" => {
                 "any_of" => "[SizeFilterInput!]",
                 "not" => "SizeFilterInput",

--- a/spec_support/lib/elastic_graph/spec_support/factories/teams.rb
+++ b/spec_support/lib/elastic_graph/spec_support/factories/teams.rb
@@ -135,6 +135,7 @@ FactoryBot.define do
     __typename { "TeamSeason" }
     year { Faker::Number.between(from: 1950, to: 2023) }
     record { build :team_record }
+    was_shortened { false }
 
     notes do
       Array.new(Faker::Number.between(from: 1, to: 3)) { Faker::TvShows::MichaelScott.quote }

--- a/spec_support/lib/elastic_graph/spec_support/factories/widgets.rb
+++ b/spec_support/lib/elastic_graph/spec_support/factories/widgets.rb
@@ -36,6 +36,7 @@ FactoryBot.define do
     size { Faker::Base.sample(["SMALL", "MEDIUM", "LARGE"]) }
     the_size { size }
     color { Faker::Base.sample(["RED", "GREEN", "BLUE"]) }
+    is_draft { false }
   end
 
   factory :person, parent: :hash_base do


### PR DESCRIPTION
We've discovered that there's a sub-aggregation bug related to grouping on `Boolean` fields. To exercise that case, we need a `Boolean` field in our test schema that we can group on (`TeamSeason.was_shortened`).

I've also added `WidgetOptions.is_draft` which will allow us to exercise root aggregation grouping on a `Boolean` (as that is also not covered).

The actual fixes and new tests will come in a follow up PR. Here I'm just updating the schema.