### PR TITLE
Provide new useful metrics from our query log messages.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_executor.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_executor.rb
@@ -101,12 +101,16 @@ module ElasticGraph
             "query_fingerprint" => fingerprint_for(query),
             "query_name" => query.operation_name,
             "duration_ms" => duration,
-            # Here we log how long the datastore queries took according to what the datastore itself reported.
+            # How long the datastore queries took according to what the datastore itself reported.
             "datastore_server_duration_ms" => query_tracker.datastore_query_server_duration_ms,
-            # Here we log an estimate for how much overhead ElasticGraph added on top of how long the datastore took.
+            # An estimate for how much overhead ElasticGraph added on top of how long the datastore took.
             # This is based on the duration, excluding how long the datastore calls took from the client side
             # (e.g. accounting for network latency, serialization time, etc)
             "elasticgraph_overhead_ms" => duration - query_tracker.datastore_query_client_duration_ms,
+            # An estimate for the time spent on transport (network latency, JSON serialization, etc).
+            "datastore_request_transport_duration_ms" => query_tracker.datastore_request_transport_duration_ms,
+            # How many datastore shards were queried, in total. This is a measure of how much load the query caused on the datastore.
+            "queried_shard_count" => query_tracker.queried_shard_count,
             # According to https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html#metric-filters-extract-json,
             # > Value nodes can be strings or numbers...If a property selector points to an array or object, the metric filter won't match the log format.
             # So, to allow flexibility to deal with cloud watch metric filters, we coerce these values to a string here.

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/query_details_tracker.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/query_details_tracker.rbs
@@ -7,6 +7,7 @@ module ElasticGraph
       attr_accessor query_counts_per_datastore_request: ::Array[::Integer]
       attr_accessor datastore_query_server_duration_ms: ::Integer
       attr_accessor datastore_query_client_duration_ms: ::Integer
+      attr_accessor queried_shard_count: ::Integer
       attr_accessor mutex: ::Thread::Mutex
 
       def initialize: (
@@ -16,6 +17,7 @@ module ElasticGraph
         query_counts_per_datastore_request: ::Array[::Integer],
         datastore_query_server_duration_ms: ::Integer,
         datastore_query_client_duration_ms: ::Integer,
+        queried_shard_count: ::Integer,
         mutex: ::Thread::Mutex
       ) -> void
     end
@@ -24,7 +26,13 @@ module ElasticGraph
       def self.empty: () -> QueryDetailsTracker
       def record_datastore_queries_for_single_request: (::Array[DatastoreQuery]) -> void
       def record_hidden_type: (::String) -> void
-      def record_datastore_query_duration_ms: (client: ::Integer, server: ::Integer?) -> void
+      def record_datastore_query_metrics: (
+        client_duration_ms: ::Integer,
+        server_duration_ms: ::Integer?,
+        queried_shard_count: ::Integer
+      ) -> void
+
+      def datastore_request_transport_duration_ms: () -> ::Integer
     end
   end
 end


### PR DESCRIPTION
Specifically, this adds two new metrics to the `ElasticGraphQueryExecutorQueryDuration` messages:

- `queried_shard_count`: this measures how much load a query imposed on the datastore. It is a sum of the `_shards.total` values from all datastore search responses.
- `datastore_request_transport_duration_ms`: this measures network transport time, simply by subtracting the duration the server reported from the duration the client observed.

Closes #245.