### PR TITLE
Respect the configured `index.max_result_window`.

### DIFF
--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -1250,6 +1250,7 @@ index_templates:
         index.mapping.coerce: false
         index.number_of_replicas: 1
         index.number_of_shards: 1
+        index.max_result_window: 10000
   widget_currencies:
     index_patterns:
     - widget_currencies_rollover__*
@@ -1318,6 +1319,7 @@ index_templates:
         index.mapping.coerce: false
         index.number_of_replicas: 1
         index.number_of_shards: 1
+        index.max_result_window: 10000
   widgets:
     index_patterns:
     - widgets_rollover__*
@@ -1462,6 +1464,7 @@ index_templates:
         index.mapping.coerce: false
         index.number_of_replicas: 1
         index.number_of_shards: 3
+        index.max_result_window: 10000
 indices:
   addresses:
     aliases: {}
@@ -1503,6 +1506,7 @@ indices:
       index.mapping.coerce: false
       index.number_of_replicas: 1
       index.number_of_shards: 1
+      index.max_result_window: 10000
   components:
     aliases: {}
     mappings:
@@ -1559,6 +1563,7 @@ indices:
       index.mapping.coerce: false
       index.number_of_replicas: 1
       index.number_of_shards: 1
+      index.max_result_window: 10000
   electrical_parts:
     aliases: {}
     mappings:
@@ -1587,6 +1592,7 @@ indices:
       index.mapping.coerce: false
       index.number_of_replicas: 1
       index.number_of_shards: 1
+      index.max_result_window: 10000
   manufacturers:
     aliases: {}
     mappings:
@@ -1611,6 +1617,7 @@ indices:
       index.mapping.coerce: false
       index.number_of_replicas: 1
       index.number_of_shards: 1
+      index.max_result_window: 10000
   mechanical_parts:
     aliases: {}
     mappings:
@@ -1639,6 +1646,7 @@ indices:
       index.mapping.coerce: false
       index.number_of_replicas: 1
       index.number_of_shards: 1
+      index.max_result_window: 10000
   sponsors:
     aliases: {}
     mappings:
@@ -1660,6 +1668,7 @@ indices:
       index.mapping.coerce: false
       index.number_of_replicas: 1
       index.number_of_shards: 1
+      index.max_result_window: 10000
   widget_workspaces:
     aliases: {}
     mappings:
@@ -1688,6 +1697,7 @@ indices:
       index.mapping.coerce: false
       index.number_of_replicas: 1
       index.number_of_shards: 1
+      index.max_result_window: 10000
 scripts:
   update_WidgetCurrency_from_Widget_0f26b3e9ea093af29e5cef02a25e75ca:
     context: update

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -1250,6 +1250,7 @@ index_templates:
         index.mapping.coerce: false
         index.number_of_replicas: 1
         index.number_of_shards: 1
+        index.max_result_window: 10000
   widget_currencies:
     index_patterns:
     - widget_currencies_rollover__*
@@ -1318,6 +1319,7 @@ index_templates:
         index.mapping.coerce: false
         index.number_of_replicas: 1
         index.number_of_shards: 1
+        index.max_result_window: 10000
   widgets:
     index_patterns:
     - widgets_rollover__*
@@ -1462,6 +1464,7 @@ index_templates:
         index.mapping.coerce: false
         index.number_of_replicas: 1
         index.number_of_shards: 3
+        index.max_result_window: 10000
 indices:
   addresses:
     aliases: {}
@@ -1503,6 +1506,7 @@ indices:
       index.mapping.coerce: false
       index.number_of_replicas: 1
       index.number_of_shards: 1
+      index.max_result_window: 10000
   components:
     aliases: {}
     mappings:
@@ -1559,6 +1563,7 @@ indices:
       index.mapping.coerce: false
       index.number_of_replicas: 1
       index.number_of_shards: 1
+      index.max_result_window: 10000
   electrical_parts:
     aliases: {}
     mappings:
@@ -1587,6 +1592,7 @@ indices:
       index.mapping.coerce: false
       index.number_of_replicas: 1
       index.number_of_shards: 1
+      index.max_result_window: 10000
   manufacturers:
     aliases: {}
     mappings:
@@ -1611,6 +1617,7 @@ indices:
       index.mapping.coerce: false
       index.number_of_replicas: 1
       index.number_of_shards: 1
