### PR TITLE
Omit `resolver` from runtime metadata of input fields.

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
@@ -736,9 +736,13 @@ module ElasticGraph
             .as_static_derived_type(filter_field_category(for_single_value))
             .name
 
-          params = to_h
-            .slice(*@@initialize_param_names)
-            .merge(type: filter_type, parent_type: parent_type, name_in_index: name_in_index, type_for_derived_types: nil)
+          params = to_h.slice(*@@initialize_param_names).merge(
+            type: filter_type,
+            parent_type: parent_type,
+            name_in_index: name_in_index,
+            type_for_derived_types: nil,
+            resolver: nil
+          )
 
           schema_def_state.factory.new_field(**params).tap do |f|
             f.documentation derived_documentation(

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/input_type.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/input_type.rb
@@ -41,10 +41,14 @@ module ElasticGraph
         end
 
         def runtime_metadata(extra_update_targets)
+          graphql_input_fields_by_name = graphql_fields_by_name.transform_values do |field|
+            field.runtime_metadata_graphql_field.with(resolver: nil)
+          end
+
           SchemaArtifacts::RuntimeMetadata::ObjectType.new(
             update_targets: extra_update_targets,
             index_definition_names: [],
-            graphql_fields_by_name: graphql_fields_by_name.transform_values(&:runtime_metadata_graphql_field),
+            graphql_fields_by_name: graphql_input_fields_by_name,
             elasticgraph_category: nil,
             source_type: nil,
             graphql_only_return_type: false

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/filters_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/filters_spec.rb
@@ -632,6 +632,24 @@ module ElasticGraph
           EOS
         end
 
+        it "avoids copying the `resolver` into the filter field" do
+          results = []
+
+          define_schema do |api|
+            api.object_type "Widget" do |t|
+              t.field "id", "ID!" do |f|
+                f.resolver = :list_records
+
+                f.customize_filter_field do |ff|
+                  results << ff.resolver
+                end
+              end
+            end
+          end
+
+          expect(results.uniq).to eq [nil]
+        end
+
         it "references a `*ListFilterInput` from a list-of-text-strings field on the filter type" do
           result = define_schema do |api|
             api.object_type "Widget" do |t|

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/graphql_fields_by_name_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/graphql_fields_by_name_spec.rb
@@ -39,6 +39,25 @@ module ElasticGraph
         })
       end
 
+      it "omits `resolver` from input fields" do
+        metadata = object_type_metadata_for "WidgetFilterInput" do |s|
+          s.object_type "Widget" do |t|
+            t.field "id", "ID", name_in_index: "id2"
+
+            t.field "title", "String", name_in_index: "title2" do |f|
+              f.customize_filter_field do |ff|
+                ff.resolver = :other2
+              end
+            end
+          end
+        end
+
+        expect(metadata.graphql_fields_by_name.transform_values(&:resolver)).to eq({
+          "id" => nil,
+          "title" => nil
+        })
+      end
+
       it "raises an error when a custom `Query` field lacks a resolver, as it won't be resolvable by elasticgraph-graphql" do
         expect {
           object_type_metadata_for "Query" do |s|


### PR DESCRIPTION
Resolvers only apply to return fields.