### PR TITLE
Bug fix: interpret sub-aggregation Boolean groupings correctly.

### DIFF
--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/grouped_by.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/grouped_by.rbs
@@ -27,6 +27,10 @@ module ElasticGraph
 
         class GroupedBy < GroupedBySupertype
           include GraphQL::Resolvers::_Resolvable
+
+          private
+
+          def work_around_terms_aggregation_boolean_value: (untyped) -> untyped
         end
       end
     end

--- a/elasticgraph-graphql/spec/acceptance/sub_aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/sub_aggregations_spec.rb
@@ -53,7 +53,7 @@ module ElasticGraph
               current_players: [build(:player, name: "Bob")],
               formed_on: "1903-01-01",
               seasons: [
-                build(:team_season, year: 2020, record: build(:team_record, wins: 50, losses: 12, first_win_on: "2020-03-02", last_win_on: "2020-11-12"), notes: ["pandemic", "shortened"], started_at: "2020-01-15T12:02:20Z", players: [
+                build(:team_season, year: 2020, was_shortened: true, record: build(:team_record, wins: 50, losses: 12, first_win_on: "2020-03-02", last_win_on: "2020-11-12"), notes: ["pandemic", "shortened"], started_at: "2020-01-15T12:02:20Z", players: [
                   build(:player, name: "Ted", seasons: [build(:player_season, year: 2018, games_played: 20), build(:player_season, year: 2018, games_played: 30)]),
                   build(:player, name: "Dave", seasons: [build(:player_season, year: 2022, games_played: 10)])
                 ])
@@ -65,10 +65,10 @@ module ElasticGraph
               formed_on: "1883-01-01",
               current_players: [build(:player, name: "Kat", seasons: []), build(:player, name: "Sue", seasons: [])],
               seasons: [
-                build(:team_season, year: 2020, record: build(:team_record, wins: 30, losses: 22, first_win_on: "2020-05-02", last_win_on: "2020-12-12"), notes: ["pandemic", "covid"], started_at: "2020-01-15T12:02:20Z", players: []),
-                build(:team_season, year: 2021, record: build(:team_record, wins: nil, losses: 22, first_win_on: nil, last_win_on: "2021-12-12"), notes: [], started_at: "2021-02-16T13:03:30Z", players: []),
-                build(:team_season, year: 2022, record: build(:team_record, wins: 40, losses: 15, first_win_on: "2022-06-02", last_win_on: "2022-08-12"), notes: [], started_at: "2022-03-17T14:04:40Z", players: []),
-                build(:team_season, year: 2023, record: build(:team_record, wins: 50, losses: nil, first_win_on: "2023-01-06", last_win_on: nil), notes: [], started_at: "2023-04-18T12:02:59Z", players: [])
+                build(:team_season, year: 2020, was_shortened: true, record: build(:team_record, wins: 30, losses: 22, first_win_on: "2020-05-02", last_win_on: "2020-12-12"), notes: ["pandemic", "covid"], started_at: "2020-01-15T12:02:20Z", players: []),
+                build(:team_season, year: 2021, was_shortened: false, record: build(:team_record, wins: nil, losses: 22, first_win_on: nil, last_win_on: "2021-12-12"), notes: [], started_at: "2021-02-16T13:03:30Z", players: []),
+                build(:team_season, year: 2022, was_shortened: false, record: build(:team_record, wins: 40, losses: 15, first_win_on: "2022-06-02", last_win_on: "2022-08-12"), notes: [], started_at: "2022-03-17T14:04:40Z", players: []),
+                build(:team_season, year: 2023, was_shortened: false, record: build(:team_record, wins: 50, losses: nil, first_win_on: "2023-01-06", last_win_on: nil), notes: [], started_at: "2023-04-18T12:02:59Z", players: [])
               ]
             ),
             build(
@@ -77,7 +77,7 @@ module ElasticGraph
               formed_on: "1901-01-01",
               current_players: [build(:player, name: "Ed", seasons: []), build(:player, name: "Ty", seasons: [])],
               seasons: [
-                build(:team_season, year: 2019, record: build(:team_record, wins: 40, losses: 7, first_win_on: "2019-04-02", last_win_on: "2019-07-12"), notes: ["old rules"], started_at: "2019-01-15T12:02:20Z", players: [])
+                build(:team_season, year: 2019, was_shortened: false, record: build(:team_record, wins: 40, losses: 7, first_win_on: "2019-04-02", last_win_on: "2019-07-12"), notes: ["old rules"], started_at: "2019-01-15T12:02:20Z", players: [])
               ]
             ),
             build(
@@ -184,6 +184,13 @@ module ElasticGraph
             {"year" => 2021} => count_detail_of(1),
             {"year" => 2022} => count_detail_of(1),
             {"year" => 2023} => count_detail_of(1)
+          })
+
+          # Test a simple sub-aggregation grouping of one Boolean `terms` field
+          team_seasons_nodes = aggregate_season_counts_grouped_by("was_shortened")
+          expect(indexed_counts_from(team_seasons_nodes)).to eq({
+            {case_correctly("was_shortened") => true} => count_detail_of(2),
+            {case_correctly("was_shortened") => false} => count_detail_of(4)
           })
 
           # Test what happens if all grouped by fields are excluded via a directive.


### PR DESCRIPTION
Sub-aggregations use a `terms` aggregation instead of a `composite` aggregation, and it turns out that Elasticsearch/OpenSearch return 0/1 instead of false/true from a `term` aggregation when grouping by a `Boolean` field. We never realized this edge case before and didn't have any `Boolean`-specific aggregation tests to catch it. This adds the coverage and fixes the underlying issue through a slightly hacky (but appropriately self-contained) mechanism.

In addition, I've added test coverage for an "outer" aggregation. While it didn't suffer from this issue (since it uses a `composite` aggregation under the covers), it's good to add coverage since `Boolean` values need some special treatment.