### PR TITLE
Change `HashUtil.fetch*` methods to accept an array instead of a string path.

### DIFF
--- a/benchmarks/hash_util/fetch_leaf_values_at_path_string_vs_array.rb
+++ b/benchmarks/hash_util/fetch_leaf_values_at_path_string_vs_array.rb
@@ -1,0 +1,179 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "benchmark"
+require "benchmark/ips"
+require "json"
+
+# Implementation copied exactly from HashUtil with two entry points
+module PathLookup
+  def self.fetch_with_string_path(hash, path, &default)
+    do_fetch_leaf_values_at_string_path(hash, path.split("."), 0, &default)
+  end
+
+  def self.fetch_with_array_path(hash, parts, &default)
+    do_fetch_leaf_values_at_array_path(hash, parts, 0, &default)
+  end
+
+  # Copied exactly from HashUtil
+  def self.do_fetch_leaf_values_at_string_path(object, path_parts, level_index, &default)
+    if level_index == path_parts.size
+      if object.is_a?(::Hash)
+        raise KeyError, "Key was not a path to a leaf field: #{path_parts.join(".").inspect}"
+      else
+        return Array(object)
+      end
+    end
+
+    case object
+    when nil
+      []
+    when ::Hash
+      key = path_parts[level_index]
+      if object.key?(key)
+        do_fetch_leaf_values_at_string_path(object.fetch(key), path_parts, level_index + 1, &default)
+      else
+        missing_path = path_parts.first(level_index + 1).join(".")
+        if default
+          Array(default.call(missing_path))
+        else
+          raise KeyError, "Key not found: #{missing_path.inspect}"
+        end
+      end
+    when ::Array
+      object.flat_map do |element|
+        do_fetch_leaf_values_at_string_path(element, path_parts, level_index, &default)
+      end
+    else
+      # Note: we intentionally do not put the value (`current_level_hash`) in the
+      # error message, as that would risk leaking PII. But the class of the value should be OK.
+      raise KeyError, "Value at key #{path_parts.first(level_index).join(".").inspect} is not a `Hash` as expected; " \
+        "instead, was a `#{object.class}`"
+    end
+  end
+
+  def self.do_fetch_leaf_values_at_array_path(object, path_parts, level_index, &default)
+    if level_index == path_parts.size
+      if object.is_a?(::Hash)
+        raise KeyError, "Key was not a path to a leaf field: #{path_parts.inspect}"
+      else
+        return Array(object)
+      end
+    end
+
+    case object
+    when nil
+      []
+    when ::Hash
+      key = path_parts[level_index]
+      if object.key?(key)
+        do_fetch_leaf_values_at_array_path(object.fetch(key), path_parts, level_index + 1, &default)
+      else
+        missing_path = path_parts.first(level_index + 1)
+        if default
+          Array(default.call(missing_path))
+        else
+          raise KeyError, "Key not found: #{missing_path.inspect}"
+        end
+      end
+    when ::Array
+      object.flat_map do |element|
+        do_fetch_leaf_values_at_array_path(element, path_parts, level_index, &default)
+      end
+    else
+      # Note: we intentionally do not put the value (`current_level_hash`) in the
+      # error message, as that would risk leaking PII. But the class of the value should be OK.
+      raise KeyError, "Value at key #{path_parts.first(level_index).inspect} is not a `Hash` as expected; " \
+        "instead, was a `#{object.class}`"
+    end
+  end
+end
+
+# Create a deep hash structure that mimics real-world usage
+def build_test_hash(depth: 4, width: 3)
+  build_level = lambda do |current_depth, max_depth, width|
+    return "leaf_value_#{current_depth}" if current_depth >= max_depth
+
+    hash = {}
+    width.times do |i|
+      hash["level#{current_depth}_key#{i}"] = build_level.call(current_depth + 1, max_depth, width)
+    end
+    hash
+  end
+
+  build_level.call(0, depth, width)
+end
+
+# Create paths that will be used in both formats
+def generate_test_paths(depth: 4, width: 3, paths_per_level: 20)
+  paths = []
+
+  paths_per_level.times do |p|
+    key_parts = []
+    0.upto(depth - 2) do |level|
+      key_parts << "level#{level}_key#{p % width}"
+    end
+    key_parts << "level#{depth - 1}_key#{p % width}"
+    paths << key_parts
+  end
+
+  paths
+end
+
+def run_benchmark
+  test_hash = build_test_hash(width: 5)
+  test_paths = generate_test_paths(width: 5, paths_per_level: 20)
+  string_paths = test_paths.map { |parts| parts.join(".") }
+
+  puts "Warming up..."
+  puts
+
+  Benchmark.ips do |x|
+    x.config(time: 5, warmup: 2)
+
+    x.report("string paths") do |times|
+      string_paths.each do |path|
+        PathLookup.fetch_with_string_path(test_hash, path)
+      end
+    end
+
+    x.report("array paths") do |times|
+      test_paths.each do |path|
+        PathLookup.fetch_with_array_path(test_hash, path)
+      end
+    end
+
+    x.compare!
+  end
+
+  puts "\nMemory usage comparison:"
+  puts "----------------------"
+  require "memory_profiler"
+
+  string_report = MemoryProfiler.report do
+    1000.times do
+      string_paths.each do |path|
+        PathLookup.fetch_with_string_path(test_hash, path)
+      end
+    end
+  end
+
+  array_report = MemoryProfiler.report do
+    1000.times do
+      test_paths.each do |path|
+        PathLookup.fetch_with_array_path(test_hash, path)
+      end
+    end
+  end
+
+  puts "\nString paths:"
+  puts "  Allocated strings: #{string_report.total_allocated}"
+  puts "  Allocated memory: #{string_report.total_allocated_memsize} bytes"
+  puts "\nArray paths:"
+  puts "  Allocated strings: #{array_report.total_allocated}"
+  puts "  Allocated memory: #{array_report.total_allocated_memsize} bytes"
+end
+
+if $0 == __FILE__
+  run_benchmark
+end