+      index.max_result_window: 10000
   mechanical_parts:
     aliases: {}
     mappings:
@@ -1639,6 +1646,7 @@ indices:
       index.mapping.coerce: false
       index.number_of_replicas: 1
       index.number_of_shards: 1
+      index.max_result_window: 10000
   sponsors:
     aliases: {}
     mappings:
@@ -1660,6 +1668,7 @@ indices:
       index.mapping.coerce: false
       index.number_of_replicas: 1
       index.number_of_shards: 1
+      index.max_result_window: 10000
   widget_workspaces:
     aliases: {}
     mappings:
@@ -1688,6 +1697,7 @@ indices:
       index.mapping.coerce: false
       index.number_of_replicas: 1
       index.number_of_shards: 1
+      index.max_result_window: 10000
 scripts:
   update_WidgetCurrency_from_Widget_0f26b3e9ea093af29e5cef02a25e75ca:
     context: update

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core.rb
@@ -49,7 +49,8 @@ module ElasticGraph
             name: name,
             runtime_metadata: index_def_metadata,
             config: config,
-            datastore_clients_by_name: clients_by_name
+            datastore_clients_by_name: clients_by_name,
+            schema_artifacts: schema_artifacts
           )
 
           [name, index_def]

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/base.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/base.rb
@@ -46,6 +46,12 @@ module ElasticGraph
           route_with != "id"
         end
 
+        def max_result_window
+          @max_result_window ||= flattened_env_setting_overrides.fetch("index.max_result_window") do
+            env_agnostic_settings.fetch("index.max_result_window")
+          end
+        end
+
         # Indicates if a search on this index definition may hit incomplete documents. An incomplete document
         # can occur when multiple event types flow into the same index. An index that has only one source type
         # can never have incomplete documents, but an index that has 2 or more sources can have incomplete

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/index.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/index.rb
@@ -15,15 +15,16 @@ module ElasticGraph
     module IndexDefinition
       class Index < Support::MemoizableData.define(
         :name, :route_with, :default_sort_clauses, :current_sources, :fields_by_path,
-        :env_index_config, :defined_clusters, :datastore_clients_by_name
+        :env_index_config, :defined_clusters, :datastore_clients_by_name, :env_agnostic_settings
       )
         # `Data.define` provides all these methods:
-        # @dynamic name, route_with, default_sort_clauses, current_sources, fields_by_path, env_index_config, defined_clusters, datastore_clients_by_name, initialize
+        # @dynamic name, route_with, default_sort_clauses, current_sources, fields_by_path, env_index_config, env_agnostic_settings
+        # @dynamic defined_clusters, datastore_clients_by_name, initialize,
 
         # `include IndexDefinition::Base` provides all these methods. Steep should be able to detect it
         # but can't for some reason so we have to declare them with `@dynamic`.
         # @dynamic flattened_env_setting_overrides, routing_value_for_prepared_record, has_custom_routing?, cluster_to_query, use_updates_for_indexing?
-        # @dynamic clusters_to_index_into, all_accessible_cluster_names, ignored_values_for_routing, searches_could_hit_incomplete_docs?
+        # @dynamic clusters_to_index_into, all_accessible_cluster_names, ignored_values_for_routing, searches_could_hit_incomplete_docs?, max_result_window
         # @dynamic accessible_cluster_names_to_index_into, accessible_from_queries?, known_related_query_rollover_indices, list_counts_field_paths_for_source
         include IndexDefinition::Base
 

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/rollover_index_template.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/rollover_index_template.rb
@@ -22,16 +22,17 @@ module ElasticGraph
     module IndexDefinition
       class RolloverIndexTemplate < Support::MemoizableData.define(
         :name, :route_with, :default_sort_clauses, :current_sources, :fields_by_path, :env_index_config,
-        :index_args, :defined_clusters, :datastore_clients_by_name, :timestamp_field_path, :frequency
+        :index_args, :defined_clusters, :datastore_clients_by_name, :timestamp_field_path, :frequency,
+        :env_agnostic_settings
       )
         # `Data.define` provides all these methods:
