### PR TITLE
Remove backticks from around inline code snippets.

### DIFF
--- a/config/site/src/assets/css/tailwind.css
+++ b/config/site/src/assets/css/tailwind.css
@@ -20,6 +20,17 @@
   }
 }
 
+@layer utilities {
+  .prose {
+    code {
+      &::before,
+      &::after {
+        content: none;
+      }
+    }
+  }
+}
+
 @layer components {
   /* NOTE: Be sure to include `dark:` prefixed styles for handling dark-mode UI */
   /* Buttons */


### PR DESCRIPTION
It comes with tailwindcss typography, but I don't like it.

Before:

![image](https://github.com/user-attachments/assets/de718dd1-8abf-4539-8107-40b5e6ffd05d)

After:

![image](https://github.com/user-attachments/assets/ab4cb05e-c68d-48ae-8a65-bc32d7d2162d)
