### PR TITLE
Standardize `DatastoreQuery` on `filters:`.

### DIFF
--- a/elasticgraph-apollo/apollo_tests_implementation/lib/product_resolver.rb
+++ b/elasticgraph-apollo/apollo_tests_implementation/lib/product_resolver.rb
@@ -24,7 +24,7 @@ class ProductResolver
     query = @datastore_query_builder.new_query(
       search_index_definitions: [@product_index_def],
       monotonic_clock_deadline: context[:monotonic_clock_deadline],
-      filter: {"id" => {"equalToAnyOf" => [args.fetch("id")]}},
+      filters: [{"id" => {"equalToAnyOf" => [args.fetch("id")]}}],
       individual_docs_needed: true,
       requested_fields: %w[
         id sku package notes

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/entities_field_resolver.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/entities_field_resolver.rb
@@ -166,7 +166,7 @@ module ElasticGraph
               query.merge_with(
                 document_pagination: {first: representations.length},
                 requested_fields: additional_requested_fields_for(representations),
-                filter: filter
+                filters: [filter]
               )
             end
 
@@ -242,7 +242,7 @@ module ElasticGraph
               # In the case of representations which don't query Id, we ask for 2 documents so that
               # if something weird is going on and it matches more than 1, we can detect that and return an error.
               document_pagination: {first: 2},
-              filter: build_filter_for_hash(fields)
+              filters: [build_filter_for_hash(fields)]
             )
           end
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
@@ -33,7 +33,6 @@ module ElasticGraph
       :monotonic_clock_deadline, :schema_element_names
     ) {
       def initialize(
-        filter: nil,
         filters: nil,
         sort: nil,
         document_pagination: nil,
@@ -44,9 +43,7 @@ module ElasticGraph
         monotonic_clock_deadline: nil,
         **kwargs
       )
-        # Deal with `:filter` vs `:filters` input and normalize it to a single `filters` set.
         filters = ::Set.new(filters || [])
-        filters << filter if filter && !filter.empty?
         filters.freeze
 
         aggregations ||= {}

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/aggregation_pagination_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/aggregation_pagination_spec.rb
@@ -118,7 +118,7 @@ module ElasticGraph
             document_pagination: {first: 0}, # make sure we don't ask for any documents, just aggregations.
             aggregations: [aggregation_query],
             total_document_count_needed: groupings.empty?,
-            filter: ({"name" => {"equal_to_any_of" => ids_of(filter_to)}} if filter_to)
+            filters: [({"name" => {"equal_to_any_of" => ids_of(filter_to)}} if filter_to)].compact
           )
 
           connection = Aggregation::Resolvers::RelayConnectionBuilder.build_from_search_response(

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/datastore_query_integration_support.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/datastore_query_integration_support.rb
@@ -24,7 +24,7 @@ module ElasticGraph
 
       let(:graphql) { build_graphql }
 
-      def search_datastore(index_def_name: "widgets", aggregations: [], graphql: self.graphql, **options, &before_msearch)
+      def search_datastore(index_def_name: "widgets", aggregations: [], graphql: self.graphql, filter: nil, filters: [], **options, &before_msearch)
         index_def = graphql.datastore_core.index_definitions_by_name.fetch(index_def_name)
 
         query = graphql.datastore_query_builder.new_query(
@@ -32,6 +32,7 @@ module ElasticGraph
           requested_fields: ["id"],
           sort: index_def.default_sort_clauses,
           aggregations: aggregations.to_h { |agg| [agg.name, agg] },
+          filters: filters + [filter].compact,
           **options
         )
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_optimizer_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_optimizer_spec.rb
@@ -36,7 +36,7 @@ module ElasticGraph
             computations: [computation_of("amountMoney", "amount", :sum)]
           )
 
-          base_query = new_query(filter: {"age" => {"equal_to_any_of" => [0]}})
+          base_query = new_query(filters: [{"age" => {"equal_to_any_of" => [0]}}])
 
           by_size = with_aggs(base_query, [by_size_agg])
           by_color = with_aggs(base_query, [by_color_agg])
@@ -77,7 +77,7 @@ module ElasticGraph
             computations: [computation_of("amountMoney", "amount", :sum)]
           )
 
-          base_query = new_query(filter: {"age" => {"equal_to_any_of" => [0]}})
+          base_query = new_query(filters: [{"age" => {"equal_to_any_of" => [0]}}])
 
           by_size = with_aggs(base_query, [by_size_agg])
           by_color = with_aggs(base_query, [by_color_agg])