-        # @dynamic name, route_with, default_sort_clauses, current_sources, fields_by_path, env_index_config,
+        # @dynamic name, route_with, default_sort_clauses, current_sources, fields_by_path, env_index_config, env_agnostic_settings
         # @dynamic index_args, defined_clusters, datastore_clients_by_name, timestamp_field_path, frequency, initialize
 
         # `include IndexDefinition::Base` provides all these methods. Steep should be able to detect it
         # but can't for some reason so we have to declare them with `@dynamic`.
         # @dynamic flattened_env_setting_overrides, routing_value_for_prepared_record, has_custom_routing?, cluster_to_query, use_updates_for_indexing?
-        # @dynamic clusters_to_index_into, all_accessible_cluster_names, ignored_values_for_routing, searches_could_hit_incomplete_docs?
+        # @dynamic clusters_to_index_into, all_accessible_cluster_names, ignored_values_for_routing, searches_could_hit_incomplete_docs?, max_result_window
         # @dynamic accessible_cluster_names_to_index_into, accessible_from_queries?, known_related_query_rollover_indices, list_counts_field_paths_for_source
         include IndexDefinition::Base
 

--- a/elasticgraph-datastore_core/sig/elastic_graph/datastore_core/index_definition.rbs
+++ b/elasticgraph-datastore_core/sig/elastic_graph/datastore_core/index_definition.rbs
@@ -7,6 +7,7 @@ module ElasticGraph
       def use_updates_for_indexing?: () -> bool
       def routing_value_for_prepared_record: (::Hash[::String, untyped], ?route_with_path: ::String?, ?id_path: ::String) -> ::String?
       def has_custom_routing?: () -> bool
+      def max_result_window: () -> ::Integer
       def searches_could_hit_incomplete_docs?: () -> bool
       def cluster_to_query: () -> ::String
       def clusters_to_index_into: () -> ::Array[::String]
@@ -26,6 +27,7 @@ module ElasticGraph
       def current_sources: () -> ::Set[::String]
       def fields_by_path: () -> ::Hash[::String, SchemaArtifacts::RuntimeMetadata::IndexField]
       def env_index_config: () -> Configuration::IndexDefinition
+      def env_agnostic_settings: () -> ::Hash[::String, untyped]
       def defined_clusters: () -> ::Set[::String]
       def datastore_clients_by_name: () -> ::Hash[::String, DatastoreCore::_Client]
       def rollover_index_template?: () -> bool
@@ -48,7 +50,8 @@ module ElasticGraph
         name: ::String,
         runtime_metadata: SchemaArtifacts::RuntimeMetadata::IndexDefinition,
         config: DatastoreCore::Config,
-        datastore_clients_by_name: ::Hash[::String, DatastoreCore::_Client]
+        datastore_clients_by_name: ::Hash[::String, DatastoreCore::_Client],
+        schema_artifacts: schemaArtifacts
       ) -> indexDefinition
     end
   end

--- a/elasticgraph-datastore_core/sig/elastic_graph/datastore_core/index_definition/base.rbs
+++ b/elasticgraph-datastore_core/sig/elastic_graph/datastore_core/index_definition/base.rbs
@@ -10,6 +10,7 @@ module ElasticGraph
         @known_related_query_rollover_indices: ::Array[RolloverIndex]?
         @searches_could_hit_incomplete_docs: bool
         @list_counts_field_paths_for_source: ::Hash[::String, ::Set[::String]]
+        @max_result_window: ::Integer?
 
         private
 

--- a/elasticgraph-datastore_core/spec/integration/elastic_graph/datastore_core/index_definition/index_spec.rb
+++ b/elasticgraph-datastore_core/spec/integration/elastic_graph/datastore_core/index_definition/index_spec.rb
@@ -58,6 +58,10 @@ module ElasticGraph
           end
 
           it "ignores non-existing index" do
+            allow(datastore_core.schema_artifacts).to receive(:indices).and_wrap_original do |original|
+              original.call.merge("does_not_exist" => {"settings" => {}})
+            end
+
             index_def_not_exist = index_def_named("does_not_exist")
 
             expect {
@@ -90,7 +94,8 @@ module ElasticGraph
             name: name,
             config: datastore_core.config,
             runtime_metadata: runtime_metadata,
-            datastore_clients_by_name: datastore_core.clients_by_name
+            datastore_clients_by_name: datastore_core.clients_by_name,
+            schema_artifacts: datastore_core.schema_artifacts
           )
         end
       end