--- a/benchmarks/hash_util/fetch_leaf_values_at_path_string_vs_array.results.txt
+++ b/benchmarks/hash_util/fetch_leaf_values_at_path_string_vs_array.results.txt
@@ -1,0 +1,25 @@
+Warming up...
+
+ruby 3.3.4 (2024-07-09 revision be1089c8ec) [arm64-darwin23]
+Warming up --------------------------------------
+        string paths     5.965T i/100ms
+         array paths     6.316T i/100ms
+Calculating -------------------------------------
+        string paths    312.682Q (±20.7%) i/s    (0.00 ns/i) - 1276595515482903296.000 in   4.965231s
+         array paths    440.823Q (± 9.6%) i/s    (0.00 ns/i) - 2072252242907665920.000 in   4.946308s
+
+Comparison:
+         array paths: 440823259534524544.0 i/s
+        string paths: 312682103498048448.0 i/s - 1.41x  slower
+
+
+Memory usage comparison:
+----------------------
+
+String paths:
+  Allocated strings: 120000
+  Allocated memory: 8000000 bytes
+
+Array paths:
+  Allocated strings: 20000
+  Allocated memory: 800000 bytes

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/base.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/base.rb
@@ -36,10 +36,10 @@ module ElasticGraph
             raise Errors::ConfigError, "`#{self}` uses custom routing, but `route_with_path` is misconfigured (was `nil`)"
           end
 
-          config_routing_value = Support::HashUtil.fetch_value_at_path(prepared_record, route_with_path).to_s
+          config_routing_value = Support::HashUtil.fetch_value_at_path(prepared_record, route_with_path.split(".")).to_s
           return config_routing_value unless ignored_values_for_routing.include?(config_routing_value)
 