@@ -103,8 +103,8 @@ module ElasticGraph
         end
 
         it "can merge non-aggregation queries that are identical as well" do
-          q1 = new_query(filter: {"age" => {"equal_to_any_of" => [0]}})
-          q2 = new_query(filter: {"age" => {"equal_to_any_of" => [0]}})
+          q1 = new_query(filters: [{"age" => {"equal_to_any_of" => [0]}}])
+          q2 = new_query(filters: [{"age" => {"equal_to_any_of" => [0]}}])
           expect(q1).to eq(q2)
 
           results_by_query = optimize_queries(q1, q2)
@@ -122,8 +122,8 @@ module ElasticGraph
 
         it "keeps queries separate when they have non-aggregation differences" do
           optimize_queries(
-            base_query = new_query(filter: {"age" => {"equal_to_any_of" => [0]}}, individual_docs_needed: true),
-            alt_filter = base_query.with(filter: {"age" => {"equal_to_any_of" => [1]}}),
+            base_query = new_query(filters: [{"age" => {"equal_to_any_of" => [0]}}], individual_docs_needed: true),
+            alt_filter = base_query.with(filters: [{"age" => {"equal_to_any_of" => [1]}}]),
             alt_pagination = base_query.with(document_pagination: {first: 1}),
             alt_individual_docs_needed = base_query.with(individual_docs_needed: !base_query.individual_docs_needed),
             alt_sort = base_query.with(sort: [{"age" => {"order" => "desc"}}]),
@@ -156,14 +156,14 @@ module ElasticGraph
             groupings: [field_term_grouping_of("options", "color")]
           )
 
-          base_query = new_query(filter: {"age" => {"equal_to_any_of" => [0]}})
+          base_query = new_query(filters: [{"age" => {"equal_to_any_of" => [0]}}])
 
           by_size = base_query.with(
-            filter: {"age" => {"equal_to_any_of" => [0]}},
+            filters: [{"age" => {"equal_to_any_of" => [0]}}],
             aggregations: {by_size_agg.name => by_size_agg}
           )
           by_color = base_query.with(
-            filter: {"age" => {"equal_to_any_of" => [1]}},
+            filters: [{"age" => {"equal_to_any_of" => [1]}}],
             aggregations: {by_color_agg.name => by_color_agg}
           )
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/datastore_query_unit_support.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/datastore_query_unit_support.rb
@@ -24,10 +24,11 @@ module ElasticGraph
         end
       end
 
-      def new_query(aggregations: [], **options)
+      def new_query(aggregations: [], filter: nil, filters: [], **options)
         builder.new_query(
           aggregations: aggregations.to_h { |agg| [agg.name, agg] },
           search_index_definitions: graphql.datastore_core.index_definitions_by_graphql_type.fetch("Widget"),
+          filters: filters + [filter].compact,
           **options
         )
       end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/merge_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/merge_spec.rb
@@ -51,8 +51,8 @@ module ElasticGraph
       end
 
       it "can merge `equal_to_any_of` conditions from two separate queries that are on separate fields", covers: :filters do
-        query1 = new_query(filter: {"age" => {"equal_to_any_of" => [25, 30]}})
-        query2 = new_query(filter: {"size" => {"equal_to_any_of" => [10]}})
+        query1 = new_query(filters: [{"age" => {"equal_to_any_of" => [25, 30]}}])
+        query2 = new_query(filters: [{"size" => {"equal_to_any_of" => [10]}}])
 
         merged = merge(query1, query2)
 
@@ -63,8 +63,8 @@ module ElasticGraph
       end
 
       it "can merge `equal_to_any_of` conditions from two separate queries that are on the same field", covers: :filters do
-        query1 = new_query(filter: {"age" => {"equal_to_any_of" => [25, 30]}})
-        query2 = new_query(filter: {"age" => {"equal_to_any_of" => [35, 30]}})
+        query1 = new_query(filters: [{"age" => {"equal_to_any_of" => [25, 30]}}])
+        query2 = new_query(filters: [{"age" => {"equal_to_any_of" => [35, 30]}}])
 
         merged = merge(query1, query2)
 
@@ -75,12 +75,12 @@ module ElasticGraph
       end
 
       it "can merge using `merge_with(**query_options)` as well", covers: :filters do
