### PR TITLE
Refactor: make `SearchResponse#raw_data` private.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/relay_connection_builder.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/relay_connection_builder.rb
@@ -55,17 +55,16 @@ module ElasticGraph
           end
 
           private_class_method def self.extract_buckets_from(search_response, for_query:)
-            search_response.raw_data.dig(
-              "aggregations",
+            search_response.aggregations.dig(
               for_query.name,
               "buckets"
-            ) || [build_bucket(for_query, search_response.raw_data)]
+            ) || [build_bucket(for_query, search_response)]
           end
 
           private_class_method def self.build_bucket(query, response)
             defaults = {
               "key" => query.groupings.to_h { |g| [g.key, nil] },
-              "doc_count" => response.dig("hits", "total", "value") || 0
+              "doc_count" => response.total_document_count(default: 0)
             }
 
             empty_bucket_computations = query.computations.to_h do |computation|
@@ -74,7 +73,7 @@ module ElasticGraph
 
             defaults
               .merge(empty_bucket_computations)
-              .merge(response["aggregations"] || {})
+              .merge(response.aggregations)
           end
         end
       end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_response/search_response.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_response/search_response.rb
@@ -21,6 +21,8 @@ module ElasticGraph
         include Enumerable
         extend Forwardable
 
+        private :raw_data
+
         def_delegators :documents, :each, :to_a, :size, :empty?
 
         EXCLUDED_METADATA_KEYS = %w[hits aggregations].freeze
@@ -99,8 +101,12 @@ module ElasticGraph
           (documents.size < 3) ? documents.inspect : "[#{documents.first}, ..., #{documents.last}]"
         end
 
-        def total_document_count
-          super || raise(Errors::CountUnavailableError, "#{__method__} is unavailable; set `query.total_document_count_needed = true` to make it available")
+        def total_document_count(default: nil)
+          super() || default || raise(Errors::CountUnavailableError, "#{__method__} is unavailable; set `query.total_document_count_needed = true` to make it available")
+        end
+
+        def aggregations
+          raw_data["aggregations"] || {}
         end
 
         def to_s

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/relay_connection_builder.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/relay_connection_builder.rbs
@@ -30,7 +30,7 @@ module ElasticGraph
             for_query: Query
           ) -> ::Array[::Hash[::String, untyped]]
 
-          def self.build_bucket: (Query, ::Hash[::String, untyped]) -> ::Hash[::String, untyped]
+          def self.build_bucket: (Query, DatastoreResponse::SearchResponse) -> ::Hash[::String, untyped]
         end
       end
     end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/datastore_response/search_response.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/datastore_response/search_response.rbs
@@ -5,12 +5,14 @@ module ElasticGraph
       class SearchResponse
         include ::Enumerable[Document]
         attr_reader raw_data: ::Hash[::String, untyped]
-        attr_reader total_document_count: ::Integer
         attr_reader documents: Array[Document]
         attr_reader docs_description: ::String
         attr_reader size: ::Integer
 
         def each: () { (Document) -> void } -> void | () -> Enumerator[Document, void]
+
+        def total_document_count: (?default: ::Integer?) -> ::Integer
+        def aggregations: () -> ::Hash[::String, untyped]
       end
     end
   end

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/datastore_query_integration_support.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/datastore_query_integration_support.rb
@@ -49,7 +49,7 @@ module ElasticGraph
           .first
           .tap do |response|
             # To ensure that aggregations always satisfy the `QueryOptimizer` requirements, we validate all queries here.
-            aggregations = response.raw_data["aggregations"]
+            aggregations = response.aggregations
             verify_aggregations_satisfy_optimizer_requirements(aggregations, for_query: query)
           end
       end

--- a/elasticgraph-graphql/spec/support/aggregations_helpers.rb
+++ b/elasticgraph-graphql/spec/support/aggregations_helpers.rb
@@ -159,7 +159,7 @@ module ElasticGraph
     # This helper method is used from our unit and integration tests for `DatastoreQuery` to verify that
     # that requirement is satisfied.
     def verify_aggregations_satisfy_optimizer_requirements(aggregations, for_query:)
-      return if aggregations.nil?
+      return if aggregations.nil? || aggregations.empty?
 
       actual_agg_names = aggregations.keys.map do |key|
         GraphQL::Aggregation::Key.extract_aggregation_name_from(key)


### PR DESCRIPTION
Previously, we accessed `aggregations` through it, but it's better if we expose `aggregations` explicitly.