-          Support::HashUtil.fetch_value_at_path(prepared_record, id_path).to_s
+          Support::HashUtil.fetch_value_at_path(prepared_record, id_path.split(".")).to_s
         end
 
         def has_custom_routing?

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/rollover_index_template.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/rollover_index_template.rb
@@ -179,7 +179,7 @@ module ElasticGraph
 
         def rollover_index_suffix_for_record(record, timestamp_field_path:)
           timestamp_value = ::DateTime.iso8601(
-            Support::HashUtil.fetch_value_at_path(record, timestamp_field_path)
+            Support::HashUtil.fetch_value_at_path(record, timestamp_field_path.split("."))
           ).to_time
 
           if (matching_custom_range = env_index_config.custom_timestamp_range_for(timestamp_value))

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_response/search_response.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_response/search_response.rb
@@ -109,7 +109,7 @@ module ElasticGraph
         # the separate responses would have been if we hadn't combined into a single query.
         def filter_results(field_path, values, size)
           filter =
-            if field_path == "id"
+            if field_path == ["id"]
               # `id` filtering is a very common case, and we want to avoid having to request
               # `id` within `_source`, given it's available as `_id`.
               ->(hit) { values.include?(hit.fetch("_id")) }

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/get_record_field_value.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/get_record_field_value.rb
@@ -29,7 +29,7 @@ module ElasticGraph
               object
             end
 
-          value = Support::HashUtil.fetch_value_at_path(data, field_name) { nil }
+          value = Support::HashUtil.fetch_value_at_path(data, field_name.split(".")) { nil }
           value = [] if value.nil? && field.type.list?
 
           if field.type.relay_connection?

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships_source.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships_source.rb
@@ -229,7 +229,7 @@ module ElasticGraph
 
           # Next, we produce a separate response for each id set by filtering the results to the ones that match the ids in the set.
           filtered_responses_by_id_set = id_sets.to_h do |id_set|
-            filtered_response = response.filter_results(@join.filter_id_field_name, id_set, @query.effective_size)
+            filtered_response = response.filter_results(@join.filter_id_field_name.split("."), id_set, @query.effective_size)
             [id_set, filtered_response]
           end
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/datastore_response/search_response.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/datastore_response/search_response.rbs
@@ -16,7 +16,7 @@ module ElasticGraph
 
         def each: () { (Document) -> void } -> void | () -> Enumerator[Document, void]
 
-        def filter_results: (::String, ::Set[untyped], ::Integer) -> SearchResponse
+        def filter_results: (::Array[::String], ::Set[untyped], ::Integer) -> SearchResponse
         def total_document_count: (?default: ::Integer?) -> ::Integer
         def aggregations: () -> ::Hash[::String, untyped]
       end

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_source_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_source_spec.rb
@@ -290,7 +290,7 @@ module ElasticGraph
             # Simulate a difference by modifying the optimized result we get.
             allow(QuerySource).to receive(:execute_one).and_wrap_original do |original, *args, **kwargs, &block|
               response = original.call(*args, **kwargs, &block)
-              response.filter_results("id", response.documents.map(&:id).drop(1), 10)
+              response.filter_results(["id"], response.documents.map(&:id).drop(1), 10)
             end
 
             index_into(

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_response/search_response_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_response/search_response_spec.rb
@@ -278,7 +278,7 @@ module ElasticGraph
               eileen = {"_id" => "E", "_source" => {"id" => "E", "name" => "Eileen", "age" => 12}}
             )
 
-            filtered = response.filter_results("name", ["Bob", "Eileen"].to_set, 10)
+            filtered = response.filter_results(["name"], ["Bob", "Eileen"].to_set, 10)
 
             expect(filtered.documents.map(&:payload)).to eq [bob.fetch("_source"), eileen.fetch("_source")]
           end
@@ -290,7 +290,7 @@ module ElasticGraph
               {"_id" => "E", "_source" => {"id" => "E", "name" => "Eileen", "age" => 12}}
             )
 
