### PR TITLE
Simplify code snippets: use triple backticks.

### DIFF
--- a/config/site/Rakefile
+++ b/config/site/Rakefile
@@ -269,29 +269,6 @@ module ElasticGraph
           run_jekyll :serve
         end
 
-        desc "Validates the markdown of the website"
-        task :validate_markdown do
-          files_needing_fixes = ::Dir["#{__dir__}/src/**/*.md"].select do |file|
-            ::File.read(file).include?("```")
-          end
-
-          if files_needing_fixes.any?
-            abort <<~EOS
-              Failure: #{files_needing_fixes.size} files have code snippets using triple backticks (```) but we have standardized
-              on Jekyll's code snippet highlight:
-
-              https://jekyllrb.com/docs/liquid/tags/#code-snippet-highlighting
-              {% highlight language %}
-              some code
-              {% endhighlight %}
-
-              To fix, update the following files to use the Jekyll syntax instead of triple backticks:
-
-              #{files_needing_fixes.sort.map { |f| "- #{f}" }.join("\n")}
-            EOS
-          end
-        end
-
         desc "Validate the site's HTML output"
         task :validate_html_output do
           require "html-proofer"
@@ -329,10 +306,11 @@ module ElasticGraph
         end
 
         desc "Perform validations of the website, including doc tests and doc coverage"
-        task validate: [:validate_markdown, :build, :validate_html_output, :docs_coverage, :doctest]
+        task validate: [:build, :validate_html_output, :docs_coverage, :doctest]
 
         task build_css: :npm_install do
           require "rouge"
+          require_relative "support/syntax_theme"
           build_css
         end
 
@@ -414,8 +392,11 @@ module ElasticGraph
     def build_css
       ::Dir.chdir(SITE_SOURCE_DIR) do
         sh "npm run build:css"
-        # tulip appears to provide the best looking syntax highlighting theme of all the built-in rouge themes.
-        ::File.write("assets/css/highlight.css", ::Rouge::Theme.find("tulip").render(scope: ".highlight"))
+
+        ::Dir.chdir(SITE_SOURCE_DIR) do
+          sh "npm run build:css"
+          ::File.write("assets/css/highlight.css", ::ElasticGraph::SyntaxTheme.new.render)
+        end
       end
     end
 

--- a/config/site/src/getting-started.md
+++ b/config/site/src/getting-started.md
@@ -19,14 +19,14 @@ Before you begin, ensure you have the following installed on your system:
 
 Confirm these are installed using your terminal:
 
-{% highlight shell %}
+```shell
 $ ruby -v
 ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
 $ docker compose version
 Docker Compose version v2.32.4-desktop.1
 $ git -v
 git version 2.46.0
-{% endhighlight %}
+```
 
 {: .alert-note}
 **Note**{: .alert-title}
@@ -36,11 +36,11 @@ You don't need these exact versions (these are just examples). Your Ruby version
 
 Run the following command in your terminal:
 
-{% highlight shell %}
+```shell
 $ gem exec elasticgraph new path/to/project --datastore elasticsearch
 # or
 $ gem exec elasticgraph new path/to/project --datastore opensearch
-{% endhighlight %}
+```
 
 {: .alert-note}
 **Note**{: .alert-title}
@@ -62,10 +62,10 @@ This will:
 The initial project skeleton comes with everything you need to run ElasticGraph locally.
 Confirm it works by running the following:
 
-{% highlight shell %}
+```shell
 $ cd path/to/project
 $ bundle exec rake boot_locally
-{% endhighlight %}
+```
 
 This will:
 
@@ -77,9 +77,9 @@ This will:
 
 Run some example queries in GraphiQL to confirm it's working. Here's an example query to get you started:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.FindArtistsFormedIn90s }}
-{% endhighlight %}
+```
 
 Visit the [Query API docs]({% link query-api.md %}) for other example queries that work against the example schema.
 
@@ -91,7 +91,7 @@ worked in an ElasticGraph project before).
 
 Let's add a `Venue.yearOpened` field to our schema. Here's a git diff showing what to change:
 
-{% highlight diff %}
+```diff
 diff --git a/config/schema/artists.rb b/config/schema/artists.rb
 index 77e63de..7999fe4 100644
 --- a/config/schema/artists.rb
