### PR TITLE
Tighten up `query_datastore` expectations.

### DIFF
--- a/elasticgraph-apollo/spec/integration/elastic_graph/apollo/graphql/entities_field_resolver_spec.rb
+++ b/elasticgraph-apollo/spec/integration/elastic_graph/apollo/graphql/entities_field_resolver_spec.rb
@@ -24,7 +24,7 @@ module ElasticGraph
         let(:indexer) { build_indexer(datastore_core: graphql.datastore_core) }
 
         before do
-          # Perform any cached calls to the datastore to happen before our `query_datastore`
+          # Perform any cached calls to the datastore to happen before our `perform_datastore_msearch`
           # matcher below which tries to assert which specific requests get made, since index definitions
           # have caching behavior that can make the presence or absence of that request slightly non-deterministic.
           pre_cache_index_state(graphql)
@@ -600,7 +600,7 @@ module ElasticGraph
             expect(datastore_msearch_requests("main").size).to eq(1)
             # ...with 2 searches (1 for the `id` queries, one for the `total_edge_count`)
             expect(performed_search_metadata("main")).to have_total_widget_searches(2)
-          }.to query_datastore("main", 1).time
+          }.to perform_datastore_msearch("main", 1).time
         end
 
         def execute(query, **options)
@@ -608,7 +608,7 @@ module ElasticGraph
 
           expect {
             response = graphql.graphql_query_executor.execute(query, **options)
-          }.to query_datastore("main", 1).time.or query_datastore("main", 0).times
+          }.to perform_datastore_msearch("main", 1).time.or perform_datastore_msearch("main", 0).times
 
           response
         end

--- a/elasticgraph-graphql/spec/acceptance/datastore_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/datastore_spec.rb
@@ -76,7 +76,7 @@ module ElasticGraph
             "widgets" => {case_correctly("total_edge_count") => 0},
             case_correctly("widget_currencies") => {case_correctly("total_edge_count") => 0}
           )
-        }.to query_datastore("main", 1).time
+        }.to perform_datastore_msearch("main", 1).time.and perform_datastore_search("main", 8).times
       end
 
       it "handles queries against non-existing fields in the datastore gracefully--such as when a new field is added to a rollover index template after the template has been used" do

--- a/elasticgraph-graphql/spec/acceptance/elasticgraph_graphql_acceptance_support.rb
+++ b/elasticgraph-graphql/spec/acceptance/elasticgraph_graphql_acceptance_support.rb
@@ -33,8 +33,8 @@ module ElasticGraph
     end
 
     before do
-      # Perform any cached calls to the datastore to happen before our `query_datastore`
-      # matcher below which tries to assert which specific requests get made, since index definitions
+      # Perform any cached calls to the datastore to happen before our `perform_datastore_msearch`
+      # matcher in some tests which tries to assert which specific requests get made, since index definitions
       # have caching behavior that can make the presence or absence of that request slightly non-deterministic.
       pre_cache_index_state(graphql)
     end

--- a/elasticgraph-graphql/spec/acceptance/nested_relationships_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/nested_relationships_spec.rb
@@ -91,7 +91,7 @@ module ElasticGraph
                 }
               }
             ]
-          }.to query_datastore("main", 1).time
+          }.to perform_datastore_search("main", 1).time
 
           # Test a relates_to_many case (Widget.components) with `id_DESC` sorting.
           expect {
@@ -113,7 +113,7 @@ module ElasticGraph
                 }
               }
             ]
-          }.to query_datastore("main", 1).time
+          }.to perform_datastore_search("main", 1).time
 
           # Test a relates_to_many case (Widget.components) with default (non-id) sorting--it has to make 2 queries.
           expect {
@@ -135,7 +135,7 @@ module ElasticGraph
                 }
               }
             ]
-          }.to query_datastore("main", 2).times
+          }.to perform_datastore_msearch("main", 2).times.and perform_datastore_search("main", 2).times
 
           # Test a relates_to_many case (Widget.components) with additional requested fields--it has to make 2 queries.
           expect {
@@ -161,7 +161,7 @@ module ElasticGraph
                 }
               }
             ]
