### PR TITLE
Verify GraphQL resolvers when dumping schema artifacts.

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
@@ -7,6 +7,7 @@
 # frozen_string_literal: true
 
 require "elastic_graph/errors"
+require "elastic_graph/graphql/resolvers/interface"
 require "elastic_graph/schema_artifacts/runtime_metadata/extension"
 require "elastic_graph/schema_definition/mixins/has_readable_to_s_and_inspect"
 require "elastic_graph/schema_definition/results"
@@ -302,7 +303,12 @@ module ElasticGraph
       # @example Register a custom resolver for use by a custom `Query` field
       #   # In `add_resolver.rb`:
       #   class AddResolver
-      #     # ...
+      #     def initialize(elasticgraph_graphql:, config:)
+      #     end
+      #
+      #     def resolve(field:, object:, args:, context:, lookahead:)
+      #       args.fetch("x") + args.fetch("y")
+      #     end
       #   end
       #
       #   # In `config/schema.rb`:
@@ -319,7 +325,9 @@ module ElasticGraph
       #     end
       #   end
       def register_graphql_resolver(name, klass, defined_at:, **resolver_config)
-        @state.graphql_resolvers_by_name[name] = SchemaArtifacts::RuntimeMetadata::Extension.new(klass, defined_at, resolver_config)
+        resolver = SchemaArtifacts::RuntimeMetadata::Extension.new(klass, defined_at, resolver_config)
+        resolver.verify_against(GraphQL::Resolvers::Interface)
+        @state.graphql_resolvers_by_name[name] = resolver
         nil
       end
 

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/results.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/results.rbs
@@ -44,6 +44,7 @@ module ElasticGraph
       def generate_sdl: () -> ::String
       def build_public_json_schema: () -> ::Hash[::String, untyped]
       def json_schema_indexing_field_types_by_name: () -> ::Hash[::String, Indexing::_FieldType]
+      def verify_runtime_metadata: (SchemaArtifacts::RuntimeMetadata::Schema) -> void
       def strip_trailing_whitespace: (::String) -> ::String
       def check_for_circular_dependencies!: () -> void
       def recursively_add_referenced_types_to: (SchemaElements::TypeReference, ::Hash[::String, ::Set[::String]]) -> void

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/graphql_resolvers_by_name_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/graphql_resolvers_by_name_spec.rb
@@ -7,6 +7,7 @@
 # frozen_string_literal: true
 
 require_relative "runtime_metadata_support"
+require "elastic_graph/errors"
 require "elastic_graph/spec_support/example_extensions/graphql_resolvers"
 
 module ElasticGraph
@@ -40,6 +41,82 @@ module ElasticGraph
         end
 
         expect(result.fetch(:resolver1)).to eq(graphql_resolver1(param: 15))
