### PR TITLE
Link `Documentation` button to docs of latest released version.

### DIFF
--- a/config/site/src/index.html
+++ b/config/site/src/index.html
@@ -21,7 +21,7 @@ title: ElasticGraph - Open-source GraphQL and Elasticsearch / OpenSearch framewo
         Get Started
       </a>
 
-      <a href="{{ '/docs/main' | relative_url }}"
+      <a href="{{ '/docs/' | append: site.data.doc_versions.latest_version | relative_url }}"
         class="bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 py-2 px-6 rounded-sm hover:bg-gray-300 dark:hover:bg-gray-600 transition">
         Documentation
       </a>


### PR DESCRIPTION
...rather than the `main` docs.