-          }.to query_datastore("main", 2).time
+          }.to perform_datastore_msearch("main", 2).times.and perform_datastore_search("main", 3).times
 
           # Test a relates_to_many case (Widget.components) with ascending forwards pagination
           paginate_widgets_and_component_ids(backwards: false, first_page: :min, last_page: :max) do |cursor|
@@ -197,7 +197,7 @@ module ElasticGraph
                 "manufacturer" => string_hash_of(manufacturer1, :id)
               }
             ]
-          }.to query_datastore("main", 1).time
+          }.to perform_datastore_search("main", 1).time
         end
 
         it "supports loading bi-directional relationships, starting from either end", :expect_search_routing do
@@ -226,7 +226,7 @@ module ElasticGraph
                   ))
                 ))
               )
-            }.to query_datastore("main", 5).times
+            }.to perform_datastore_msearch("main", 5).times.and perform_datastore_search("main", 10).times
 
             expect_to_have_routed_to_shards_with("main",
               # Root `widgets` query isn't filtering on anything and uses no routing.
@@ -267,7 +267,7 @@ module ElasticGraph
                     ))
                   )))
               )
-            }.to query_datastore("main", 5).times
+            }.to perform_datastore_msearch("main", 5).times.and perform_datastore_search("main", 11).times
 
             expect_to_have_routed_to_shards_with("main",
               # Root `addresses` query isn't filtering on anything and uses no routing.
@@ -460,7 +460,7 @@ module ElasticGraph
                 }
               }
             ]
-          }.to query_datastore("main", 3).times
+          }.to perform_datastore_msearch("main", 3).times.and perform_datastore_search("main", 3).times
         end
 
         def query_all_relationship_levels_from_widgets(component_args: {}, part_args: {})

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_spec.rb
@@ -731,14 +731,14 @@ module ElasticGraph
         def resolve(*args, requested_fields: ["id", "created_at"], **options)
           result = nil
 
-          # Perform any cached calls to the datastore to happen before our `query_datastore`
+          # Perform any cached calls to the datastore to happen before our `perform_datastore_search`
           # matcher below which tries to assert which specific requests get made, since index definitions
           # have caching behavior that can make the presence or absence of that request slightly non-deterministic.
           pre_cache_index_state(graphql)
 
           expect {
             result = super(*args, query_overrides: {requested_fields: requested_fields}, **options)
-          }.to query_datastore("main", 0).times.or query_datastore("main", 1).time
+          }.to perform_datastore_search("main", 0).times.or perform_datastore_search("main", 1).time
 
           result
         end

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/query_source_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/query_source_spec.rb
@@ -37,7 +37,7 @@ module ElasticGraph
           )
 
           # Perform any cached calls to the datastore to prevent them from alter interacting with the
-          # `query_datastore` assertion below.
+          # `perform_datastore_msearch` assertion below.
           pre_cache_index_state(graphql)
           query_tracker = QueryDetailsTracker.empty
 
@@ -49,7 +49,7 @@ module ElasticGraph
 
             expect(widget_results.first.fetch("id")).to eq widget.fetch(:id)
             expect(component_results.first.fetch("id")).to eq component.fetch(:id)
-          }.to query_datastore(components_def.cluster_to_query, 1).time
+          }.to perform_datastore_msearch(components_def.cluster_to_query, 1).time.and perform_datastore_search(components_def.cluster_to_query, 2).times
         end
       end
     end


### PR DESCRIPTION
In a bunch of places we had expectations like:

```ruby
expect {
  do_something
}.to query_datastore("main", 3).times
```

However, "query datastore" is a bit ambiguous since we use `msearch` requests
which can have many individual searches within them. To make it more explicit
I've split `query_datastore` into two matchers:

* `perform_datastore_msearch` for when we expect a number of msearch requests
* `perform_datastore_search` for when we expect a total number of search queries (across any number of `msearch` requests)

Note: I was going to call these methods `msearch_datastore` and `search_datastore`
but that winds up conflicting with an existing `search_datastore` method which
actually runs a search.
