### PR TITLE
Have dependabot update github-actions monthly instead of weekly.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
 
   - package-ecosystem: bundler
     directory: /


### PR DESCRIPTION
GitHub actions updates often take a bit of extra work to incorporate, because `ci.yaml` is a generated artifact. I'd prefer to apply updates a bit less often.