@@ -106,18 +106,18 @@ index 77e63de..7999fe4 100644
      t.field "location", "GeoLocation"
      t.field "capacity", "Int"
      t.relates_to_many "featuredArtists", "Artist", via: "tours.shows.venueId", dir: :in, singular: "featuredArtist"
-{% endhighlight %}
+```
 
 Next, rebuild the project:
 
-{% highlight shell %}
+```shell
 $ bundle exec rake build
-{% endhighlight %}
+```
 
 This will re-generate the schema artifacts, run the test suite, and fail. The failing test will indicate
 that the `:venue` factory is missing the new field. To fix it, define `yearOpened` on the `:venue` factory in the `factories.rb` file under `lib`:
 
-{% highlight diff %}
+```diff
 diff --git a/lib/my_eg_project/factories.rb b/lib/my_eg_project/factories.rb
 index 0d8659c..509f274 100644
 --- a/lib/my_eg_project/factories.rb
@@ -130,7 +130,7 @@ index 0d8659c..509f274 100644
      location { build(:geo_location) }
      capacity { Faker::Number.between(from: 200, to: 100_000) }
    end
-{% endhighlight %}
+```
 
 Re-run `bundle exec rake build` and everything should pass. You can also run `bundle exec rake boot_locally`
 and query your new field to confirm the fake values being generated for it.
@@ -143,9 +143,9 @@ Congratulations! You've set up ElasticGraph locally and run your first queries. 
 
 Delete the `artist` schema definition:
 
-{% highlight shell %}
+```shell
 $ rm config/schema/artists.rb
-{% endhighlight %}
+```
 
 Then define your own schema in a Ruby file under `config/schema`.
 
@@ -157,9 +157,9 @@ Then define your own schema in a Ruby file under `config/schema`.
 
 Your ElasticGraph project includes a command that's designed to be run on CI:
 
-{% highlight shell %}
+```shell
 $ bundle exec rake check
-{% endhighlight %}
+```
 
 This should be run on every commit (ideally before merging a pull request) using a CI system
 such as [GitHub Actions](https://github.com/features/actions), [Buildkite](https://buildkite.com/),

--- a/config/site/src/guides/ai-tools.md
+++ b/config/site/src/guides/ai-tools.md
@@ -14,11 +14,11 @@ Build faster with ElasticGraph using AI tools. Here's how to get started with Ch
 
 ### Copy the prompt
 
-{% highlight text %}
+```text
 I'm building with ElasticGraph. Here's the documentation:
 
 [the contents of llms-full.txt go here]
-{% endhighlight %}
+```
 
 <button id="copy-button" class="btn-primary">Copy this prompt</button>
 
@@ -43,9 +43,9 @@ The [elasticgraph-mcp-server](https://pypi.org/project/elasticgraph-mcp-server/)
 
 Install and run the MCP server, for example as a [Goose extension](https://block.github.io/goose/docs/getting-started/using-extensions), using:
 
-{% highlight bash %}
+```bash
 uvx elasticgraph-mcp-server
-{% endhighlight %}
+```
 
 Full documentation for [elasticgraph-mcp-server](https://pypi.org/project/elasticgraph-mcp-server/).
 

--- a/config/site/src/query-api/aggregations.md
+++ b/config/site/src/query-api/aggregations.md
@@ -8,9 +8,9 @@ menu_order: 3
 ElasticGraph offers a powerful aggregations API. Each indexed type gets a corresponding `*Aggregations` field.
 Here's a complete example:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.aggregations.BluegrassArtistAggregations }}
-{% endhighlight %}
+```
 
 Aggregation fields support [filtering]({% link query-api/filtering.md %}) and [pagination]({% link query-api/pagination.md %})
 but do _not_ support client-specified [sorting]({% link query-api/sorting.md %})[^1]. Under an aggregations field, each node

--- a/config/site/src/query-api/aggregations/aggregated-values.md
+++ b/config/site/src/query-api/aggregations/aggregated-values.md
@@ -8,9 +8,9 @@ menu_order: 1
 Aggregated values can be computed from all values of a particular field from all documents backing an aggregation node.
 Here's an example:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.aggregations.BluegrassArtistLifetimeSales }}
