### PR TITLE
Fix typo: `documenation` -> `documentation`.

### DIFF
--- a/ai_tools/README.md
+++ b/ai_tools/README.md
@@ -20,4 +20,4 @@ You can use the MCP server with a variety of tools and platforms, including:
 
 ## Additional Resources
 
-- ElasticGraph follows [llmstxt.org](https://llmstxt.org/) and publishes all documenation concatenated into one `llms-full.txt` file: https://block.github.io/elasticgraph/llms-full.txt
+- ElasticGraph follows [llmstxt.org](https://llmstxt.org/) and publishes all documentation concatenated into one `llms-full.txt` file: https://block.github.io/elasticgraph/llms-full.txt


### PR DESCRIPTION
This should fix the build (`script/spellcheck` was failing on this).