### PR TITLE
Update site publishing workflow.

### DIFF
--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -4,12 +4,23 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  publish-docs:
+  # Build job
+  build:
     runs-on: ubuntu-latest
 
     permissions:
@@ -31,20 +42,28 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@277ba2a127aba66d45bad0fa2dc56f80dbfedffa # v1.222.0
       with:
-        ruby-version: "3.3"
+        ruby-version: "3.4"
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-    - name: Build YARD docs and Jekyll site
+    - name: Build Jekyll site
       run: bundle exec rake site:build
+      env:
+        JEKYLL_ENV: production
 
-    - name: Deploy to GitHub Pages
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+    - name: Upload artifact
+      # Automatically uploads an artifact from the './_site' directory by default
+      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
       with:
-        # The GitHub Actions runner automatically creates this `GITHUB_TOKEN` secret
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        # The output directory for Jekyll
-        publish_dir: config/site/_site
-        # The branch to push to for GitHub Pages
-        publish_branch: gh-pages
-        enable_jekyll: true
+        path: config/site/_site
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
Previously, we relied on the "classic" branch-based site deployment. However, I've discovered that this is pinned to Jekyll 3.x, and they have no plans to upgrade it to Jekyll 4.x:

https://github.com/github/pages-gem/issues/651#issuecomment-2712968982

Instead, they recommend switching to a workflow-based deployment, in which we have full control of the version of Jekyll that is used. This updates `publish-site.yaml` to be our new deployment workflow.

This provides multiple benefits:

* It ensures that the version of Jekyll we use locally matches what is used to deploy the site.
* It should fix an issue I've noticed: the `_index.html` file generated by YARD is still a 404 at the deployed site, in spite of it working locally after my fixes in #312.
* It gets us off of the legacy deployment approach.

## Testing

I used `workflow_dispatch` to trigger a deploy and it works!

https://block.github.io/elasticgraph/docs/main/_index.html

<img width="996" alt="image" src="https://github.com/user-attachments/assets/2f17a9e6-ebdd-492d-b656-f62b3a2f1bbb" />

(That page was previously a 404.)