-{% endhighlight %}
+```
 
 This example query aggregates the values of the `Artist.lifetimeSales` field using all 4 of the standard numeric
 aggregated values: `min`, `max`, `avg`, and `sum`. These are qualified with `approximate` or `exact` to indicate
@@ -32,9 +32,9 @@ the level of precision they offer. The documentation for `approximateSum` and `e
 
 Besides these standard numeric aggregated values, ElasticGraph offers one more:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.aggregations.SkaArtistHomeCountries }}
-{% endhighlight %}
+```
 
 The `approximateDistinctValueCount` field uses the [HyperLogLog++ algorithm](https://research.google.com/pubs/archive/40671.pdf)
 to provide an approximate count of distinct values for the field. In this case, it can give us an idea of how many countries ska

--- a/config/site/src/query-api/aggregations/counts.md
+++ b/config/site/src/query-api/aggregations/counts.md
@@ -7,9 +7,9 @@ menu_order: 2
 ---
 The aggregations API allows you to count documents within a grouping:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.aggregations.ArtistCountsByCountry }}
-{% endhighlight %}
+```
 
 This query, for example, returns a grouping for each country, and provides a count of how many artists
 call each country home.

--- a/config/site/src/query-api/aggregations/grouping.md
+++ b/config/site/src/query-api/aggregations/grouping.md
@@ -7,9 +7,9 @@ menu_order: 3
 ---
 When aggregating documents, the groupings are defined by `groupedBy`. Here's an example:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.aggregations.ArtistCountsByYearFormedAndHomeCountry }}
-{% endhighlight %}
+```
 
 In this case, we're grouping by multiple fields; a grouping will be returned for each
 combination of `Artist.bio.yearFormed` and `Artist.bio.homeCountry` found in the data.
@@ -20,45 +20,45 @@ In the example above, the grouping was performed on the raw values of the `group
 However, for `Date` fields it's generally more useful to group by _truncated_ values.
 Here's an example:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.aggregations.AlbumSalesByReleaseYear }}
-{% endhighlight %}
+```
 
 In this case, we're truncating the `Album.releaseOn` dates to the year to give us one grouping per
 year rather than one grouping per distinct date. The `truncationUnit` argument supports `DAY`, `MONTH`,
 `QUARTER`, `WEEK` and `YEAR` values. In addition, an `offset` argument is supported, which can be used
 to shift what grouping a `Date` falls into. This is particularly useful when using `WEEK`:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.aggregations.AlbumSalesByReleaseWeek }}
-{% endhighlight %}
+```
 
 With no offset, grouped weeks run Monday to Sunday, but we can shift it using `offset`. In this case, the weeks have been
 shifted to run Sunday to Saturday.
 
 Finally, we can also group `Date` fields by what day of week they fall into using `asDayOfWeek` instead of `asDate`:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.aggregations.AlbumSalesByReleaseDayOfWeek }}
-{% endhighlight %}
+```
 
 ### DateTime Grouping
 
 `DateTime` fields offer a similar grouping API. `asDate` and `asDayOfWeek` work the same, but they accept an optional `timeZone`
 argument (default is "UTC"):
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.aggregations.TourAttendanceByYear }}
-{% endhighlight %}
+```
 
 Sub-day granualarities (`HOUR`, `MINUTE`, `SECOND`) are supported when you use `asDateTime` instead of `asDate`:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.aggregations.TourAttendanceByHour }}
-{% endhighlight %}
+```
 
 Finally, you can group by the time of day (while ignoring the date) by using `asTimeOfDay`:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.aggregations.TourAttendanceByHourOfDay }}
-{% endhighlight %}
+```

--- a/config/site/src/query-api/aggregations/sub-aggregations.md
+++ b/config/site/src/query-api/aggregations/sub-aggregations.md
@@ -17,16 +17,16 @@ ElasticGraph supports aggregations on these nested fields via `subAggregations`.
 to aggregate directly on the data of one of these fields. For example, this query returns the
 total sales for all albums of all artists:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.aggregations.TotalAlbumSales }}
-{% endhighlight %}
+```
 
 Sub-aggregations can also be performed under the groupings of an outer aggregation. For example,
 this query returns the total album sales grouped by the home country of the artist:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.aggregations.TotalAlbumSalesByArtistHomeCountry }}
-{% endhighlight %}
+```
 
 Sub-aggregation nodes offer the standard set of aggregation operations:
 
@@ -40,25 +40,25 @@ Sub-aggregation nodes offer the standard set of aggregation operations:
 The data included in a sub-aggregation can be filtered. For example, this query gets the total
 sales of all albums released in the 21st century:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.aggregations.TwentyFirstCenturyAlbumSales }}
