### PR TITLE
Automate keeping copyright notices up to date.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2024 Block, Inc.
+Copyright (c) 2024 - 2025 Block, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/Steepfile
+++ b/Steepfile
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/config/docker_demo/Gemfile
+++ b/config/docker_demo/Gemfile
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/config/linting/custom_cops/require_standard_comment_header.rb
+++ b/config/linting/custom_cops/require_standard_comment_header.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/config/linting/custom_cops/require_standard_comment_header.rb
+++ b/config/linting/custom_cops/require_standard_comment_header.rb
@@ -7,6 +7,7 @@
 # frozen_string_literal: true
 
 require "rubocop"
+require "date"
 
 module ElasticGraph
   class RequireStandardCommentHeader < ::RuboCop::Cop::Base
@@ -21,40 +22,42 @@ module ElasticGraph
     #
     # For further discussion, see:
     # https://github.com/standardrb/standard/pull/181
-    STANDARD_COMMENT_HEADER = <<~EOS
-      # Copyright 2024 Block, Inc.
-      #
-      # Use of this source code is governed by an MIT-style
-      # license that can be found in the LICENSE file or at
-      # https://opensource.org/licenses/MIT.
-      #
-      # frozen_string_literal: true
 
-    EOS
+    def standard_comment_header
+      <<~EOS
+        # Copyright 2024 - #{Date.today.year} Block, Inc.
+        #
+        # Use of this source code is governed by an MIT-style
+        # license that can be found in the LICENSE file or at
+        # https://opensource.org/licenses/MIT.
+        #
+        # frozen_string_literal: true
 
-    STANDARD_COMMENT_HEADER_LINES = STANDARD_COMMENT_HEADER.lines.map(&:chomp)
+      EOS
+    end
 
     def on_new_investigation
       # Don't mess with files that start with a shebang line -- that must go first and can't be changed.
       return if processed_source.lines.first.start_with?("#!")
 
+      header_lines = standard_comment_header.lines.map(&:chomp)
       last_leading_comment_line_number = find_last_leading_comment_line_number
       leading_comment_lines = processed_source.lines[0...last_leading_comment_line_number - 1]
-      possible_header_lines = leading_comment_lines.first(STANDARD_COMMENT_HEADER_LINES.size)
+      possible_header_lines = leading_comment_lines.first(header_lines.size)
 
-      unless possible_header_lines == STANDARD_COMMENT_HEADER_LINES
+      unless possible_header_lines == header_lines
         if possible_header_lines.join("\n").include?("Block, Inc.") && possible_header_lines.join("\n").include?("frozen_string_literal: true")
-          range = processed_source.buffer.line_range(STANDARD_COMMENT_HEADER_LINES.size - 1)
+          range = processed_source.buffer.line_range(header_lines.size - 1)
           add_offense(range, message: "Standard header is out of date.") do |corrector|
             first_line_to_replace = processed_source.buffer.line_range(1)
-            last_line_to_replace = processed_source.buffer.line_range(STANDARD_COMMENT_HEADER_LINES.size - 1)
+            last_line_to_replace = processed_source.buffer.line_range(header_lines.size - 1)
             range = first_line_to_replace.join(last_line_to_replace)
 
             replacement =
-              if processed_source.buffer.line_range(STANDARD_COMMENT_HEADER_LINES.size).source == ""
-                STANDARD_COMMENT_HEADER.strip
+              if processed_source.buffer.line_range(header_lines.size).source == ""
+                standard_comment_header.strip
               else
-                STANDARD_COMMENT_HEADER.strip + "\n"
+                standard_comment_header.strip + "\n"
               end
 
             corrector.replace(range, replacement)
@@ -62,7 +65,7 @@ module ElasticGraph
         else
           range = processed_source.buffer.line_range(1)
           add_offense(range, message: "Missing standard comment header at top of file.") do |corrector|
-            corrector.insert_before(range, STANDARD_COMMENT_HEADER)
+            corrector.insert_before(range, standard_comment_header)
           end
         end
       end

--- a/config/linting/custom_cops/require_standard_comment_header_spec.rb
+++ b/config/linting/custom_cops/require_standard_comment_header_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/config/linting/custom_cops/require_standard_comment_header_spec.rb
+++ b/config/linting/custom_cops/require_standard_comment_header_spec.rb
@@ -8,12 +8,16 @@
 
 require_relative "require_standard_comment_header"
 require "rubocop/rspec/support"
+require "date"
 
 module ElasticGraph
   RSpec.describe RequireStandardCommentHeader do
     include ::RuboCop::RSpec::ExpectOffense
+
     let(:cop) { RequireStandardCommentHeader.new(config) }
     let(:config) { ::RuboCop::Config.new("ElasticGraph/RequireStandardCommentHeader" => {"Enabled" => true}) }
+    let(:current_year) { Date.today.year }
+    let(:year_range) { "2024 - #{current_year}" }
 
     it "autocorrects a file that does not have the standard header" do
       expect_offense(<<~RUBY)
@@ -23,7 +27,7 @@ module ElasticGraph
       RUBY
 
       expect_correction(<<~RUBY)
-        # Copyright 2024 Block, Inc.
+        # Copyright #{year_range} Block, Inc.
         #
         # Use of this source code is governed by an MIT-style
         # license that can be found in the LICENSE file or at
@@ -38,7 +42,7 @@ module ElasticGraph
 
     it "does not register an offense when a file has the standard header (and no other leading comments)" do
       expect_no_offenses(<<~RUBY)
-        # Copyright 2024 Block, Inc.
+        # Copyright #{year_range} Block, Inc.
         #
         # Use of this source code is governed by an MIT-style
         # license that can be found in the LICENSE file or at
@@ -53,7 +57,7 @@ module ElasticGraph
 
     it "autocorrects a file when the class documentation has no blank line between it and the standard header" do
       expect_offense(<<~RUBY)
-        # Copyright 2024 Block, Inc.
+        # Copyright #{year_range} Block, Inc.
         #
         # Use of this source code is governed by an MIT-style
         # license that can be found in the LICENSE file or at
@@ -67,7 +71,7 @@ module ElasticGraph
       RUBY
 
       expect_correction(<<~RUBY)
-        # Copyright 2024 Block, Inc.
+        # Copyright #{year_range} Block, Inc.
         #
         # Use of this source code is governed by an MIT-style
         # license that can be found in the LICENSE file or at
@@ -83,7 +87,7 @@ module ElasticGraph
 
     it "does not register an offense when a file has the standard header and other leading comments with a blank line in between" do
       expect_no_offenses(<<~RUBY)
-        # Copyright 2024 Block, Inc.
+        # Copyright #{year_range} Block, Inc.
         #
         # Use of this source code is governed by an MIT-style
         # license that can be found in the LICENSE file or at
@@ -105,7 +109,7 @@ module ElasticGraph
       RUBY
 
       expect_correction(<<~RUBY)
-        # Copyright 2024 Block, Inc.
+        # Copyright #{year_range} Block, Inc.
         #
         # Use of this source code is governed by an MIT-style
         # license that can be found in the LICENSE file or at
@@ -120,7 +124,7 @@ module ElasticGraph
 
     it "does not register an offense when a file is only comments and has the standard header" do
       expect_no_offenses(<<~RUBY)
-        # Copyright 2024 Block, Inc.
+        # Copyright #{year_range} Block, Inc.
         #
         # Use of this source code is governed by an MIT-style
         # license that can be found in the LICENSE file or at
@@ -135,7 +139,7 @@ module ElasticGraph
 
     it "autocorrects a comments-only file when the non-standard comments have no blank comment line between them and the standard header" do
       expect_offense(<<~RUBY)
-        # Copyright 2024 Block, Inc.
+        # Copyright #{year_range} Block, Inc.
         #
         # Use of this source code is governed by an MIT-style
         # license that can be found in the LICENSE file or at
@@ -148,7 +152,7 @@ module ElasticGraph
       RUBY
 
       expect_correction(<<~RUBY)
-        # Copyright 2024 Block, Inc.
+        # Copyright #{year_range} Block, Inc.
         #
         # Use of this source code is governed by an MIT-style
         # license that can be found in the LICENSE file or at
