### PR TITLE
Optimize `DatastoreQuery` merging.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -116,7 +116,7 @@ module ElasticGraph
     def datastore_query_builder
       @datastore_query_builder ||= begin
         require "elastic_graph/graphql/datastore_query"
-        DatastoreQuery::Builder.with(
+        DatastoreQuery::Builder.new(
           filter_interpreter:,
           filter_node_interpreter:,
           runtime_metadata:,

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/datastore_query.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/datastore_query.rbs
@@ -14,7 +14,7 @@ module ElasticGraph
       def to_datastore_msearch_header_and_body: () -> [::Hash[::String, untyped], ::Hash[::String, untyped]]
 
       class Builder
-        def self.with: (
+        def self.new: (
           runtime_metadata: SchemaArtifacts::RuntimeMetadata::Schema,
           logger: ::Logger,
           **untyped

--- a/elasticgraph-graphql/spec/support/resolver.rb
+++ b/elasticgraph-graphql/spec/support/resolver.rb
@@ -34,7 +34,9 @@ module ResolverHelperMethods
 
       query = nil
       query_builder = -> {
-        query ||= query_adapter.build_query_from(field: field, lookahead: lookahead, args: args, context: context).with(**query_overrides)
+        query ||= query_adapter
+          .build_query_from(field: field, lookahead: lookahead, args: args, context: context)
+          .merge_with(**query_overrides)
       }
 
       begin

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/aggregations_spec.rb
@@ -15,11 +15,6 @@ module ElasticGraph
       include AggregationsHelpers
       include_context "DatastoreQueryUnitSupport"
 
-      it "excludes `aggs` if `aggregations` is `nil`" do
-        query = new_query(aggregations: nil)
-        expect(datastore_body_of(query)).to exclude(:aggs)
-      end
-
       it "excludes `aggs` if `aggregations` is not given" do
         expect(datastore_body_of(new_query)).to exclude(:aggs)
       end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/datastore_query_unit_support.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/datastore_query_unit_support.rb
@@ -24,9 +24,11 @@ module ElasticGraph
         end
       end
 
-      def new_query(aggregations: [], filter: nil, filters: [], **options)
+      def new_query(aggregations: {}, filter: nil, filters: [], **options)
+        aggregations = aggregations.to_h { |agg| [agg.name, agg] } if aggregations.is_a?(::Array)
+
         builder.new_query(
-          aggregations: aggregations.to_h { |agg| [agg.name, agg] },
+          aggregations: aggregations,
           search_index_definitions: graphql.datastore_core.index_definitions_by_graphql_type.fetch("Widget"),
           filters: filters + [filter].compact,
           **options

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/merge_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/merge_spec.rb
@@ -38,23 +38,22 @@ module ElasticGraph
           "but the following do not appear to have coverage: #{@attributes_needing_merge_test_coverage}"
       end
 
-      it "throws exception if attempting to merge two queries with different `search_index_definitions` values", covers: :search_index_definitions do
+      it "does not allow `search_index_definitions` to be overridden", covers: :search_index_definitions do
         widgets_def = graphql.datastore_core.index_definitions_by_name.fetch("widgets")
         components_def = graphql.datastore_core.index_definitions_by_name.fetch("components")
 
-        query1 = new_query(search_index_definitions: [widgets_def])
-        query2 = new_query(search_index_definitions: [components_def])
+        query = new_query(search_index_definitions: [widgets_def])
 
         expect {
-          merge(query1, query2)
-        }.to raise_error(ElasticGraph::Errors::InvalidMergeError, a_string_including("search_index_definitions", "widgets", "components"))
+          query.merge_with(search_index_definitions: [components_def])
+        }.to raise_error ArgumentError, a_string_including("search_index_definitions")
       end
 
       it "can merge `equal_to_any_of` conditions from two separate queries that are on separate fields", covers: :filters do
-        query1 = new_query(filters: [{"age" => {"equal_to_any_of" => [25, 30]}}])
-        query2 = new_query(filters: [{"size" => {"equal_to_any_of" => [10]}}])
-
-        merged = merge(query1, query2)
+        merged = merge(
+          {filters: [{"age" => {"equal_to_any_of" => [25, 30]}}]},
+          {filters: [{"size" => {"equal_to_any_of" => [10]}}]}
+        )
 
         expect(datastore_body_of(merged)).to filter_datastore_with(
           {terms: {"age" => [25, 30]}},
@@ -63,10 +62,10 @@ module ElasticGraph
       end
 
       it "can merge `equal_to_any_of` conditions from two separate queries that are on the same field", covers: :filters do
-        query1 = new_query(filters: [{"age" => {"equal_to_any_of" => [25, 30]}}])
-        query2 = new_query(filters: [{"age" => {"equal_to_any_of" => [35, 30]}}])
-
-        merged = merge(query1, query2)
+        merged = merge(
+          {filters: [{"age" => {"equal_to_any_of" => [25, 30]}}]},
+          {filters: [{"age" => {"equal_to_any_of" => [35, 30]}}]}
+        )
 
         expect(datastore_body_of(merged)).to filter_datastore_with(
           {terms: {"age" => [25, 30]}},
@@ -74,110 +73,99 @@ module ElasticGraph
         )
       end
 
-      it "can merge using `merge_with(**query_options)` as well", covers: :filters do
-        query1 = new_query(filters: [{"age" => {"equal_to_any_of" => [25, 30]}}])
-
-        merged = nil
-
-        expect {
-          merged = query1.merge_with(filters: [{"age" => {"equal_to_any_of" => [35, 30]}, "size" => {"equal_to_any_of" => [10]}}])
-        }.to maintain { query1 }.and maintain { query1.filters }
-
-        expect(datastore_body_of(merged)).to filter_datastore_with(
-          {terms: {"age" => [25, 30]}},
-          {terms: {"age" => [35, 30]}},
-          {terms: {"size" => [10]}}
-        )
-      end
-
       it "de-duplicates filters that are present in both queries", covers: :filters do
-        query1 = new_query(filters: [{"age" => {"equal_to_any_of" => [25, 30]}}])
-
-        merged = merge(query1, query1)
+        merged = merge(
+          {filters: [{"age" => {"equal_to_any_of" => [25, 30]}}]},
+          {filters: [{"age" => {"equal_to_any_of" => [25, 30]}}]}
+        )
 
         expect(merged.filters).to contain_exactly({"age" => {"equal_to_any_of" => [25, 30]}})
       end
 
-      it "uses only the tiebreaking sort clauses when merging two queries that have a `nil` sort", covers: :sort do
-        query1 = new_query(sort: nil, individual_docs_needed: true)
-        query2 = new_query(sort: nil, individual_docs_needed: true)
+      it "uses only the tiebreaking sort clauses when merging two queries that have an empty sort", covers: :sort do
+        merged = merge(
+          {sort: [], individual_docs_needed: true},
+          {sort: [], individual_docs_needed: true}
+        )
 
-        expect(datastore_body_of(merge(query1, query2))).to include_sort_with_tiebreaker
+        expect(datastore_body_of(merged)).to include_sort_with_tiebreaker
       end
 
       it "does not use tiebreaking sort clauses when any of the two queries already specifies them", covers: :sort do
-        # tiebreaker uses `asc` instead of `desc`
-        query1 = new_query(sort: [{"id" => {"order" => "desc"}}], individual_docs_needed: true)
-        query2 = new_query(sort: nil, individual_docs_needed: true)
+        merged = merge(
+          {sort: [{"id" => {"order" => "desc"}}], individual_docs_needed: true},
+          {sort: [], individual_docs_needed: true}
+        )
 
-        expect(datastore_body_of(merge(query1, query2))).to include(sort: [{"id" => {"order" => "desc", "missing" => "_last"}}])
+        expect(datastore_body_of(merged)).to include(sort: [{"id" => {"order" => "desc", "missing" => "_last"}}])
       end
 
       it "uses the `sort` value from either query when only one of them has a value", covers: :sort do
-        query1 = new_query(sort: [{created_at: {"order" => "asc"}}], individual_docs_needed: true)
-        query2 = new_query(sort: nil, individual_docs_needed: true)
-
-        merged = merge(query1, query2)
-        merged_reverse = merge(query2, query1)
+        merged = merge(
+          {sort: [{created_at: {"order" => "asc"}}], individual_docs_needed: true},
+          {sort: [], individual_docs_needed: true}
+        )
 
         expect(datastore_body_of(merged)).to include_sort_with_tiebreaker(created_at: {"order" => "asc"})
-        expect(datastore_body_of(merged_reverse)).to eq(datastore_body_of(merged))
       end
 
-      it "uses the `sort` value from the `query` argument when both queries have a `sort` value and logs a warning", covers: :sort do
-        query1 = new_query(sort: [{created_at: {"order" => "asc"}}], individual_docs_needed: true)
-        query2 = new_query(sort: [{created_at: {"order" => "desc"}}], individual_docs_needed: true)
+      it "uses the `sort` value from the `merge_with` argument when both queries have a `sort` value and logs a warning", covers: :sort do
+        query = new_query(sort: [{created_at: {"order" => "asc"}}], individual_docs_needed: true)
+        merged = nil
 
         expect {
-          merged = merge(query1, query2)
-          expect(datastore_body_of(merged)).to include_sort_with_tiebreaker(created_at: {"order" => "desc"})
-        }.to log a_string_including("Tried to merge two queries that both define `sort`")
+          merged = query.merge_with(
+            sort: [{created_at: {"order" => "desc"}}],
+            individual_docs_needed: true
+          )
+        }.to log a_string_including("Tried to merge conflicting values of `sort`")
+
+        expect(datastore_body_of(merged)).to include_sort_with_tiebreaker(created_at: {"order" => "desc"})
       end
 
       it "uses one of the `sort` values when `sort` values are the same and does not log a warning", covers: :sort do
-        query1 = new_query(sort: [{created_at: {"order" => "asc"}}], individual_docs_needed: true)
-        query2 = new_query(sort: [{created_at: {"order" => "asc"}}], individual_docs_needed: true)
-
         expect {
-          merged = merge(query1, query2)
+          merged = merge(
+            {sort: [{created_at: {"order" => "asc"}}], individual_docs_needed: true},
+            {sort: [{created_at: {"order" => "asc"}}], individual_docs_needed: true}
+          )
           expect(datastore_body_of(merged)).to include_sort_with_tiebreaker(created_at: {"order" => "asc"})
         }.to avoid_logging_warnings
       end
 
-      it "maintains a `document_pagination` value of `nil` when merging two queries that have a `nil` `document_pagination`", covers: :document_pagination do
-        query1 = new_query(document_pagination: nil)
-        query2 = new_query(document_pagination: nil)
-
-        merged = merge(query1, query2)
+      it "maintains a `document_pagination` value of `{}` when merging two queries that have `{}` for `document_pagination`", covers: :document_pagination do
+        merged = merge(
+          {document_pagination: {}},
+          {document_pagination: {}}
+        )
         expect(merged.document_pagination).to eq({})
       end
 
       it "uses the `document_pagination` value from either query when only one of them has a value", covers: :document_pagination do
-        query1 = new_query(document_pagination: {first: 2})
-        query2 = new_query(document_pagination: nil)
-
-        merged = merge(query1, query2)
-        merged_reverse = merge(query2, query1)
+        merged = merge(
+          {document_pagination: {first: 2}},
+          {document_pagination: {}}
+        )
         expect(merged.document_pagination).to eq({first: 2})
-        expect(merged_reverse.document_pagination).to eq(merged.document_pagination)
       end
 
-      it "uses the `document_pagination` value from the `query` argument when both queries have a `document_pagination` value and logs a warning", covers: :document_pagination do
-        query1 = new_query(document_pagination: {first: 2})
-        query2 = new_query(document_pagination: {first: 5})
+      it "uses the `document_pagination` value from the `merge_with` argument when both queries have a `document_pagination` value and logs a warning", covers: :document_pagination do
+        query = new_query(document_pagination: {first: 2})
+        merged = nil
 
         expect {
-          merged = merge(query1, query2)
-          expect(merged.document_pagination).to eq({first: 5})
-        }.to log a_string_including("Tried to merge two queries that both define `document_pagination`")
+          merged = query.merge_with(document_pagination: {first: 5})
+        }.to log a_string_including("Tried to merge conflicting values of `document_pagination`")
+
+        expect(merged.document_pagination).to eq({first: 5})
       end
 
       it "uses one of the `document_pagination` values when `document_pagination` values are the same and does not log a warning", covers: :document_pagination do
-        query1 = new_query(document_pagination: {first: 10})
-        query2 = new_query(document_pagination: {first: 10})
-
         expect {
-          merged = merge(query1, query2)
+          merged = merge(
+            {document_pagination: {first: 10}},
+            {document_pagination: {first: 10}}
+          )
           expect(merged.document_pagination).to eq({first: 10})
         }.to avoid_logging_warnings
       end
@@ -197,14 +185,12 @@ module ElasticGraph
           field_term_grouping_of("foo1", "bar1")
         ])
 
-        query1 = new_query(aggregations: [agg1, agg3])
-        query2 = new_query(aggregations: [agg2, agg3])
+        merged = merge(
+          {aggregations: {"a1" => agg1, "a3" => agg3}},
+          {aggregations: {"a2" => agg2, "a3" => agg3}}
+        )
 
-        merged1 = query1.merge(query2).aggregations
-        merged2 = query2.merge(query1).aggregations
-
-        expect(merged1).to eq(merged2)
-        expect(merged1).to eq({
+        expect(merged.aggregations).to eq({
           "a1" => agg1,
           "a2" => agg2,
           "a3" => agg3
@@ -212,95 +198,98 @@ module ElasticGraph
       end
 
       it "correctly merges requested fields from multiple queries by concatenating and de-duplicating them", covers: :requested_fields do
-        query1 = new_query(requested_fields: ["a", "b"])
-        query2 = new_query(requested_fields: ["b", "c"])
-
         expect {
-          expect(merge(query1, query2).requested_fields).to contain_exactly("a", "b", "c")
+          merged = merge(
+            {requested_fields: ["a", "b"]},
+            {requested_fields: ["b", "c"]}
+          )
+          expect(merged.requested_fields).to contain_exactly("a", "b", "c")
         }.to avoid_logging_warnings
       end
 
       it "sets `individual_docs_needed` to `true` if it is set on either query", covers: :individual_docs_needed do
-        query1 = new_query(individual_docs_needed: true)
-        query2 = new_query(individual_docs_needed: false)
-
-        expect(query1.merge(query2).individual_docs_needed).to be true
-        expect(query2.merge(query1).individual_docs_needed).to be true
+        merged = merge(
+          {individual_docs_needed: true},
+          {individual_docs_needed: false}
+        )
+        expect(merged.individual_docs_needed).to be true
       end
 
       it "sets `individual_docs_needed` to `false` if it is set to `false` on both queries", covers: :individual_docs_needed do
-        query1 = new_query(individual_docs_needed: false)
-        query2 = new_query(individual_docs_needed: false)
-
-        expect(query1.merge(query2).individual_docs_needed).to be false
-        expect(query2.merge(query1).individual_docs_needed).to be false
+        merged = merge(
+          {individual_docs_needed: false},
+          {individual_docs_needed: false}
+        )
+        expect(merged.individual_docs_needed).to be false
       end
 
       it "sets `total_document_count_needed` to `true` if it is set on either query", covers: :total_document_count_needed do
-        query1 = new_query(total_document_count_needed: true)
-        query2 = new_query(total_document_count_needed: false)
-
-        expect(query1.merge(query2).total_document_count_needed).to be true
-        expect(query2.merge(query1).total_document_count_needed).to be true
+        merged = merge(
+          {total_document_count_needed: true},
+          {total_document_count_needed: false}
+        )
+        expect(merged.total_document_count_needed).to be true
       end
 
       it "sets `total_document_count_needed` to `false` if it is set to `false` on both queries", covers: :total_document_count_needed do
-        query1 = new_query(total_document_count_needed: false)
-        query2 = new_query(total_document_count_needed: false)
-
-        expect(query1.merge(query2).total_document_count_needed).to be false
-        expect(query2.merge(query1).total_document_count_needed).to be false
+        merged = merge(
+          {total_document_count_needed: false},
+          {total_document_count_needed: false}
+        )
+        expect(merged.total_document_count_needed).to be false
       end
 
       it "forces `total_document_count_needed` to `true` if either query has an aggregation query that requires it", covers: :total_document_count_needed do
-        query1 = new_query(total_document_count_needed: false, aggregations: [aggregation_query_of(needs_doc_count: true)])
-        query2 = new_query(total_document_count_needed: false)
-
-        expect(query1.merge(query2).total_document_count_needed).to be true
-        expect(query2.merge(query1).total_document_count_needed).to be true
+        merged = merge(
+          {total_document_count_needed: false, aggregations: {"agg" => aggregation_query_of(needs_doc_count: true)}},
+          {total_document_count_needed: false}
+        )
+        expect(merged.total_document_count_needed).to be true
       end
 
       it "does not force `total_document_count_needed` to `true` if the aggregations query has groupings", covers: :total_document_count_needed do
-        query1 = new_query(total_document_count_needed: false, aggregations: [aggregation_query_of(
-          needs_doc_count: true,
-          groupings: [field_term_grouping_of("age")]
-        )])
-        query2 = new_query(total_document_count_needed: false)
-
-        expect(query1.merge(query2).total_document_count_needed).to be false
-        expect(query2.merge(query1).total_document_count_needed).to be false
+        merged = merge(
+          {
+            total_document_count_needed: false,
+            aggregations: {"agg" => aggregation_query_of(
+              needs_doc_count: true,
+              groupings: [field_term_grouping_of("age")]
+            )}
+          },
+          {total_document_count_needed: false}
+        )
+        expect(merged.total_document_count_needed).to be false
       end
 
       specify "#merge_with can merge in an empty filter", covers: :filters do
-        query1 = new_query(filters: [{"age" => {"equal_to_any_of" => [25, 30]}}])
-
-        expect(query1.merge_with).to eq query1
-        expect(query1.merge_with(filters: [])).to eq query1
+        query = new_query(filters: [{"age" => {"equal_to_any_of" => [25, 30]}}])
+        expect(query.merge_with).to eq query
+        expect(query.merge_with(filters: [])).to eq query
       end
 
       it "prefers a set `monotonic_clock_deadline` value to an unset one", covers: :monotonic_clock_deadline do
-        query1 = new_query(monotonic_clock_deadline: 5000)
-        query2 = new_query(monotonic_clock_deadline: nil)
-
-        expect(query1.merge(query2).monotonic_clock_deadline).to eq 5000
-        expect(query2.merge(query1).monotonic_clock_deadline).to eq 5000
+        merged = merge(
+          {monotonic_clock_deadline: 5000},
+          {monotonic_clock_deadline: nil}
+        )
+        expect(merged.monotonic_clock_deadline).to eq 5000
       end
 
       it "prefers the shorter `monotonic_clock_deadline` value so that we can default to an application config setting, " \
          "and override it with a shorter deadline", covers: :monotonic_clock_deadline do
-        query1 = new_query(monotonic_clock_deadline: 3000)
-        query2 = new_query(monotonic_clock_deadline: 6000)
-
-        expect(query1.merge(query2).monotonic_clock_deadline).to eq 3000
-        expect(query2.merge(query1).monotonic_clock_deadline).to eq 3000
+        merged = merge(
+          {monotonic_clock_deadline: 3000},
+          {monotonic_clock_deadline: 6000}
+        )
+        expect(merged.monotonic_clock_deadline).to eq 3000
       end
 
       it "leaves `monotonic_clock_deadline` unset if unset on both source queries", covers: :monotonic_clock_deadline do
-        query1 = new_query(monotonic_clock_deadline: nil)
-        query2 = new_query(monotonic_clock_deadline: nil)
-
-        expect(query1.merge(query2).monotonic_clock_deadline).to eq nil
-        expect(query2.merge(query1).monotonic_clock_deadline).to eq nil
+        merged = merge(
+          {monotonic_clock_deadline: nil},
+          {monotonic_clock_deadline: nil}
+        )
+        expect(merged.monotonic_clock_deadline).to eq nil
       end
 
       def filter_datastore_with(*filters)
@@ -312,15 +301,18 @@ module ElasticGraph
         include(sort: sort_list_with_missing_option_for(*sort_clauses))
       end
 
-      def merge(query1, query2)
-        merged = nil
+      def merge(query_attrs1, query_attrs2)
+        query1 = new_query(**query_attrs1)
+        merged_2_into_1 = query1.merge_with(**query_attrs2)
 
-        # merging should not mutate either query, so we assert that here
-        expect {
-          merged = query1.merge(query2)
-        }.to maintain { query1 }.and maintain { query2 }
+        query2 = new_query(**query_attrs2)
+        merged_1_into_2 = query2.merge_with(**query_attrs1)
 
-        merged
+        # Merge order should never matter.
+        expect(merged_1_into_2).to eq(merged_2_into_1)
+
+        # Shouldn't matter which we return since we've verified they are equal.
+        merged_2_into_1
       end
     end
   end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/pagination_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/pagination_spec.rb
@@ -16,8 +16,8 @@ module ElasticGraph
       let(:max_page_size) { 200 }
       let(:graphql) { build_graphql(default_page_size: default_page_size, max_page_size: max_page_size) }
 
-      it "excludes `search_after` when document_pagination is nil" do
-        query = new_query(document_pagination: nil)
+      it "excludes `search_after` when document_pagination is empty" do
+        query = new_query(document_pagination: {})
         expect(datastore_body_of(query).keys).to_not include(:search_after)
       end
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/shard_routing_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/shard_routing_spec.rb
@@ -536,7 +536,7 @@ module ElasticGraph
         end
       end
 
-      def shard_routing_for(route_with_field_paths, filter_or_filters, ignored_routing_values: [], aggregations: nil)
+      def shard_routing_for(route_with_field_paths, filter_or_filters, ignored_routing_values: [], aggregations: {})
         options = if filter_or_filters.is_a?(Array)
           {filters: filter_or_filters}
         else

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/sorting_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/sorting_spec.rb
@@ -20,11 +20,6 @@ module ElasticGraph
         expect(datastore_body_of(query)).to include_sort_with_tiebreaker
       end
 
-      it "uses only the tiebreaker sort clauses when given a nil `sort`" do
-        query = new_query(sort: nil, individual_docs_needed: true)
-        expect(datastore_body_of(query)).to include_sort_with_tiebreaker
-      end
-
       it "ignores duplicate sort fields, preferring whichever direction comes first" do
         query = new_query(sort: [{"foo" => {"order" => "asc"}}, {"foo" => {"order" => "desc"}}], individual_docs_needed: true)
         expect(datastore_body_of(query)).to include(sort: [{"foo" => {"order" => "asc", "missing" => "_first"}}, {"id" => {"order" => "asc", "missing" => "_first"}}])

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
@@ -284,12 +284,13 @@ module ElasticGraph
           end
         end
 
-        def new_widgets_query(**args)
+        def new_widgets_query(default_page_size: 50, **args)
           options = {
             search_index_definitions: [graphql.datastore_core.index_definitions_by_name.fetch("widgets")],
             sort: sort_list
           }.merge(args)
-          datastore_query_builder.new_query(**options)
+
+          datastore_query_builder.with(default_page_size: default_page_size).new_query(**options)
         end
       end
 


### PR DESCRIPTION
Profiling has revealed that `DatastoreQuery#merge_with` imposes significant overhead on some query patterns (particularly when nested relationships are resolved). The `NestedRelationship` resolver calls `query.merge_with(filters: ...)` each time it resolves a field. I've seen example cases where that happens more than 18,000 times for one GraphQL query.

The old implementation of `merge_with` was quite inefficient. It would:

* Make a new instance of `DatastoreQuery` using `#with`.
  * This would run our custom `initialize` logic as it was making a new instance.
* Delegate to `#merge`, which had its own complex attribute merging logic.
  * `#merge` would delegate to `#with`.
    * `#with` would make a new instance which would run our custom `initialize` logic again.

This optimizes it:

* We've removed support for `query1.merge(query2)`. We didn't actually use it outside tests.
* The custom `initialize` logic has been removed; instead we can apply it when q query is first created from `DatastoreQueryBuilder`.
* `#merge_with` has been updated to directly make the new instance with the overrides.

In my benchmarking, this makes some queries about 6% faster.