### PR TITLE
Improve Query API documentation in a variety of ways.

### DIFF
--- a/config/site/examples/music/queries/filtering/FindMarch2025Shows.graphql
+++ b/config/site/examples/music/queries/filtering/FindMarch2025Shows.graphql
@@ -1,0 +1,31 @@
+query FindMarch2025Shows {
+  artists(filter: {
+    tours: {anySatisfy: {shows: {anySatisfy: {
+      startedAt: {
+        gte: "2025-03-01T00:00:00Z"
+        lt: "2025-04-01T00:00:00Z"
+
+        # Using gte/lt to fully cover the range is simpler than gte/lte:
+        # gte: "2025-03-01T00:00:00Z"
+        # lte: "2025-03-31T23:59:99.999Z"
+
+        # ...and simpler than gt/lt:
+        # gt: "2025-02-28T23:59:99.999Z"
+        # lt: "2025-04-01T00:00:00Z"
+      }
+    }}}}
+  }) {
+    nodes {
+      name
+
+      tours {
+        shows {
+          venue {
+            id
+          }
+          startedAt
+        }
+      }
+    }
+  }
+}

--- a/config/site/examples/music/queries/filtering/FindU2OrRadiohead.graphql
+++ b/config/site/examples/music/queries/filtering/FindU2OrRadiohead.graphql
@@ -1,4 +1,4 @@
-query EqualityFilter {
+query FindU2OrRadiohead {
   artists(filter: {
     name: {equalToAnyOf: ["U2", "Radiohead"]}
   }) {

--- a/config/site/examples/music/queries/filtering/FindUnnamedArtists.graphql
+++ b/config/site/examples/music/queries/filtering/FindUnnamedArtists.graphql
@@ -1,9 +1,9 @@
-query EqualityFilterNull {
+query FindUnnamedArtists {
   artists(filter: {
     name: {equalToAnyOf: [null]}
   }) {
     nodes {
-      name
+      name # will be null on all returned nodes
       bio {
         yearFormed
       }

--- a/config/site/src/_includes/filtering_predicate_definitions/conjunctions.md
+++ b/config/site/src/_includes/filtering_predicate_definitions/conjunctions.md
@@ -1,4 +1,4 @@
-[`allOf`]({% link query-api/filtering/conjunctions.md %})
+[`allOf`]({% link query-api/filtering/conjunctions.md %}#anding-subfilters-with-allof)
 : Matches records where all of the provided sub-filters evaluate to true.
   This works just like an `AND` operator in SQL.
 
@@ -8,7 +8,7 @@
 
   When `null` or an empty list is passed, matches all documents.
 
-[`anyOf`]({% link query-api/filtering/conjunctions.md %})
+[`anyOf`]({% link query-api/filtering/conjunctions.md %}#oring-subfilters-with-anyof)
 : Matches records where any of the provided sub-filters evaluate to true.
   This works just like an `OR` operator in SQL.
 

--- a/config/site/src/_includes/filtering_predicate_definitions/fulltext.md
+++ b/config/site/src/_includes/filtering_predicate_definitions/fulltext.md
@@ -1,11 +1,11 @@
-[`matchesPhrase`]({% link query-api/filtering/full-text-search.md %})
+[`matchesPhrase`]({% link query-api/filtering/full-text-search.md %}#matches-phrase)
 : Matches records where the field value has a phrase matching the provided phrase using
   full text search. This is stricter than `matchesQuery`: all terms must match
   and be in the same order as the provided phrase.
 
   When `null` is passed, matches all documents.
 
-[`matchesQuery`]({% link query-api/filtering/full-text-search.md %})
+[`matchesQuery`]({% link query-api/filtering/full-text-search.md %}#matches-query)
 : Matches records where the field value matches the provided query using full text search.
   This is more lenient than `matchesPhrase`: the order of terms is ignored, and, by default,
   only one search term is required to be in the field value.

--- a/config/site/src/_includes/filtering_predicate_definitions/list.md
+++ b/config/site/src/_includes/filtering_predicate_definitions/list.md
@@ -1,9 +1,9 @@
-[`anySatisfy`]({% link query-api/filtering/list.md %})
+[`anySatisfy`]({% link query-api/filtering/list.md %}#filtering-on-list-elements-with-anysatisfy)
 : Matches records where any of the list elements match the provided sub-filter.
 
   When `null` or an empty object is passed, matches all documents.
 
-[`count`]({% link query-api/filtering/list.md %})
+[`count`]({% link query-api/filtering/list.md %}#filtering-on-the-list-size-with-count)
 : Used to filter on the number of non-null elements in this list field.
 
   When `null` or an empty object is passed, matches all documents.

--- a/config/site/src/_layouts/query-api.html
+++ b/config/site/src/_layouts/query-api.html
@@ -2,29 +2,33 @@
 layout: markdown
 ---
 
-<div class="alert-note">
-  <div class="alert-title">
-    Try these example queries by visiting the <a href="{{ site.localhost_eg_url }}" class="underline hover:no-underline">GraphiQL UI</a> after booting locally.
-    <button onclick="toggleCommand(this)" class="ml-auto text-sm bg-blue-300 text-gray-900 w-6 h-6 rounded-full flex items-center justify-center hover:bg-blue-200 transition-colors shrink-0 float-right" aria-label="Show startup command">
-      {% include icons/command-chevron-down.svg %}
-      {% include icons/command-chevron-up.svg %}
-    </button>
+{% unless page.hide_try_queries_tip %}
+  <div class="alert-tip">
+    <div class="alert-title">
+      Try these example queries by visiting the <a href="{{ site.localhost_eg_url }}" class="underline hover:no-underline">GraphiQL UI</a> after booting locally.
+      <button onclick="toggleCommand(this)" class="ml-auto text-sm bg-green-300 text-gray-900 w-6 h-6 rounded-full flex items-center justify-center hover:bg-green-200 transition-colors shrink-0 float-right" aria-label="Show startup command">
+        {% include icons/command-chevron-down.svg %}
+        {% include icons/command-chevron-up.svg %}
+      </button>
+    </div>
+    <div class="hidden mt-3" data-command-container>
+      {% include code-box.html command=site.demo_oneliner %}
+    </div>
   </div>
-  <div class="hidden mt-3" data-command-container>
-    {% include code-box.html command=site.demo_oneliner %}
-  </div>
-</div>
+{% endunless %}
 
 {{ content }}
 
-<script>
-function toggleCommand(button) {
-  const container = button.closest('.alert-note').querySelector('[data-command-container]');
-  const showIcon = button.querySelector('[data-show-icon]');
-  const hideIcon = button.querySelector('[data-hide-icon]');
+{% unless page.hide_try_queries_tip %}
+  <script>
+  function toggleCommand(button) {
+    const container = button.closest('.alert-tip').querySelector('[data-command-container]');
+    const showIcon = button.querySelector('[data-show-icon]');
+    const hideIcon = button.querySelector('[data-hide-icon]');
 
-  container.classList.toggle('hidden');
-  showIcon.classList.toggle('hidden');
-  hideIcon.classList.toggle('hidden');
-}
-</script>
+    container.classList.toggle('hidden');
+    showIcon.classList.toggle('hidden');
+    hideIcon.classList.toggle('hidden');
+  }
+  </script>
+{% endunless %}

--- a/config/site/src/assets/css/tailwind.css
+++ b/config/site/src/assets/css/tailwind.css
@@ -61,6 +61,21 @@
     content: 'ⓘ';
   }
 
+  /* Tip alert */
+  .alert-tip {
+    @apply my-4 rounded-lg border-l-4 p-4 border-green-400 bg-green-50/30 dark:border-green-500 dark:bg-green-950/20;
+  }
+
+  .alert-tip > p:first-of-type,
+  .alert-tip > .alert-title {
+    @apply mb-2 flex items-center gap-2 text-lg font-semibold text-green-700 dark:text-green-400;
+  }
+
+  .alert-tip > p:first-of-type::before,
+  .alert-tip > .alert-title::before {
+    content: '💡';
+  }
+
   /* Warning alert */
   .alert-warning {
     @apply my-4 rounded-lg border-l-4 p-4 border-amber-400 bg-amber-50/30 dark:border-amber-500 dark:bg-amber-950/20;
@@ -78,24 +93,28 @@
 
   /* Alert content */
   .alert-note > p:not(:first-of-type),
-  .alert-warning > p:not(:first-of-type) {
+  .alert-warning > p:not(:first-of-type),
+  .alert-tip > p:not(:first-of-type) {
     @apply text-gray-700 dark:text-gray-300;
   }
 
   /* Remove margin from last element in alerts to maintain consistent padding */
   .alert-note > :last-child,
-  .alert-warning > :last-child {
+  .alert-warning > :last-child,
+  .alert-tip > :last-child {
     @apply mb-0;
   }
 
   /* Code blocks within alerts */
   .alert-note .highlight,
-  .alert-warning .highlight {
+  .alert-warning .highlight,
+  .alert-tip .highlight {
     @apply my-4 mx-0;
   }
 
   .alert-note pre,
-  .alert-warning pre {
+  .alert-warning pre,
+  .alert-tip pre {
     @apply bg-white/50 dark:bg-gray-900/50;
   }
 

--- a/config/site/src/getting-started.md
+++ b/config/site/src/getting-started.md
@@ -28,7 +28,9 @@ $ git -v
 git version 2.46.0
 {% endhighlight %}
 
-Note: you don't need these exact versions (these are just examples). Your Ruby version does need to be 3.3.x or greater, though.
+{: .alert-note}
+**Note**{: .alert-title}
+You don't need these exact versions (these are just examples). Your Ruby version does need to be 3.3.x or greater, though.
 
 ## Step 1: Bootstrap a new ElasticGraph Project
 

--- a/config/site/src/query-api.md
+++ b/config/site/src/query-api.md
@@ -1,7 +1,8 @@
 ---
-layout: markdown
+layout: query-api
 title: Query API
 permalink: /query-api/
+hide_try_queries_tip: true
 ---
 
 Learn how to effectively use ElasticGraph's powerful Query API to search, filter, sort, and aggregate your data.

--- a/config/site/src/query-api/filtering/available-predicates.md
+++ b/config/site/src/query-api/filtering/available-predicates.md
@@ -4,6 +4,7 @@ title: 'ElasticGraph Query API: Available Filter Predicates'
 permalink: "/query-api/filtering/available-predicates/"
 nav_title: Available Predicates
 menu_order: 1
+hide_try_queries_tip: true
 ---
 ElasticGraph offers a variety of filtering predicates:
 

--- a/config/site/src/query-api/filtering/comparison.md
+++ b/config/site/src/query-api/filtering/comparison.md
@@ -9,6 +9,8 @@ ElasticGraph offers a standard set of comparison filter predicates:
 
 {% include filtering_predicate_definitions/comparison.md %}
 
+Here's an example:
+
 {% highlight graphql %}
 {{ site.data.music_queries.filtering.FindArtistsFormedIn90s }}
 {% endhighlight %}

--- a/config/site/src/query-api/filtering/conjunctions.md
+++ b/config/site/src/query-api/filtering/conjunctions.md
@@ -19,7 +19,7 @@ formed after the year 2000 with "accordion" in their bio:
 ### ORing subfilters with `anyOf`
 
 To instead find artists formed after the year 2000 OR with "accordion" in their bio, you
-can wrap the sub-filters in an `anyOf`:
+can pass the sub-filters as a list to `anyOf`:
 
 {% highlight graphql %}
 {{ site.data.music_queries.filtering.FindRecentOrAccordionArtists }}

--- a/config/site/src/query-api/filtering/date-time.md
+++ b/config/site/src/query-api/filtering/date-time.md
@@ -20,8 +20,14 @@ ElasticGraph supports three different date/time types:
   formatted based on the [partial-time portion of RFC3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6).
 
 All three support the standard set of [equality]({% link query-api/filtering/equality.md %}) and
-[comparison]({% link query-api/filtering/comparison.md %}) predicates. In addition, `DateTime` fields
-support one more filtering operator:
+[comparison]({% link query-api/filtering/comparison.md %}) predicates. When using comparison
+predicates to cover a range, it's usually simplest to pair `gte` with `lt`:
+
+{% highlight graphql %}
+{{ site.data.music_queries.filtering.FindMarch2025Shows }}
+{% endhighlight %}
+
+In addition, `DateTime` fields support one more filtering operator:
 
 {% include filtering_predicate_definitions/time_of_day.md %}
 

--- a/config/site/src/query-api/filtering/equality.md
+++ b/config/site/src/query-api/filtering/equality.md
@@ -12,11 +12,11 @@ The most commonly used predicate supports equality filtering:
 Here's a basic example:
 
 {% highlight graphql %}
-{{ site.data.music_queries.filtering.EqualityFilter }}
+{{ site.data.music_queries.filtering.FindU2OrRadiohead }}
 {% endhighlight %}
 
 Unlike the SQL `IN` operator, you can find records with `null` values if you put `null` in the list:
 
 {% highlight graphql %}
-{{ site.data.music_queries.filtering.EqualityFilterNull }}
+{{ site.data.music_queries.filtering.FindUnnamedArtists }}
 {% endhighlight %}

--- a/config/site/src/query-api/filtering/geographic.md
+++ b/config/site/src/query-api/filtering/geographic.md
@@ -9,6 +9,8 @@ The `GeoLocation` type supports a special predicate:
 
 {% include filtering_predicate_definitions/near.md %}
 
+Here's an example of this predicate:
+
 {% highlight graphql %}
 {{ site.data.music_queries.filtering.FindSeattleVenues }}
 {% endhighlight %}

--- a/config/site/src/query-api/overview.md
+++ b/config/site/src/query-api/overview.md
@@ -12,8 +12,34 @@ ElasticGraph provides an extremely flexible GraphQL query API. As with every Gra
 {{ site.data.music_queries.basic.ListArtistAlbums }}
 {% endhighlight %}
 
-If you're just getting started with GraphQL, we recommend you review the [graphql.org learning materials](https://graphql.org/learn/queries/).
+If you're just getting started with GraphQL, we recommend you review the [graphql.org
+learning materials](https://graphql.org/learn/queries/).
 
 ElasticGraph offers a number of query features that go far beyond a traditional GraphQL
-API. Each of these features is implemented directly by the ElasticGraph framework, ensuring
-consistent, predictable behavior across your entire schema.
+API (we like to call it "GraphQL with superpowers"). Each of these features is implemented
+directly by the ElasticGraph framework, ensuring consistent, predictable behavior across your
+entire schema.
+
+[Filtering]({% link query-api/filtering.md %})
+: ElasticGraph's filtering support allows clients to filter on _any_ field defined in the schema
+  with a wide array of filtering predicates. Native support is included to
+  [negate]({% link query-api/filtering/negation.md %}) and
+  [combine]({% link query-api/filtering/conjunctions.md %}) filters in arbitrary ways.
+
+[Aggregations]({% link query-api/aggregations.md %})
+: ElasticGraph includes an intuitive, flexible aggregations API which allows clients to [group
+  records]({% link query-api/aggregations/grouping.md %}) by _any_ field in your schema.
+  Within each grouping, clients can [count records]({% link query-api/aggregations/counts.md %})
+  or compute [aggregated values]({% link query-api/aggregations/aggregated-values.md %}) over
+  the set of values from any field. Further [sub-aggregations]({% link query-api/aggregations/sub-aggregations.md %})
+  can be applied on list-of-object fields.
+
+[Sorting]({% link query-api/sorting.md %})
+: ElasticGraph allows clients to sort by _any_ field defined in the schema.
+
+[Pagination]({% link query-api/pagination.md %})
+: ElasticGraph implements the industry standard [Relay GraphQL Cursor Connections
+  Specification](https://relay.dev/graphql/connections.htm) to support pagination, and
+  extends it with support for `totalEdgeCount` and `nodes`.
+  Pagination is available under both a "raw data" field (e.g `artists`) and under
+  an aggregations field (e.g. `artistAggregations`).

--- a/config/site/src/query-api/pagination.md
+++ b/config/site/src/query-api/pagination.md
@@ -3,7 +3,7 @@ layout: query-api
 title: 'ElasticGraph Query API: Pagination'
 permalink: "/query-api/pagination/"
 nav_title: Pagination
-menu_order: 4
+menu_order: 5
 ---
 To provide pagination, ElasticGraph implements the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm). Here's an example query showing
@@ -12,6 +12,11 @@ pagination in action:
 {% highlight graphql %}
 {{ site.data.music_queries.pagination.PaginationExample }}
 {% endhighlight %}
+
+This example uses `first:`, `after:`, and `pageInfo { hasNextPage, endCursor }` to implement forward pagination.
+If `pageInfo.hasNextPage` indicates there is another page, the client can pass `pageInfo.endCursor` as the
+`$cursor` value on the next request. Relay backwards pagination is also supported using `last:`, `before:`,
+and `pageInfo { hasPreviousPage, startCursor }`.
 
 In addition, ElasticGraph offers some additional features beyond the Relay spec.
 
@@ -24,7 +29,9 @@ It can be used to get a total count of matching records:
 {{ site.data.music_queries.pagination.Count21stCenturyArtists }}
 {% endhighlight %}
 
-Note: `totalEdgeCount` is not available under an [aggregations]({% link query-api/aggregations.md %}) field.
+{: .alert-note}
+**Note**{: .alert-title}
+`totalEdgeCount` is not available under an [aggregations]({% link query-api/aggregations.md %}) field.
 
 ### Nodes
 

--- a/config/site/src/query-api/sorting.md
+++ b/config/site/src/query-api/sorting.md
@@ -3,7 +3,7 @@ layout: query-api
 title: 'ElasticGraph Query API: Sorting'
 permalink: "/query-api/sorting/"
 nav_title: Sorting
-menu_order: 5
+menu_order: 4
 ---
 Use `orderBy:` on a root query field to control how the results are sorted:
 
@@ -12,3 +12,5 @@ Use `orderBy:` on a root query field to control how the results are sorted:
 {% endhighlight %}
 
 This query, for example, would sort by `name` (ascending), with `bio.yearFormed` (descending) as a tie breaker.
+When no `orderBy:` argument is provided, ElasticGraph will sort according to the
+[default sort configured on the index]({{ '/docs/' | append: site.data.doc_versions.latest_version | append: '/ElasticGraph/SchemaDefinition/Indexing/Index.html#default_sort-instance_method' | relative_url }}).


### PR DESCRIPTION
- Convert the "note" alert to a "tip" alert (green instead of blue, with a lightbulb icon).
- Deep link to a specific spot of a page where appropriate.
- Rename queries so they match the kind of name a user might give the query.
- Hide the "Try these example queries..." alert on the pages that don't have any example queries.
- Apply the alert note styling in a couple more places where it's appropriate.
- Add more query examples.
- Explain how to paginate instead of just referring readers to the Relay spec.
- Describe the notable features ElasticGraph offers over most GraphQL APIs at the overview page.