@@ -163,7 +167,7 @@ module ElasticGraph
 
     it "autocorrects an out-of-date standard header" do
       expect_offense(<<~RUBY)
-        # Copyright 2023 Block, Inc.
+        # Copyright 2024 Block, Inc.
         #
         # Use of this source code is governed by an MIT-style
         # license that can be found in the LICENSE file or at
@@ -177,7 +181,7 @@ module ElasticGraph
       RUBY
 
       expect_correction(<<~RUBY)
-        # Copyright 2024 Block, Inc.
+        # Copyright #{year_range} Block, Inc.
         #
         # Use of this source code is governed by an MIT-style
         # license that can be found in the LICENSE file or at
@@ -196,6 +200,17 @@ module ElasticGraph
 
         puts "hello world"
       RUBY
+    end
+
+    describe "LICENSE.txt" do
+      let(:expected_copyright) { "Copyright (c) 2024 - #{current_year} Block, Inc." }
+
+      it "has an up-to-date copyright notice" do
+        license_content = File.read(File.expand_path("../../../LICENSE.txt", __dir__))
+        copyright_line = license_content.lines.find { |line| line.include?("Copyright") }.to_s.strip
+
+        expect(copyright_line).to eq(expected_copyright)
+      end
     end
   end
 end

--- a/config/release/Gemfile
+++ b/config/release/Gemfile
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/config/release/Rakefile
+++ b/config/release/Rakefile
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/config/schema.rb
+++ b/config/schema.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/config/schema/teams.rb
+++ b/config/schema/teams.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/config/schema/widgets.rb
+++ b/config/schema/widgets.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/config/site/Rakefile
+++ b/config/site/Rakefile
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/config/site/examples/music/schema.rb
+++ b/config/site/examples/music/schema.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/config/site/src/_includes/footer.html
+++ b/config/site/src/_includes/footer.html
@@ -56,7 +56,7 @@
 
     <div class="mt-8 pt-8 border-t border-gray-300 dark:border-gray-700 text-sm text-gray-600 dark:text-gray-400 flex justify-between items-center">
       <div>
-        &copy; {{ 'now' | date: "%Y" }} Block, Inc. Released under the MIT License.
+        &copy; 2024 - {{ 'now' | date: "%Y" }} Block, Inc. Released under the MIT License.
       </div>
       <div class="flex items-center gap-4">
         {% if page.path %}

