### PR TITLE
Refactor site layouts: extract `base.html`.

### DIFF
--- a/config/site/src/_layouts/base.html
+++ b/config/site/src/_layouts/base.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en"{% if layout.html_class %} class="{{ layout.html_class }}"{% endif %}>
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ page.title }}</title>
+  <meta name="description" content="{{ site.description }}">
+  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+  <link rel="stylesheet" href="{{ '/assets/css/highlight.css' | relative_url }}">
+  {% if layout.use_anchor_headings %}
+  <script src="{{ '/assets/js/anchor-headings.js' | relative_url }}" defer></script>
+  {% endif %}
+</head>
+
+<body class="{{ site.style.body }}">
+  {% include navbar.html %}
+  {{ content }}
+  {% include footer.html %}
+</body>
+
+</html>

--- a/config/site/src/_layouts/default.html
+++ b/config/site/src/_layouts/default.html
@@ -1,21 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{{ page.title }}</title>
-  <meta name="description" content="{{ site.description }}">
-  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
-  <link rel="stylesheet" href="{{ '/assets/css/highlight.css' | relative_url }}">
-</head>
-
-<body class="{{ site.style.body }}">
-  {% include navbar.html %}
-
-  {{ content }}
-
-  {% include footer.html %}
-</body>
-
-</html>
+---
+layout: base
+---
+{{ content }}

--- a/config/site/src/_layouts/markdown.html
+++ b/config/site/src/_layouts/markdown.html
@@ -1,29 +1,14 @@
-<!DOCTYPE html>
-<html lang="en" class="dark">
+---
+layout: base
+html_class: dark
+use_anchor_headings: true
+---
+<main class="grow">
+  <div class="container mx-auto px-4 py-8 lg:py-20">
+    <article class="prose dark:prose-invert lg:prose-xl">
+      <h2>{{ page.title }}</h2>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{{ page.title }}</title>
-  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
-  <link rel="stylesheet" href="{{ '/assets/css/highlight.css' | relative_url }}">
-  <script src="{{ '/assets/js/anchor-headings.js' | relative_url }}" defer></script>
-</head>
-
-<body class="{{ site.style.body }}">
-  {% include navbar.html %}
-
-  <main class="grow">
-    <div class="container mx-auto px-4 py-8 lg:py-20">
-      <article class="prose dark:prose-invert lg:prose-xl">
-        <h2>{{ page.title }}</h2>
-
-        {{ content }}
-      </article>
-    </div>
-  </main>
-
-  {% include footer.html %}
-</body>
-
-</html>
+      {{ content }}
+    </article>
+  </div>
+</main>


### PR DESCRIPTION
This allows `default.html` and `markdown.html` to avoid repeating the same common elements, and gives us a single place to make changes that impact the layout of any page on the site.