### PR TITLE
Improve website code snippet styling and functionality.

### DIFF
--- a/config/site/src/_includes/copyable_code_snippet.html
+++ b/config/site/src/_includes/copyable_code_snippet.html
@@ -20,7 +20,30 @@
 <div class="relative {% if include.style == 'dark' %}bg-gray-800 dark:bg-gray-900 text-white py-3 px-6 rounded-sm not-prose mx-auto max-w-3xl{% endif %}">
   <div class="absolute right-2 top-2 z-10">
     <div class="relative">
-      <button onclick="copyToClipboard(this, {{ code | jsonify | escape }})"
+      {% if include.language == "shell" %}
+        {% assign lines = code | newline_to_br | split: "<br />" %}
+        {% assign has_prompt = false %}
+        {% assign clipboard_lines = "" %}
+        {% for line in lines %}
+          {% if line contains "$" %}
+            {% assign has_prompt = true %}
+            {% assign cmd = line | split: "$" | last | strip %}
+            {% assign clipboard_lines = clipboard_lines | append: cmd | append: "
+" %}
+          {% endif %}
+        {% endfor %}
+        {% if has_prompt %}
+          {% assign clipboard_content = clipboard_lines %}
+          {% assign display_content = code %}
+        {% else %}
+          {% assign clipboard_content = code %}
+          {% assign display_content = "$ " | append: code %}
+        {% endif %}
+      {% else %}
+        {% assign clipboard_content = code %}
+        {% assign display_content = code %}
+      {% endif %}
+      <button onclick="copyToClipboard(this, {{ clipboard_content | jsonify | escape }})"
         class="{% if include.style == 'dark' %}text-white hover:text-blue-300{% else %}text-gray-400 hover:text-blue-300{% endif %} transition-all cursor-pointer"
         aria-label="Copy code">
         <span class="sr-only">Copy code</span>
@@ -33,12 +56,7 @@
   </div>
 
   <div class="{% if include.font_size %}{{ include.font_size }}{% endif %}">
-    {% if include.language == "shell" %}
-      {% capture shell_display %}$ {{ code }}{% endcapture %}
-      {% capture md_include %}{% include code_block.md language=include.language code=shell_display %}{% endcapture %}
-    {% else %}
-      {% capture md_include %}{% include code_block.md language=include.language code=code %}{% endcapture %}
-    {% endif %}
+    {% capture md_include %}{% include code_block.md language=include.language code=display_content %}{% endcapture %}
     {{ md_include | markdownify }}
   </div>
 </div>

--- a/config/site/src/assets/css/tailwind.css
+++ b/config/site/src/assets/css/tailwind.css
@@ -28,6 +28,21 @@
         content: none;
       }
     }
+
+    pre.highlight {
+      margin-top: 18px;
+      margin-bottom: 18px;
+      padding-top: 12px;
+      padding-bottom: 12px;
+    }
+  }
+
+  .alert-tip div.highlight pre.highlight {
+    margin-bottom: 0px;
+  }
+
+  .alert-tip div.highlight {
+    margin-bottom: 0px;
   }
 }
 

--- a/config/site/src/getting-started.md
+++ b/config/site/src/getting-started.md
@@ -19,14 +19,12 @@ Before you begin, ensure you have the following installed on your system:
 
 Confirm these are installed using your terminal:
 
-```shell
-$ ruby -v
+{% include copyable_code_snippet.html language="shell" code="$ ruby -v
 ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
 $ docker compose version
 Docker Compose version v2.32.4-desktop.1
 $ git -v
-git version 2.46.0
-```
+git version 2.46.0" %}
 
 {: .alert-note}
 **Note**{: .alert-title}
@@ -83,22 +81,20 @@ worked in an ElasticGraph project before).
 
 Let's add a `Venue.yearOpened` field to our schema. Here's a git diff showing what to change:
 
-```diff
-diff --git a/config/schema/artists.rb b/config/schema/artists.rb
+{% include copyable_code_snippet.html language="diff" code="diff --git a/config/schema/artists.rb b/config/schema/artists.rb
 index 77e63de..7999fe4 100644
 --- a/config/schema/artists.rb
 +++ b/config/schema/artists.rb
 @@ -56,6 +56,9 @@ ElasticGraph.define_schema do |schema|
-   schema.object_type "Venue" do |t|
-     t.field "id", "ID"
-     t.field "name", "String"
-+    t.field "yearOpened", "Int" do |f|
+   schema.object_type \"Venue\" do |t|
+     t.field \"id\", \"ID\"
+     t.field \"name\", \"String\"
++    t.field \"yearOpened\", \"Int\" do |f|
 +      f.json_schema minimum: 1900, maximum: 2100
 +    end
-     t.field "location", "GeoLocation"
-     t.field "capacity", "Int"
-     t.relates_to_many "featuredArtists", "Artist", via: "tours.shows.venueId", dir: :in, singular: "featuredArtist"
-```
+     t.field \"location\", \"GeoLocation\"
+     t.field \"capacity\", \"Int\"
+     t.relates_to_many \"featuredArtists\", \"Artist\", via: \"tours.shows.venueId\", dir: :in, singular: \"featuredArtist\"" %}
 
 Next, rebuild the project:
 
@@ -107,20 +103,18 @@ Next, rebuild the project:
 This will re-generate the schema artifacts, run the test suite, and fail. The failing test will indicate
 that the `:venue` factory is missing the new field. To fix it, define `yearOpened` on the `:venue` factory in the `factories.rb` file under `lib`:
 
-```diff
-diff --git a/lib/my_eg_project/factories.rb b/lib/my_eg_project/factories.rb
+{% include copyable_code_snippet.html language="diff" code="diff --git a/lib/my_eg_project/factories.rb b/lib/my_eg_project/factories.rb
 index 0d8659c..509f274 100644
 --- a/lib/my_eg_project/factories.rb
 +++ b/lib/my_eg_project/factories.rb
 @@ -95,6 +95,7 @@ FactoryBot.define do
-       "#{city_name} #{venue_type}"
+       \"#{city_name} #{venue_type}\"
      end
 
 +    yearOpened { Faker::Number.between(from: 1900, to: 2025) }
      location { build(:geo_location) }
      capacity { Faker::Number.between(from: 200, to: 100_000) }
-   end
-```
+   end" %}
 
 Re-run `bundle exec rake build` and everything should pass. You can also run `bundle exec rake boot_locally`
 and query your new field to confirm the fake values being generated for it.


### PR DESCRIPTION
- Adjust the margins and padding so it looks better.
- Use the `copyable_code_snippet` include on all snippets on the geting started page.
- Support copying multi-line shell snippets that include output.

For example, we have a snippet that renders like this:

```shell
$ ruby -v
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
$ docker compose version
Docker Compose version v2.32.4-desktop.1
$ git -v
git version 2.46.0"
```

But we only want to copy the commands, not the output (and not the `$` characters):

```shell
ruby -v
docker compose version
git -v
```

Before:

<img width="877" alt="image" src="https://github.com/user-attachments/assets/ef712789-a0c5-4182-a520-14d14d93dfac" />

<img width="864" alt="image" src="https://github.com/user-attachments/assets/986acde1-0877-434e-aa3b-12f3d50baf2d" />

After:

<img width="872" alt="image" src="https://github.com/user-attachments/assets/ee9bb366-5f21-4bb1-a3ae-403d9277b38f" />
<img width="880" alt="image" src="https://github.com/user-attachments/assets/83831ddd-effd-4fdd-ac6c-4789086b7037" />