-{% endhighlight %}
+```
 
 ### Sub-Aggregation Limitations
 
 Sub-aggregation pagination support is limited. You can use `first` to request how many
 nodes are returned, but there is no `pageInfo` and you cannot request the next page of data:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.aggregations.AlbumSalesByReleaseMonth }}
-{% endhighlight %}
+```
 
 Sub-aggregation counts are approximate. Instead of `count`, ElasticGraph offers `countDetail`
 with multiple subfields:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.aggregations.AlbumCount }}
-{% endhighlight %}
+```
 
 `approximateValue`
 : The (approximate) count of documents in this aggregation bucket.

--- a/config/site/src/query-api/filtering.md
+++ b/config/site/src/query-api/filtering.md
@@ -7,9 +7,9 @@ menu_order: 2
 ---
 Use `filter:` on a root query field to narrow down the returned results:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.FindArtist }}
-{% endhighlight %}
+```
 
 As shown here, filters have two basic parts:
 
@@ -22,14 +22,14 @@ As shown here, filters have two basic parts:
 Filters with a value of `null` or empty object (`{}`) match all documents. When negated with `not`, no documents are matched.
 The filters in this query match all documents:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.EmptyFilters }}
-{% endhighlight %}
+```
 
 This particularly comes in handy when using [query variables](https://graphql.org/learn/queries/#variables).
 It allows a query to flexibly support a wide array of filters without requiring them to all be used for an
 individual request.
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.FindArtists }}
-{% endhighlight %}
+```

--- a/config/site/src/query-api/filtering/comparison.md
+++ b/config/site/src/query-api/filtering/comparison.md
@@ -11,6 +11,6 @@ ElasticGraph offers a standard set of comparison filter predicates:
 
 Here's an example:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.FindArtistsFormedIn90s }}
-{% endhighlight %}
+```

--- a/config/site/src/query-api/filtering/conjunctions.md
+++ b/config/site/src/query-api/filtering/conjunctions.md
@@ -12,18 +12,18 @@ ElasticGraph supports two conjunction predicates:
 By default, multiple filters are ANDed together. For example, this query finds artists
 formed after the year 2000 with "accordion" in their bio:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.FindRecentAccordionArtists }}
-{% endhighlight %}
+```
 
 ### ORing subfilters with `anyOf`
 
 To instead find artists formed after the year 2000 OR with "accordion" in their bio, you
 can pass the sub-filters as a list to `anyOf`:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.FindRecentOrAccordionArtists }}
-{% endhighlight %}
+```
 
 `anyOf` is available at all levels of the filtering structure so that you can OR
 sub-filters anywhere you like.
@@ -35,17 +35,17 @@ come in handy when you'd otherwise have a duplicate key collision on a filter in
 case where this comes in handy is when using `anySatisfy` to [filter on a
 list]({% link query-api/filtering/list.md %}). Consider this query:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.ArtistsWithPlatinum90sAlbum }}
-{% endhighlight %}
+```
 
 This query finds artists who released an album in the 90's that sold more than million copies.
 If you wanted to broaden the query to find artists with at least one 90's album and at least one
 platinum-selling album--without requiring it to be the same album--you could do this:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.ArtistsWith90sAlbumAndPlatinumAlbum }}