+      end
+
+      it "verifies the registered resolver to confirm it confirms to the resolver interface" do
+        expect {
+          graphql_resolvers_by_name do |schema|
+            schema.register_graphql_resolver :missing_args,
+              MissingArgumentsResolver,
+              defined_at: "elastic_graph/spec_support/example_extensions/graphql_resolvers"
+          end
+        }.to raise_error Errors::InvalidExtensionError
+      end
+
+      it "verifies that all referenced resolvers exist" do
+        expect {
+          graphql_resolvers_by_name do |schema|
+            schema.on_root_query_type do |t|
+              t.field "foo1", "Int" do |f|
+                f.resolver = :resolver1
+              end
+
+              t.field "foo2", "Int" do |f|
+                f.resolver = :get_record_field_value
+              end
+
+              t.field "foo3", "Int" do |f|
+                f.resolver = :resolver1
+              end
+            end
+
+            schema.object_type "MyType" do |t|
+              t.field "bar", "Int" do |f|
+                f.resolver = :resolver2
+              end
+            end
+          end
+        }.to raise_error Errors::SchemaError do |error|
+          expect(error.message).to eq <<~EOS
+            GraphQL resolver `:resolver1` is unregistered but is assigned to 2 field(s):
+
+              - Query.foo1
+              - Query.foo3
+
+            GraphQL resolver `:resolver2` is unregistered but is assigned to 1 field(s):
+
+              - MyType.bar
+
+            To continue, register the named resolvers with `schema.register_graphql_resolver`
+            or update the fields listed above to use one of the other registered resolvers:
+
+              - :get_record_field_value
+              - :list_records
+              - :nested_relationships
+              - :object
+          EOS
+        end
+      end
+
+      it "warns when resolvers are registered but never used" do
+        output = StringIO.new
+
+        graphql_resolvers_by_name(output: output) do |schema|
+          schema.register_graphql_resolver :resolver1,
+            GraphQLResolver1,
+            defined_at: "elastic_graph/spec_support/example_extensions/graphql_resolvers"
+
+          schema.register_graphql_resolver :resolver2,
+            GraphQLResolver2,
+            defined_at: "elastic_graph/spec_support/example_extensions/graphql_resolvers"
+        end
+
+        expect(output.string).to eq(<<~EOS)
+          WARNING: 2 GraphQL resolver(s) have been registered but are unused:
+            - resolver1
+            - resolver2
+          These resolvers can be removed.
+        EOS
       end
 
       def graphql_resolvers_by_name(...)

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/graphql_fields_by_name_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/graphql_fields_by_name_spec.rb
@@ -16,26 +16,26 @@ module ElasticGraph
       it "defaults the `resolver` of each individual field to the parent type's `default_graphql_resolver`" do
         metadata = object_type_metadata_for "Widget" do |s|
           s.object_type "Widget" do |t|
-            t.default_graphql_resolver = :parent_default
+            t.default_graphql_resolver = :list_records
 
             t.field "id", "ID"
             t.field "description", "String"
 
             t.field "name", "String" do |f|
-              f.resolver = :other1
+              f.resolver = :get_record_field_value
             end
 
             t.field "title", "String" do |f|
-              f.resolver = :other2
+              f.resolver = :object
             end
           end
         end
 
         expect(metadata.graphql_fields_by_name).to eq({
-          "id" => graphql_field_with(name_in_index: "id", resolver: :parent_default),
-          "description" => graphql_field_with(name_in_index: "description", resolver: :parent_default),
-          "name" => graphql_field_with(name_in_index: "name", resolver: :other1),
-          "title" => graphql_field_with(name_in_index: "title", resolver: :other2)
+          "id" => graphql_field_with(name_in_index: "id", resolver: :list_records),
+          "description" => graphql_field_with(name_in_index: "description", resolver: :list_records),
+          "name" => graphql_field_with(name_in_index: "name", resolver: :get_record_field_value),
+          "title" => graphql_field_with(name_in_index: "title", resolver: :object)
         })
       end
 

--- a/spec_support/lib/elastic_graph/spec_support/example_extensions/graphql_resolvers.rb
+++ b/spec_support/lib/elastic_graph/spec_support/example_extensions/graphql_resolvers.rb
@@ -14,4 +14,20 @@ module ElasticGraph
     def resolve(field:, object:, args:, context:, lookahead:)
     end
   end
+
+  class GraphQLResolver2
+    def initialize(elasticgraph_graphql:, config:)
+    end
+
+    def resolve(field:, object:, args:, context:, lookahead:)
+    end
+  end
+
+  class MissingArgumentsResolver
+    def initialize(elasticgraph_graphql:, config:)
+    end
+
+    def resolve(field:, object:, args:, context:)
+    end
+  end
 end


### PR DESCRIPTION
- Verify the resolver definition implements the resolver interface.
- Verify that every field resolver has been registered.
- Warn if there are registered resolvers that are unused (except for the built-in ones).

The goal is to provide feedback as early as possible if the resolvers configured or defined incorrectly.