--- a/elasticgraph-datastore_core/spec/integration/elastic_graph/datastore_core/index_definition/rollover_index_template_spec.rb
+++ b/elasticgraph-datastore_core/spec/integration/elastic_graph/datastore_core/index_definition/rollover_index_template_spec.rb
@@ -76,6 +76,10 @@ module ElasticGraph
           end
 
           it "ignores non-existing index template and index" do
+            allow(datastore_core.schema_artifacts).to receive(:index_templates).and_wrap_original do |original|
+              original.call.merge("does_not_exist" => {"template" => {"settings" => {}}})
+            end
+
             index_def_not_exist = index_def_named("does_not_exist", rollover: {
               timestamp_field_path: "created_at", frequency: :monthly
             })
@@ -573,7 +577,8 @@ module ElasticGraph
             name: name,
             config: datastore_core.config,
             runtime_metadata: runtime_metadata,
-            datastore_clients_by_name: datastore_core.clients_by_name
+            datastore_clients_by_name: datastore_core.clients_by_name,
+            schema_artifacts: datastore_core.schema_artifacts
           )
         end
       end

--- a/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/index_definition/implementation_shared_examples.rb
+++ b/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/index_definition/implementation_shared_examples.rb
@@ -74,6 +74,28 @@ module ElasticGraph
           end
         end
 
+        describe "#max_result_window" do
+          it "returns the default (10000) when it has not been explicitly configured on the index definition" do
+            index = define_index
+
+            expect(index.max_result_window).to eq 10000
+          end
+
+          it "respects an override configured in the env-agnostic schema definition" do
+            index = define_index(max_result_window: 9876)
+
+            expect(index.max_result_window).to eq 9876
+          end
+
+          it "respects an override configured in an env-specific settings file" do
+            index = define_index("my_type", max_result_window: 9876, config_overrides: {index_definitions: {
+              "my_type" => config_index_def_of(setting_overrides: {"max_result_window" => 1234})
+            }})
+
+            expect(index.max_result_window).to eq 1234
+          end
+        end
+
         describe "#cluster_to_query" do
           it "references query_cluster from config" do
             index = define_index("my_type", config_overrides: {index_definitions: {

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
@@ -217,6 +217,7 @@ module ElasticGraph
           decoded_cursor_factory: decoded_cursor_factory,
           schema_element_names: schema_element_names,
           size_multiplier: size_multiplier,
+          max_effective_size: search_index_definitions.map { |i| i.max_result_window }.min,
           paginator: Paginator.new(
             default_page_size: default_page_size,
             max_page_size: max_page_size,

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/datastore_query_unit_support.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/datastore_query_unit_support.rb
@@ -24,12 +24,12 @@ module ElasticGraph
         end
       end
 
-      def new_query(aggregations: {}, filter: nil, filters: [], **options)
+      def new_query(aggregations: {}, filter: nil, filters: [], types: ["Widget"], **options)
         aggregations = aggregations.to_h { |agg| [agg.name, agg] } if aggregations.is_a?(::Array)
 
         builder.new_query(
           aggregations: aggregations,
-          search_index_definitions: graphql.datastore_core.index_definitions_by_graphql_type.fetch("Widget"),
+          search_index_definitions: types.flat_map { |t| graphql.datastore_core.index_definitions_by_graphql_type.fetch(t) },
           filters: filters + [filter].compact,
           **options
         )

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/index.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/index.rb
@@ -248,7 +248,9 @@ module ElasticGraph
           "index.mapping.ignore_malformed" => false,
           "index.mapping.coerce" => false,
           "index.number_of_replicas" => 1,
-          "index.number_of_shards" => 1
+          "index.number_of_shards" => 1,
+          # 10K is the default: https://www.elastic.co/guide/en/elasticsearch/reference/8.17/index-modules.html#dynamic-index-settings
+          "index.max_result_window" => 10000
         }
 
         def mappings


### PR DESCRIPTION
If we submit a query with `size` set to a value larger than `index.max_result_window`, we get an exception from Elasticsearch/OpenSearch. With the new `size_multiplier` added in #364, it's quite easy to exceed the `max_result_window` without realizing it.

To solve this, we can always record the `max_result_window` in our `datastore_config.yaml`. (Previously, it was only recorded if explicitly configured). Then we can read the value and respect it when building a datastore query.