### PR TITLE
Bugfix: always return `[]` as the list representation of "no data".

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/get_record_field_value.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/get_record_field_value.rb
@@ -29,9 +29,8 @@ module ElasticGraph
               object
             end
 
-          value = Support::HashUtil.fetch_value_at_path(data, field_name) do
-            field.type.list? ? [] : nil
-          end
+          value = Support::HashUtil.fetch_value_at_path(data, field_name) { nil }
+          value = [] if value.nil? && field.type.list?
 
           if field.type.relay_connection?
             RelayConnection::ArrayAdapter.build(value, args, @schema_element_names, context)

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/get_record_field_value_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/get_record_field_value_spec.rb
@@ -75,6 +75,12 @@ module ElasticGraph
 
             expect(value).to eq []
           end
+
+          it "returns a blank list when a list field was indexed with a `null` value" do
+            value = resolve("Person", "nicknames", {"id" => 2, "nicknames" => nil})
+
+            expect(value).to eq []
+          end
         end
 
         context "for a field with customizations" do


### PR DESCRIPTION
Previously, we returned `[]` from a list field added to the schema after a document was indexed (such that the document lacks the field entirely). But for a document that was indexed with a value of `null` for the list field (e.g. because the field was defined as nullable), we returned `null`. This causes a problem when the field type is changed to non-null (which our docs encourage for list fields), and is inconsistent--we want to treat an explicit `null` value the same as a field being missing from a document.