--- a/config/site/src/_plugins/doc_versions.rb
+++ b/config/site/src/_plugins/doc_versions.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/config/site/support/content_extractor.rb
+++ b/config/site/support/content_extractor.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/config/site/support/doctest_helper.rb
+++ b/config/site/support/doctest_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/elasticgraph-admin.gemspec
+++ b/elasticgraph-admin/elasticgraph-admin.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/lib/elastic_graph/admin.rb
+++ b/elasticgraph-admin/lib/elastic_graph/admin.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/lib/elastic_graph/admin/cluster_configurator.rb
+++ b/elasticgraph-admin/lib/elastic_graph/admin/cluster_configurator.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/lib/elastic_graph/admin/cluster_configurator/action_reporter.rb
+++ b/elasticgraph-admin/lib/elastic_graph/admin/cluster_configurator/action_reporter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/lib/elastic_graph/admin/cluster_configurator/cluster_settings_manager.rb
+++ b/elasticgraph-admin/lib/elastic_graph/admin/cluster_configurator/cluster_settings_manager.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/lib/elastic_graph/admin/cluster_configurator/script_configurator.rb
+++ b/elasticgraph-admin/lib/elastic_graph/admin/cluster_configurator/script_configurator.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/lib/elastic_graph/admin/datastore_client_dry_run_decorator.rb
+++ b/elasticgraph-admin/lib/elastic_graph/admin/datastore_client_dry_run_decorator.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/lib/elastic_graph/admin/index_definition_configurator.rb
+++ b/elasticgraph-admin/lib/elastic_graph/admin/index_definition_configurator.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/lib/elastic_graph/admin/index_definition_configurator/for_index.rb
+++ b/elasticgraph-admin/lib/elastic_graph/admin/index_definition_configurator/for_index.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/lib/elastic_graph/admin/index_definition_configurator/for_index_template.rb
+++ b/elasticgraph-admin/lib/elastic_graph/admin/index_definition_configurator/for_index_template.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/lib/elastic_graph/admin/rake_tasks.rb
+++ b/elasticgraph-admin/lib/elastic_graph/admin/rake_tasks.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/spec/integration/elastic_graph/admin/cluster_configurator_spec.rb
+++ b/elasticgraph-admin/spec/integration/elastic_graph/admin/cluster_configurator_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/for_index_spec.rb
+++ b/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/for_index_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/for_index_template_spec.rb
+++ b/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/for_index_template_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/shared_examples.rb
+++ b/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/shared_examples.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/spec/integration/elastic_graph/admin/rake_tasks_spec.rb
+++ b/elasticgraph-admin/spec/integration/elastic_graph/admin/rake_tasks_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/spec/spec_helper.rb
+++ b/elasticgraph-admin/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/spec/unit/elastic_graph/admin/cluster_configurator/cluster_setting_manager_spec.rb
+++ b/elasticgraph-admin/spec/unit/elastic_graph/admin/cluster_configurator/cluster_setting_manager_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/spec/unit/elastic_graph/admin/rake_tasks_spec.rb
+++ b/elasticgraph-admin/spec/unit/elastic_graph/admin/rake_tasks_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin/spec/unit/elastic_graph/admin_spec.rb
+++ b/elasticgraph-admin/spec/unit/elastic_graph/admin_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin_lambda/elasticgraph-admin_lambda.gemspec
+++ b/elasticgraph-admin_lambda/elasticgraph-admin_lambda.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin_lambda/lib/elastic_graph/admin_lambda.rb
+++ b/elasticgraph-admin_lambda/lib/elastic_graph/admin_lambda.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin_lambda/lib/elastic_graph/admin_lambda/Rakefile
+++ b/elasticgraph-admin_lambda/lib/elastic_graph/admin_lambda/Rakefile
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin_lambda/lib/elastic_graph/admin_lambda/lambda_function.rb
+++ b/elasticgraph-admin_lambda/lib/elastic_graph/admin_lambda/lambda_function.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin_lambda/lib/elastic_graph/admin_lambda/rake_adapter.rb
+++ b/elasticgraph-admin_lambda/lib/elastic_graph/admin_lambda/rake_adapter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin_lambda/spec/integration/elastic_graph/admin_lambda/rake_adapter_spec.rb
+++ b/elasticgraph-admin_lambda/spec/integration/elastic_graph/admin_lambda/rake_adapter_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin_lambda/spec/spec_helper.rb
+++ b/elasticgraph-admin_lambda/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin_lambda/spec/unit/elastic_graph/admin_lambda/lambda_function_spec.rb
+++ b/elasticgraph-admin_lambda/spec/unit/elastic_graph/admin_lambda/lambda_function_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-admin_lambda/spec/unit/elastic_graph/admin_lambda_spec.rb
+++ b/elasticgraph-admin_lambda/spec/unit/elastic_graph/admin_lambda_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/apollo_tests_implementation/Gemfile
+++ b/elasticgraph-apollo/apollo_tests_implementation/Gemfile
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/apollo_tests_implementation/Rakefile
+++ b/elasticgraph-apollo/apollo_tests_implementation/Rakefile
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/apollo_tests_implementation/config.ru
+++ b/elasticgraph-apollo/apollo_tests_implementation/config.ru
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/apollo_tests_implementation/config/products_schema.rb
+++ b/elasticgraph-apollo/apollo_tests_implementation/config/products_schema.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/apollo_tests_implementation/lib/product_resolver.rb
+++ b/elasticgraph-apollo/apollo_tests_implementation/lib/product_resolver.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/elasticgraph-apollo.gemspec
+++ b/elasticgraph-apollo/elasticgraph-apollo.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/engine_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/engine_extension.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/entities_field_resolver.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/entities_field_resolver.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/http_endpoint_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/http_endpoint_extension.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/service_field_resolver.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/service_field_resolver.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/api_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/api_extension.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/apollo_directives.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/apollo_directives.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/argument_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/argument_extension.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/entity_type_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/entity_type_extension.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/enum_type_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/enum_type_extension.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/enum_value_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/enum_value_extension.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/factory_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/factory_extension.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/field_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/field_extension.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/input_type_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/input_type_extension.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/interface_type_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/interface_type_extension.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/object_type_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/object_type_extension.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/scalar_type_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/scalar_type_extension.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/state_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/state_extension.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/union_type_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/union_type_extension.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/spec/integration/elastic_graph/apollo/graphql/entities_field_resolver_spec.rb
+++ b/elasticgraph-apollo/spec/integration/elastic_graph/apollo/graphql/entities_field_resolver_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/spec/spec_helper.rb
+++ b/elasticgraph-apollo/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/spec/unit/elastic_graph/apollo/apollo_directives_spec.rb
+++ b/elasticgraph-apollo/spec/unit/elastic_graph/apollo/apollo_directives_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/spec/unit/elastic_graph/apollo/graphql/http_endpoint_extension_spec.rb
+++ b/elasticgraph-apollo/spec/unit/elastic_graph/apollo/graphql/http_endpoint_extension_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/spec/unit/elastic_graph/apollo/graphql/service_field_resolver_spec.rb
+++ b/elasticgraph-apollo/spec/unit/elastic_graph/apollo/graphql/service_field_resolver_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
+++ b/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/elasticgraph-datastore_core.gemspec
+++ b/elasticgraph-datastore_core/elasticgraph-datastore_core.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/config.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/config.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/configuration/client_faraday_adapter.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/configuration/client_faraday_adapter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/configuration/cluster_definition.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/configuration/cluster_definition.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/configuration/index_definition.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/configuration/index_definition.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_config_normalizer.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_config_normalizer.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/base.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/base.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/index.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/index.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/rollover_index.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/rollover_index.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/rollover_index_template.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/rollover_index_template.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/spec/integration/elastic_graph/datastore_core/index_definition/implementation_shared_examples.rb
+++ b/elasticgraph-datastore_core/spec/integration/elastic_graph/datastore_core/index_definition/implementation_shared_examples.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/spec/integration/elastic_graph/datastore_core/index_definition/index_spec.rb
+++ b/elasticgraph-datastore_core/spec/integration/elastic_graph/datastore_core/index_definition/index_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/spec/integration/elastic_graph/datastore_core/index_definition/rollover_index_template_spec.rb
+++ b/elasticgraph-datastore_core/spec/integration/elastic_graph/datastore_core/index_definition/rollover_index_template_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/spec/spec_helper.rb
+++ b/elasticgraph-datastore_core/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/config_spec.rb
+++ b/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/config_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/index_config_normalizer_spec.rb
+++ b/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/index_config_normalizer_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/index_definition/implementation_shared_examples.rb
+++ b/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/index_definition/implementation_shared_examples.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/index_definition/index_spec.rb
+++ b/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/index_definition/index_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/index_definition/rollover_index_template_spec.rb
+++ b/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/index_definition/rollover_index_template_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core_spec.rb
+++ b/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-elasticsearch/elasticgraph-elasticsearch.gemspec
+++ b/elasticgraph-elasticsearch/elasticgraph-elasticsearch.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-elasticsearch/lib/elastic_graph/elasticsearch/client.rb
+++ b/elasticgraph-elasticsearch/lib/elastic_graph/elasticsearch/client.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-elasticsearch/spec/spec_helper.rb
+++ b/elasticgraph-elasticsearch/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-elasticsearch/spec/unit/elastic_graph/elasticsearch/client_spec.rb
+++ b/elasticgraph-elasticsearch/spec/unit/elastic_graph/elasticsearch/client_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/elasticgraph-graphql.gemspec
+++ b/elasticgraph-graphql/elasticgraph-graphql.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/composite_grouping_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/composite_grouping_adapter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/computation.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/computation.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/date_histogram_grouping.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/date_histogram_grouping.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/field_path_encoder.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/field_path_encoder.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/field_term_grouping.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/field_term_grouping.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/key.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/key.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/nested_sub_aggregation.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/nested_sub_aggregation.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/non_composite_grouping_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/non_composite_grouping_adapter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/path_segment.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/path_segment.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_adapter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_optimizer.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_optimizer.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/count_detail.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/count_detail.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/grouped_by.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/grouped_by.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/node.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/node.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/relay_connection_builder.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/relay_connection_builder.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/sub_aggregations.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/sub_aggregations.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/script_term_grouping.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/script_term_grouping.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/term_grouping.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/term_grouping.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/client.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/client.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/config.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/config.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/document_paginator.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/document_paginator.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/index_expression_builder.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/index_expression_builder.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/paginator.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/paginator.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/routing_picker.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/routing_picker.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_response/document.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_response/document.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_response/search_response.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_response/search_response.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_search_router.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_search_router.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/decoded_cursor.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/decoded_cursor.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/boolean_query.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/boolean_query.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/field_path.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/field_path.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_args_translator.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_args_translator.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_interpreter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_interpreter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_node_interpreter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_node_interpreter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_value_set_extractor.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_value_set_extractor.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/range_query.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/range_query.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/monkey_patches/schema_field.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/monkey_patches/schema_field.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/monkey_patches/schema_object.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/monkey_patches/schema_object.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/filters.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/filters.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/pagination.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/pagination.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/requested_fields.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/requested_fields.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/sort.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/sort.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_details_tracker.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_details_tracker.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_executor.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_executor.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/get_record_field_value.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/get_record_field_value.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter_builder.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter_builder.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/interface.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/interface.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/list_records.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/list_records.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/object.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/object.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/query_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/query_adapter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/query_source.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/query_source.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/array_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/array_adapter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/generic_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/generic_adapter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/page_info.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/page_info.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/search_response_adapter_builder.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/search_response_adapter_builder.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/resolvable_value.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/resolvable_value.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/cursor.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/cursor.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/date.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/date.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/date_time.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/date_time.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/local_time.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/local_time.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/longs.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/longs.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/no_op.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/no_op.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/time_zone.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/time_zone.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/untyped.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/untyped.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/valid_time_zones.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/valid_time_zones.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/arguments.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/arguments.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/enum_value.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/enum_value.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/field.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/field.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/relation_join.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/relation_join.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/type.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/type.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/script/dump_time_zones
+++ b/elasticgraph-graphql/script/dump_time_zones
@@ -8,7 +8,7 @@ updated_code_filename = "#{__dir__}/../../tmp/updated_valid_time_zones.rb"
 java_time_zones = `java --source 11 #{__dir__}/dump_time_zones.java`.split("\n")
 
 ::File.write(updated_code_filename, <<~EOS)
-  # Copyright 2024 Block, Inc.
+  # Copyright 2024 - 2025 Block, Inc.
   #
   # Use of this source code is governed by an MIT-style
   # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/acceptance/aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/aggregations_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/acceptance/datastore_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/datastore_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/acceptance/elasticgraph_graphql_acceptance_support.rb
