### PR TITLE
Add `size_multiplier` to `DatastoreQuery`.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
@@ -30,7 +30,7 @@ module ElasticGraph
       :total_document_count_needed, :aggregations, :logger, :filter_interpreter, :routing_picker,
       :index_expression_builder, :default_page_size, :search_index_definitions, :max_page_size,
       :filters, :sort, :document_pagination, :requested_fields, :individual_docs_needed,
-      :monotonic_clock_deadline, :schema_element_names
+      :size_multiplier, :monotonic_clock_deadline, :schema_element_names
     )
       # Load these files after the `Query` class has been defined, to avoid
       # `TypeError: superclass mismatch for class Query`
@@ -100,6 +100,7 @@ module ElasticGraph
         sort: [],
         requested_fields: [],
         document_pagination: {},
+        size_multiplier: 1,
         monotonic_clock_deadline: nil,
         aggregations: {}
       )
@@ -110,6 +111,7 @@ module ElasticGraph
           sort: merge_attribute(:sort, sort),
           requested_fields: self.requested_fields + requested_fields,
           document_pagination: merge_attribute(:document_pagination, document_pagination),
+          size_multiplier: self.size_multiplier * size_multiplier,
           monotonic_clock_deadline: [self.monotonic_clock_deadline, monotonic_clock_deadline].compact.min,
           aggregations: self.aggregations.merge(aggregations)
         )
@@ -214,6 +216,7 @@ module ElasticGraph
           total_document_count_needed: total_document_count_needed,
           decoded_cursor_factory: decoded_cursor_factory,
           schema_element_names: schema_element_names,
+          size_multiplier: size_multiplier,
           paginator: Paginator.new(
             default_page_size: default_page_size,
             max_page_size: max_page_size,
@@ -321,6 +324,7 @@ module ElasticGraph
           filters: [],
           sort: [],
           document_pagination: {},
+          size_multiplier: 1,
           aggregations: {},
           requested_fields: [],
           individual_docs_needed: false,
@@ -340,6 +344,7 @@ module ElasticGraph
             filters: filters.to_set,
             sort: sort,
             document_pagination: document_pagination,
+            size_multiplier: size_multiplier,
             aggregations: aggregations,
             requested_fields: requested_fields.to_set,
             individual_docs_needed: individual_docs_needed || !requested_fields.empty?,

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/document_paginator.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/document_paginator.rb
@@ -22,7 +22,8 @@ module ElasticGraph
         :individual_docs_needed,
         # `total_document_count_needed`: when false, `track_total_hits` will be 0 in our datastore query.
         # This will prevent the datastore from doing extra work to get an accurate count
-        :total_document_count_needed
+        :total_document_count_needed,
+        :size_multiplier
       )
         # Builds a hash containing the portions of a datastore search body related to pagination.
         def to_datastore_body
@@ -60,7 +61,7 @@ module ElasticGraph
         private
 
         def effective_size
-          individual_docs_needed ? paginator.requested_page_size : 0
+          (individual_docs_needed ? paginator.requested_page_size : 0) * size_multiplier
         end
 
         def effective_sort

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/merge_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/merge_spec.rb
@@ -170,6 +170,17 @@ module ElasticGraph
         }.to avoid_logging_warnings
       end
 
+      it "multiplies the `size_multiplier` when merging", covers: :size_multiplier do
+        merged = merge({size_multiplier: 1}, {size_multiplier: 1})
+        expect(merged.size_multiplier).to eq(1)
+
+        merged = merge({size_multiplier: 5}, {size_multiplier: 1})
+        expect(merged.size_multiplier).to eq(5)
+
+        merged = merge({size_multiplier: 2}, {size_multiplier: 7})
+        expect(merged.size_multiplier).to eq(14)
+      end
+
       it "merges `aggregations` by merging the hashes", covers: :aggregations do
         agg1 = aggregation_query_of(name: "a1", groupings: [
           field_term_grouping_of("foo1", "bar1"),

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/pagination_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/pagination_spec.rb
@@ -46,6 +46,14 @@ module ElasticGraph
 
         expect(datastore_body_of(query)).to include(size: 0)
       end
+
+      it "applies the `size_multiplier` to the size we request from the datastore" do
+        query = new_query(individual_docs_needed: true, document_pagination: {first: 7})
+        multiplied_query = query.merge_with(size_multiplier: 3)
+
+        # 24 because we add 1 to the "base" size and (7 + 1) * 3 = 24
+        expect(datastore_body_of(multiplied_query)).to include(size: 24)
+      end
     end
   end
 end


### PR DESCRIPTION
This is needed by a optimization I'm working on, in which I'm merging queries in order to more efficiently query the datastore. When we do that we need to apply a multiplier to the size we request.