### PR TITLE
Build multi-platform docker images.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ env:
   # We use the VCR gem as a local "test accelerator" which caches datastore requests/responses for us.
   # But in our CI build we don't want to use it at all, so we disable it here.
   NO_VCR: "1"
+  docker_platforms: linux/amd64,linux/arm64
 
 jobs:
   ci-check:
@@ -95,6 +96,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        with:
+          driver: docker-container
 
       - name: Build OpenSearch image
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
@@ -138,6 +141,7 @@ jobs:
           context: elasticgraph-local/lib/elastic_graph/local/opensearch
           file: elasticgraph-local/lib/elastic_graph/local/opensearch/Dockerfile
           push: true
+          platforms: ${{ env.docker_platforms }}
           build-args: |
             VERSION=${{ env.OPENSEARCH_VERSION }}
           tags: |
@@ -151,6 +155,7 @@ jobs:
           context: .
           file: config/docker_demo/Dockerfile
           push: true
+          platforms: ${{ env.docker_platforms }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/elasticgraph-demo:${{ github.sha }}
             ghcr.io/${{ github.repository_owner }}/elasticgraph-demo:latest

--- a/script/update_ci_yaml
+++ b/script/update_ci_yaml
@@ -105,6 +105,7 @@ env:
   # We use the VCR gem as a local "test accelerator" which caches datastore requests/responses for us.
   # But in our CI build we don't want to use it at all, so we disable it here.
   NO_VCR: "1"
+  docker_platforms: linux/amd64,linux/arm64
 
 jobs:
   ci-check:
@@ -185,6 +186,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        with:
+          driver: docker-container
 
       - name: Build OpenSearch image
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
@@ -228,6 +231,7 @@ jobs:
           context: elasticgraph-local/lib/elastic_graph/local/opensearch
           file: elasticgraph-local/lib/elastic_graph/local/opensearch/Dockerfile
           push: true
+          platforms: ${{ env.docker_platforms }}
           build-args: |
             VERSION=${{ env.OPENSEARCH_VERSION }}
           tags: |
@@ -241,6 +245,7 @@ jobs:
           context: .
           file: config/docker_demo/Dockerfile
           push: true
+          platforms: ${{ env.docker_platforms }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/elasticgraph-demo:${{ github.sha }}
             ghcr.io/${{ github.repository_owner }}/elasticgraph-demo:latest


### PR DESCRIPTION
When using our published docker images, I'm getting an error:

```
$ curl -s https://raw.githubusercontent.com/block/elasticgraph/refs/heads/main/config/docker_demo/docker-compose.yaml | docker compose -f - up
[+] Running 2/2
 ✘ opensearch Error   context canceled                                                                                                                                                                                                                                                                                                                                 0.7s
 ✘ elasticgraph Error no matching manifest for linux/arm64/v8 in the manifest list entries: no match for platform in manifest: not found                                                                                                                                                                                                                               0.7s
Error response from daemon: no matching manifest for linux/arm64/v8 in the manifest list entries: no match for platform in manifest: not found
```

I am hopeful this will fix it.