### PR TITLE
Vastly improve the performance of our `NestedRelationships` resolver.

### DIFF
--- a/benchmarks/query_optimizations/nested_relationships_source.rb
+++ b/benchmarks/query_optimizations/nested_relationships_source.rb
@@ -1,0 +1,165 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "benchmark"
+require "bundler/setup"
+require "elastic_graph/graphql"
+require "fileutils"
+require "net/http"
+require "yaml"
+
+# Query that exercises nested relationships in the Widget schema
+QUERY = <<~GRAPHQL
+  query {
+    widgets(first: 500) {
+      nodes {
+        id
+        name
+        components(first: 500) {
+          nodes {
+            id
+            name
+            parts(first: 500) {
+              nodes {
+                ... on MechanicalPart {
+                  id
+                  name
+                  material
+                  manufacturer {
+                    id
+                    name
+                    address {
+                      full_address
+                    }
+                  }
+                }
+                ... on ElectricalPart {
+                  id
+                  name
+                  voltage
+                  manufacturer {
+                    id
+                    name
+                    address {
+                      full_address
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+GRAPHQL
+
+def ensure_datastore_running
+  uri = URI("http://localhost:9334")
+  Net::HTTP.get(uri)
+  true
+rescue Errno::ECONNREFUSED
+  puts "Error: Datastore is not running. Please run:"
+  puts "  bundle exec rake elasticsearch:local:daemon 'index_fake_data:widgets[80]'"
+  puts
+  puts "Then try running this benchmark again."
+  exit 1
+end
+
+def create_config_file(mode)
+  # Load the development config
+  config = YAML.load_file("config/settings/development.yaml", aliases: true)
+
+  # Update the resolver mode
+  config["graphql"]["nested_relationship_resolver_mode"] = mode.to_s
+
+  # Create tmp directory if it doesn't exist
+  FileUtils.mkdir_p("tmp")
+
+  # Write the modified config
+  path = "tmp/development_#{mode}.yaml"
+  File.write(path, config.to_yaml)
+  path
+end
+
+def run_benchmark(iterations = 10)
+  ensure_datastore_running
+  results_by_mode = {}
+
+  [:original, :optimized].each do |mode|
+    puts "\nTesting with nested_relationship_resolver_mode: #{mode}"
+    puts "------------------------------------------------"
+
+    config_path = create_config_file(mode)
+    graphql = ElasticGraph::GraphQL.from_yaml_file(config_path)
+    executor = graphql.graphql_query_executor
+
+    times = []
+    results = []
+    puts "Running #{iterations} iterations..."
+
+    iterations.times do |i|
+      time = Benchmark.realtime do
+        result = executor.execute(QUERY)
+        if result["errors"]
+          puts "Query errors: #{result["errors"].inspect}"
+          exit 1
+        end
+      rescue => e
+        puts "Error executing query: #{e.message}"
+        puts e.backtrace
+        exit 1
+      end
+
+      times << time
+      puts "Iteration #{i + 1}: #{time.round(3)}s"
+    end
+
+    avg_time = (times.sum / times.size).round(3)
+    std_dev = Math.sqrt(times.map { |t| (t - avg_time)**2 }.sum / times.size).round(3)
+
+    puts "\nResults:"
+    puts "  Average time: #{avg_time}s"
+    puts "  Standard deviation: #{std_dev}s"
+    puts "  Min time: #{times.min.round(3)}s"
+    puts "  Max time: #{times.max.round(3)}s"
+
+    results_by_mode[mode] = {
+      times: times,
+      results: results
+    }
+  end
+
+  puts "\nComparing results between modes..."
+  results_by_mode[:original][:results].each_with_index do |original_result, i|
+    optimized_result = results_by_mode[:optimized][:results][i]
+    if original_result == optimized_result
+      puts "Iteration #{i + 1}: Results match"
+    else
+      puts "Iteration #{i + 1}: Results differ!"
+      puts "Original result hash: #{original_result.hash}"
+      puts "Optimized result hash: #{optimized_result.hash}"
+      # Write the results to files for inspection
+      File.write("tmp/original_result_#{i}.json", JSON.pretty_generate(original_result))
+      File.write("tmp/optimized_result_#{i}.json", JSON.pretty_generate(optimized_result))
+      puts "Full results written to tmp/original_result_#{i}.json and tmp/optimized_result_#{i}.json"
+    end
+  end
+
+  puts "\nPerformance Summary:"
+  original_times = results_by_mode[:original][:times]
+  optimized_times = results_by_mode[:optimized][:times]
+  improvement = ((original_times.sum / original_times.size) - (optimized_times.sum / optimized_times.size)) * 1000
+  puts "  Average improvement with optimization: #{improvement.round(2)}ms"
+end
+
+if $0 == __FILE__
+  puts "This benchmark requires the datastore to be running with test data loaded."
+  puts "To prepare:"
+  puts "  bundle exec rake elasticsearch:local:daemon 'index_fake_data:widgets[80]'"
+  puts
+  puts "Press enter to continue, or Ctrl+C to exit"
+  $stdin.gets
+
+  run_benchmark
+end

--- a/benchmarks/query_optimizations/nested_relationships_source.results.txt
+++ b/benchmarks/query_optimizations/nested_relationships_source.results.txt
@@ -1,0 +1,44 @@
+Testing with nested_relationship_resolver_mode: original
+------------------------------------------------
+Running 10 iterations...
+Iteration 1: 2.828s
+Iteration 2: 2.555s
+Iteration 3: 2.552s
+Iteration 4: 2.54s
+Iteration 5: 2.486s
+Iteration 6: 2.492s
+Iteration 7: 2.488s
+Iteration 8: 2.483s
+Iteration 9: 2.48s
+Iteration 10: 2.481s
+
+Results:
+  Average time: 2.539s
+  Standard deviation: 0.101s
+  Min time: 2.48s
+  Max time: 2.828s
+
+Testing with nested_relationship_resolver_mode: optimized
+------------------------------------------------
+Running 10 iterations...
+Iteration 1: 0.721s
+Iteration 2: 0.726s
+Iteration 3: 0.731s
+Iteration 4: 0.729s
+Iteration 5: 0.741s
+Iteration 6: 0.73s
+Iteration 7: 0.716s
+Iteration 8: 0.712s
+Iteration 9: 0.714s
+Iteration 10: 0.714s
+
+Results:
+  Average time: 0.723s
+  Standard deviation: 0.009s
+  Min time: 0.712s
+  Max time: 0.741s
+
+Comparing results between modes...
+
+Performance Summary:
+  Average improvement with optimization: 1815.04ms

--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -79,7 +79,8 @@ module ElasticGraph
           monotonic_clock: monotonic_clock,
           logger: logger,
           slow_query_threshold_ms: @config.slow_query_latency_warning_threshold_in_ms,
-          datastore_search_router: datastore_search_router
+          datastore_search_router: datastore_search_router,
+          config: config
         )
       end
     end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
@@ -230,6 +230,10 @@ module ElasticGraph
         )
       end
 
+      def effective_size
+        document_paginator.effective_size
+      end
+
       private
 
       def merge_attribute(attribute, other_value)

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/document_paginator.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/document_paginator.rb
@@ -59,14 +59,14 @@ module ElasticGraph
           end
         end
 
-        private
-
         def effective_size
           @effective_size ||= begin
             uncapped_size = (individual_docs_needed ? paginator.requested_page_size : 0) * size_multiplier
             (uncapped_size > max_effective_size) ? max_effective_size : uncapped_size
           end
         end
+
+        private
 
         def effective_sort
           return [] unless effective_size > 0

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/index_expression_builder.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/index_expression_builder.rb
@@ -142,8 +142,7 @@ module ElasticGraph
       private_constant :IndexExpressionBuilder
 
       # Steep is complaining that it can't find some `Query` but they are not in this file...
-      # @dynamic aggregations, shard_routing_values, search_index_definitions, merge_with, search_index_expression
-      # @dynamic with, to_datastore_msearch_header_and_body, document_paginator
+      # @dynamic shard_routing_values, effective_size, merge_with, search_index_expression, with, to_datastore_msearch_header_and_body
     end
   end
 end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/routing_picker.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/routing_picker.rb
@@ -168,8 +168,7 @@ module ElasticGraph
       private_constant :RoutingValueSet
 
       # Steep is complaining that it can't find some `Query` but they are not in this file...
-      # @dynamic aggregations, shard_routing_values, search_index_definitions, merge_with, search_index_expression
-      # @dynamic with, to_datastore_msearch_header_and_body, document_paginator
+      # @dynamic shard_routing_values, effective_size, merge_with, search_index_expression, with, to_datastore_msearch_header_and_body
     end
   end
 end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_executor.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_executor.rb
@@ -18,12 +18,13 @@ module ElasticGraph
       # @dynamic schema
       attr_reader :schema
 
-      def initialize(schema:, monotonic_clock:, logger:, slow_query_threshold_ms:, datastore_search_router:)
+      def initialize(schema:, monotonic_clock:, logger:, slow_query_threshold_ms:, datastore_search_router:, config:)
         @schema = schema
         @monotonic_clock = monotonic_clock
         @logger = logger
         @slow_query_threshold_ms = slow_query_threshold_ms
         @datastore_search_router = datastore_search_router
+        @config = config
       end
 
       # Executes the given `query_string` using the provided `variables`.
@@ -60,11 +61,13 @@ module ElasticGraph
           operation_name: operation_name,
           client: client,
           context: context.merge({
+            logger: @logger,
             monotonic_clock_deadline: timeout_in_ms&.+(start_time_in_ms),
             elastic_graph_schema: @schema,
             schema_element_names: @schema.element_names,
             elastic_graph_query_tracker: query_tracker,
-            datastore_search_router: @datastore_search_router
+            datastore_search_router: @datastore_search_router,
+            nested_relationship_resolver_mode: @config.nested_relationship_resolver_mode
           }.compact)
         )
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships_source.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships_source.rb
@@ -1,0 +1,312 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/graphql/resolvers/query_source"
+
+module ElasticGraph
+  class GraphQL
+    module Resolvers
+      # A GraphQL dataloader responsible for solving a thorny N+1 query problem related to our `NestedRelationships` resolver.
+      # The `QuerySource` dataloader implements a basic batching optimization: multiple datastore queries are batched up into
+      # a single `msearch` call against the dataastore. This is significantly better than submitting a separate request per
+      # query, but is still not optimal--the datastore still must execute N different queries, which could cause significant load.
+      #
+      # A significantly improved optimization is possible in one particular situation from our `NestedRelationships` resolver.
+      # Here's an example of that situation:
+      #
+      #   - `Part` documents are indexed in a `parts` index and `Manufacturer` documents are indexed in a `manufacturers` index.
+      #   - `Part.manufacturer` is defined as: `t.relates_to_one "manufacturer", "Manufacturer", via: "manufacturer_id", dir: :out`.
+      #   - We are processing a GraphQL query like this: `parts(first: 10) { nodes { manufacturer { name } } }`.
+      #   - For each of the 10 parts, the `NestedRelationships` resolver has to resolve its related `Part.manufacturer`.
+      #   - Without the optimization provided by this class, `NestedRelationships` would have to execute 10 different queries,
+      #     each of which is identical except for a different filter: `{id: {equal_to_any_of: [part.manufacturer_id]}}`.
+      #   - Instead of executing this as 10 different queries, we can instead execute it as one query with this combined filter:
+      #     `{id: {equal_to_any_of: [part1.manufacturer_id, ..., part10.manufacturer_id]}}`
+      #   - When we do this, we get a single response, but `NestedRelationships` expects a separate response for each one.
+      #   - To satisfy that, we can split the single response into 10 different responses (one per filter).
+      #
+      # This optimization, when we can apply it, results in much less load on the datastore. In addition, it also helps to reduce
+      # the amount of overhead imposed by ElasticGraph. Profiling has shown that significant overhead is incurred when we repeatedly
+      # merge filters into a query (e.g. `query.merge_with(filters: [{id: {equal_to_any_of: [part.manufacturer_id]}}])` 10 times to
+      # produce 10 different queries). This optimization also avoids that overhead.
+      #
+      # Note: while the comments discuss the examples in terms of _parent objects_, in the implementation, we deal with id sets.
+      # A set of ids is contributed by each parent object.
+      class NestedRelationshipsSource < ::GraphQL::Dataloader::Source
+        # The optimization implemented by this class is not guaranteed to get all expected results in a single query for cases where
+        # the sorted search results are not well-distributed among each of the parent objects while we're resolving a `relates_to_many`
+        # field. (See the comments on `fetch_via_single_query_with_merged_filters` for a detailed description of when this occurs).
+        #
+        # To deal with this situation, we retry the query for just the parent objects which may have incomplete results. However,
+        # each attempt is run in serial, and we want to put a strict upper bound on how many attempts are made. This constant defines
+        # the maximum number of optimized attempts we allow.
+        #
+        # When exceeded, we fall back to building and executing a separate query (via a single `msearch` request) for each parent object.
+        MAX_OPTIMIZED_ATTEMPTS = 3
+
+        # Reattempts are less likely to be needed when we execute the query with a larger `size`, because we are more likely to get back
+        # complete results for each parent object. This multiplier is applied to the requested size to achieve that.
+        #
+        # 4 was chosen somewhat arbitrarily, but should make reattempts needed much less often while avoiding asking for an unreasonably
+        # large number of results.
+        #
+        # Note: asking the datastore for a larger `size` is quite a bit more efficient than needing to execute more queries.
+        # Once the datastore has gone to the spot in its inverted index with the matching documents, asking for more results
+        # isn't particularly expensive, compared to needing to re-run an extra query.
+        EXTRA_SIZE_MULTIPLIER = 4
+
+        def initialize(query:, join:, context:, monotonic_clock:, mode:)
+          @query = query
+          @join = join
+          @context = context
+          @schema_element_names = @context.fetch(:schema_element_names)
+          @logger = context.fetch(:logger)
+          @monotonic_clock = monotonic_clock
+          @mode = mode
+        end
+
+        def fetch(id_sets)
+          case @mode
+          when :original
+            fetch_original(id_sets)
+          when :comparison
+            fetch_comparison(id_sets)
+          else
+            fetch_optimized(id_sets)
+          end
+        end
+
+        def self.execute_one(ids, query:, join:, context:, monotonic_clock:, mode:)
+          context.dataloader.with(self, query:, join:, context:, monotonic_clock:, mode:).load(ids)
+        end
+
+        private
+
+        def fetch_optimized(id_sets)
+          return fetch_via_separate_queries(id_sets) unless can_merge_filters?
+
+          attempt_count = 0
+          duration_ms, responses_by_id_set = time_duration do
+            fetch_via_single_query_with_merged_filters(id_sets) { attempt_count += 1 }
+          end
+
+          @logger.info({
+            "message_type" => "NestedRelationshipsMergedQueries",
+            "field" => @join.field.description,
+            "optimized_attempt_count" => [attempt_count, MAX_OPTIMIZED_ATTEMPTS].min,
+            "degraded_to_separate_queries" => (attempt_count > MAX_OPTIMIZED_ATTEMPTS),
+            "id_set_count" => id_sets.size,
+            "total_id_count" => id_sets.reduce(:union).size,
+            "duration_ms" => duration_ms
+          })
+
+          id_sets.map { |id_set| responses_by_id_set.fetch(id_set) }
+        end
+
+        def fetch_original(id_sets, requested_fields: [])
+          fetch_via_separate_queries(id_sets, requested_fields: requested_fields)
+        end
+
+        def fetch_comparison(id_sets)
+          # Note: we'd ideally run both versions of the logic in parallel, but our attempts to do that resulted in errors
+          # because of the fiber context in which dataloaders run.
+          original_duration_ms, original_results = time_duration do
+            # In the `fetch_optimized` implementation, we request this extra field. We don't need it for
+            # the original implementation (so `fetch_original` doesn't also request that field...) but for
+            # the purposes of comparison we need to request it so that the document payloads will have the
+            # same fields.
+            fetch_original(id_sets, requested_fields: [@join.filter_id_field_name])
+          end
+
+          optimized_duration_ms, optimized_results = time_duration do
+            fetch_optimized(id_sets)
+          end
+
+          # To see if we got the same results we only look at the documents, because we expect differences outside
+          # of the documents--for example, the `SearchResponse#metadata` will report different `took` values.
+          if original_results.map(&:documents) == optimized_results.map(&:documents)
+            @logger.info({
+              "message_type" => "NestedRelationshipsComparisonResults",
+              "field" => @join.field.description,
+              "original_duration_ms" => original_duration_ms,
+              "optimized_duration_ms" => optimized_duration_ms,
+              "optimized_faster" => (optimized_duration_ms < original_duration_ms)
+            })
+          else
+            @logger.error({
+              "message_type" => "NestedRelationshipsComparisonGotDifferentResults",
+              "field" => @join.field.description,
+              "original_documents" => loggable_results(original_results),
+              "optimized_documents" => loggable_results(optimized_results)
+            })
+          end
+
+          original_results
+        end
+
+        # For "simple", document-based queries, we can safely merge filters. However, this cannot be done safely when the response
+        # cannot safely be "pulled part" into the bits that apply to a particular set of ids for a parent object. Specifically:
+        #
+        #   - If `total_document_count_needed` is true, we can't merge filters, because there's no way to get a separate count
+        #     for each parent object unless we execute separate queries (or combine them into a grouped aggregation count query,
+        #     but that requires a much more challenging transformation of the query and response).
+        #   - If the query has any `aggregations`, we likewise can't merge the filters, because we have no way to "pull apart"
+        #     the aggregations response.
+        def can_merge_filters?
+          !@query.total_document_count_needed && @query.aggregations.empty?
+        end
+
+        # Executes a single query that contains a merged filter from the set union of the given `id_sets`.
+        # This merged query is (theoretically) capable of getting all the results we're looking for in a
+        # single query, which is much more efficient than building and performing a separate query for each
+        # id set. We can use `search_response.filter_results(id_set)` with each id set to get a
+        # response with the documents filtered down to just the ones that match the id set. (Essentially,
+        # this is the response we would have gotten if we had executed a separate query for the id set).
+        #
+        # However, it is not guaranteed that we will get back complete results with this approach. Consider this example:
+        #
+        #   - The datastore has 50 documents that match `id_set_1`, and 50 that match `id_set_2`.
+        #   - The requested size of `@query` is 10 (meaning the client expects the first 10 results matching `id_set_1` and
+        #     the first 10 results matching `id_set_2).
+        #   - All 50 documents that match `id_set_1` sort before all 50 documents that match `id_set_2`.
+        #   - When we execute our merged query filtering on the `union(id_set_1, id_set_2)` set, we ask for
+        #     20 documents (since we want 10 for `id_set_1` and 10 for `id_set_2`).
+        #   - ...but we get back 20 documents for `id_set_1` and 0 documents for `id_set_2`.
+        #
+        # There is no way to guarantee that we get back the desired number of results for each id set unless we build and
+        # execute a separate query per id set, which is inefficient (in some situations, it causes one GraphQL query to
+        # execute hundreds of queries against the datastore!).
+        #
+        # To deal with this possibility, this method takes an iterative approach:
+        #
+        #   - It builds and executes an initial optimized merged query, with a large `size_multiplier` which gives us a good bit of
+        #     "headroom" for this kind of situation. In the example above, if we requested 60 results from the datastore, we'd be
+        #     able to get the 10 results for both id sets we are looking for--50 for `id_set_1` nad 10 for `id_set_2`.
+        #   - It then inspects the response. If the datastore returned fewer results than we asked for, then there are no missing
+        #     results and we can trust that we got all the results we would have gotten if we had executed a separate query per
+        #     id set.
+        #   - If we got back the number of results we asked for, then it's possible that we've run into this situation. We need
+        #     to inspect each filtered response produced for each id set to see if more results were expected.
+        #     - Note: the fact that more results were expected doesn't necessarily mean there are more results. But we have no way
+        #       to tell for sure without querying the datastore again, so we err on the side of safety and treat this kind of response
+        #       as being incomplete.
+        #   - For each id set that appears to be incomplete, we try again. But on the next attempt, we exclude the id sets
+        #     which got a complete set of results.
+        #   - This may cause us to iterate a couple of times (which could make the single GraphQL query we are processing slower than
+        #     it would have been without this optimization, particularly if the datastore was not under any other load...) but we expect
+        #     it to make a big difference in the amount of load we put on the datastore, and that helps _all_ query traffic to be more
+        #     performant overall.
+        def fetch_via_single_query_with_merged_filters(id_sets, remaining_attempts: MAX_OPTIMIZED_ATTEMPTS)
+          yield # yield to signal an attempt
+
+          # Fallback to executing separate queries when one of the following occurs:
+          #
+          #   - We lack multiple sets of ids.
+          #   - We have exhausted our MAX_OPTIMIZED_ATTEMPTS.
+          if id_sets.size < 2 || remaining_attempts < 1
+            return id_sets.zip(fetch_via_separate_queries(id_sets)).to_h
+          end
+
+          # First, we build a combined query with filters that account for all ids we are filtering on from all `id_sets`.
+          filtered_query = @query.merge_with(
+            filters: filters_for(id_sets.reduce(:union)),
+            requested_fields: [@join.filter_id_field_name],
+            # We need to request a larger size than `@query` originally had. If the original size was `10` and we have
+            # 5 sets of ids, then, at a minimum, we need to request 50 results (10 results for each id set).
+            #
+            # In addition, we apply `EXTRA_SIZE_MULTIPLIER` to increase the size further and make it less likely that
+            # we we get incomplete results and have to retry.
+            size_multiplier: id_sets.size * EXTRA_SIZE_MULTIPLIER
+          )
+
+          # Then we execute that combined query.
+          response = QuerySource.execute_one(filtered_query, for_context: @context)
+
+          # Next, we produce a separate response for each id set by filtering the results to the ones that match the ids in the set.
+          filtered_responses_by_id_set = id_sets.to_h do |id_set|
+            filtered_response = response.filter_results(@join.filter_id_field_name, id_set, @query.effective_size)
+            [id_set, filtered_response]
+          end
+
+          # If our merged/filtered query got back fewer results than we requested, then no matching results are missing,
+          # and we know that we've gotten complete results for all id sets.
+          if response.size < filtered_query.effective_size
+            return filtered_responses_by_id_set
+          end
+
+          # Since our `filtered_query` got back as many results as we asked for, there may be additional matching results that
+          # were not returned, and some id sets may have gotten fewer results than requested by the client.
+          # Here we determine which id sets that applies to.
+          id_sets_with_apparently_incomplete_results = filtered_responses_by_id_set.filter_map do |id_set, filtered_response|
+            id_set if filtered_response.size < @query.effective_size
+          end
+
+          # Then we try again, excluding the id sets which have already gotten complete results.
+          another_attempt_results = fetch_via_single_query_with_merged_filters(
+            id_sets_with_apparently_incomplete_results,
+            remaining_attempts: remaining_attempts - 1
+          ) { yield }
+
+          # Finally, we merge the results.
+          filtered_responses_by_id_set.merge(another_attempt_results)
+        end
+
+        def fetch_via_separate_queries(id_sets, requested_fields: [])
+          queries = id_sets.map do |ids|
+            @query.merge_with(filters: filters_for(ids), requested_fields: requested_fields)
+          end
+
+          results = QuerySource.execute_many(queries, for_context: @context)
+          queries.map { |q| results.fetch(q) }
+        end
+
+        def filters_for(ids)
+          join_filter = build_filter(@join.filter_id_field_name, nil, @join.foreign_key_nested_paths, ids.to_a)
+
+          if @join.additional_filter.empty?
+            [join_filter]
+          else
+            [join_filter, @join.additional_filter]
+          end
+        end
+
+        def build_filter(path, previous_nested_path, nested_paths, ids)
+          next_nested_path, *rest_nested_paths = nested_paths
+
+          if next_nested_path.nil?
+            path = path.delete_prefix("#{previous_nested_path}.") if previous_nested_path
+            {path => {@schema_element_names.equal_to_any_of => ids}}
+          else
+            sub_filter = build_filter(path, next_nested_path, rest_nested_paths, ids)
+            next_nested_path = next_nested_path.delete_prefix("#{previous_nested_path}.") if previous_nested_path
+            {next_nested_path => {@schema_element_names.any_satisfy => sub_filter}}
+          end
+        end
+
+        def time_duration
+          start_time = @monotonic_clock.now_in_ms
+          result = yield
+          stop_time = @monotonic_clock.now_in_ms
+          [stop_time - start_time, result]
+        end
+
+        # Converts the given list of responses into a format we can safely log when we are logging
+        # response differences. We include the `id` (to identify the document) and the `hash` (so
+        # we can tell if the payload of a document differed, without logging the contents of that
+        # payload).
+        def loggable_results(responses)
+          responses.map do |response|
+            response.documents.map do |doc|
+              "#{doc.id} (hash: #{doc.hash})"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/query_source.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/query_source.rb
@@ -11,11 +11,14 @@ require "graphql"
 module ElasticGraph
   class GraphQL
     module Resolvers
-      # Provides a way to avoid N+1 query problems by batching up multiple
-      # datastore queries into one `msearch` call. In general, it is recommended
+      # Provides a way to avoid N+1 request problems by batching up multiple
+      # datastore queries into one `msearch` request. In general, it is recommended
       # that you use this from any resolver that needs to query the datastore, to
       # maximize our ability to combine multiple datastore requests. Importantly,
       # this should never be instantiated directly; instead use the `execute` method from below.
+      #
+      # Note: `NestedRelationshipsSource` implements further optimizations on top of this, and should
+      # be used rather than this class when applicable.
       class QuerySource < ::GraphQL::Dataloader::Source
         def initialize(datastore_router, query_tracker)
           @datastore_router = datastore_router

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/config.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/config.rbs
@@ -1,9 +1,12 @@
 module ElasticGraph
   class GraphQL
+    type nestedRelationshipResolverMode = :optimized | :original | :comparison
+
     class ConfigSupertype
       attr_reader default_page_size: ::Integer
       attr_reader max_page_size: ::Integer
       attr_reader slow_query_latency_warning_threshold_in_ms: ::Integer
+      attr_reader nested_relationship_resolver_mode: nestedRelationshipResolverMode
       attr_reader client_resolver: Client::_Resolver
       attr_reader extension_modules: ::Array[::Module]
       attr_reader extension_settings: parsedYamlSettings
@@ -12,6 +15,7 @@ module ElasticGraph
         default_page_size: ::Integer,
         max_page_size: ::Integer,
         slow_query_latency_warning_threshold_in_ms: ::Integer,
+        nested_relationship_resolver_mode: nestedRelationshipResolverMode,
         client_resolver: Client::_Resolver,
         extension_modules: ::Array[::Module],
         extension_settings: parsedYamlSettings
@@ -21,6 +25,7 @@ module ElasticGraph
         ?default_page_size: ::Integer,
         ?max_page_size: ::Integer,
         ?slow_query_latency_warning_threshold_in_ms: ::Integer,
+        ?nested_relationship_resolver_mode: nestedRelationshipResolverMode,
         ?client_resolver: Client::_Resolver,
         ?extension_modules: ::Array[::Module],
         ?extension_settings: parsedYamlSettings
@@ -37,6 +42,7 @@ module ElasticGraph
       extend _BuildableFromParsedYaml[Config]
       EXPECTED_KEYS: ::Array[::String]
       ELASTICGRAPH_CONFIG_KEYS: ::Array[::String]
+      VALID_NESTED_RELATIONSHIP_RESOLVER_MODES: ::Array[nestedRelationshipResolverMode]
     end
   end
 end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/datastore_query.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/datastore_query.rbs
@@ -1,15 +1,19 @@
 module ElasticGraph
   class GraphQL
-    # Note: this is a partial signature definition (`query.rb` is ignored in `Steepfile`)
-    class DatastoreQuery
+    class DatastoreQuerySupertype
       attr_reader search_index_definitions: ::Array[DatastoreCore::_IndexDefinition]
       attr_reader aggregations: ::Hash[::String, Aggregation::Query]
-      attr_reader document_paginator: DocumentPaginator
+      attr_reader document_paginator: DatastoreQuery::DocumentPaginator
+      attr_reader total_document_count_needed: bool
+    end
 
+    # Note: this is a partial signature definition
+    class DatastoreQuery < DatastoreQuerySupertype
       def shard_routing_values: () -> ::Array[::String]?
       def merge_with: (**untyped) -> DatastoreQuery
       def search_index_expression: () -> ::String
       def with: (**untyped) -> DatastoreQuery
+      def effective_size: () -> ::Integer
 
       def to_datastore_msearch_header_and_body: () -> [::Hash[::String, untyped], ::Hash[::String, untyped]]
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/datastore_response/search_response.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/datastore_response/search_response.rbs
@@ -16,6 +16,7 @@ module ElasticGraph
 
         def each: () { (Document) -> void } -> void | () -> Enumerator[Document, void]
 
+        def filter_results: (::String, ::Set[untyped], ::Integer) -> SearchResponse
         def total_document_count: (?default: ::Integer?) -> ::Integer
         def aggregations: () -> ::Hash[::String, untyped]
       end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/query_executor.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/query_executor.rbs
@@ -6,7 +6,8 @@ module ElasticGraph
         monotonic_clock: Support::MonotonicClock,
         logger: ::Logger,
         slow_query_threshold_ms: ::Integer,
-        datastore_search_router: DatastoreSearchRouter
+        datastore_search_router: DatastoreSearchRouter,
+        config: Config
       ) -> void
 
       def execute: (
@@ -26,6 +27,7 @@ module ElasticGraph
       @logger: ::Logger
       @slow_query_threshold_ms: ::Integer
       @datastore_search_router: DatastoreSearchRouter
+      @config: Config
 
       def build_and_execute_query: (
         query_string: ::String?,

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/nested_relationships_source.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/nested_relationships_source.rbs
@@ -1,0 +1,67 @@
+module ElasticGraph
+  class GraphQL
+    module Resolvers
+      class NestedRelationshipsSource < ::GraphQL::Dataloader::Source
+        MAX_OPTIMIZED_ATTEMPTS: ::Integer
+        EXTRA_SIZE_MULTIPLIER: ::Integer
+
+        def initialize: (
+          query: DatastoreQuery,
+          join: Schema::RelationJoin,
+          context: ::GraphQL::Query::Context,
+          monotonic_clock: Support::MonotonicClock,
+          mode: nestedRelationshipResolverMode
+        ) -> void
+
+        @query: DatastoreQuery
+        @join: Schema::RelationJoin
+        @context: ::GraphQL::Query::Context
+        @schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames
+        @logger: ::Logger
+        @monotonic_clock: Support::MonotonicClock
+        @mode: nestedRelationshipResolverMode
+
+        def fetch: (::Array[::Set[untyped]]) -> ::Array[DatastoreResponse::SearchResponse]
+
+        def self.execute_one: (
+          ::Set[::String],
+          query: DatastoreQuery,
+          join: Schema::RelationJoin,
+          context: ::GraphQL::Query::Context,
+          monotonic_clock: Support::MonotonicClock,
+          mode: nestedRelationshipResolverMode
+        ) -> DatastoreResponse::SearchResponse
+
+        private
+
+        def fetch_optimized: (::Array[::Set[untyped]]) -> ::Array[DatastoreResponse::SearchResponse]
+        def fetch_original: (::Array[::Set[untyped]], ?requested_fields: ::Array[::String]) -> ::Array[DatastoreResponse::SearchResponse]
+        def fetch_comparison: (::Array[::Set[untyped]]) -> ::Array[DatastoreResponse::SearchResponse]
+
+        def can_merge_filters?: () -> bool
+
+        def fetch_via_single_query_with_merged_filters: (
+          ::Array[::Set[untyped]],
+          ?remaining_attempts: ::Integer
+        ) ?{ () -> void } -> ::Hash[::Set[untyped], DatastoreResponse::SearchResponse]
+
+        def fetch_via_separate_queries: (
+          ::Array[::Set[untyped]],
+          ?requested_fields: ::Array[::String]
+        ) -> ::Array[DatastoreResponse::SearchResponse]
+
+        def filters_for: (::Set[untyped]) -> ::Array[::Hash[::String, untyped]]
+
+        def build_filter: (
+          ::String,
+          ::String?,
+          ::Array[::String],
+          ::Array[untyped]
+        ) -> ::Hash[::String, untyped]
+
+        def time_duration: [T] () { () -> T } -> [::Integer, T]
+        def loggable_results: (::Array[DatastoreResponse::SearchResponse]) -> ::Array[::Array[::String]]
+      end
+    end
+  end
+end

--- a/elasticgraph-graphql/sig/graphql_gem.rbs
+++ b/elasticgraph-graphql/sig/graphql_gem.rbs
@@ -7,6 +7,7 @@ module GraphQL
   class Dataloader
     class Source
       def load_all: [Req, Res] (::Array[Req]) -> ::Array[Res]
+      def load: [Req, Res] (Req) -> Res
     end
 
     def with: (Class, *untyped, **untyped) -> Source

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_source_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_source_spec.rb
@@ -1,0 +1,378 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/graphql/query_details_tracker"
+require "elastic_graph/graphql/resolvers/nested_relationships_source"
+require "graphql"
+require "support/aggregations_helpers"
+
+module ElasticGraph
+  class GraphQL
+    module Resolvers
+      RSpec.describe NestedRelationshipsSource, :factories, :uses_datastore, :capture_logs do
+        include AggregationsHelpers
+        let(:merged_queries_message_type) { "NestedRelationshipsMergedQueries" }
+
+        context "when `nested_relationship_resolver_mode` is set to `optimized`" do
+          let(:graphql) { build_graphql(nested_relationship_resolver_mode: :optimized) }
+
+          it "allows a single query to be run with multiple filter value sets" do
+            index_into(
+              graphql,
+              build(:widget, id: "w1", component_ids: ["c1", "c7"]),
+              build(:widget, id: "w2", component_ids: ["c2"]),
+              build(:widget, id: "w3", component_ids: ["c5"]),
+              build(:widget, id: "w4", component_ids: ["c1", "c2"]),
+              build(:widget, id: "w5", component_ids: ["c6"])
+            )
+
+            expect {
+              response1, response2, response3 = resolve_field("Component.widget", ["c1"], ["c2", "c5", "notfound"], ["c1"])
+
+              expect(response1.map(&:id)).to contain_exactly("w1", "w4")
+              expect(response2.map(&:id)).to contain_exactly("w2", "w3", "w4")
+              expect(response3.map(&:id)).to contain_exactly("w1", "w4")
+            }.to perform_datastore_search("main", 1).time
+
+            expect(logged_jsons_of_type(merged_queries_message_type)).to match [a_hash_including({
+              "message_type" => merged_queries_message_type,
+              "field" => "Component.widget",
+              "optimized_attempt_count" => 1,
+              "degraded_to_separate_queries" => false,
+              "id_set_count" => 2,
+              "total_id_count" => 4
+            })]
+          end
+
+          it "runs multiple filter value sets as separate queries if `total_document_count` is requested" do
+            index_into(
+              graphql,
+              build(:widget, id: "w1", component_ids: ["c1", "c7"]),
+              build(:widget, id: "w2", component_ids: ["c2"]),
+              build(:widget, id: "w3", component_ids: ["c1"]),
+              build(:widget, id: "w4", component_ids: ["c1", "c9"])
+            )
+
+            expect {
+              response1, response2 = resolve_field("Component.widget", ["c1"], ["c2", "c5"], total_document_count_needed: true)
+
+              expect(response1.total_document_count).to eq 3
+              expect(response2.total_document_count).to eq 1
+            }.to perform_datastore_search("main", 2).times
+
+            expect(logged_jsons_of_type(merged_queries_message_type)).to eq([])
+          end
+
+          it "runs multiple filter value sets as separate queries if the query has aggregations`" do
+            index_into(
+              graphql,
+              build(:widget, id: "w1", component_ids: ["c1", "c7"], amount_cents: 100),
+              build(:widget, id: "w2", component_ids: ["c2"], amount_cents: 200),
+              build(:widget, id: "w3", component_ids: ["c1"], amount_cents: 300),
+              build(:widget, id: "w4", component_ids: ["c1", "c9"], amount_cents: 400)
+            )
+
+            agg_query = aggregation_query_of(name: "agg", computations: [computation_of("amount_cents", :sum)])
+
+            expect {
+              response1, response2 = resolve_field(
+                "Component.widget_aggregations",
+                ["c1"], ["c2", "c5"],
+                aggregations: {"agg" => agg_query}
+              )
+
+              expect(response1.aggregations).to eq({"agg:amount_cents:sum" => {"value" => 800.0}}) # 100 + 300 + 400
+              expect(response2.aggregations).to eq({"agg:amount_cents:sum" => {"value" => 200.0}}) # just 200
+            }.to perform_datastore_search("main", 2).times
+
+            expect(logged_jsons_of_type(merged_queries_message_type)).to eq([])
+          end
+
+          it "performs multiple queries as needed to when we get back incomplete results" do
+            all_widgets = 1.upto(4).flat_map do |c|
+              1.upto(10 * NestedRelationshipsSource::EXTRA_SIZE_MULTIPLIER).map do |w|
+                build(:widget, id: "c#{c}_w#{w}", component_ids: ["c#{c}"], amount_cents: (100 * c) + w)
+              end
+            end
+            index_into(graphql, *all_widgets)
+
+            # If we request 5 results per id set, it takes an extra attempt:
+            #   - Attempt 1 final size: (5 + 1) * id_sets.size * EXTRA_SIZE_MULTIPLIER = 6 * 4 * 4 = 96 results
+            #     - We get back 40 results for `c1`, 40 results for `c2`, and 16 results for `c3`.
+            #   - Attempt 2 final size: (5 + 1) * id_sets.size * EXTRA_SIZE_MULTIPLIER = 6 * 2 * 4 = 48 results
+            #     - We get back 40 results for `c3` and 8 results for `c4`.
+            expect {
+              response1, response2, response3, response4 = resolve_field(
+                "Component.widgets",
+                ["c1"], ["c2"], ["c3"], ["c4"],
+                sort: [{amount_cents: {"order" => "asc"}}],
+                document_pagination: {first: 5} # note: we get back 1 extra result since it's needed for `has_next_page`
+              )
+
+              expect(response1.map(&:id)).to contain_exactly("c1_w1", "c1_w2", "c1_w3", "c1_w4", "c1_w5", "c1_w6")
+              expect(response2.map(&:id)).to contain_exactly("c2_w1", "c2_w2", "c2_w3", "c2_w4", "c2_w5", "c2_w6")
+              expect(response3.map(&:id)).to contain_exactly("c3_w1", "c3_w2", "c3_w3", "c3_w4", "c3_w5", "c3_w6")
+              expect(response4.map(&:id)).to contain_exactly("c4_w1", "c4_w2", "c4_w3", "c4_w4", "c4_w5", "c4_w6")
+            }.to perform_datastore_msearch("main", 2).times.and perform_datastore_search("main", 2).times
+
+            expect(logged_jsons_of_type(merged_queries_message_type)).to match [a_hash_including({
+              "message_type" => merged_queries_message_type,
+              "field" => "Component.widgets",
+              "optimized_attempt_count" => 2,
+              "degraded_to_separate_queries" => false,
+              "id_set_count" => 4,
+              "total_id_count" => 4
+            })]
+            flush_logs
+
+            # If we request 2 results per id set, it takes a full 3 optimized attempts:
+            #   - Attempt 1 final size: (2 + 1) * id_sets.size * EXTRA_SIZE_MULTIPLIER = 3 * 4 * 4 = 48 results
+            #     - We get back 48 results for `c1`, and 8 for `c2`.
+            #   - Attempt 2 final size: (2 + 1) * id_sets.size * EXTRA_SIZE_MULTIPLIER = 3 * 2 * 4 = 24 results
+            #     - We get back 24 results for `c3`.
+            #   - Attempt 3 final size: (2 + 1) * id_sets.size * EXTRA_SIZE_MULTIPLIER = 3 * 1 * 4 = 12 results
+            #     - We get back 12 results for `c3`.
+            expect {
+              response1, response2, response3, response4 = resolve_field(
+                "Component.widgets",
+                ["c1"], ["c2"], ["c3"], ["c4"],
+                sort: [{amount_cents: {"order" => "asc"}}],
+                document_pagination: {first: 2} # note: we get back 1 extra result since it's needed for `has_next_page`
+              )
+
+              expect(response1.map(&:id)).to contain_exactly("c1_w1", "c1_w2", "c1_w3")
+              expect(response2.map(&:id)).to contain_exactly("c2_w1", "c2_w2", "c2_w3")
+              expect(response3.map(&:id)).to contain_exactly("c3_w1", "c3_w2", "c3_w3")
+              expect(response4.map(&:id)).to contain_exactly("c4_w1", "c4_w2", "c4_w3")
+            }.to perform_datastore_msearch("main", 3).times.and perform_datastore_search("main", 3).times
+
+            expect(logged_jsons_of_type(merged_queries_message_type)).to match [a_hash_including({
+              "message_type" => merged_queries_message_type,
+              "field" => "Component.widgets",
+              "optimized_attempt_count" => 3,
+              "degraded_to_separate_queries" => false,
+              "id_set_count" => 4,
+              "total_id_count" => 4
+            })]
+            flush_logs
+
+            # If we request 2 results per id set with MAX_OPTIMIZED_ATTEMPTS reduced to 1, we fallback to separate queries after one attempt:
+            #   - Attempt 1 final size: (2 + 1) * id_sets.size * EXTRA_SIZE_MULTIPLIER = 3 * 4 * 4 = 48 results
+            #     - We get back 48 results for `c1`, and 8 for `c2`.
+            #   - ...then we submit a single msearch request containing 2 queries (for c3 and c4).
+            stub_const("#{NestedRelationshipsSource}::MAX_OPTIMIZED_ATTEMPTS", 1)
+            expect {
+              response1, response2, response3, response4 = resolve_field(
+                "Component.widgets",
+                ["c1"], ["c2"], ["c3"], ["c4"],
+                sort: [{amount_cents: {"order" => "asc"}}],
+                document_pagination: {first: 2} # note: we get back 1 extra result since it's needed for `has_next_page`
+              )
+
+              expect(response1.map(&:id)).to contain_exactly("c1_w1", "c1_w2", "c1_w3")
+              expect(response2.map(&:id)).to contain_exactly("c2_w1", "c2_w2", "c2_w3")
+              expect(response3.map(&:id)).to contain_exactly("c3_w1", "c3_w2", "c3_w3")
+              expect(response4.map(&:id)).to contain_exactly("c4_w1", "c4_w2", "c4_w3")
+            }.to perform_datastore_msearch("main", 2).times.and perform_datastore_search("main", 3).times
+
+            expect(logged_jsons_of_type(merged_queries_message_type)).to match [a_hash_including({
+              "message_type" => merged_queries_message_type,
+              "field" => "Component.widgets",
+              "optimized_attempt_count" => 1,
+              "degraded_to_separate_queries" => true,
+              "id_set_count" => 4,
+              "total_id_count" => 4
+            })]
+          end
+
+          it "respects any additional filters configured on the join" do
+            index_into(
+              graphql,
+              build(:widget, id: "w1", component_ids: ["c1"], amount_cents: 100),
+              build(:widget, id: "w2", component_ids: ["c1"], amount_cents: 200),
+              build(:widget, id: "w3", component_ids: ["c2"], amount_cents: 300)
+            )
+
+            expect {
+              response1, response2 = resolve_field("Component.dollar_widget", ["c1"], ["c2"])
+
+              expect(response1.map(&:id)).to contain_exactly("w1")
+              expect(response2.map(&:id)).to be_empty
+            }.to perform_datastore_search("main", 1).time
+
+            expect(logged_jsons_of_type(merged_queries_message_type)).to match [a_hash_including({
+              "message_type" => merged_queries_message_type,
+              "field" => "Component.dollar_widget",
+              "optimized_attempt_count" => 1,
+              "degraded_to_separate_queries" => false,
+              "id_set_count" => 2,
+              "total_id_count" => 2
+            })]
+          end
+        end
+
+        context "when `nested_relationship_resolver_mode` is set to `original`" do
+          let(:graphql) { build_graphql(nested_relationship_resolver_mode: :original) }
+
+          it "does not combine queries or log anything" do
+            index_into(
+              graphql,
+              build(:widget, id: "w1", component_ids: ["c1", "c7"]),
+              build(:widget, id: "w2", component_ids: ["c2"]),
+              build(:widget, id: "w3", component_ids: ["c5"]),
+              build(:widget, id: "w4", component_ids: ["c1", "c2"]),
+              build(:widget, id: "w5", component_ids: ["c6"])
+            )
+
+            flush_logs
+
+            expect {
+              response1, response2, response3 = resolve_field("Component.widget", ["c1"], ["c2", "c5", "notfound"], ["c1"])
+
+              expect(response1.map(&:id)).to contain_exactly("w1", "w4")
+              expect(response2.map(&:id)).to contain_exactly("w2", "w3", "w4")
+              expect(response3.map(&:id)).to contain_exactly("w1", "w4")
+            }.to perform_datastore_search("main", 2).times.and perform_datastore_msearch("main", 1).time
+
+            expect(logged_jsons).to be_empty
+          end
+        end
+
+        context "when `nested_relationship_resolver_mode` is set to `comparison`" do
+          let(:graphql) { build_graphql(nested_relationship_resolver_mode: :comparison) }
+          let(:results_match_message_type) { "NestedRelationshipsComparisonResults" }
+          let(:results_differ_message_type) { "NestedRelationshipsComparisonGotDifferentResults" }
+
+          it "performs the `:optimized` and `:original` logic and then compares and logs the results" do
+            index_into(
+              graphql,
+              build(:widget, id: "w1", component_ids: ["c1", "c7"]),
+              build(:widget, id: "w2", component_ids: ["c2"]),
+              build(:widget, id: "w3", component_ids: ["c5"]),
+              build(:widget, id: "w4", component_ids: ["c1", "c2"]),
+              build(:widget, id: "w5", component_ids: ["c6"])
+            )
+
+            flush_logs
+
+            expect {
+              response1, response2, response3 = resolve_field("Component.widget", ["c1"], ["c2", "c5", "notfound"], ["c1"])
+
+              expect(response1.map(&:id)).to contain_exactly("w1", "w4")
+              expect(response2.map(&:id)).to contain_exactly("w2", "w3", "w4")
+              expect(response3.map(&:id)).to contain_exactly("w1", "w4")
+            }.to perform_datastore_search("main", 3).times.and perform_datastore_msearch("main", 2).time
+
+            expect(logged_jsons_of_type(merged_queries_message_type)).to match [a_hash_including({
+              "message_type" => merged_queries_message_type,
+              "field" => "Component.widget",
+              "optimized_attempt_count" => 1,
+              "degraded_to_separate_queries" => false,
+              "id_set_count" => 2,
+              "total_id_count" => 4
+            })]
+
+            expect(logged_jsons_of_type(results_match_message_type)).to match [a_hash_including({
+              "message_type" => results_match_message_type,
+              "field" => "Component.widget",
+              "optimized_faster" => (a_value == true).or(a_value == false)
+            })]
+
+            expect(logged_jsons_of_type(results_differ_message_type)).to be_empty
+          end
+
+          it "logs the document differences when there are any" do
+            # Simulate a difference by modifying the optimized result we get.
+            allow(QuerySource).to receive(:execute_one).and_wrap_original do |original, *args, **kwargs, &block|
+              response = original.call(*args, **kwargs, &block)
+              response.filter_results("id", response.documents.map(&:id).drop(1), 10)
+            end
+
+            index_into(
+              graphql,
+              build(:widget, id: "w1", component_ids: ["c1", "c7"]),
+              build(:widget, id: "w2", component_ids: ["c2"]),
+              build(:widget, id: "w3", component_ids: ["c5"]),
+              build(:widget, id: "w4", component_ids: ["c1", "c2"]),
+              build(:widget, id: "w5", component_ids: ["c6"])
+            )
+
+            flush_logs
+
+            expect {
+              response1, response2, response3 = resolve_field("Component.widget", ["c1"], ["c2", "c5", "notfound"], ["c1"])
+
+              expect(response1.map(&:id)).to contain_exactly("w1", "w4")
+              expect(response2.map(&:id)).to contain_exactly("w2", "w3", "w4")
+              expect(response3.map(&:id)).to contain_exactly("w1", "w4")
+            }.to perform_datastore_search("main", 3).times
+              .and perform_datastore_msearch("main", 2).time
+              .and log_warning(a_string_including(results_differ_message_type))
+
+            expect(logged_jsons_of_type(merged_queries_message_type)).to match [a_hash_including({
+              "message_type" => merged_queries_message_type,
+              "field" => "Component.widget",
+              "optimized_attempt_count" => 1,
+              "degraded_to_separate_queries" => false,
+              "id_set_count" => 2,
+              "total_id_count" => 4
+            })]
+
+            expect(logged_jsons_of_type(results_match_message_type)).to be_empty
+            diff_messages = logged_jsons_of_type(results_differ_message_type)
+
+            expect(diff_messages.size).to eq 1
+            expect(diff_messages.first).to include(
+              "message_type" => results_differ_message_type,
+              "field" => "Component.widget"
+            )
+
+            expect(diff_messages.dig(0, "original_documents")).to match [
+              [a_string_including("w1 (hash:"), a_string_including("w4 (hash: ")],
+              [a_string_including("w2 (hash:"), a_string_including("w3 (hash: "), a_string_including("w4 (hash: ")]
+            ]
+
+            expect(diff_messages.dig(0, "optimized_documents")).to match [
+              [a_string_including("w4 (hash: ")],
+              [a_string_including("w2 (hash:"), a_string_including("w3 (hash: "), a_string_including("w4 (hash: ")]
+            ]
+          end
+        end
+
+        def resolve_field(field, *value_sets, **query_args)
+          graphql_field = graphql.schema.field_named(*field.split("."))
+          join = graphql_field.relation_join
+          monotonic_clock = graphql.monotonic_clock
+          mode = graphql.config.nested_relationship_resolver_mode
+          query = graphql.datastore_query_builder.new_query(
+            search_index_definitions: graphql_field.type.unwrap_fully.search_index_definitions,
+            # We need to request at least one field, or individual documents won't be requested.
+            requested_fields: ["name"],
+            **query_args
+          )
+
+          ::GraphQL::Dataloader.with_dataloading do |dataloader|
+            context = ::GraphQL::Query::Context.new(
+              query: instance_double(::GraphQL::Query),
+              schema: graphql.schema.graphql_schema,
+              values: {
+                logger: graphql.logger,
+                dataloader: dataloader,
+                schema_element_names: graphql.runtime_metadata.schema_element_names,
+                datastore_search_router: graphql.datastore_search_router,
+                elastic_graph_query_tracker: QueryDetailsTracker.empty
+              }
+            )
+
+            dataloader.with(NestedRelationshipsSource, query:, join:, context:, monotonic_clock:, mode:).load_all(value_sets.map(&:to_set))
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/query_source_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/query_source_spec.rb
@@ -16,7 +16,7 @@ module ElasticGraph
       RSpec.describe QuerySource, :factories, :uses_datastore do
         let(:graphql) { build_graphql }
 
-        it "batches up multiple queries, returning a chainable promise for each" do
+        it "batches up multiple queries, sending an msearch request containing them all to the datastore" do
           index_into(
             graphql,
             widget = build(:widget),

--- a/elasticgraph-graphql/spec/support/resolver.rb
+++ b/elasticgraph-graphql/spec/support/resolver.rb
@@ -24,11 +24,13 @@ module ResolverHelperMethods
         query: nil,
         schema: graphql.schema.graphql_schema,
         values: {
+          logger: graphql.logger,
           elastic_graph_schema: graphql.schema,
           schema_element_names: graphql.runtime_metadata.schema_element_names,
           dataloader: dataloader,
           elastic_graph_query_tracker: query_details_tracker,
-          datastore_search_router: graphql.datastore_search_router
+          datastore_search_router: graphql.datastore_search_router,
+          nested_relationship_resolver_mode: graphql.config.nested_relationship_resolver_mode
         }
       )
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/config_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/config_spec.rb
@@ -55,6 +55,45 @@ module ElasticGraph
         }.to raise_error Errors::ConfigError, a_string_including("fake_setting")
       end
 
+      describe "#nested_relationship_resolver_mode" do
+        it "default to `:optimized`" do
+          config = Config.from_parsed_yaml("graphql" => {
+            "default_page_size" => 27,
+            "max_page_size" => 270
+          })
+
+          expect(config.nested_relationship_resolver_mode).to eq :optimized
+        end
+
+        it "can be set to `:optimized`, `:original` or `:comparison`" do
+          results = %w[optimized original comparison].to_h do |yaml_value|
+            config = Config.from_parsed_yaml("graphql" => {
+              "default_page_size" => 27,
+              "max_page_size" => 270,
+              "nested_relationship_resolver_mode" => yaml_value
+            })
+
+            [yaml_value, config.nested_relationship_resolver_mode]
+          end
+
+          expect(results).to eq({
+            "optimized" => :optimized,
+            "original" => :original,
+            "comparison" => :comparison
+          })
+        end
+
+        it "raises an error if it is set to any other value" do
+          expect {
+            Config.from_parsed_yaml("graphql" => {
+              "default_page_size" => 27,
+              "max_page_size" => 270,
+              "nested_relationship_resolver_mode" => "unknown_value"
+            })
+          }.to raise_error Errors::ConfigError, a_string_including("unknown_value")
+        end
+      end
+
       describe "#client_resolver" do
         it "raises an error when given an invalid require path" do
           expect {

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/graphql_extension.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/graphql_extension.rb
@@ -24,6 +24,7 @@ module ElasticGraph
             logger: logger,
             slow_query_threshold_ms: config.slow_query_latency_warning_threshold_in_ms,
             datastore_search_router: datastore_search_router,
+            config: config,
             registry_directory: registry_config.path_to_registry,
             allow_unregistered_clients: registry_config.allow_unregistered_clients,
             allow_any_query_for_clients: registry_config.allow_any_query_for_clients
@@ -41,14 +42,16 @@ module ElasticGraph
         monotonic_clock:,
         logger:,
         slow_query_threshold_ms:,
-        datastore_search_router:
+        datastore_search_router:,
+        config:
       )
         super(
           schema: schema,
           monotonic_clock: monotonic_clock,
           logger: logger,
           slow_query_threshold_ms: slow_query_threshold_ms,
-          datastore_search_router: datastore_search_router
+          datastore_search_router: datastore_search_router,
+          config: config
         )
 
         @registry = Registry.build_from_directory(

--- a/elasticgraph-query_registry/sig/elastic_graph/query_registry/graphql_extension.rbs
+++ b/elasticgraph-query_registry/sig/elastic_graph/query_registry/graphql_extension.rbs
@@ -13,7 +13,8 @@ module ElasticGraph
         monotonic_clock: Support::MonotonicClock,
         logger: ::Logger,
         slow_query_threshold_ms: ::Integer,
-        datastore_search_router: GraphQL::DatastoreSearchRouter
+        datastore_search_router: GraphQL::DatastoreSearchRouter,
+        config: GraphQL::Config
       ) -> void
 
       private

--- a/spec_support/lib/elastic_graph/spec_support/builds_graphql.rb
+++ b/spec_support/lib/elastic_graph/spec_support/builds_graphql.rb
@@ -18,6 +18,7 @@ module ElasticGraph
       extension_modules: [],
       extension_settings: {},
       slow_query_latency_warning_threshold_in_ms: 30000,
+      nested_relationship_resolver_mode: :optimized,
       max_page_size: 500,
       default_page_size: 50,
       datastore_core: nil,
@@ -37,6 +38,7 @@ module ElasticGraph
           max_page_size: max_page_size,
           default_page_size: default_page_size,
           slow_query_latency_warning_threshold_in_ms: slow_query_latency_warning_threshold_in_ms,
+          nested_relationship_resolver_mode: nested_relationship_resolver_mode,
           client_resolver: client_resolver || GraphQL::Client::DefaultResolver.new({}),
           extension_modules: extension_modules,
           extension_settings: extension_settings


### PR DESCRIPTION
See the inline comments on `NestedRelationshipsSource` for a detailed description of how the optimization works.

Based on my benchmarks, it drastically improves the performance of an example query that heavily relies on the `NestedRelationships` resolver, from ~2.5s to ~720ms.

Given how this significantly changes how ElasticGraph resolves nested relationships, there is a possibility of it impacting the results in a subtle way. I've included a new `nested_relationship_resolver_mode` config option that can be used to opt-out of this new mode, or to enable a `comparison` mode which can be used during upgrades for greater safety.

The `nested_relationship_resolver_mode` config option defaults to `optimized` (so that new ElasticGraph projects automatically benefit from it) and I plan to remove it in a future release, only supporting `optimized` mode.