-{% endhighlight %}
+```
 
 GraphQL input objects don't allow duplicate keys, so
 `albums: {anySatisfy: {...}, anySatisfy: {...}}` isn't supported, but `allOf`
@@ -57,16 +57,16 @@ enables this use case.
 When using `allOf` or `anyOf`, be sure to pass the sub-filters as a list. If you instead
 pass them as an object, it won't work as expected. Consider this query:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.AnyOfGotcha }}
-{% endhighlight %}
+```
 
 While this query will return results, it doesn't behave as it appears. The GraphQL
 spec mandates that list inputs [coerce non-list values into a list of one
 value](https://spec.graphql.org/October2021/#sec-List.Input-Coercion). In this case,
 that means that the `anyOf` expression is coerced into this:
 
-{% highlight graphql %}
+```graphql
 query AnyOfGotcha {
   artists(filter: {
     bio: {
@@ -79,12 +79,12 @@ query AnyOfGotcha {
     # ...
   }
 }
-{% endhighlight %}
+```
 
 Using `anyOf` with only a single sub-expression, as we have here, doesn't do anything;
 the query is equivalent to:
 
-{% highlight graphql %}
+```graphql
 query AnyOfGotcha {
   artists(filter: {
     bio: {
@@ -95,5 +95,5 @@ query AnyOfGotcha {
     # ...
   }
 }
-{% endhighlight %}
+```
 </div>

--- a/config/site/src/query-api/filtering/date-time.md
+++ b/config/site/src/query-api/filtering/date-time.md
@@ -23,9 +23,9 @@ All three support the standard set of [equality]({% link query-api/filtering/equ
 [comparison]({% link query-api/filtering/comparison.md %}) predicates. When using comparison
 predicates to cover a range, it's usually simplest to pair `gte` with `lt`:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.FindMarch2025Shows }}
-{% endhighlight %}
+```
 
 In addition, `DateTime` fields support one more filtering operator:
 
@@ -33,6 +33,6 @@ In addition, `DateTime` fields support one more filtering operator:
 
 For example, you could use it to find shows that started between noon and 3 pm on any date:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.FindEarlyAfternoonShows }}
-{% endhighlight %}
+```

--- a/config/site/src/query-api/filtering/equality.md
+++ b/config/site/src/query-api/filtering/equality.md
@@ -11,12 +11,12 @@ The most commonly used predicate supports equality filtering:
 
 Here's a basic example:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.FindU2OrRadiohead }}
-{% endhighlight %}
+```
 
 Unlike the SQL `IN` operator, you can find records with `null` values if you put `null` in the list:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.FindUnnamedArtists }}
-{% endhighlight %}
+```

--- a/config/site/src/query-api/filtering/full-text-search.md
+++ b/config/site/src/query-api/filtering/full-text-search.md
@@ -13,9 +13,9 @@ ElasticGraph supports two full-text search filtering predicates:
 
 `matchesQuery` is the more lenient of the two predicates. It's designed to match broadly. Here's an example:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.AccordionOrViolinSearch }}
-{% endhighlight %}
+```
 
 This query will match artists with bios like:
 
@@ -28,22 +28,22 @@ Notably, the description needs `accordion` OR `violin`, but not both. In additio
 mentioned "viola" since it supports fuzzy matching by default and "viola" is only 2 edits away from "violin". Arguments
 are supported to control both aspects to make matching stricter:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.AccordionAndViolinStrictSearch }}
-{% endhighlight %}
+```
 
 ### Matches Phrase
 
 `matchesPhrase` is even stricter: it requires all terms _in the provided order_ (`matchesQuery` doesn't care about order). It's particularly useful when you want to search on a particular multi-word expression:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.PhraseSearch }}
-{% endhighlight %}
+```
 
 ### Bypassing matchesPhrase and matchesQuery
 
 In order to make a `matchesPhrase` or `matchesQuery` filter optional, you can supply `null` to the `MatchesQueryFilterInput` parameter, like this:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.OptionalMatchingFilter }}
-{% endhighlight %}
+```

--- a/config/site/src/query-api/filtering/geographic.md
+++ b/config/site/src/query-api/filtering/geographic.md
@@ -11,6 +11,6 @@ The `GeoLocation` type supports a special predicate:
 
 Here's an example of this predicate:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.FindSeattleVenues }}
-{% endhighlight %}
+```

--- a/config/site/src/query-api/filtering/list.md
+++ b/config/site/src/query-api/filtering/list.md
@@ -14,9 +14,9 @@ ElasticGraph supports a couple predicates for filtering on list fields:
 When filtering on a list field, use `anySatisfy` to find records with matching list elements.
 This query, for example, will find artists that released a platinum-selling album in the 1990s:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.ArtistsWithPlatinum90sAlbum }}
-{% endhighlight %}
+```
 
 {: .alert-warning}
 **Warning**{: .alert-title}
@@ -30,6 +30,6 @@ their albums will be returned--even ones that sold poorly or were released outsi
 
 If you'd rather filter on the _size_ of a list, use `count`:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.FindProlificArtists }}
-{% endhighlight %}
+```

--- a/config/site/src/query-api/filtering/negation.md
+++ b/config/site/src/query-api/filtering/negation.md
@@ -11,9 +11,9 @@ ElasticGraph supports a negation predicate:
 
 One of the more common use cases is to filter to non-null values:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.filtering.FindArtistsWithBios }}
-{% endhighlight %}
+```
 
 `not` is available at any level of a `filter`. All of these are equivalent:
 