+++ b/elasticgraph-graphql/spec/acceptance/elasticgraph_graphql_acceptance_support.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/acceptance/graphql_types_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/graphql_types_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/acceptance/hidden_types_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/hidden_types_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/acceptance/nested_relationships_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/nested_relationships_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/acceptance/schema_evolution_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/schema_evolution_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/acceptance/search_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/search_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/acceptance/sub_aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/sub_aggregations_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/aggregation_pagination_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/aggregation_pagination_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/aggregations_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/datastore_aggregation_query_integration_support.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/datastore_aggregation_query_integration_support.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/datastore_query_integration_support.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/datastore_query_integration_support.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/filtering_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/filtering_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/misc_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/misc_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/pagination_shared_examples.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/pagination_shared_examples.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/pagination_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/pagination_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/requested_fields_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/requested_fields_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/sub_aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/sub_aggregations_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/total_document_count_needed_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/total_document_count_needed_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/list_records_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/list_records_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/query_source_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/query_source_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/spec_helper.rb
+++ b/elasticgraph-graphql/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/support/aggregations_helpers.rb
+++ b/elasticgraph-graphql/spec/support/aggregations_helpers.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/support/client_resolvers.rb
+++ b/elasticgraph-graphql/spec/support/client_resolvers.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/support/ensure_no_orphaned_types.rb
+++ b/elasticgraph-graphql/spec/support/ensure_no_orphaned_types.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/support/graphql.rb
+++ b/elasticgraph-graphql/spec/support/graphql.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/support/query_adapter.rb
+++ b/elasticgraph-graphql/spec/support/query_adapter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/support/resolver.rb
+++ b/elasticgraph-graphql/spec/support/resolver.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/support/scalar_coercion_adapter.rb
+++ b/elasticgraph-graphql/spec/support/scalar_coercion_adapter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/support/sort.rb
+++ b/elasticgraph-graphql/spec/support/sort.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/support/sub_aggregation_support.rb
+++ b/elasticgraph-graphql/spec/support/sub_aggregation_support.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/computation_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/computation_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/date_histogram_grouping_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/date_histogram_grouping_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/field_path_encoder_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/field_path_encoder_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/field_term_grouping_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/field_term_grouping_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/key_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/key_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_adapter_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_optimizer_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_optimizer_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/aggregation_resolver_support.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/aggregation_resolver_support.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/aggregations_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/relay_connection_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/relay_connection_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/sub_aggregations_with_composite_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/sub_aggregations_with_composite_adapter_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/sub_aggregations_with_non_composite_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/sub_aggregations_with_non_composite_adapter_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/ungrouped_sub_aggregation_shared_examples.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/ungrouped_sub_aggregation_shared_examples.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/script_term_grouping_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/script_term_grouping_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/client_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/client_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/config_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/config_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/aggregations_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/cluster_name_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/cluster_name_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/datastore_query_unit_support.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/datastore_query_unit_support.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/filtering_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/filtering_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/individual_docs_needed_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/individual_docs_needed_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/merge_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/merge_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/misc_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/misc_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/pagination_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/pagination_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/perform_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/perform_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/requested_fields_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/requested_fields_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/route_with_field_paths_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/route_with_field_paths_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/search_index_expression_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/search_index_expression_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/shard_routing_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/shard_routing_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/sorting_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/sorting_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/sub_aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/sub_aggregations_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/track_total_hits_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/track_total_hits_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_response/document_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_response/document_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_response/search_response_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_response/search_response_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/decoded_cursor_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/decoded_cursor_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/filtering/filter_interpreter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/filtering/filter_interpreter_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/http_endpoint_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/http_endpoint_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/monkey_patches/schema_object_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/monkey_patches/schema_object_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/filters_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/filters_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/requested_fields_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/requested_fields_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_executor_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_executor_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/get_record_field_value_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/get_record_field_value_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/query_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/query_adapter_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection/array_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection/array_adapter_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection/search_response_adapter_builder_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection/search_response_adapter_builder_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/scalar_coercion_adapters/cursor_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/scalar_coercion_adapters/cursor_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/scalar_coercion_adapters/date_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/scalar_coercion_adapters/date_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/scalar_coercion_adapters/date_time_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/scalar_coercion_adapters/date_time_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/scalar_coercion_adapters/local_time_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/scalar_coercion_adapters/local_time_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/scalar_coercion_adapters/longs_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/scalar_coercion_adapters/longs_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/scalar_coercion_adapters/no_op_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/scalar_coercion_adapters/no_op_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/scalar_coercion_adapters/time_zone_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/scalar_coercion_adapters/time_zone_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/scalar_coercion_adapters/untyped_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/scalar_coercion_adapters/untyped_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/enum_value_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/enum_value_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/field_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/field_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/type_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/type_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql_lambda/elasticgraph-graphql_lambda.gemspec
+++ b/elasticgraph-graphql_lambda/elasticgraph-graphql_lambda.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql_lambda/lib/elastic_graph/graphql_lambda.rb
+++ b/elasticgraph-graphql_lambda/lib/elastic_graph/graphql_lambda.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql_lambda/lib/elastic_graph/graphql_lambda/graphql_endpoint.rb
+++ b/elasticgraph-graphql_lambda/lib/elastic_graph/graphql_lambda/graphql_endpoint.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql_lambda/lib/elastic_graph/graphql_lambda/lambda_function.rb
+++ b/elasticgraph-graphql_lambda/lib/elastic_graph/graphql_lambda/lambda_function.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql_lambda/spec/spec_helper.rb
+++ b/elasticgraph-graphql_lambda/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql_lambda/spec/unit/elastic_graph/graphql_lambda/graphql_endpoint_spec.rb
+++ b/elasticgraph-graphql_lambda/spec/unit/elastic_graph/graphql_lambda/graphql_endpoint_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql_lambda/spec/unit/elastic_graph/graphql_lambda/lambda_function_spec.rb
+++ b/elasticgraph-graphql_lambda/spec/unit/elastic_graph/graphql_lambda/lambda_function_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-graphql_lambda/spec/unit/elastic_graph/graphql_lambda_spec.rb
+++ b/elasticgraph-graphql_lambda/spec/unit/elastic_graph/graphql_lambda_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-health_check/elasticgraph-health_check.gemspec
+++ b/elasticgraph-health_check/elasticgraph-health_check.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-health_check/lib/elastic_graph/health_check/config.rb
+++ b/elasticgraph-health_check/lib/elastic_graph/health_check/config.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-health_check/lib/elastic_graph/health_check/constants.rb
+++ b/elasticgraph-health_check/lib/elastic_graph/health_check/constants.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-health_check/lib/elastic_graph/health_check/envoy_extension.rb
+++ b/elasticgraph-health_check/lib/elastic_graph/health_check/envoy_extension.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-health_check/lib/elastic_graph/health_check/envoy_extension/graphql_http_endpoint_decorator.rb
+++ b/elasticgraph-health_check/lib/elastic_graph/health_check/envoy_extension/graphql_http_endpoint_decorator.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-health_check/lib/elastic_graph/health_check/health_checker.rb
+++ b/elasticgraph-health_check/lib/elastic_graph/health_check/health_checker.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-health_check/lib/elastic_graph/health_check/health_status.rb
+++ b/elasticgraph-health_check/lib/elastic_graph/health_check/health_status.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-health_check/spec/acceptance/health_checker_spec.rb
+++ b/elasticgraph-health_check/spec/acceptance/health_checker_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-health_check/spec/spec_helper.rb
+++ b/elasticgraph-health_check/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-health_check/spec/unit/elastic_graph/health_check/config_spec.rb
+++ b/elasticgraph-health_check/spec/unit/elastic_graph/health_check/config_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-health_check/spec/unit/elastic_graph/health_check/health_checker_spec.rb
+++ b/elasticgraph-health_check/spec/unit/elastic_graph/health_check/health_checker_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-health_check/spec/unit/elastic_graph/health_check/health_status_spec.rb
+++ b/elasticgraph-health_check/spec/unit/elastic_graph/health_check/health_status_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-health_check/spec/unit/envoy_extension_spec.rb
+++ b/elasticgraph-health_check/spec/unit/envoy_extension_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/elasticgraph-indexer.gemspec
+++ b/elasticgraph-indexer/elasticgraph-indexer.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/lib/elastic_graph/indexer.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/config.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/config.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/datastore_indexing_router.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/datastore_indexing_router.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/event_id.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/event_id.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/failed_event_error.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/failed_event_error.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/hash_differ.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/hash_differ.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/indexing_failures_error.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/indexing_failures_error.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/indexing_preparers/integer.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/indexing_preparers/integer.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/indexing_preparers/no_op.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/indexing_preparers/no_op.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/indexing_preparers/untyped.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/indexing_preparers/untyped.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/operation/count_accumulator.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/operation/count_accumulator.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/operation/factory.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/operation/factory.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/operation/result.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/operation/result.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/operation/update.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/operation/update.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/operation/upsert.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/operation/upsert.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/processor.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/processor.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/record_preparer.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/record_preparer.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/spec_support/event_matcher.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/spec_support/event_matcher.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/test_support/converters.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/test_support/converters.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/acceptance/derived_indexing_types_spec.rb
+++ b/elasticgraph-indexer/spec/acceptance/derived_indexing_types_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/acceptance/list_fields_spec.rb
+++ b/elasticgraph-indexer/spec/acceptance/list_fields_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/acceptance/multi_source_indexing_spec.rb
+++ b/elasticgraph-indexer/spec/acceptance/multi_source_indexing_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/acceptance/schema_evolution_spec.rb
+++ b/elasticgraph-indexer/spec/acceptance/schema_evolution_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/integration/elastic_graph/indexer/datastore_indexing_router_spec.rb
+++ b/elasticgraph-indexer/spec/integration/elastic_graph/indexer/datastore_indexing_router_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/integration/elastic_graph/indexer/processor_spec.rb
+++ b/elasticgraph-indexer/spec/integration/elastic_graph/indexer/processor_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/spec_helper.rb
+++ b/elasticgraph-indexer/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/support/indexing_preparer.rb
+++ b/elasticgraph-indexer/spec/support/indexing_preparer.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/support/multiple_version_support.rb
+++ b/elasticgraph-indexer/spec/support/multiple_version_support.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/config_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/config_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/datastore_indexing_router_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/datastore_indexing_router_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/event_id_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/event_id_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/hash_differ_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/hash_differ_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/indexing_preparers/integer_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/indexing_preparers/integer_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/indexing_preparers/no_op_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/indexing_preparers/no_op_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/indexing_preparers/untyped_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/indexing_preparers/untyped_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/operation/count_accumulator_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/operation/count_accumulator_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/operation/factory_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/operation/factory_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/operation/update_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/operation/update_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/operation/upsert_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/operation/upsert_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/processor_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/processor_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/record_preparer_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/record_preparer_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/spec_support/event_matcher_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/spec_support/event_matcher_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/test_support/converters_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/test_support/converters_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer_autoscaler_lambda/elasticgraph-indexer_autoscaler_lambda.gemspec
+++ b/elasticgraph-indexer_autoscaler_lambda/elasticgraph-indexer_autoscaler_lambda.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer_autoscaler_lambda/lib/elastic_graph/indexer_autoscaler_lambda.rb
+++ b/elasticgraph-indexer_autoscaler_lambda/lib/elastic_graph/indexer_autoscaler_lambda.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer_autoscaler_lambda/lib/elastic_graph/indexer_autoscaler_lambda/concurrency_scaler.rb
+++ b/elasticgraph-indexer_autoscaler_lambda/lib/elastic_graph/indexer_autoscaler_lambda/concurrency_scaler.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer_autoscaler_lambda/lib/elastic_graph/indexer_autoscaler_lambda/details_logger.rb
+++ b/elasticgraph-indexer_autoscaler_lambda/lib/elastic_graph/indexer_autoscaler_lambda/details_logger.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer_autoscaler_lambda/lib/elastic_graph/indexer_autoscaler_lambda/lambda_function.rb
+++ b/elasticgraph-indexer_autoscaler_lambda/lib/elastic_graph/indexer_autoscaler_lambda/lambda_function.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer_autoscaler_lambda/spec/spec_helper.rb
+++ b/elasticgraph-indexer_autoscaler_lambda/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer_autoscaler_lambda/spec/support/builds_indexer_autoscaler.rb
+++ b/elasticgraph-indexer_autoscaler_lambda/spec/support/builds_indexer_autoscaler.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer_autoscaler_lambda/spec/unit/elastic_graph/indexer_autoscaler_lambda/concurrency_scaler_spec.rb
+++ b/elasticgraph-indexer_autoscaler_lambda/spec/unit/elastic_graph/indexer_autoscaler_lambda/concurrency_scaler_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer_autoscaler_lambda/spec/unit/elastic_graph/indexer_autoscaler_lambda/lambda_function_spec.rb
+++ b/elasticgraph-indexer_autoscaler_lambda/spec/unit/elastic_graph/indexer_autoscaler_lambda/lambda_function_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer_autoscaler_lambda/spec/unit/elastic_graph/indexer_autoscaler_lambda_spec.rb
+++ b/elasticgraph-indexer_autoscaler_lambda/spec/unit/elastic_graph/indexer_autoscaler_lambda_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer_lambda/elasticgraph-indexer_lambda.gemspec
+++ b/elasticgraph-indexer_lambda/elasticgraph-indexer_lambda.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer_lambda/lib/elastic_graph/indexer_lambda.rb
+++ b/elasticgraph-indexer_lambda/lib/elastic_graph/indexer_lambda.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer_lambda/lib/elastic_graph/indexer_lambda/lambda_function.rb
+++ b/elasticgraph-indexer_lambda/lib/elastic_graph/indexer_lambda/lambda_function.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer_lambda/lib/elastic_graph/indexer_lambda/sqs_processor.rb
+++ b/elasticgraph-indexer_lambda/lib/elastic_graph/indexer_lambda/sqs_processor.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer_lambda/spec/spec_helper.rb
+++ b/elasticgraph-indexer_lambda/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer_lambda/spec/unit/elastic_graph/indexer_lambda/lambda_function_spec.rb
+++ b/elasticgraph-indexer_lambda/spec/unit/elastic_graph/indexer_lambda/lambda_function_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer_lambda/spec/unit/elastic_graph/indexer_lambda/sqs_processor_spec.rb
+++ b/elasticgraph-indexer_lambda/spec/unit/elastic_graph/indexer_lambda/sqs_processor_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-indexer_lambda/spec/unit/elastic_graph/indexer_lambda_spec.rb
+++ b/elasticgraph-indexer_lambda/spec/unit/elastic_graph/indexer_lambda_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-json_schema/elasticgraph-json_schema.gemspec
+++ b/elasticgraph-json_schema/elasticgraph-json_schema.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-json_schema/lib/elastic_graph/json_schema/meta_schema_validator.rb
+++ b/elasticgraph-json_schema/lib/elastic_graph/json_schema/meta_schema_validator.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-json_schema/lib/elastic_graph/json_schema/validator.rb
+++ b/elasticgraph-json_schema/lib/elastic_graph/json_schema/validator.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-json_schema/lib/elastic_graph/json_schema/validator_factory.rb
+++ b/elasticgraph-json_schema/lib/elastic_graph/json_schema/validator_factory.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-json_schema/spec/spec_helper.rb
+++ b/elasticgraph-json_schema/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-json_schema/spec/unit/elastic_graph/json_schema/meta_schema_validator_spec.rb
+++ b/elasticgraph-json_schema/spec/unit/elastic_graph/json_schema/meta_schema_validator_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-json_schema/spec/unit/elastic_graph/json_schema/validator_factory_spec.rb
+++ b/elasticgraph-json_schema/spec/unit/elastic_graph/json_schema/validator_factory_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-json_schema/spec/unit/elastic_graph/json_schema/validator_spec.rb
+++ b/elasticgraph-json_schema/spec/unit/elastic_graph/json_schema/validator_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-lambda_support/elasticgraph-lambda_support.gemspec
+++ b/elasticgraph-lambda_support/elasticgraph-lambda_support.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-lambda_support/lib/elastic_graph/lambda_support.rb
+++ b/elasticgraph-lambda_support/lib/elastic_graph/lambda_support.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-lambda_support/lib/elastic_graph/lambda_support/json_aware_lambda_log_formatter.rb
+++ b/elasticgraph-lambda_support/lib/elastic_graph/lambda_support/json_aware_lambda_log_formatter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-lambda_support/lib/elastic_graph/lambda_support/lambda_function.rb
+++ b/elasticgraph-lambda_support/lib/elastic_graph/lambda_support/lambda_function.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-lambda_support/spec/spec_helper.rb
+++ b/elasticgraph-lambda_support/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-lambda_support/spec/unit/elastic_graph/lambda_support/json_aware_lambda_log_formatter_spec.rb
+++ b/elasticgraph-lambda_support/spec/unit/elastic_graph/lambda_support/json_aware_lambda_log_formatter_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-lambda_support/spec/unit/elastic_graph/lambda_support/lambda_function_spec.rb
+++ b/elasticgraph-lambda_support/spec/unit/elastic_graph/lambda_support/lambda_function_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-lambda_support/spec/unit/elastic_graph/lambda_support_spec.rb
+++ b/elasticgraph-lambda_support/spec/unit/elastic_graph/lambda_support_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-local/elasticgraph-local.gemspec
+++ b/elasticgraph-local/elasticgraph-local.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-local/lib/elastic_graph/local/config.ru
+++ b/elasticgraph-local/lib/elastic_graph/local/config.ru
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-local/lib/elastic_graph/local/docker_runner.rb
+++ b/elasticgraph-local/lib/elastic_graph/local/docker_runner.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-local/lib/elastic_graph/local/indexing_coordinator.rb
+++ b/elasticgraph-local/lib/elastic_graph/local/indexing_coordinator.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-local/lib/elastic_graph/local/local_indexer.rb
+++ b/elasticgraph-local/lib/elastic_graph/local/local_indexer.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-local/lib/elastic_graph/local/rake_tasks.rb
+++ b/elasticgraph-local/lib/elastic_graph/local/rake_tasks.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-local/lib/elastic_graph/local/spec_support/common_project_specs.rb
+++ b/elasticgraph-local/lib/elastic_graph/local/spec_support/common_project_specs.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-local/spec/acceptance/rake_tasks_spec.rb
+++ b/elasticgraph-local/spec/acceptance/rake_tasks_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-local/spec/spec_helper.rb
+++ b/elasticgraph-local/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-local/spec/unit/elastic_graph/local/rake_tasks_spec.rb
+++ b/elasticgraph-local/spec/unit/elastic_graph/local/rake_tasks_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-local/spec/unit/elastic_graph/local/spec_support/common_project_specs_spec.rb
+++ b/elasticgraph-local/spec/unit/elastic_graph/local/spec_support/common_project_specs_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-opensearch/elasticgraph-opensearch.gemspec
+++ b/elasticgraph-opensearch/elasticgraph-opensearch.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-opensearch/lib/elastic_graph/opensearch/client.rb
+++ b/elasticgraph-opensearch/lib/elastic_graph/opensearch/client.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-opensearch/spec/spec_helper.rb
+++ b/elasticgraph-opensearch/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-opensearch/spec/unit/elastic_graph/opensearch/client_spec.rb
+++ b/elasticgraph-opensearch/spec/unit/elastic_graph/opensearch/client_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_interceptor/elasticgraph-query_interceptor.gemspec
+++ b/elasticgraph-query_interceptor/elasticgraph-query_interceptor.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_interceptor/lib/elastic_graph/query_interceptor/config.rb
+++ b/elasticgraph-query_interceptor/lib/elastic_graph/query_interceptor/config.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_interceptor/lib/elastic_graph/query_interceptor/datastore_query_adapter.rb
+++ b/elasticgraph-query_interceptor/lib/elastic_graph/query_interceptor/datastore_query_adapter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_interceptor/lib/elastic_graph/query_interceptor/graphql_extension.rb
+++ b/elasticgraph-query_interceptor/lib/elastic_graph/query_interceptor/graphql_extension.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_interceptor/spec/spec_helper.rb
+++ b/elasticgraph-query_interceptor/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_interceptor/spec/unit/elastic_graph/query_interceptor/config_spec.rb
+++ b/elasticgraph-query_interceptor/spec/unit/elastic_graph/query_interceptor/config_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_interceptor/spec/unit/elastic_graph/query_interceptor/graphql_extension_spec.rb
+++ b/elasticgraph-query_interceptor/spec/unit/elastic_graph/query_interceptor/graphql_extension_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_registry/elasticgraph-query_registry.gemspec
+++ b/elasticgraph-query_registry/elasticgraph-query_registry.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/client_data.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/client_data.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/graphql_extension.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/graphql_extension.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/query_validator.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/query_validator.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/query_validators/for_registered_client.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/query_validators/for_registered_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/query_validators/for_unregistered_client.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/query_validators/for_unregistered_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/rake_tasks.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/rake_tasks.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/registry.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/registry.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/variable_backward_incompatibility_detector.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/variable_backward_incompatibility_detector.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/variable_dumper.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/variable_dumper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_registry/spec/acceptance/query_registry_spec.rb
+++ b/elasticgraph-query_registry/spec/acceptance/query_registry_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_registry/spec/spec_helper.rb
+++ b/elasticgraph-query_registry/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/query_validator_spec.rb
+++ b/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/query_validator_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/rake_tasks_spec.rb
+++ b/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/rake_tasks_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/registry_spec.rb
+++ b/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/registry_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/variable_backward_incompatibility_detector_spec.rb
+++ b/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/variable_backward_incompatibility_detector_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/variable_dumper_spec.rb
+++ b/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/variable_dumper_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-rack/elasticgraph-rack.gemspec
+++ b/elasticgraph-rack/elasticgraph-rack.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-rack/lib/elastic_graph/rack.rb
+++ b/elasticgraph-rack/lib/elastic_graph/rack.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-rack/lib/elastic_graph/rack/graphiql.rb
+++ b/elasticgraph-rack/lib/elastic_graph/rack/graphiql.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-rack/lib/elastic_graph/rack/graphql_endpoint.rb
+++ b/elasticgraph-rack/lib/elastic_graph/rack/graphql_endpoint.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-rack/spec/acceptance/graphiql_spec.rb
+++ b/elasticgraph-rack/spec/acceptance/graphiql_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-rack/spec/acceptance/graphql_endpoint_spec.rb
+++ b/elasticgraph-rack/spec/acceptance/graphql_endpoint_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-rack/spec/spec_helper.rb
+++ b/elasticgraph-rack/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-rack/spec/support/rack_app.rb
+++ b/elasticgraph-rack/spec/support/rack_app.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/elasticgraph-schema_artifacts.gemspec
+++ b/elasticgraph-schema_artifacts/elasticgraph-schema_artifacts.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/artifacts_helper_methods.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/artifacts_helper_methods.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/from_disk.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/from_disk.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/computation_detail.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/computation_detail.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/enum.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/enum.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/extension.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/extension.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/extension_loader.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/extension_loader.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/graphql_field.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/graphql_field.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/hash_dumper.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/hash_dumper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/index_definition.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/index_definition.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/index_field.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/index_field.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/interface_verifier.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/interface_verifier.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/object_type.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/object_type.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/params.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/params.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/relation.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/relation.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/scalar_type.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/scalar_type.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/schema.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/schema.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/sort_field.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/sort_field.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/update_target.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/update_target.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/spec_helper.rb
+++ b/elasticgraph-schema_artifacts/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/support/example_extensions/additional_methods.rb
+++ b/elasticgraph-schema_artifacts/spec/support/example_extensions/additional_methods.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/support/example_extensions/args_mismatch.rb
+++ b/elasticgraph-schema_artifacts/spec/support/example_extensions/args_mismatch.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/support/example_extensions/graphql_extension_modules.rb
+++ b/elasticgraph-schema_artifacts/spec/support/example_extensions/graphql_extension_modules.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/support/example_extensions/indexing_preparers.rb
+++ b/elasticgraph-schema_artifacts/spec/support/example_extensions/indexing_preparers.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/support/example_extensions/initialize_doesnt_match.rb
+++ b/elasticgraph-schema_artifacts/spec/support/example_extensions/initialize_doesnt_match.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/support/example_extensions/initialize_missing.rb
+++ b/elasticgraph-schema_artifacts/spec/support/example_extensions/initialize_missing.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/support/example_extensions/missing_class_method.rb
+++ b/elasticgraph-schema_artifacts/spec/support/example_extensions/missing_class_method.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/support/example_extensions/missing_instance_method.rb
+++ b/elasticgraph-schema_artifacts/spec/support/example_extensions/missing_instance_method.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/support/example_extensions/name_mismatch.rb
+++ b/elasticgraph-schema_artifacts/spec/support/example_extensions/name_mismatch.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/support/example_extensions/not_a_class_or_module.rb
+++ b/elasticgraph-schema_artifacts/spec/support/example_extensions/not_a_class_or_module.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/support/example_extensions/scalar_coercion_adapters.rb
+++ b/elasticgraph-schema_artifacts/spec/support/example_extensions/scalar_coercion_adapters.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/support/example_extensions/valid.rb
+++ b/elasticgraph-schema_artifacts/spec/support/example_extensions/valid.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/support/example_extensions/valid_instantiable.rb
+++ b/elasticgraph-schema_artifacts/spec/support/example_extensions/valid_instantiable.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/support/example_extensions/valid_module.rb
+++ b/elasticgraph-schema_artifacts/spec/support/example_extensions/valid_module.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/from_disk_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/from_disk_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/enum_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/enum_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/extension_loader_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/extension_loader_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/extension_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/extension_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/graphql_field_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/graphql_field_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/index_definition_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/index_definition_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/index_field_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/index_field_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/interface_verifier_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/interface_verifier_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/object_type_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/object_type_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/params_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/params_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/relation_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/relation_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/scalar_type_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/scalar_type_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/sort_field_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/sort_field_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/update_target_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/update_target_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/elasticgraph-schema_definition.gemspec
+++ b/elasticgraph-schema_definition/elasticgraph-schema_definition.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_fields/append_only_set.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_fields/append_only_set.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_fields/field_initializer_support.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_fields/field_initializer_support.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_fields/immutable_value.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_fields/immutable_value.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_fields/min_or_max_value.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_fields/min_or_max_value.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_indexed_type.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_indexed_type.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/event_envelope.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/event_envelope.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/field.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/field.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/field_reference.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/field_reference.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/field_type/enum.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/field_type/enum.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/field_type/object.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/field_type/object.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/field_type/scalar.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/field_type/scalar.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/field_type/union.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/field_type/union.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/index.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/index.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/json_schema_field_metadata.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/json_schema_field_metadata.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/json_schema_with_metadata.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/json_schema_with_metadata.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/list_counts_mapping.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/list_counts_mapping.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/relationship_resolver.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/relationship_resolver.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/rollover_config.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/rollover_config.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/update_target_factory.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/update_target_factory.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/update_target_resolver.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/update_target_resolver.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/json_schema_pruner.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/json_schema_pruner.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/can_be_graphql_only.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/can_be_graphql_only.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_derived_graphql_type_customizations.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_derived_graphql_type_customizations.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_directives.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_directives.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_documentation.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_documentation.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_readable_to_s_and_inspect.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_readable_to_s_and_inspect.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_subtypes.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_subtypes.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_type_info.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_type_info.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/implements_interfaces.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/implements_interfaces.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_default_value.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_default_value.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_filtering_and_aggregation.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_filtering_and_aggregation.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/verifies_graphql_name.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/verifies_graphql_name.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/rake_tasks.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/rake_tasks.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_artifact_manager.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_artifact_manager.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/argument.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/argument.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/deprecated_element.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/deprecated_element.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/directive.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/directive.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/enum_type.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/enum_type.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/enum_value.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/enum_value.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/enum_value_namer.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/enum_value_namer.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/enums_for_indexed_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/enums_for_indexed_types.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field_path.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field_path.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field_source.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field_source.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/graphql_sdl_enumerator.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/graphql_sdl_enumerator.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/input_field.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/input_field.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/input_type.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/input_type.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/interface_type.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/interface_type.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/list_counts_state.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/list_counts_state.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/object_type.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/object_type.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/relationship.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/relationship.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/scalar_type.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/scalar_type.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/sort_order_enum_value.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/sort_order_enum_value.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/sub_aggregation_path.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/sub_aggregation_path.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_namer.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_namer.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_reference.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_reference.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_with_subfields.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_with_subfields.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/union_type.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/union_type.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/file_system_repository.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/file_system_repository.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/script.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/script.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/state.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/state.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/test_support.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/test_support.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/fixtures/script_repos/unsupported_language/filter/by_age.rb
+++ b/elasticgraph-schema_definition/spec/fixtures/script_repos/unsupported_language/filter/by_age.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/static_scripts_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/static_scripts_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts/append_only_set_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts/append_only_set_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts/immutable_value_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts/immutable_value_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts/min_or_max_value_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts/min_or_max_value_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/spec_helper.rb
+++ b/elasticgraph-schema_definition/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/support/example_extensions/indexing_preparer.rb
+++ b/elasticgraph-schema_definition/spec/support/example_extensions/indexing_preparer.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/support/example_extensions/scalar_coercion_adapter.rb
+++ b/elasticgraph-schema_definition/spec/support/example_extensions/scalar_coercion_adapter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/support/json_schema_matcher.rb
+++ b/elasticgraph-schema_definition/spec/support/json_schema_matcher.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/support/json_schema_matcher_spec.rb
+++ b/elasticgraph-schema_definition/spec/support/json_schema_matcher_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/support/script_support.rb
+++ b/elasticgraph-schema_definition/spec/support/script_support.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/support/validate_script_support.rb
+++ b/elasticgraph-schema_definition/spec/support/validate_script_support.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_definition_spec_support.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_definition_spec_support.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/abstract_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/abstract_types_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/counts_field_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/counts_field_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/index_mappings_spec_support.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/index_mappings_spec_support.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/indexing_only_fields_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/indexing_only_fields_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/mapping_customizations_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/mapping_customizations_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/miscellaneous_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/miscellaneous_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/paginated_collection_field_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/paginated_collection_field_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/relation_fields_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/relation_fields_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_overview_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_overview_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_settings_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_settings_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/aggregated_values_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/aggregated_values_type_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/aggregation_grouped_by_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/aggregation_grouped_by_type_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/built_in_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/built_in_types_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/define_schema_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/define_schema_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/derived_graphql_type_customizations_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/derived_graphql_type_customizations_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/enum_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/enum_type_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/field_arguments_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/field_arguments_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/filters_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/filters_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/graphql_schema_spec_support.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/graphql_schema_spec_support.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/implements_shared_examples.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/implements_shared_examples.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/indexed_aggregation_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/indexed_aggregation_type_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/interface_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/interface_type_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/object_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/object_type_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/paginated_collection_field_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/paginated_collection_field_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/relay_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/relay_types_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/root_query_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/root_query_type_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/scalar_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/scalar_type_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/sort_order_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/sort_order_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/sub_aggregation_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/sub_aggregation_type_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/union_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/union_type_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/indexing/json_schema_with_metadata_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/indexing/json_schema_with_metadata_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/json_schema_field_metadata_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/json_schema_field_metadata_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/json_schema_pruner_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/json_schema_pruner_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/json_schema_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/json_schema_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/enum_types_by_name_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/enum_types_by_name_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/graphql_extension_modules_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/graphql_extension_modules_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/graphql_resolvers_by_name_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/graphql_resolvers_by_name_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/index_definitions_by_name_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/index_definitions_by_name_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/derived_aggregation_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/derived_aggregation_types_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/for_built_in_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/for_built_in_types_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/for_relay_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/for_relay_types_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/graphql_fields_by_name_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/graphql_fields_by_name_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/graphql_only_return_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/graphql_only_return_type_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/index_definition_names_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/index_definition_names_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/object_type_metadata_support.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/object_type_metadata_support.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/pruning_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/pruning_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/relation_metadata_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/relation_metadata_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/update_targets_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/update_targets_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/runtime_metadata_support.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/runtime_metadata_support.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/scalar_types_by_name_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/scalar_types_by_name_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/static_script_ids_by_scoped_name_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/static_script_ids_by_scoped_name_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/schema_elements/enum_value_namer_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/schema_elements/enum_value_namer_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/schema_elements/field_path_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/schema_elements/field_path_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/schema_elements/type_namer_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/schema_elements/type_namer_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/schema_elements/type_reference_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/schema_elements/type_reference_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/scripting/file_system_repository_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/scripting/file_system_repository_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/static_scripts_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/static_scripts_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/elasticgraph-support.gemspec
+++ b/elasticgraph-support/elasticgraph-support.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/lib/elastic_graph/constants.rb
+++ b/elasticgraph-support/lib/elastic_graph/constants.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/lib/elastic_graph/errors.rb
+++ b/elasticgraph-support/lib/elastic_graph/errors.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/lib/elastic_graph/support/faraday_middleware/msearch_using_get_instead_of_post.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/faraday_middleware/msearch_using_get_instead_of_post.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/lib/elastic_graph/support/faraday_middleware/support_timeouts.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/faraday_middleware/support_timeouts.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/lib/elastic_graph/support/from_yaml_file.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/from_yaml_file.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/lib/elastic_graph/support/graphql_formatter.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/graphql_formatter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/lib/elastic_graph/support/hash_util.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/hash_util.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/lib/elastic_graph/support/logger.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/logger.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/lib/elastic_graph/support/memoizable_data.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/memoizable_data.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/lib/elastic_graph/support/monotonic_clock.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/monotonic_clock.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/lib/elastic_graph/support/threading.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/threading.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/lib/elastic_graph/support/time_set.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/time_set.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/lib/elastic_graph/support/time_util.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/time_util.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/lib/elastic_graph/support/untyped_encoder.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/untyped_encoder.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/lib/elastic_graph/version.rb
+++ b/elasticgraph-support/lib/elastic_graph/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/spec/spec_helper.rb
+++ b/elasticgraph-support/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/spec/unit/elastic_graph/constants_spec.rb
+++ b/elasticgraph-support/spec/unit/elastic_graph/constants_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/spec/unit/elastic_graph/support/faraday_middleware/msearch_using_get_instead_of_post_spec.rb
+++ b/elasticgraph-support/spec/unit/elastic_graph/support/faraday_middleware/msearch_using_get_instead_of_post_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/spec/unit/elastic_graph/support/faraday_middleware/support_timeouts_spec.rb
+++ b/elasticgraph-support/spec/unit/elastic_graph/support/faraday_middleware/support_timeouts_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/spec/unit/elastic_graph/support/from_yaml_file_spec.rb
+++ b/elasticgraph-support/spec/unit/elastic_graph/support/from_yaml_file_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/spec/unit/elastic_graph/support/graphql_formatter_spec.rb
+++ b/elasticgraph-support/spec/unit/elastic_graph/support/graphql_formatter_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/spec/unit/elastic_graph/support/hash_util_spec.rb
+++ b/elasticgraph-support/spec/unit/elastic_graph/support/hash_util_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/spec/unit/elastic_graph/support/logger_spec.rb
+++ b/elasticgraph-support/spec/unit/elastic_graph/support/logger_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/spec/unit/elastic_graph/support/memoizable_data_spec.rb
+++ b/elasticgraph-support/spec/unit/elastic_graph/support/memoizable_data_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/spec/unit/elastic_graph/support/monotonic_clock_spec.rb
+++ b/elasticgraph-support/spec/unit/elastic_graph/support/monotonic_clock_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/spec/unit/elastic_graph/support/threading_spec.rb
+++ b/elasticgraph-support/spec/unit/elastic_graph/support/threading_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/spec/unit/elastic_graph/support/time_set_spec.rb
+++ b/elasticgraph-support/spec/unit/elastic_graph/support/time_set_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/spec/unit/elastic_graph/support/time_util_spec.rb
+++ b/elasticgraph-support/spec/unit/elastic_graph/support/time_util_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph-support/spec/unit/elastic_graph/support/untyped_encoder_spec.rb
+++ b/elasticgraph-support/spec/unit/elastic_graph/support/untyped_encoder_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph/elasticgraph.gemspec
+++ b/elasticgraph/elasticgraph.gemspec
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph/lib/elastic_graph/cli.rb
+++ b/elasticgraph/lib/elastic_graph/cli.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph/spec/acceptance/cli_new_spec.rb
+++ b/elasticgraph/spec/acceptance/cli_new_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph/spec/spec_helper.rb
+++ b/elasticgraph/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/elasticgraph/spec/unit/elastic_graph/gem_spec.rb
+++ b/elasticgraph/spec/unit/elastic_graph/gem_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/builds_admin.rb
+++ b/spec_support/lib/elastic_graph/spec_support/builds_admin.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/builds_datastore_core.rb
+++ b/spec_support/lib/elastic_graph/spec_support/builds_datastore_core.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/builds_graphql.rb
+++ b/spec_support/lib/elastic_graph/spec_support/builds_graphql.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/builds_indexer.rb
+++ b/spec_support/lib/elastic_graph/spec_support/builds_indexer.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/cluster_configuration_manager.rb
+++ b/spec_support/lib/elastic_graph/spec_support/cluster_configuration_manager.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/datastore_client_shared_examples.rb
+++ b/spec_support/lib/elastic_graph/spec_support/datastore_client_shared_examples.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/enable_simplecov.rb
+++ b/spec_support/lib/elastic_graph/spec_support/enable_simplecov.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/example_extensions/graphql_resolvers.rb
+++ b/spec_support/lib/elastic_graph/spec_support/example_extensions/graphql_resolvers.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/factories.rb
+++ b/spec_support/lib/elastic_graph/spec_support/factories.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/factories/shared.rb
+++ b/spec_support/lib/elastic_graph/spec_support/factories/shared.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/factories/teams.rb
+++ b/spec_support/lib/elastic_graph/spec_support/factories/teams.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/factories/widgets.rb
+++ b/spec_support/lib/elastic_graph/spec_support/factories/widgets.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/graphql_profiling_logger_decorator.rb
+++ b/spec_support/lib/elastic_graph/spec_support/graphql_profiling_logger_decorator.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/have_readable_to_s_and_inspect_output.rb
+++ b/spec_support/lib/elastic_graph/spec_support/have_readable_to_s_and_inspect_output.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/in_sub_process.rb
+++ b/spec_support/lib/elastic_graph/spec_support/in_sub_process.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/lambda_function.rb
+++ b/spec_support/lib/elastic_graph/spec_support/lambda_function.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/logging.rb
+++ b/spec_support/lib/elastic_graph/spec_support/logging.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/optimize_graphql.rb
+++ b/spec_support/lib/elastic_graph/spec_support/optimize_graphql.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/parallel_spec_runner.rb
+++ b/spec_support/lib/elastic_graph/spec_support/parallel_spec_runner.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/parallel_spec_runner/cluster_configuration_manager_adapter.rb
+++ b/spec_support/lib/elastic_graph/spec_support/parallel_spec_runner/cluster_configuration_manager_adapter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/parallel_spec_runner/datastore_client_adapter.rb
+++ b/spec_support/lib/elastic_graph/spec_support/parallel_spec_runner/datastore_client_adapter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/parallel_spec_runner/datastore_core_adapter.rb
+++ b/spec_support/lib/elastic_graph/spec_support/parallel_spec_runner/datastore_core_adapter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/parallel_spec_runner/datastore_spec_support_adapter.rb
+++ b/spec_support/lib/elastic_graph/spec_support/parallel_spec_runner/datastore_spec_support_adapter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/parallel_spec_runner/elastic_graph_profiler_adapter.rb
+++ b/spec_support/lib/elastic_graph/spec_support/parallel_spec_runner/elastic_graph_profiler_adapter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/parallel_spec_runner/request_tracker_request_adapter.rb
+++ b/spec_support/lib/elastic_graph/spec_support/parallel_spec_runner/request_tracker_request_adapter.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/profiling.rb
+++ b/spec_support/lib/elastic_graph/spec_support/profiling.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/rake_task.rb
+++ b/spec_support/lib/elastic_graph/spec_support/rake_task.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/runtime_metadata_support.rb
+++ b/spec_support/lib/elastic_graph/spec_support/runtime_metadata_support.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/schema_definition_helpers.rb
+++ b/spec_support/lib/elastic_graph/spec_support/schema_definition_helpers.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/stub_datastore_client.rb
+++ b/spec_support/lib/elastic_graph/spec_support/stub_datastore_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/uses_datastore.rb
+++ b/spec_support/lib/elastic_graph/spec_support/uses_datastore.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/validate_graphql_schemas.rb
+++ b/spec_support/lib/elastic_graph/spec_support/validate_graphql_schemas.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/lib/elastic_graph/spec_support/vcr.rb
+++ b/spec_support/lib/elastic_graph/spec_support/vcr.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at

--- a/spec_support/spec_helper.rb
+++ b/spec_support/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Block, Inc.
+# Copyright 2024 - 2025 Block, Inc.
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at


### PR DESCRIPTION
Note: this PR has been split into two commits to make it easier to review. The first one is the one with the interesting changes; the 2nd one just applies `standardrb --fix`.