### PR TITLE
Expose a shorter demo one-liner from the website.

### DIFF
--- a/config/site/src/_config.yaml
+++ b/config/site/src/_config.yaml
@@ -23,5 +23,5 @@ style:
   navbar_dropdown: relative rounded-lg bg-white dark:bg-gray-700 shadow-lg border border-gray-200/80 dark:border-gray-600/50
   dropdown_pip: absolute -top-1.5 left-4 h-3 w-3 bg-white dark:bg-gray-700 transform rotate-45 border-t border-l border-gray-200/80 dark:border-gray-600/50
 
-demo_oneliner: "curl -s https://raw.githubusercontent.com/block/elasticgraph/refs/heads/main/config/docker_demo/docker-compose.yaml | docker compose -f - up"
+demo_oneliner: "curl -s https://block.github.io/elasticgraph/docker-compose.yaml | docker compose -f - up"
 localhost_eg_url: "http://localhost:9000/"

--- a/config/site/src/_includes/code-box.html
+++ b/config/site/src/_includes/code-box.html
@@ -1,4 +1,4 @@
-<div class="relative bg-gray-800 dark:bg-gray-900 text-white py-3 px-6 rounded-sm {% unless include.full_width %}w-full{% endunless %}">
+<div class="relative bg-gray-800 dark:bg-gray-900 text-white py-3 px-6 rounded-sm {% unless include.full_width %}w-full{% endunless %} not-prose">
   <div class="flex items-center">
     {% if include.full_width %}
     <div class="font-mono text-xs font-normal">{{ include.command }}</div>

--- a/config/site/src/docker-compose.yaml
+++ b/config/site/src/docker-compose.yaml
@@ -1,0 +1,1 @@
+../../docker_demo/docker-compose.yaml


### PR DESCRIPTION
Rather than this:

```
curl -s https://raw.githubusercontent.com/block/elasticgraph/refs/heads/main/config/docker_demo/docker-compose.yaml | docker compose -f - up
```

Expose this:

```
curl -s https://block.github.io/elasticgraph/docker-compose.yaml | docker compose -f - up
```

It fits much better now. To make this work, I've symlinked `docker-compose.yaml` from the site's `src` directory so it'll always stay in sync.

In addition, I've added `not-prose` to the CSS class around the code box as our font size selection was being overriden by the font size configured for prose.

Now that one-liner fits without needing any scrolling!

Before:

![image](https://github.com/user-attachments/assets/46f23cbf-bb07-4fce-936a-55e9e4e10217)
![image](https://github.com/user-attachments/assets/7831e533-30f7-42d9-b4e2-d8d95e41fbeb)

After:

![image](https://github.com/user-attachments/assets/1f2f6bc5-737e-45eb-a795-1892dddd0a7b)
![image](https://github.com/user-attachments/assets/45857710-ce57-434c-9e2d-b619a27d5843)
