### PR TITLE
Remove unnecessary buttons from homepage.

### DIFF
--- a/config/site/src/index.html
+++ b/config/site/src/index.html
@@ -14,16 +14,6 @@ title: ElasticGraph - Open-source GraphQL and Elasticsearch / OpenSearch framewo
     <h1 class="text-xl opacity-90 mb-4">
       {{ site.description }}
     </h1>
-
-    <div class="mt-8 flex justify-center space-x-4">
-      <a href="{% link getting-started.md %}" class="btn-primary">
-        Get Started
-      </a>
-
-      <a href="{{ '/docs/' | append: site.data.doc_versions.latest_version | relative_url }}" class="btn-secondary">
-        Documentation
-      </a>
-    </div>
   </div>
 </div>
 


### PR DESCRIPTION
We have links available to these things from the nav bar.

Before:

<img width="895" alt="image" src="https://github.com/user-attachments/assets/0279f561-eee2-4d5a-b564-a0c2ae7d859d" />

After:

<img width="847" alt="image" src="https://github.com/user-attachments/assets/284617aa-1097-49eb-b3ae-1f90dbca964e" />