--- a/config/site/src/query-api/overview.md
+++ b/config/site/src/query-api/overview.md
@@ -8,9 +8,9 @@ menu_order: 1
 
 ElasticGraph provides an extremely flexible GraphQL query API. As with every GraphQL API, you request the fields you want:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.basic.ListArtistAlbums }}
-{% endhighlight %}
+```
 
 If you're just getting started with GraphQL, we recommend you review the [graphql.org
 learning materials](https://graphql.org/learn/queries/).

--- a/config/site/src/query-api/pagination.md
+++ b/config/site/src/query-api/pagination.md
@@ -9,9 +9,9 @@ To provide pagination, ElasticGraph implements the [Relay GraphQL Cursor Connect
 Specification](https://relay.dev/graphql/connections.htm). Here's an example query showing
 pagination in action:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.pagination.PaginationExample }}
-{% endhighlight %}
+```
 
 This example uses `first:`, `after:`, and `pageInfo { hasNextPage, endCursor }` to implement forward pagination.
 If `pageInfo.hasNextPage` indicates there is another page, the client can pass `pageInfo.endCursor` as the
@@ -25,9 +25,9 @@ In addition, ElasticGraph offers some additional features beyond the Relay spec.
 As an extension to the Relay spec, ElasticGraph offers a `totalEdgeCount` field alongside `edges` and `pageInfo`.
 It can be used to get a total count of matching records:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.pagination.Count21stCenturyArtists }}
-{% endhighlight %}
+```
 
 {: .alert-note}
 **Note**{: .alert-title}
@@ -39,6 +39,6 @@ As an alternative to `edges.node`, ElasticGraph offers `nodes`. This is recommen
 a per-node `cursor` (which is available under `edges`) since it removes an extra layer of nesting, providing a simpler
 response structure:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.pagination.PaginationNodes }}
-{% endhighlight %}
+```

--- a/config/site/src/query-api/sorting.md
+++ b/config/site/src/query-api/sorting.md
@@ -7,9 +7,9 @@ menu_order: 4
 ---
 Use `orderBy:` on a root query field to control how the results are sorted:
 
-{% highlight graphql %}
+```graphql
 {{ site.data.music_queries.sorting.ListArtists }}
-{% endhighlight %}
+```
 
 This query, for example, would sort by `name` (ascending), with `bio.yearFormed` (descending) as a tie breaker.
 When no `orderBy:` argument is provided, ElasticGraph will sort according to the

--- a/config/site/support/syntax_theme.rb
+++ b/config/site/support/syntax_theme.rb
@@ -1,0 +1,22 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "rouge"
+
+module ElasticGraph
+  # A custom Rouge theme based on Tulip but without the purple background
+  # Tulip appears to provide the best looking syntax highlighting theme of all the built-in rouge themes,
+  # apart from the purple background..
+  class SyntaxTheme < Rouge::Themes::Tulip
+    name "elasticgraph"
+
+    # Override just the background color from the parent theme
+    style Text, {}  # Empty style to remove background color
+    style Generic::Output, {}  # Empty style to remove background color
+  end
+end


### PR DESCRIPTION
Previously, when triple backticks were used, an ugly purple background color would be rendered, but `{% highlight ... %}` tags would retain the nice black background. However, it's a lot simpler to use triple backticks, and that's standard markdown syntax, so it's what we prefer.

Here I've updated the syntax highlighting theme to fix this. Here's a diff showing what has changed in the generated `highlight.css` file:

```diff
diff --git a/tmp/old_highlight.css b/config/site/src/assets/css/highlight.css
index 7e5e6d3b..85a5dfa8 100644
--- a/tmp/old_highlight.css
+++ b/config/site/src/assets/css/highlight.css
@@ -1,9 +1,5 @@
 .highlight table td { padding: 5px; }
 .highlight table pre { margin: 0; }
-.highlight {
-  color: #FFFFFF;
-  background-color: #231529;
-}
 .highlight .c, .highlight .ch, .highlight .cd, .highlight .cm, .highlight .cpf, .highlight .c1, .highlight .cs {
   color: #6D6E70;
   font-style: italic;
```