-        query1 = new_query(filter: {"age" => {"equal_to_any_of" => [25, 30]}})
+        query1 = new_query(filters: [{"age" => {"equal_to_any_of" => [25, 30]}}])
 
         merged = nil
 
         expect {
-          merged = query1.merge_with(filter: {"age" => {"equal_to_any_of" => [35, 30]}, "size" => {"equal_to_any_of" => [10]}})
+          merged = query1.merge_with(filters: [{"age" => {"equal_to_any_of" => [35, 30]}, "size" => {"equal_to_any_of" => [10]}}])
         }.to maintain { query1 }.and maintain { query1.filters }
 
         expect(datastore_body_of(merged)).to filter_datastore_with(
@@ -91,7 +91,7 @@ module ElasticGraph
       end
 
       it "de-duplicates filters that are present in both queries", covers: :filters do
-        query1 = new_query(filter: {"age" => {"equal_to_any_of" => [25, 30]}})
+        query1 = new_query(filters: [{"age" => {"equal_to_any_of" => [25, 30]}}])
 
         merged = merge(query1, query1)
 
@@ -272,11 +272,10 @@ module ElasticGraph
       end
 
       specify "#merge_with can merge in an empty filter", covers: :filters do
-        query1 = new_query(filter: {"age" => {"equal_to_any_of" => [25, 30]}})
+        query1 = new_query(filters: [{"age" => {"equal_to_any_of" => [25, 30]}}])
 
         expect(query1.merge_with).to eq query1
-        expect(query1.merge_with(filter: nil)).to eq query1
-        expect(query1.merge_with(filter: {})).to eq query1
+        expect(query1.merge_with(filters: [])).to eq query1
       end
 
       it "prefers a set `monotonic_clock_deadline` value to an unset one", covers: :monotonic_clock_deadline do

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/search_index_expression_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/search_index_expression_spec.rb
@@ -467,7 +467,7 @@ module ElasticGraph
           options = if filter_or_filters.is_a?(Array)
             {filters: filter_or_filters}
           else
-            {filter: filter_or_filters}
+            {filters: [filter_or_filters].compact}
           end
 
           index_def = graphql.datastore_core.index_definitions_by_name.fetch("widgets")

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/http_endpoint_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/http_endpoint_spec.rb
@@ -60,7 +60,7 @@ module ElasticGraph
             adapter = Class.new do
               def call(query:, context:, **)
                 user_name = context.fetch(:http_request).normalized_headers["USER-NAME"]
-                query.merge_with(filter: {"user_name" => {"equal_to_any_of" => [user_name]}})
+                query.merge_with(filters: [{"user_name" => {"equal_to_any_of" => [user_name]}}])
               end
             end.new
 

--- a/elasticgraph-health_check/lib/elastic_graph/health_check/health_checker.rb
+++ b/elasticgraph-health_check/lib/elastic_graph/health_check/health_checker.rb
@@ -73,7 +73,7 @@ module ElasticGraph
 
         @datastore_query_builder.new_query(
           search_index_definitions: type.search_index_definitions,
-          filter: build_index_optimization_filter_for(recency_config),
+          filters: [build_index_optimization_filter_for(recency_config)],
           requested_fields: ["id", recency_config.timestamp_field],
           document_pagination: {first: 1},
           sort: [{recency_config.timestamp_field => {"order" => "desc"}}]

--- a/elasticgraph-query_interceptor/spec/unit/elastic_graph/query_interceptor/graphql_extension_spec.rb
+++ b/elasticgraph-query_interceptor/spec/unit/elastic_graph/query_interceptor/graphql_extension_spec.rb
@@ -39,7 +39,7 @@ module ElasticGraph
               end
 
               def intercept(query, field:, args:, http_request:, context:)
-                query.merge_with(filter: {"public" => {"equal_to_any_of" => [false]}})
+                query.merge_with(filters: [{"public" => {"equal_to_any_of" => [false]}}])
               end
             end
           end
@@ -57,7 +57,7 @@ module ElasticGraph
 
               def intercept(query, field:, args:, http_request:, context:)
                 user_name = http_request.normalized_headers[@config.fetch("header")]
-                query.merge_with(filter: {@config.fetch("key") => {"equal_to_any_of" => [user_name]}})
+                query.merge_with(filters: [{@config.fetch("key") => {"equal_to_any_of" => [user_name]}}])
               end
             end
           end


### PR DESCRIPTION
Previously, it supported both `filter:` and `filters:`, and merged them. This was convenient, but benchmarking has demonstrated that our DatastoreQuery logic is a bottleneck for certain query patterns, and we can simplify by only supporting `filters:`.

However, in some test files where we were relying on `filter:`, we've retained support by handling it in an existing helper method, in cases where that was significantly easier than updating tons of test call sites.