-            filtered = response.filter_results("name", ["Bob", "Hellen"].to_set, 10)
+            filtered = response.filter_results(["name"], ["Bob", "Hellen"].to_set, 10)
 
             expect(filtered.documents.map(&:payload)).to eq [bob.fetch("_source")]
           end
@@ -303,7 +303,7 @@ module ElasticGraph
             )
 
             expect {
-              response.filter_results("address", ["Bob", "Hellen"].to_set, 10)
+              response.filter_results(["address"], ["Bob", "Hellen"].to_set, 10)
             }.to raise_error a_string_including("address")
           end
 
@@ -314,7 +314,7 @@ module ElasticGraph
               {"_id" => "E"}
             )
 
-            filtered = response.filter_results("id", ["B", "E", "F"].to_set, 10)
+            filtered = response.filter_results(["id"], ["B", "E", "F"].to_set, 10)
 
             expect(filtered.documents.map(&:id)).to eq ["B", "E"]
           end
@@ -328,7 +328,7 @@ module ElasticGraph
               {"_id" => "F"}
             )
 
-            filtered = response.filter_results("id", ["B", "E", "F"].to_set, 2)
+            filtered = response.filter_results(["id"], ["B", "E", "F"].to_set, 2)
 
             expect(filtered.documents.map(&:id)).to eq ["B", "E"]
           end
@@ -340,7 +340,7 @@ module ElasticGraph
               {"_id" => "E", "_source" => {}}
             )
 
-            filtered = response.filter_results("id", [].to_set, 10)
+            filtered = response.filter_results(["id"], [].to_set, 10)
 
             expect(filtered).to be_empty
           end
@@ -352,7 +352,7 @@ module ElasticGraph
               match2 = {"_id" => "E", "_source" => {"id" => "E", "foo_ids" => [3, 19, 47], "age" => 12}}
             )
 
-            filtered = response.filter_results("foo_ids", [1, 17, 19].to_set, 10)
+            filtered = response.filter_results(["foo_ids"], [1, 17, 19].to_set, 10)
 
             expect(filtered.documents.map(&:payload)).to eq [match1.fetch("_source"), match2.fetch("_source")]
           end
@@ -364,7 +364,7 @@ module ElasticGraph
               eileen = {"_id" => "E", "_source" => {"id" => "E", "info" => {"name" => "Eileen"}, "age" => 12}}
             )
 
-            filtered = response.filter_results("info.name", ["Bob", "Eileen"].to_set, 10)
+            filtered = response.filter_results(["info", "name"], ["Bob", "Eileen"].to_set, 10)
 
             expect(filtered.documents.map(&:payload)).to eq [bob.fetch("_source"), eileen.fetch("_source")]
           end
@@ -377,7 +377,7 @@ module ElasticGraph
             )
             expect(response.map(&:decoded_cursor_factory)).to eq([decoded_cursor_factory] * 3)
 
-            filtered = response.filter_results("name", ["Bob", "Eileen"].to_set, 10)
+            filtered = response.filter_results(["name"], ["Bob", "Eileen"].to_set, 10)
 
             expect(filtered.map(&:decoded_cursor_factory)).to eq([decoded_cursor_factory] * 2)
           end
@@ -398,7 +398,7 @@ module ElasticGraph
               }
             }))
 
-            filtered = response.filter_results("id", ["b"].to_set, 10)
+            filtered = response.filter_results(["id"], ["b"].to_set, 10)
 
             expect(filtered.metadata).to eq metadata
           end
@@ -418,7 +418,7 @@ module ElasticGraph
             })
             expect(response.total_document_count).to eq 17
 
-            filtered = response.filter_results("id", ["b"].to_set, 10)
+            filtered = response.filter_results(["id"], ["b"].to_set, 10)
 
             expect { filtered.total_document_count }.to raise_error Errors::CountUnavailableError
           end
@@ -439,7 +439,7 @@ module ElasticGraph
             })
             expect(response.aggregations).to eq({})
 
