### PR TITLE
Add all_of to GraphQL filtering schema alongside any_of

### DIFF
--- a/config/schema/artifacts/schema.graphql
+++ b/config/schema/artifacts/schema.graphql
@@ -163,6 +163,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input AddressFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `AddressFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [AddressFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -262,6 +274,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input AddressTimestampsFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `AddressTimestampsFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [AddressTimestampsFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -320,6 +344,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input AffiliationsFieldsListFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `AffiliationsFieldsListFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [AffiliationsFieldsListFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -364,6 +400,18 @@ Input type used to specify filters on `Affiliations` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input AffiliationsFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `AffiliationsFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [AffiliationsFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -458,6 +506,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input BooleanFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `BooleanFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [BooleanFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -492,6 +552,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input BooleanListElementFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `BooleanListElementFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [BooleanListElementFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -522,8 +594,8 @@ input BooleanListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `BooleanListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -574,6 +646,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input ColorFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `ColorFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [ColorFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -614,6 +698,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input ColorListElementFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `ColorListElementFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [ColorListElementFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -644,8 +740,8 @@ input ColorListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `ColorListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -1070,6 +1166,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input ComponentFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `ComponentFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [ComponentFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -1329,6 +1437,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input CurrencyDetailsFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `CurrencyDetailsFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [CurrencyDetailsFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -1430,6 +1550,18 @@ Input type used to specify filters on `Date` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input DateFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `DateFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [DateFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -1608,6 +1740,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input DateListElementFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `DateListElementFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [DateListElementFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -1666,8 +1810,8 @@ input DateListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `DateListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -1753,6 +1897,18 @@ Input type used to specify filters on `DateTime` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input DateTimeFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `DateTimeFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [DateTimeFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -2024,6 +2180,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input DateTimeListElementFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `DateTimeListElementFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [DateTimeListElementFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -2089,8 +2257,8 @@ input DateTimeListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `DateTimeListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -2574,6 +2742,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input ElectricalPartFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `ElectricalPartFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [ElectricalPartFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -2743,6 +2923,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input FloatFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `FloatFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [FloatFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -2846,6 +3038,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input GeoLocationFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `GeoLocationFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [GeoLocationFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -2883,6 +3087,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input IDFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `IDFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [IDFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -2917,6 +3133,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input IDListElementFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `IDListElementFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [IDListElementFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -2947,8 +3175,8 @@ input IDListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `IDListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -3051,6 +3279,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input IntFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `IntFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [IntFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -3113,6 +3353,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input IntListElementFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `IntListElementFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [IntListElementFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -3171,8 +3423,8 @@ input IntListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `IntListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -3238,6 +3490,18 @@ Input type used to specify filters on `Inventor` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input InventorFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `InventorFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [InventorFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -3389,6 +3653,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input JsonSafeLongFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `JsonSafeLongFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [JsonSafeLongFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -3451,6 +3727,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input JsonSafeLongListElementFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `JsonSafeLongListElementFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [JsonSafeLongListElementFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -3509,8 +3797,8 @@ input JsonSafeLongListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `JsonSafeLongListFilterInput` input because of
-  collisions between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -3597,6 +3885,18 @@ Input type used to specify filters on `LocalTime` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input LocalTimeFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `LocalTimeFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [LocalTimeFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -3821,6 +4121,18 @@ Input type used to specify filters on `LongString` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input LongStringFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `LongStringFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [LongStringFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -4119,6 +4431,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input ManufacturerFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `ManufacturerFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [ManufacturerFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -4279,6 +4603,18 @@ Input type used to specify filters on `Material` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input MaterialFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `MaterialFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [MaterialFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -4559,6 +4895,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input MechanicalPartFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `MechanicalPartFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [MechanicalPartFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -4698,6 +5046,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input MoneyFieldsListFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `MoneyFieldsListFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [MoneyFieldsListFilterInput!]
+
+  """
   Used to filter on the `amount_cents` field.
 
   When `null` or an empty object is passed, matches all documents.
@@ -4742,6 +5102,18 @@ Input type used to specify filters on `Money` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input MoneyFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `MoneyFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [MoneyFilterInput!]
+
   """
   Used to filter on the `amount_cents` field.
 
@@ -4800,8 +5172,8 @@ input MoneyListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `MoneyListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -5166,6 +5538,18 @@ Input type used to specify filters on `NamedEntity` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input NamedEntityFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `NamedEntityFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [NamedEntityFilterInput!]
+
   """
   Used to filter on the `amount_cents` field.
 
@@ -6222,6 +6606,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input NamedInventorFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `NamedInventorFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [NamedInventorFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -6474,6 +6870,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input PartFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `PartFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [PartFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -6660,6 +7068,18 @@ input PlayerFieldsListFilterInput {
   affiliations: AffiliationsFieldsListFilterInput
 
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `PlayerFieldsListFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [PlayerFieldsListFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -6724,6 +7144,18 @@ input PlayerFilterInput {
   When `null` or an empty object is passed, matches all documents.
   """
   affiliations: AffiliationsFilterInput
+
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `PlayerFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [PlayerFilterInput!]
 
   """
   Matches records where any of the provided sub-filters evaluate to true.
@@ -6809,8 +7241,8 @@ input PlayerListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `PlayerListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -6921,6 +7353,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input PlayerSeasonFieldsListFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `PlayerSeasonFieldsListFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [PlayerSeasonFieldsListFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -6972,6 +7416,18 @@ Input type used to specify filters on `PlayerSeason` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input PlayerSeasonFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `PlayerSeasonFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [PlayerSeasonFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -7037,8 +7493,8 @@ input PlayerSeasonListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `PlayerSeasonListFilterInput` input because of
-  collisions between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -7102,6 +7558,18 @@ Input type used to specify filters on `Position` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input PositionFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `PositionFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [PositionFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -8511,6 +8979,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input SizeFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `SizeFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [SizeFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -8551,6 +9031,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input SizeListElementFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `SizeListElementFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [SizeListElementFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -8581,8 +9073,8 @@ input SizeListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `SizeListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -8957,6 +9449,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input SponsorFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `SponsorFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [SponsorFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -9052,6 +9556,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input SponsorshipFieldsListFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `SponsorshipFieldsListFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [SponsorshipFieldsListFilterInput!]
+
+  """
   Used to filter on the `annual_total` field.
 
   When `null` or an empty object is passed, matches all documents.
@@ -9096,6 +9612,18 @@ Input type used to specify filters on `Sponsorship` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input SponsorshipFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `SponsorshipFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [SponsorshipFilterInput!]
+
   """
   Used to filter on the `annual_total` field.
 
@@ -9154,8 +9682,8 @@ input SponsorshipListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `SponsorshipListFilterInput` input because of
-  collisions between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -9248,6 +9776,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input StringFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `StringFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [StringFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -9282,6 +9822,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input StringListElementFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `StringListElementFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [StringListElementFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -9312,8 +9864,8 @@ input StringListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `StringListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -9853,6 +10405,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input TeamDetailsFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `TeamDetailsFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [TeamDetailsFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -9920,6 +10484,18 @@ Input type used to specify filters on `Team` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input TeamFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `TeamFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [TeamFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -10181,6 +10757,18 @@ Input type used to specify filters on `TeamNestedFields` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input TeamNestedFieldsFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `TeamNestedFieldsFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [TeamNestedFieldsFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -10463,6 +11051,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input TeamRecordFieldsListFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `TeamRecordFieldsListFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [TeamRecordFieldsListFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -10535,6 +11135,18 @@ Input type used to specify filters on `TeamRecord` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input TeamRecordFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `TeamRecordFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [TeamRecordFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -10734,6 +11346,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input TeamSeasonFieldsListFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `TeamSeasonFieldsListFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [TeamSeasonFieldsListFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -10834,6 +11458,18 @@ Input type used to specify filters on `TeamSeason` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input TeamSeasonFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `TeamSeasonFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [TeamSeasonFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -11057,8 +11693,8 @@ input TeamSeasonListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `TeamSeasonListFilterInput` input because of
-  collisions between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -11541,6 +12177,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input TextFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `TextFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [TextFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -11620,6 +12268,18 @@ Input type used to specify filters on `Untyped` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input UntypedFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `UntypedFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [UntypedFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -12274,6 +12934,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input WidgetCurrencyFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `WidgetCurrencyFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [WidgetCurrencyFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -12435,6 +13107,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input WidgetCurrencyNestedFieldsFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `WidgetCurrencyNestedFieldsFilterInput` input because
+  of collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [WidgetCurrencyNestedFieldsFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -12580,6 +13264,18 @@ Input type used to specify filters on `Widget` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input WidgetFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `WidgetFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [WidgetFilterInput!]
+
   """
   Used to filter on the `amount_cents` field.
 
@@ -13086,6 +13782,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input WidgetOptionSetsFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `WidgetOptionSetsFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [WidgetOptionSetsFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -13155,6 +13863,18 @@ Input type used to specify filters on `WidgetOptions` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input WidgetOptionsFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `WidgetOptionsFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [WidgetOptionsFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -13530,6 +14250,18 @@ Input type used to specify filters on `WidgetOrAddress` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input WidgetOrAddressFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `WidgetOrAddressFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [WidgetOrAddressFilterInput!]
+
   """
   Used to filter on the `amount_cents` field.
 
@@ -14934,6 +15666,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input WidgetWorkspaceFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `WidgetWorkspaceFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [WidgetWorkspaceFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -15058,6 +15802,18 @@ Input type used to specify filters on `WorkspaceWidget` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input WorkspaceWidgetFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `WorkspaceWidgetFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [WorkspaceWidgetFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.

--- a/config/schema/artifacts_with_apollo/schema.graphql
+++ b/config/schema/artifacts_with_apollo/schema.graphql
@@ -196,6 +196,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input AddressFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `AddressFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [AddressFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -295,6 +307,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input AddressTimestampsFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `AddressTimestampsFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [AddressTimestampsFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -353,6 +377,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input AffiliationsFieldsListFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `AffiliationsFieldsListFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [AffiliationsFieldsListFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -397,6 +433,18 @@ Input type used to specify filters on `Affiliations` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input AffiliationsFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `AffiliationsFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [AffiliationsFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -491,6 +539,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input BooleanFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `BooleanFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [BooleanFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -525,6 +585,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input BooleanListElementFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `BooleanListElementFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [BooleanListElementFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -555,8 +627,8 @@ input BooleanListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `BooleanListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -607,6 +679,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input ColorFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `ColorFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [ColorFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -647,6 +731,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input ColorListElementFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `ColorListElementFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [ColorListElementFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -677,8 +773,8 @@ input ColorListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `ColorListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -1103,6 +1199,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input ComponentFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `ComponentFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [ComponentFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -1503,6 +1611,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input CurrencyDetailsFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `CurrencyDetailsFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [CurrencyDetailsFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -1604,6 +1724,18 @@ Input type used to specify filters on `Date` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input DateFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `DateFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [DateFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -1782,6 +1914,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input DateListElementFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `DateListElementFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [DateListElementFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -1840,8 +1984,8 @@ input DateListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `DateListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -1927,6 +2071,18 @@ Input type used to specify filters on `DateTime` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input DateTimeFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `DateTimeFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [DateTimeFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -2198,6 +2354,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input DateTimeListElementFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `DateTimeListElementFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [DateTimeListElementFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -2263,8 +2431,8 @@ input DateTimeListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `DateTimeListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -2748,6 +2916,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input ElectricalPartFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `ElectricalPartFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [ElectricalPartFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -2932,6 +3112,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input FloatFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `FloatFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [FloatFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -3035,6 +3227,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input GeoLocationFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `GeoLocationFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [GeoLocationFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -3072,6 +3276,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input IDFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `IDFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [IDFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -3106,6 +3322,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input IDListElementFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `IDListElementFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [IDListElementFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -3136,8 +3364,8 @@ input IDListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `IDListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -3240,6 +3468,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input IntFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `IntFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [IntFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -3302,6 +3542,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input IntListElementFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `IntListElementFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [IntListElementFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -3360,8 +3612,8 @@ input IntListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `IntListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -3427,6 +3679,18 @@ Input type used to specify filters on `Inventor` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input InventorFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `InventorFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [InventorFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -3578,6 +3842,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input JsonSafeLongFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `JsonSafeLongFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [JsonSafeLongFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -3640,6 +3916,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input JsonSafeLongListElementFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `JsonSafeLongListElementFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [JsonSafeLongListElementFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -3698,8 +3986,8 @@ input JsonSafeLongListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `JsonSafeLongListFilterInput` input because of
-  collisions between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -3786,6 +4074,18 @@ Input type used to specify filters on `LocalTime` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input LocalTimeFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `LocalTimeFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [LocalTimeFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -4010,6 +4310,18 @@ Input type used to specify filters on `LongString` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input LongStringFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `LongStringFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [LongStringFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -4308,6 +4620,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input ManufacturerFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `ManufacturerFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [ManufacturerFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -4468,6 +4792,18 @@ Input type used to specify filters on `Material` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input MaterialFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `MaterialFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [MaterialFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -4748,6 +5084,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input MechanicalPartFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `MechanicalPartFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [MechanicalPartFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -4887,6 +5235,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input MoneyFieldsListFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `MoneyFieldsListFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [MoneyFieldsListFilterInput!]
+
+  """
   Used to filter on the `amount_cents` field.
 
   When `null` or an empty object is passed, matches all documents.
@@ -4931,6 +5291,18 @@ Input type used to specify filters on `Money` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input MoneyFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `MoneyFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [MoneyFilterInput!]
+
   """
   Used to filter on the `amount_cents` field.
 
@@ -4989,8 +5361,8 @@ input MoneyListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `MoneyListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -5355,6 +5727,18 @@ Input type used to specify filters on `NamedEntity` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input NamedEntityFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `NamedEntityFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [NamedEntityFilterInput!]
+
   """
   Used to filter on the `amount_cents` field.
 
@@ -6411,6 +6795,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input NamedInventorFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `NamedInventorFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [NamedInventorFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -6663,6 +7059,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input PartFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `PartFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [PartFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -6849,6 +7257,18 @@ input PlayerFieldsListFilterInput {
   affiliations: AffiliationsFieldsListFilterInput
 
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `PlayerFieldsListFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [PlayerFieldsListFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -6913,6 +7333,18 @@ input PlayerFilterInput {
   When `null` or an empty object is passed, matches all documents.
   """
   affiliations: AffiliationsFilterInput
+
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `PlayerFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [PlayerFilterInput!]
 
   """
   Matches records where any of the provided sub-filters evaluate to true.
@@ -6998,8 +7430,8 @@ input PlayerListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `PlayerListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -7110,6 +7542,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input PlayerSeasonFieldsListFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `PlayerSeasonFieldsListFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [PlayerSeasonFieldsListFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -7161,6 +7605,18 @@ Input type used to specify filters on `PlayerSeason` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input PlayerSeasonFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `PlayerSeasonFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [PlayerSeasonFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -7226,8 +7682,8 @@ input PlayerSeasonListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `PlayerSeasonListFilterInput` input because of
-  collisions between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -7291,6 +7747,18 @@ Input type used to specify filters on `Position` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input PositionFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `PositionFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [PositionFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -8741,6 +9209,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input SizeFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `SizeFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [SizeFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -8781,6 +9261,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input SizeListElementFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `SizeListElementFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [SizeListElementFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -8811,8 +9303,8 @@ input SizeListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `SizeListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -9187,6 +9679,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input SponsorFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `SponsorFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [SponsorFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -9282,6 +9786,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input SponsorshipFieldsListFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `SponsorshipFieldsListFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [SponsorshipFieldsListFilterInput!]
+
+  """
   Used to filter on the `annual_total` field.
 
   When `null` or an empty object is passed, matches all documents.
@@ -9326,6 +9842,18 @@ Input type used to specify filters on `Sponsorship` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input SponsorshipFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `SponsorshipFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [SponsorshipFilterInput!]
+
   """
   Used to filter on the `annual_total` field.
 
@@ -9384,8 +9912,8 @@ input SponsorshipListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `SponsorshipListFilterInput` input because of
-  collisions between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -9478,6 +10006,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input StringFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `StringFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [StringFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -9512,6 +10052,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input StringListElementFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `StringListElementFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [StringListElementFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -9542,8 +10094,8 @@ input StringListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `StringListFilterInput` input because of collisions
-  between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -10083,6 +10635,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input TeamDetailsFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `TeamDetailsFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [TeamDetailsFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -10150,6 +10714,18 @@ Input type used to specify filters on `Team` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input TeamFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `TeamFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [TeamFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -10411,6 +10987,18 @@ Input type used to specify filters on `TeamNestedFields` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input TeamNestedFieldsFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `TeamNestedFieldsFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [TeamNestedFieldsFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -10693,6 +11281,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input TeamRecordFieldsListFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `TeamRecordFieldsListFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [TeamRecordFieldsListFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -10765,6 +11365,18 @@ Input type used to specify filters on `TeamRecord` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input TeamRecordFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `TeamRecordFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [TeamRecordFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -10964,6 +11576,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input TeamSeasonFieldsListFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `TeamSeasonFieldsListFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [TeamSeasonFieldsListFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -11064,6 +11688,18 @@ Input type used to specify filters on `TeamSeason` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input TeamSeasonFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `TeamSeasonFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [TeamSeasonFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -11287,8 +11923,8 @@ input TeamSeasonListFilterInput {
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
   be provided on a single `TeamSeasonListFilterInput` input because of
-  collisions between key names. For example, if you want to provide
-  multiple `any_satisfy: ...` filters, you could do `all_of: [{any_satisfy: ...}, {any_satisfy: ...}]`.
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
 
   When `null` or an empty list is passed, matches all documents.
   """
@@ -11771,6 +12407,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input TextFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `TextFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [TextFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -11850,6 +12498,18 @@ Input type used to specify filters on `Untyped` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input UntypedFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `UntypedFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [UntypedFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -12504,6 +13164,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input WidgetCurrencyFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `WidgetCurrencyFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [WidgetCurrencyFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -12665,6 +13337,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input WidgetCurrencyNestedFieldsFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `WidgetCurrencyNestedFieldsFilterInput` input because
+  of collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [WidgetCurrencyNestedFieldsFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -12810,6 +13494,18 @@ Input type used to specify filters on `Widget` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input WidgetFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `WidgetFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [WidgetFilterInput!]
+
   """
   Used to filter on the `amount_cents` field.
 
@@ -13316,6 +14012,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input WidgetOptionSetsFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `WidgetOptionSetsFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [WidgetOptionSetsFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -13385,6 +14093,18 @@ Input type used to specify filters on `WidgetOptions` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input WidgetOptionsFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `WidgetOptionsFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [WidgetOptionsFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
@@ -13760,6 +14480,18 @@ Input type used to specify filters on `WidgetOrAddress` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input WidgetOrAddressFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `WidgetOrAddressFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [WidgetOrAddressFilterInput!]
+
   """
   Used to filter on the `amount_cents` field.
 
@@ -15164,6 +15896,18 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input WidgetWorkspaceFilterInput {
   """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `WidgetWorkspaceFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [WidgetWorkspaceFilterInput!]
+
+  """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.
 
@@ -15288,6 +16032,18 @@ Input type used to specify filters on `WorkspaceWidget` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input WorkspaceWidgetFilterInput {
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `WorkspaceWidgetFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [WorkspaceWidgetFilterInput!]
+
   """
   Matches records where any of the provided sub-filters evaluate to true.
   This works just like an OR operator in SQL.

--- a/config/site/src/_includes/filtering_predicate_definitions/conjunctions.md
+++ b/config/site/src/_includes/filtering_predicate_definitions/conjunctions.md
@@ -4,7 +4,7 @@
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple
   filters that can't be provided on a single filter input because of collisions between key names.
-  For example, if you want to provide multiple `anySatisfy: ...` filters, you could do `allOf: [{anySatisfy: ...}, {anySatisfy: ...}]`.
+  For example, if you want to AND multiple OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do `allOf: [{anyOf: [...]}, {anyOf: [...]}]`.
 
   When `null` or an empty list is passed, matches all documents.
 

--- a/elasticgraph-apollo/spec/unit/elastic_graph/apollo/apollo_directives_spec.rb
+++ b/elasticgraph-apollo/spec/unit/elastic_graph/apollo/apollo_directives_spec.rb
@@ -214,6 +214,7 @@ module ElasticGraph
           expect(type_def_from(schema_string, "UrlFilterInput")).to eq(<<~EOS.strip)
             input UrlFilterInput @inaccessible {
               #{schema_elements.any_of}: [UrlFilterInput!]
+              #{schema_elements.all_of}: [UrlFilterInput!]
               #{schema_elements.not}: UrlFilterInput
               #{schema_elements.equal_to_any_of}: [Url]
               host: String @inaccessible
@@ -542,6 +543,7 @@ module ElasticGraph
           expect(type_def_from(schema_string, "UrlFilterInput")).to eq(<<~EOS.strip)
             input UrlFilterInput @tag(name: "test") {
               #{schema_elements.any_of}: [UrlFilterInput!]
+              #{schema_elements.all_of}: [UrlFilterInput!]
               #{schema_elements.not}: UrlFilterInput
               #{schema_elements.equal_to_any_of}: [Url]
               host: String @tag(name: "test")

--- a/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
+++ b/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
@@ -697,6 +697,7 @@ module ElasticGraph
 
           expect(type_def_for.call("WidgetFilterInput")).to eq(<<~EOS.strip)
             input WidgetFilterInput {
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.any_of}: [WidgetFilterInput!]
               id: IDFilterInput
               name: StringFilterInput @tag(name: "public")
@@ -735,6 +736,7 @@ module ElasticGraph
 
           expect(type_def_for.call("WidgetOptionsFilterInput")).to eq(<<~EOS.strip)
             input WidgetOptionsFilterInput {
+              #{schema_elements.all_of}: [WidgetOptionsFilterInput!]
               #{schema_elements.any_of}: [WidgetOptionsFilterInput!]
               color: StringFilterInput @tag(name: "public")
               not: WidgetOptionsFilterInput
@@ -788,6 +790,7 @@ module ElasticGraph
           # the tagging of those source fields. That's why `name`, `options1`, etc are tagged with `public` below.
           expect(type_def_for.call("IdentifiableFilterInput")).to eq(<<~EOS.strip)
             input IdentifiableFilterInput {
+              #{schema_elements.all_of}: [IdentifiableFilterInput!]
               #{schema_elements.any_of}: [IdentifiableFilterInput!]
               id: IDFilterInput
               name: StringFilterInput @tag(name: "public")

--- a/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/variable_dumper_spec.rb
+++ b/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/variable_dumper_spec.rb
@@ -111,7 +111,7 @@ module ElasticGraph
             "CountWithIdFilterInput" => {
               "idFilter" => {
                 "type" => "IDFilterInput!",
-                "fields" => {"any_of" => "[IDFilterInput!]", "not" => "IDFilterInput", "equal_to_any_of" => "[ID]"}
+                "fields" => {"all_of" => "[IDFilterInput!]", "any_of" => "[IDFilterInput!]", "not" => "IDFilterInput", "equal_to_any_of" => "[ID]"}
               }
             }
           })
@@ -145,24 +145,29 @@ module ElasticGraph
 
           expect(dumper.dump_variables_for_query(query_string)).to eq({"CountWithOptions" => {
             "optionsFilterInput" => {"type" => "WidgetOptionsFilterInput!", "fields" => {
+              "all_of" => "[WidgetOptionsFilterInput!]",
               "any_of" => "[WidgetOptionsFilterInput!]",
               "not" => "WidgetOptionsFilterInput",
               "color" => {"type" => "ColorFilterInput", "fields" => {
+                "all_of" => "[ColorFilterInput!]",
                 "any_of" => "[ColorFilterInput!]",
                 "not" => "ColorFilterInput",
                 "equal_to_any_of" => {"type" => "[ColorInput]", "values" => ["BLUE", "GREEN", "RED"]}
               }},
               "is_draft" => {"type" => "BooleanFilterInput", "fields" => {
+                "all_of" => "[BooleanFilterInput!]",
                 "any_of" => "[BooleanFilterInput!]",
                 "not" => "BooleanFilterInput",
                 "equal_to_any_of" => "[Boolean]"
               }},
               "size" => {"type" => "SizeFilterInput", "fields" => {
+                "all_of" => "[SizeFilterInput!]",
                 "any_of" => "[SizeFilterInput!]",
                 "not" => "SizeFilterInput",
                 "equal_to_any_of" => {"type" => "[SizeInput]", "values" => ["LARGE", "MEDIUM", "SMALL"]}
               }},
               "the_size" => {"type" => "SizeFilterInput", "fields" => {
+                "all_of" => "[SizeFilterInput!]",
                 "any_of" => "[SizeFilterInput!]",
                 "not" => "SizeFilterInput",
                 "equal_to_any_of" => {"type" => "[SizeInput]", "values" => ["LARGE", "MEDIUM", "SMALL"]}

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
@@ -282,11 +282,11 @@ module ElasticGraph
               f.default false
             end
 
-            # any_of/not don't really make sense on this filter because it doesn't make sense to
-            # apply an OR operator or negation to the fields of this type since they are all an
+            # any_of/all_of/not don't really make sense on this filter because it doesn't make sense
+            # to apply an OR operator or negation to the fields of this type since they are all an
             # indivisible part of a single filter operation on a specific field. So we remove them
             # here.
-            remove_any_of_and_not_filter_operators_on(t)
+            remove_any_of_and_all_of_and_not_filter_operators_on(t)
           end
 
           register_filter "MatchesPhrase" do |t|
@@ -300,11 +300,11 @@ module ElasticGraph
               f.documentation "The input phrase to search for."
             end
 
-            # any_of/not don't really make sense on this filter because it doesn't make sense to
-            # apply an OR operator or negation to the fields of this type since they are all an
+            # any_of/all_of/not don't really make sense on this filter because it doesn't make
+            # to apply an OR operator or negation to the fields of this type since they are all an
             # indivisible part of a single filter operation on a specific field. So we remove them
             # here.
-            remove_any_of_and_not_filter_operators_on(t)
+            remove_any_of_and_all_of_and_not_filter_operators_on(t)
           end
 
           # This is defined as a built-in ElasticGraph type so that we can leverage Elasticsearch/OpenSearch GeoLocation features
@@ -372,11 +372,11 @@ module ElasticGraph
               f.documentation "Determines the unit of the specified `#{names.max_distance}`."
             end
 
-            # any_of/not don't really make sense on this filter because it doesn't make sense to
-            # apply an OR operator or negation to the fields of this type since they are all an
+            # any_of/all_of/not don't really make sense on this filter because it doesn't make sense
+            # to apply an OR operator or negation to the fields of this type since they are all an
             # indivisible part of a single filter operation on a specific field. So we remove them
             # here.
-            remove_any_of_and_not_filter_operators_on(t)
+            remove_any_of_and_all_of_and_not_filter_operators_on(t)
           end
 
           # Note: `has_next_page`/`has_previous_page` are required to be non-null by the relay
@@ -732,11 +732,11 @@ module ElasticGraph
                 f.default "UTC"
               end
 
-              # With our initial implementation of `time_of_day` filtering, it's tricky to support `any_of`/`not` within
+              # With our initial implementation of `time_of_day` filtering, it's tricky to support `any_of`/`all_of`/`not` within
               # the `time_of_day: {...}` input object. They are still supported outside of `time_of_day` (on the parent
               # input object) so no functionality is losts by omitting these. Also, this aligns with our `GeoLocationDistanceFilterInput`
               # which is a similarly complex filter where we didn't include them.
-              remove_any_of_and_not_filter_operators_on(t)
+              remove_any_of_and_all_of_and_not_filter_operators_on(t)
             end
           end
 
@@ -1546,8 +1546,9 @@ module ElasticGraph
           schema_def_state.register_input_type(input_type)
         end
 
-        def remove_any_of_and_not_filter_operators_on(type)
+        def remove_any_of_and_all_of_and_not_filter_operators_on(type)
           type.graphql_fields_by_name.delete(names.any_of)
+          type.graphql_fields_by_name.delete(names.all_of)
           type.graphql_fields_by_name.delete(names.not)
         end
       end

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/built_in_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/built_in_types_spec.rb
@@ -108,6 +108,16 @@ module ElasticGraph
               """
               #{schema_elements.any_of}: [GeoLocationFilterInput!]
               """
+              Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+              Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+              be provided on a single `GeoLocationFilterInput` input because of collisions between key names. For example, if you want to AND multiple
+              OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do #{schema_elements.all_of}: [{#{schema_elements.any_of}: [...]}, {#{schema_elements.any_of}: [...]}].
+
+              When `null` or an empty list is passed, matches all documents.
+              """
+              #{schema_elements.all_of}: [GeoLocationFilterInput!]
+              """
               Matches records where the provided sub-filter evaluates to false.
               This works just like a NOT operator in SQL.
 
@@ -139,6 +149,16 @@ module ElasticGraph
               When an empty list is passed, this part of the filter matches no documents.
               """
               #{schema_elements.any_of}: [GeoLocationListElementFilterInput!]
+              """
+              Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+              Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+              be provided on a single `GeoLocationListElementFilterInput` input because of collisions between key names. For example, if you want to AND multiple
+              OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do #{schema_elements.all_of}: [{#{schema_elements.any_of}: [...]}, {#{schema_elements.any_of}: [...]}].
+
+              When `null` or an empty list is passed, matches all documents.
+              """
+              #{schema_elements.all_of}: [GeoLocationListElementFilterInput!]
               """
               Matches records where the field's geographic location is within a specified distance from the
               location identified by `latitude` and `longitude`.
@@ -186,6 +206,7 @@ module ElasticGraph
           expect(type_named("DateFilterInput")).to eq(<<~EOS.strip)
             input DateFilterInput {
               #{schema_elements.any_of}: [DateFilterInput!]
+              #{schema_elements.all_of}: [DateFilterInput!]
               #{schema_elements.not}: DateFilterInput
               #{schema_elements.equal_to_any_of}: [Date]
               #{schema_elements.gt}: Date
@@ -198,6 +219,7 @@ module ElasticGraph
           expect(type_named("DateListElementFilterInput")).to eq(<<~EOS.strip)
             input DateListElementFilterInput {
               #{schema_elements.any_of}: [DateListElementFilterInput!]
+              #{schema_elements.all_of}: [DateListElementFilterInput!]
               #{schema_elements.equal_to_any_of}: [Date!]
               #{schema_elements.gt}: Date
               #{schema_elements.gte}: Date
@@ -218,6 +240,7 @@ module ElasticGraph
           expect(type_named("DateTimeFilterInput")).to eq(<<~EOS.strip)
             input DateTimeFilterInput {
               #{schema_elements.any_of}: [DateTimeFilterInput!]
+              #{schema_elements.all_of}: [DateTimeFilterInput!]
               #{schema_elements.not}: DateTimeFilterInput
               #{schema_elements.equal_to_any_of}: [DateTime]
               #{schema_elements.gt}: DateTime
@@ -231,6 +254,7 @@ module ElasticGraph
           expect(type_named("DateTimeListElementFilterInput")).to eq(<<~EOS.strip)
             input DateTimeListElementFilterInput {
               #{schema_elements.any_of}: [DateTimeListElementFilterInput!]
+              #{schema_elements.all_of}: [DateTimeListElementFilterInput!]
               #{schema_elements.equal_to_any_of}: [DateTime!]
               #{schema_elements.gt}: DateTime
               #{schema_elements.gte}: DateTime
@@ -296,6 +320,7 @@ module ElasticGraph
           expect(type_def_from(result, "TimestampFilterInput")).to eq(<<~EOS.strip)
             input TimestampFilterInput {
               #{schema_elements.any_of}: [TimestampFilterInput!]
+              #{schema_elements.all_of}: [TimestampFilterInput!]
               #{schema_elements.not}: TimestampFilterInput
               #{schema_elements.equal_to_any_of}: [Timestamp]
               #{schema_elements.gt}: Timestamp
@@ -309,6 +334,7 @@ module ElasticGraph
           expect(type_def_from(result, "TimestampListElementFilterInput")).to eq(<<~EOS.strip)
             input TimestampListElementFilterInput {
               #{schema_elements.any_of}: [TimestampListElementFilterInput!]
+              #{schema_elements.all_of}: [TimestampListElementFilterInput!]
               #{schema_elements.equal_to_any_of}: [Timestamp!]
               #{schema_elements.gt}: Timestamp
               #{schema_elements.gte}: Timestamp
@@ -339,6 +365,7 @@ module ElasticGraph
           expect(type_def_from(result, "TimestampFilterInput")).to eq(<<~EOS.strip)
             input TimestampFilterInput {
               #{schema_elements.any_of}: [TimestampFilterInput!]
+              #{schema_elements.all_of}: [TimestampFilterInput!]
               #{schema_elements.not}: TimestampFilterInput
               #{schema_elements.equal_to_any_of}: [DateTime]
               #{schema_elements.gt}: DateTime
@@ -352,6 +379,7 @@ module ElasticGraph
           expect(type_def_from(result, "TimestampListElementFilterInput")).to eq(<<~EOS.strip)
             input TimestampListElementFilterInput {
               #{schema_elements.any_of}: [TimestampListElementFilterInput!]
+              #{schema_elements.all_of}: [TimestampListElementFilterInput!]
               #{schema_elements.equal_to_any_of}: [DateTime!]
               #{schema_elements.gt}: DateTime
               #{schema_elements.gte}: DateTime
@@ -374,6 +402,7 @@ module ElasticGraph
           expect(type_named("LocalTimeFilterInput")).to eq(<<~EOS.strip)
             input LocalTimeFilterInput {
               #{schema_elements.any_of}: [LocalTimeFilterInput!]
+              #{schema_elements.all_of}: [LocalTimeFilterInput!]
               #{schema_elements.not}: LocalTimeFilterInput
               #{schema_elements.equal_to_any_of}: [LocalTime]
               #{schema_elements.gt}: LocalTime
@@ -386,6 +415,7 @@ module ElasticGraph
           expect(type_named("LocalTimeListElementFilterInput")).to eq(<<~EOS.strip)
             input LocalTimeListElementFilterInput {
               #{schema_elements.any_of}: [LocalTimeListElementFilterInput!]
+              #{schema_elements.all_of}: [LocalTimeListElementFilterInput!]
               #{schema_elements.equal_to_any_of}: [LocalTime!]
               #{schema_elements.gt}: LocalTime
               #{schema_elements.gte}: LocalTime
@@ -408,6 +438,7 @@ module ElasticGraph
           expect(type_named("TimeZoneFilterInput")).to eq(<<~EOS.strip)
             input TimeZoneFilterInput {
               #{schema_elements.any_of}: [TimeZoneFilterInput!]
+              #{schema_elements.all_of}: [TimeZoneFilterInput!]
               #{schema_elements.not}: TimeZoneFilterInput
               #{schema_elements.equal_to_any_of}: [TimeZone]
             }
@@ -416,6 +447,7 @@ module ElasticGraph
           expect(type_named("TimeZoneListElementFilterInput")).to eq(<<~EOS.strip)
             input TimeZoneListElementFilterInput {
               #{schema_elements.any_of}: [TimeZoneListElementFilterInput!]
+              #{schema_elements.all_of}: [TimeZoneListElementFilterInput!]
               #{schema_elements.equal_to_any_of}: [TimeZone!]
             }
           EOS
@@ -453,6 +485,7 @@ module ElasticGraph
           expect(type_named("DateTimeUnitFilterInput")).to eq(<<~EOS.strip)
             input DateTimeUnitFilterInput {
               #{schema_elements.any_of}: [DateTimeUnitFilterInput!]
+              #{schema_elements.all_of}: [DateTimeUnitFilterInput!]
               #{schema_elements.not}: DateTimeUnitFilterInput
               #{schema_elements.equal_to_any_of}: [DateTimeUnitInput]
             }
@@ -461,6 +494,7 @@ module ElasticGraph
           expect(type_named("DateTimeUnitListElementFilterInput")).to eq(<<~EOS.strip)
             input DateTimeUnitListElementFilterInput {
               #{schema_elements.any_of}: [DateTimeUnitListElementFilterInput!]
+              #{schema_elements.all_of}: [DateTimeUnitListElementFilterInput!]
               #{schema_elements.equal_to_any_of}: [DateTimeUnitInput!]
             }
           EOS
@@ -521,6 +555,7 @@ module ElasticGraph
           expect(type_named("JsonSafeLongFilterInput")).to eq(<<~EOS.strip)
             input JsonSafeLongFilterInput {
               #{schema_elements.any_of}: [JsonSafeLongFilterInput!]
+              #{schema_elements.all_of}: [JsonSafeLongFilterInput!]
               #{schema_elements.not}: JsonSafeLongFilterInput
               #{schema_elements.equal_to_any_of}: [JsonSafeLong]
               #{schema_elements.gt}: JsonSafeLong
@@ -533,6 +568,7 @@ module ElasticGraph
           expect(type_named("JsonSafeLongListElementFilterInput")).to eq(<<~EOS.strip)
             input JsonSafeLongListElementFilterInput {
               #{schema_elements.any_of}: [JsonSafeLongListElementFilterInput!]
+              #{schema_elements.all_of}: [JsonSafeLongListElementFilterInput!]
               #{schema_elements.equal_to_any_of}: [JsonSafeLong!]
               #{schema_elements.gt}: JsonSafeLong
               #{schema_elements.gte}: JsonSafeLong
@@ -558,6 +594,7 @@ module ElasticGraph
           expect(type_named("LongStringListElementFilterInput")).to eq(<<~EOS.strip)
             input LongStringListElementFilterInput {
               #{schema_elements.any_of}: [LongStringListElementFilterInput!]
+              #{schema_elements.all_of}: [LongStringListElementFilterInput!]
               #{schema_elements.equal_to_any_of}: [LongString!]
               #{schema_elements.gt}: LongString
               #{schema_elements.gte}: LongString
@@ -574,6 +611,7 @@ module ElasticGraph
             expect(type_named("#{type}FilterInput")).to eq(<<~EOS.strip)
               input #{type}FilterInput {
                 #{schema_elements.any_of}: [#{type}FilterInput!]
+                #{schema_elements.all_of}: [#{type}FilterInput!]
                 #{schema_elements.not}: #{type}FilterInput
                 #{schema_elements.equal_to_any_of}: [#{type}]
                 #{schema_elements.gt}: #{type}
@@ -586,6 +624,7 @@ module ElasticGraph
             expect(type_named("#{type}ListElementFilterInput")).to eq(<<~EOS.strip)
               input #{type}ListElementFilterInput {
                 #{schema_elements.any_of}: [#{type}ListElementFilterInput!]
+                #{schema_elements.all_of}: [#{type}ListElementFilterInput!]
                 #{schema_elements.equal_to_any_of}: [#{type}!]
                 #{schema_elements.gt}: #{type}
                 #{schema_elements.gte}: #{type}
@@ -603,6 +642,7 @@ module ElasticGraph
             expect(type_named("#{type}FilterInput")).to eq(<<~EOS.strip)
               input #{type}FilterInput {
                 #{schema_elements.any_of}: [#{type}FilterInput!]
+                #{schema_elements.all_of}: [#{type}FilterInput!]
                 #{schema_elements.not}: #{type}FilterInput
                 #{schema_elements.equal_to_any_of}: [#{type}]
               }
@@ -611,6 +651,7 @@ module ElasticGraph
             expect(type_named("#{type}ListElementFilterInput")).to eq(<<~EOS.strip)
               input #{type}ListElementFilterInput {
                 #{schema_elements.any_of}: [#{type}ListElementFilterInput!]
+                #{schema_elements.all_of}: [#{type}ListElementFilterInput!]
                 #{schema_elements.equal_to_any_of}: [#{type}!]
               }
             EOS
@@ -636,6 +677,16 @@ module ElasticGraph
               When an empty list is passed, this part of the filter matches no documents.
               """
               #{schema_elements.any_of}: [TextFilterInput!]
+              """
+              Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+              Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+              be provided on a single `TextFilterInput` input because of collisions between key names. For example, if you want to AND multiple
+              OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do #{schema_elements.all_of}: [{#{schema_elements.any_of}: [...]}, {#{schema_elements.any_of}: [...]}].
+
+              When `null` or an empty list is passed, matches all documents.
+              """
+              #{schema_elements.all_of}: [TextFilterInput!]
               """
               Matches records where the provided sub-filter evaluates to false.
               This works just like a NOT operator in SQL.
@@ -692,6 +743,16 @@ module ElasticGraph
               When an empty list is passed, this part of the filter matches no documents.
               """
               #{schema_elements.any_of}: [TextListElementFilterInput!]
+              """
+              Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+              Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+              be provided on a single `TextListElementFilterInput` input because of collisions between key names. For example, if you want to AND multiple
+              OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do #{schema_elements.all_of}: [{#{schema_elements.any_of}: [...]}, {#{schema_elements.any_of}: [...]}].
+
+              When `null` or an empty list is passed, matches all documents.
+              """
+              #{schema_elements.all_of}: [TextListElementFilterInput!]
               """
               Matches records where the field value is equal to any of the provided values.
               This works just like an IN operator in SQL.
@@ -775,6 +836,16 @@ module ElasticGraph
                 """
                 #{schema_elements.any_of}: [#{scalar}ListFilterInput!]
                 """
+                Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+                Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+                be provided on a single `#{scalar}ListFilterInput` input because of collisions between key names. For example, if you want to AND multiple
+                OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do #{schema_elements.all_of}: [{#{schema_elements.any_of}: [...]}, {#{schema_elements.any_of}: [...]}].
+
+                When `null` or an empty list is passed, matches all documents.
+                """
+                #{schema_elements.all_of}: [#{scalar}ListFilterInput!]
+                """
                 Matches records where the provided sub-filter evaluates to false.
                 This works just like a NOT operator in SQL.
 
@@ -787,16 +858,6 @@ module ElasticGraph
                 When `null` or an empty object is passed, matches all documents.
                 """
                 #{schema_elements.any_satisfy}: #{scalar}ListElementFilterInput
-                """
-                Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
-
-                Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
-                be provided on a single `#{scalar}ListFilterInput` input because of collisions between key names. For example, if you want to provide
-                multiple `#{schema_elements.any_satisfy}: ...` filters, you could do `#{schema_elements.all_of}: [{#{schema_elements.any_satisfy}: ...}, {#{schema_elements.any_satisfy}: ...}]`.
-
-                When `null` or an empty list is passed, matches all documents.
-                """
-                #{schema_elements.all_of}: [#{scalar}ListFilterInput!]
                 """
                 Used to filter on the number of non-null elements in this list field.
 

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/field_arguments_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/field_arguments_spec.rb
@@ -95,6 +95,7 @@ module ElasticGraph
           expect(type_def_from(result, "InputWithDefaultsFilterInput")).to eq(<<~EOS.strip)
             input InputWithDefaultsFilterInput {
               #{schema_elements.any_of}: [InputWithDefaultsFilterInput!]
+              #{schema_elements.all_of}: [InputWithDefaultsFilterInput!]
               not: InputWithDefaultsFilterInput
               no_default: Int!
               default_of_null: Int = null

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/filters_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/filters_spec.rb
@@ -52,6 +52,16 @@ module ElasticGraph
               """
               #{schema_elements.any_of}: [WidgetFilterInput!]
               """
+              Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+              Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+              be provided on a single `WidgetFilterInput` input because of collisions between key names. For example, if you want to AND multiple
+              OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do #{schema_elements.all_of}: [{#{schema_elements.any_of}: [...]}, {#{schema_elements.any_of}: [...]}].
+
+              When `null` or an empty list is passed, matches all documents.
+              """
+              #{schema_elements.all_of}: [WidgetFilterInput!]
+              """
               Matches records where the provided sub-filter evaluates to false.
               This works just like a NOT operator in SQL.
 
@@ -111,6 +121,16 @@ module ElasticGraph
               """
               #{schema_elements.any_of}: [WidgetOptionsFilterInput!]
               """
+              Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+              Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+              be provided on a single `WidgetOptionsFilterInput` input because of collisions between key names. For example, if you want to AND multiple
+              OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do #{schema_elements.all_of}: [{#{schema_elements.any_of}: [...]}, {#{schema_elements.any_of}: [...]}].
+
+              When `null` or an empty list is passed, matches all documents.
+              """
+              #{schema_elements.all_of}: [WidgetOptionsFilterInput!]
+              """
               Matches records where the provided sub-filter evaluates to false.
               This works just like a NOT operator in SQL.
 
@@ -150,6 +170,16 @@ module ElasticGraph
               """
               #{schema_elements.any_of}: [WidgetOptionsListFilterInput!]
               """
+              Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+              Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+              be provided on a single `WidgetOptionsListFilterInput` input because of collisions between key names. For example, if you want to AND multiple
+              OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do #{schema_elements.all_of}: [{#{schema_elements.any_of}: [...]}, {#{schema_elements.any_of}: [...]}].
+
+              When `null` or an empty list is passed, matches all documents.
+              """
+              #{schema_elements.all_of}: [WidgetOptionsListFilterInput!]
+              """
               Matches records where the provided sub-filter evaluates to false.
               This works just like a NOT operator in SQL.
 
@@ -162,16 +192,6 @@ module ElasticGraph
               When `null` or an empty object is passed, matches all documents.
               """
               #{schema_elements.any_satisfy}: WidgetOptionsFilterInput
-              """
-              Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
-
-              Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
-              be provided on a single `WidgetOptionsListFilterInput` input because of collisions between key names. For example, if you want to provide
-              multiple `#{schema_elements.any_satisfy}: ...` filters, you could do `#{schema_elements.all_of}: [{#{schema_elements.any_satisfy}: ...}, {#{schema_elements.any_satisfy}: ...}]`.
-
-              When `null` or an empty list is passed, matches all documents.
-              """
-              #{schema_elements.all_of}: [WidgetOptionsListFilterInput!]
               """
               Used to filter on the number of non-null elements in this list field.
 
@@ -200,6 +220,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Widget")).to eq(<<~EOS.strip)
             input WidgetFilterInput {
               #{schema_elements.any_of}: [WidgetFilterInput!]
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.not}: WidgetFilterInput
               id: IDFilterInput
             }
@@ -238,6 +259,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Widget")).to eq(<<~EOS.strip)
             input WidgetFilterInput {
               #{schema_elements.any_of}: [WidgetFilterInput!]
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.not}: WidgetFilterInput
               id: IDFilterInput
               nullable_point: PointFilterInput
@@ -268,6 +290,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Widget")).to eq(<<~EOS.strip)
             input WidgetFilterInput {
               #{schema_elements.any_of}: [WidgetFilterInput!]
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.not}: WidgetFilterInput
               id: IDFilterInput
               nullable_point: PointFilterInput
@@ -298,6 +321,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Widget")).to eq(<<~EOS.strip)
             input WidgetFilterInput {
               #{schema_elements.any_of}: [WidgetFilterInput!]
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.not}: WidgetFilterInput
               id: IDFilterInput
               nullable_point: PointFilterInput
@@ -324,6 +348,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Widget")).to eq(<<~EOS.strip)
             input WidgetFilterInput {
               #{schema_elements.any_of}: [WidgetFilterInput!]
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.not}: WidgetFilterInput
               id: IDFilterInput
             }
@@ -371,6 +396,7 @@ module ElasticGraph
           expect(filter_type_from(result, "WidgetOptions")).to eq(<<~EOS.strip)
             input WidgetOptionsFilterInput {
               #{schema_elements.any_of}: [WidgetOptionsFilterInput!]
+              #{schema_elements.all_of}: [WidgetOptionsFilterInput!]
               #{schema_elements.not}: WidgetOptionsFilterInput
               size: IntFilterInput
               main_color: StringFilterInput
@@ -400,6 +426,16 @@ module ElasticGraph
               When an empty list is passed, this part of the filter matches no documents.
               """
               #{schema_elements.any_of}: [ColorFilterInput!]
+              """
+              Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+              Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+              be provided on a single `ColorFilterInput` input because of collisions between key names. For example, if you want to AND multiple
+              OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do #{schema_elements.all_of}: [{#{schema_elements.any_of}: [...]}, {#{schema_elements.any_of}: [...]}].
+
+              When `null` or an empty list is passed, matches all documents.
+              """
+              #{schema_elements.all_of}: [ColorFilterInput!]
               """
               Matches records where the provided sub-filter evaluates to false.
               This works just like a NOT operator in SQL.
@@ -435,6 +471,16 @@ module ElasticGraph
               """
               #{schema_elements.any_of}: [ColorListElementFilterInput!]
               """
+              Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+              Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+              be provided on a single `ColorListElementFilterInput` input because of collisions between key names. For example, if you want to AND multiple
+              OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do #{schema_elements.all_of}: [{#{schema_elements.any_of}: [...]}, {#{schema_elements.any_of}: [...]}].
+
+              When `null` or an empty list is passed, matches all documents.
+              """
+              #{schema_elements.all_of}: [ColorListElementFilterInput!]
+              """
               Matches records where the field value is equal to any of the provided values.
               This works just like an IN operator in SQL.
 
@@ -462,6 +508,16 @@ module ElasticGraph
               """
               #{schema_elements.any_of}: [ColorListFilterInput!]
               """
+              Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+              Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+              be provided on a single `ColorListFilterInput` input because of collisions between key names. For example, if you want to AND multiple
+              OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do #{schema_elements.all_of}: [{#{schema_elements.any_of}: [...]}, {#{schema_elements.any_of}: [...]}].
+
+              When `null` or an empty list is passed, matches all documents.
+              """
+              #{schema_elements.all_of}: [ColorListFilterInput!]
+              """
               Matches records where the provided sub-filter evaluates to false.
               This works just like a NOT operator in SQL.
 
@@ -474,16 +530,6 @@ module ElasticGraph
               When `null` or an empty object is passed, matches all documents.
               """
               #{schema_elements.any_satisfy}: ColorListElementFilterInput
-              """
-              Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
-
-              Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
-              be provided on a single `ColorListFilterInput` input because of collisions between key names. For example, if you want to provide
-              multiple `#{schema_elements.any_satisfy}: ...` filters, you could do `#{schema_elements.all_of}: [{#{schema_elements.any_satisfy}: ...}, {#{schema_elements.any_satisfy}: ...}]`.
-
-              When `null` or an empty list is passed, matches all documents.
-              """
-              #{schema_elements.all_of}: [ColorListFilterInput!]
               """
               Used to filter on the number of non-null elements in this list field.
 
@@ -512,6 +558,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Widget")).to eq(<<~EOS.strip)
             input WidgetFilterInput {
               #{schema_elements.any_of}: [WidgetFilterInput!]
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.not}: WidgetFilterInput
               id: IDFilterInput
               cost: IntFilterInput
@@ -530,6 +577,7 @@ module ElasticGraph
           expect(filter_type_from(result, "WidgetOptions")).to eq(<<~EOS.strip)
             input WidgetOptionsFilterInput {
               #{schema_elements.any_of}: [WidgetOptionsFilterInput!]
+              #{schema_elements.all_of}: [WidgetOptionsFilterInput!]
               #{schema_elements.not}: WidgetOptionsFilterInput
               size: IntFilterInput
             }
@@ -548,6 +596,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Widget")).to eq(<<~EOS.strip)
             input WidgetFilterInput {
               #{schema_elements.any_of}: [WidgetFilterInput!]
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               not: WidgetFilterInput
               id: IDFilterInput
               location: GeoLocationFilterInput
@@ -568,6 +617,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Widget")).to eq(<<~EOS.strip)
             input WidgetFilterInput {
               #{schema_elements.any_of}: [WidgetFilterInput!]
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.not}: WidgetFilterInput
               name: StringFilterInput
               description: TextFilterInput
@@ -681,6 +731,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Widget")).to eq(<<~EOS.chomp)
             input WidgetFilterInput {
               #{schema_elements.any_of}: [WidgetFilterInput!]
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.not}: WidgetFilterInput
               tags1: StringListFilterInput
               tags2: StringListFilterInput
@@ -700,6 +751,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Widget")).to eq(<<~EOS.chomp)
             input WidgetFilterInput {
               #{schema_elements.any_of}: [WidgetFilterInput!]
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.not}: WidgetFilterInput
               tags: StringListFilterInput
             }
@@ -716,6 +768,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Widget")).to eq(<<~EOS.chomp)
             input WidgetFilterInput {
               #{schema_elements.any_of}: [WidgetFilterInput!]
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.not}: WidgetFilterInput
               times: TimeOfDayListFilterInput
             }
@@ -736,6 +789,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Widget")).to eq(<<~EOS.chomp)
             input WidgetFilterInput {
               #{schema_elements.any_of}: [WidgetFilterInput!]
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.not}: WidgetFilterInput
               colors: ColorListFilterInput
             }
@@ -754,6 +808,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Widget")).to eq(<<~EOS.chomp)
             input WidgetFilterInput {
               #{schema_elements.any_of}: [WidgetFilterInput!]
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.not}: WidgetFilterInput
               tags: TextListFilterInput
             }
@@ -770,6 +825,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Widget")).to eq(<<~EOS.chomp)
             input WidgetFilterInput {
               #{schema_elements.any_of}: [WidgetFilterInput!]
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.not}: WidgetFilterInput
               locations: GeoLocationListFilterInput
             }
@@ -793,6 +849,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Widget")).to eq(<<~EOS.chomp)
             input WidgetFilterInput {
               #{schema_elements.any_of}: [WidgetFilterInput!]
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.not}: WidgetFilterInput
               id: IDFilterInput
             }
@@ -817,6 +874,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Widget")).to eq(<<~EOS.chomp)
             input WidgetFilterInput {
               #{schema_elements.any_of}: [WidgetFilterInput!]
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.not}: WidgetFilterInput
               id: IDFilterInput
               shapes: ShapeListFilterInput
@@ -842,6 +900,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Widget")).to eq(<<~EOS.chomp)
             input WidgetFilterInput {
               #{schema_elements.any_of}: [WidgetFilterInput!]
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.not}: WidgetFilterInput
               id: IDFilterInput
               shapes: ShapeFieldsListFilterInput
@@ -872,6 +931,7 @@ module ElasticGraph
           expect(fields_list_filter_type_from(result, "Player")).to eq(<<~EOS.strip)
             input PlayerFieldsListFilterInput {
               #{schema_elements.any_of}: [PlayerFieldsListFilterInput!]
+              #{schema_elements.all_of}: [PlayerFieldsListFilterInput!]
               #{schema_elements.not}: PlayerFieldsListFilterInput
               seasons: PlayerSeasonListFilterInput
               #{schema_elements.count}: IntFilterInput
@@ -902,6 +962,7 @@ module ElasticGraph
           expect(fields_list_filter_type_from(result, "Player")).to eq(<<~EOS.strip)
             input PlayerFieldsListFilterInput {
               #{schema_elements.any_of}: [PlayerFieldsListFilterInput!]
+              #{schema_elements.all_of}: [PlayerFieldsListFilterInput!]
               #{schema_elements.not}: PlayerFieldsListFilterInput
               seasons: SeasonForAPlayerListFilterInput
               #{schema_elements.count}: IntFilterInput
@@ -954,6 +1015,7 @@ module ElasticGraph
             expect(fields_list_filter_type_from(result, "WidgetOptions")).to eq(<<~EOS.strip)
               input WidgetOptionsFieldsListFilterInput {
                 #{schema_elements.any_of}: [WidgetOptionsFieldsListFilterInput!]
+                #{schema_elements.all_of}: [WidgetOptionsFieldsListFilterInput!]
                 #{schema_elements.not}: WidgetOptionsFieldsListFilterInput
                 single_color1: ColorListFilterInput
                 single_color2: ColorListFilterInput
@@ -992,6 +1054,7 @@ module ElasticGraph
             expect(fields_list_filter_type_from(result, "Widget")).to eq(<<~EOS.strip)
               input WidgetFieldsListFilterInput {
                 #{schema_elements.any_of}: [WidgetFieldsListFilterInput!]
+                #{schema_elements.all_of}: [WidgetFieldsListFilterInput!]
                 #{schema_elements.not}: WidgetFieldsListFilterInput
                 options: WidgetOptionsFieldsListFilterInput
                 embedded_options_list: WidgetOptionsFieldsListFilterInput
@@ -1012,6 +1075,7 @@ module ElasticGraph
             expect(fields_list_filter_type_from(result, "WidgetOptions")).to eq(<<~EOS.strip)
               input WidgetOptionsFieldsListFilterInput {
                 #{schema_elements.any_of}: [WidgetOptionsFieldsListFilterInput!]
+                #{schema_elements.all_of}: [WidgetOptionsFieldsListFilterInput!]
                 #{schema_elements.not}: WidgetOptionsFieldsListFilterInput
                 geo_location: GeoLocationListFilterInput
                 geo_locations: GeoLocationListFilterInput
@@ -1031,6 +1095,7 @@ module ElasticGraph
             expect(fields_list_filter_type_from(result, "WidgetOptions")).to eq(<<~EOS.strip)
               input WidgetOptionsFieldsListFilterInput {
                 #{schema_elements.any_of}: [WidgetOptionsFieldsListFilterInput!]
+                #{schema_elements.all_of}: [WidgetOptionsFieldsListFilterInput!]
                 #{schema_elements.not}: WidgetOptionsFieldsListFilterInput
                 int2: IntListFilterInput
                 #{schema_elements.count}: IntFilterInput
@@ -1084,6 +1149,7 @@ module ElasticGraph
             expect(filter_type_from(result, "Inventor")).to eq(<<~EOS.strip)
               input InventorFilterInput {
                 #{schema_elements.any_of}: [InventorFilterInput!]
+                #{schema_elements.all_of}: [InventorFilterInput!]
                 #{schema_elements.not}: InventorFilterInput
                 name: StringFilterInput
                 nationality: StringFilterInput
@@ -1148,6 +1214,7 @@ module ElasticGraph
             expect(filter_type_from(result, "ClothingItem")).to eq(<<~EOS.strip)
               input ClothingItemFilterInput {
                 #{schema_elements.any_of}: [ClothingItemFilterInput!]
+                #{schema_elements.all_of}: [ClothingItemFilterInput!]
                 #{schema_elements.not}: ClothingItemFilterInput
                 size: SizeFilterInput
                 shirt_color: StringFilterInput
@@ -1204,6 +1271,7 @@ module ElasticGraph
             expect(filter_type_from(result, "Inventor")).to eq(<<~EOS.strip)
               input InventorFilterInput {
                 #{schema_elements.any_of}: [InventorFilterInput!]
+                #{schema_elements.all_of}: [InventorFilterInput!]
                 #{schema_elements.not}: InventorFilterInput
                 name: StringFilterInput
                 stock_ticker: StringFilterInput
@@ -1264,6 +1332,7 @@ module ElasticGraph
             expect(filter_type_from(result, "Inventor")).to eq(<<~EOS.strip)
               input InventorFilterInput {
                 #{schema_elements.any_of}: [InventorFilterInput!]
+                #{schema_elements.all_of}: [InventorFilterInput!]
                 #{schema_elements.not}: InventorFilterInput
                 name: StringFilterInput
                 nationality: StringFilterInput

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/object_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/object_type_spec.rb
@@ -337,6 +337,7 @@ module ElasticGraph
             expect(filter_type_from(result, "Widget")).to eq(<<~EOS.strip)
               input WidgetFilterInput {
                 #{schema_elements.any_of}: [WidgetFilterInput!]
+                #{schema_elements.all_of}: [WidgetFilterInput!]
                 not: WidgetFilterInput
                 id: IDFilterInput
                 cost: IntFilterInput @deprecated @external

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/paginated_collection_field_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/paginated_collection_field_spec.rb
@@ -119,6 +119,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Widget")).to eq(<<~EOS.chomp)
             input WidgetFilterInput {
               #{schema_elements.any_of}: [WidgetFilterInput!]
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.not}: WidgetFilterInput
               names: StringListFilterInput
             }
@@ -161,6 +162,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Widget")).to eq(<<~EOS.chomp)
             input WidgetFilterInput {
               #{schema_elements.any_of}: [WidgetFilterInput!]
+              #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.not}: WidgetFilterInput
               times: TimeOfDayListFilterInput
             }

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/scalar_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/scalar_type_spec.rb
@@ -114,6 +114,7 @@ module ElasticGraph
           expect(filter_type_from(result, "FullText")).to eq(<<~EOS.strip)
             input FullTextFilterInput {
               #{schema_elements.any_of}: [FullTextFilterInput!]
+              #{schema_elements.all_of}: [FullTextFilterInput!]
               #{schema_elements.not}: FullTextFilterInput
               #{schema_elements.equal_to_any_of}: [FullText]
             }
@@ -129,6 +130,7 @@ module ElasticGraph
           expect(filter_type_from(result, "Short")).to eq(<<~EOS.strip)
             input ShortFilterInput {
               #{schema_elements.any_of}: [ShortFilterInput!]
+              #{schema_elements.all_of}: [ShortFilterInput!]
               #{schema_elements.not}: ShortFilterInput
               #{schema_elements.equal_to_any_of}: [Short]
               #{schema_elements.gt}: Short
@@ -148,6 +150,7 @@ module ElasticGraph
           expect(filter_type_from(result, "CalendarDate")).to eq(<<~EOS.strip)
             input CalendarDateFilterInput {
               #{schema_elements.any_of}: [CalendarDateFilterInput!]
+              #{schema_elements.all_of}: [CalendarDateFilterInput!]
               #{schema_elements.not}: CalendarDateFilterInput
               #{schema_elements.equal_to_any_of}: [CalendarDate]
               #{schema_elements.gt}: CalendarDate
@@ -180,6 +183,16 @@ module ElasticGraph
               """
               #{schema_elements.any_of}: [ShortListFilterInput!]
               """
+              Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+              Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+              be provided on a single `ShortListFilterInput` input because of collisions between key names. For example, if you want to AND multiple
+              OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do #{schema_elements.all_of}: [{#{schema_elements.any_of}: [...]}, {#{schema_elements.any_of}: [...]}].
+
+              When `null` or an empty list is passed, matches all documents.
+              """
+              #{schema_elements.all_of}: [ShortListFilterInput!]
+              """
               Matches records where the provided sub-filter evaluates to false.
               This works just like a NOT operator in SQL.
 
@@ -192,16 +205,6 @@ module ElasticGraph
               When `null` or an empty object is passed, matches all documents.
               """
               #{schema_elements.any_satisfy}: ShortListElementFilterInput
-              """
-              Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
-
-              Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
-              be provided on a single `ShortListFilterInput` input because of collisions between key names. For example, if you want to provide
-              multiple `#{schema_elements.any_satisfy}: ...` filters, you could do `#{schema_elements.all_of}: [{#{schema_elements.any_satisfy}: ...}, {#{schema_elements.any_satisfy}: ...}]`.
-
-              When `null` or an empty list is passed, matches all documents.
-              """
-              #{schema_elements.all_of}: [ShortListFilterInput!]
               """
               Used to filter on the number of non-null elements in this list field.
 
@@ -233,6 +236,16 @@ module ElasticGraph
               When an empty list is passed, this part of the filter matches no documents.
               """
               #{schema_elements.any_of}: [ByteFilterInput!]
+              """
+              Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+              Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+              be provided on a single `ByteFilterInput` input because of collisions between key names. For example, if you want to AND multiple
+              OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do #{schema_elements.all_of}: [{#{schema_elements.any_of}: [...]}, {#{schema_elements.any_of}: [...]}].
+
+              When `null` or an empty list is passed, matches all documents.
+              """
+              #{schema_elements.all_of}: [ByteFilterInput!]
               """
               Matches records where the provided sub-filter evaluates to false.
               This works just like a NOT operator in SQL.


### PR DESCRIPTION
This updates the schema to support top-level all_of filters, which has been a requested feature.

**How Tested**
- [x] update elasticgraph-schema_definition specs