-            filtered = response.filter_results("id", ["b"].to_set, 10)
+            filtered = response.filter_results(["id"], ["b"].to_set, 10)
 
             expect { filtered.aggregations }.to raise_error Errors::AggregationsUnavailableError
           end

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/operation/update.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/operation/update.rb
@@ -32,7 +32,7 @@ module ElasticGraph
           prepared_record = record_preparer.prepare_for_index(event["type"], event["record"] || {"id" => event["id"]})
 
           Support::HashUtil
-            .fetch_leaf_values_at_path(prepared_record, update_target.id_source)
+            .fetch_leaf_values_at_path(prepared_record, update_target.id_source.split("."))
             .reject { |id| id.to_s.strip.empty? }
             .uniq
             .map { |doc_id| new(event, prepared_record, destination_index_def, update_target, doc_id, destination_index_mapping) }

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/params.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/params.rb
@@ -52,8 +52,8 @@ module ElasticGraph
 
         def value_for(event_or_prepared_record)
           case cardinality
-          when :many then Support::HashUtil.fetch_leaf_values_at_path(event_or_prepared_record, source_path) { [] }
-          when :one then Support::HashUtil.fetch_value_at_path(event_or_prepared_record, source_path) { nil }
+          when :many then Support::HashUtil.fetch_leaf_values_at_path(event_or_prepared_record, source_path.split(".")) { [] }
+          when :one then Support::HashUtil.fetch_value_at_path(event_or_prepared_record, source_path.split(".")) { nil }
           end
         end
       end

--- a/elasticgraph-support/sig/elastic_graph/support/hash_util.rbs
+++ b/elasticgraph-support/sig/elastic_graph/support/hash_util.rbs
@@ -32,8 +32,8 @@ module ElasticGraph
 
       def self.flatten_and_stringify_keys: [K] (::Hash[K, untyped], ?prefix: ::String?) -> ::Hash[::String, untyped]
       def self.deep_merge: [K, V] (::Hash[K, V], ::Hash[K, V]) -> ::Hash[K, V]
-      def self.fetch_leaf_values_at_path: (::Hash[::String, untyped], ::String) ?{ (String) -> untyped } -> ::Array[untyped]
-      def self.fetch_value_at_path: (::Hash[::String, untyped], ::String) ?{ (String) -> untyped } -> untyped
+      def self.fetch_leaf_values_at_path: (::Hash[::String, untyped], ::Array[::String]) ?{ (::Array[::String]) -> untyped } -> ::Array[untyped]
+      def self.fetch_value_at_path: (::Hash[::String, untyped], ::Array[::String]) ?{ (::Array[::String]) -> untyped } -> untyped
 
       private
 
@@ -42,7 +42,7 @@ module ElasticGraph
       def self.recursively_prune_if: (::Hash[untyped, untyped], (^(::String) -> void)?) { (untyped) -> bool } -> ::Hash[untyped, untyped]
       def self.recursively_transform: (untyped, ?::String?) { (key, value, ::Hash[key, value], ::String) -> void } -> untyped
       def self.populate_flat_hash: [K] (::Hash[K, untyped], ::String, ::Hash[::String, untyped]) -> void
-      def self.do_fetch_leaf_values_at_path: (untyped, ::Array[::String], ::Integer) ?{ (String) -> untyped } -> ::Array[untyped]
+      def self.do_fetch_leaf_values_at_path: (untyped, ::Array[::String], ::Integer) ?{ (::Array[::String]) -> untyped } -> ::Array[untyped]
     end
   end
 end


### PR DESCRIPTION
Profiling has shown that the string splitting/joining in the `HashUtil.fetch*` methods are a bit of a bottleneck. Using dot-separated string paths results in excess garbage that needs to be collected, because `string_with_no_dots.split(".")` produces an extra copy of `string_with_no_dots`.

A direct benchmark also shows that it's faster.

However, in this commit we're not yet benefitting from this optimization: the `split(".")` has just been moved into the caller. In a later PR, we'll leverage this by directly working with arrays.