### PR TITLE
Optimize `NestedRelationshipsSource`: pass a pre-split path to `filter_results`.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships.rb
@@ -29,7 +29,8 @@ module ElasticGraph
         def resolve(field:, object:, args:, context:, lookahead:)
           log_warning = ->(**options) { log_field_problem_warning(field: field, **options) }
           join = field.relation_join
-          id_or_ids = join.extract_id_or_ids_from(object, log_warning)
+          payload = object.is_a?(DatastoreResponse::Document) ? object.payload : object
+          id_or_ids = join.extract_id_or_ids_from(payload, log_warning)
           query = yield
 
           response =

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/field.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/field.rb
@@ -134,13 +134,14 @@ module ElasticGraph
         end
 
         def index_id_field_names_for_relation
-          if type.unwrap_fully == parent_type # means its a self-referential relation (e.g. child to parent of same type)
-            # Since it's self-referential, the `filter_id_field` (which lives on the "remote" type) also must
-            # exist as a field in our DatastoreCore::IndexDefinition.
-            [relation_join.document_id_field_name, relation_join.filter_id_field_name]
-          else
-            [relation_join.document_id_field_name]
-          end
+          @index_id_field_names_for_relation ||=
+            if type.unwrap_fully == parent_type # means its a self-referential relation (e.g. child to parent of same type)
+              # Since it's self-referential, the `filter_id_field` (which lives on the "remote" type) also must
+              # exist as a field in our DatastoreCore::IndexDefinition.
+              [relation_join.document_id_field_path.join("."), relation_join.filter_id_field_path.join(".")]
+            else
+              [relation_join.document_id_field_path.join(".")]
+            end
         end
       end
     end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/nested_relationships_source.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/nested_relationships_source.rbs
@@ -15,6 +15,7 @@ module ElasticGraph
 
         @query: DatastoreQuery
         @join: Schema::RelationJoin
+        @filter_id_field_path_string: ::String
         @context: ::GraphQL::Query::Context
         @schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames
         @logger: ::Logger
@@ -53,9 +54,9 @@ module ElasticGraph
         def filters_for: (::Set[untyped]) -> ::Array[::Hash[::String, untyped]]
 
         def build_filter: (
-          ::String,
-          ::String?,
           ::Array[::String],
+          ::Array[::String],
+          ::Array[::Array[::String]],
           ::Array[untyped]
         ) -> ::Hash[::String, untyped]
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/schema/relation_join.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/schema/relation_join.rbs
@@ -12,39 +12,39 @@ module ElasticGraph
       class RelationJoinSupertype < Data
         def initialize: (
           field: Field,
-          document_id_field_name: ::String,
-          filter_id_field_name: ::String,
+          document_id_field_path: ::Array[::String],
+          filter_id_field_path: ::Array[::String],
           id_cardinality: RelationJoin::cardinality,
           doc_cardinality: RelationJoin::cardinality,
           additional_filter: ::Hash[::String, untyped],
-          foreign_key_nested_paths: ::Array[::String]
+          foreign_key_nested_paths: ::Array[::Array[::String]]
         ) -> void
 
         def self.new: (
           field: Field,
-          document_id_field_name: ::String,
-          filter_id_field_name: ::String,
+          document_id_field_path: ::Array[::String],
+          filter_id_field_path: ::Array[::String],
           id_cardinality: RelationJoin::cardinality,
           doc_cardinality: RelationJoin::cardinality,
           additional_filter: ::Hash[::String, untyped],
-          foreign_key_nested_paths: ::Array[::String]
+          foreign_key_nested_paths: ::Array[::Array[::String]]
         ) -> RelationJoin | (
           Field,
-          ::String,
-          ::String,
+          ::Array[::String],
+          ::Array[::String],
           RelationJoin::cardinality,
           RelationJoin::cardinality,
           ::Hash[::String, untyped],
-          ::Array[::String]
+          ::Array[::Array[::String]]
         ) -> RelationJoin
 
         attr_reader field: Field
-        attr_reader document_id_field_name: ::String
-        attr_reader filter_id_field_name: ::String
+        attr_reader document_id_field_path: ::Array[::String]
+        attr_reader filter_id_field_path: ::Array[::String]
         attr_reader id_cardinality: RelationJoin::cardinality
         attr_reader doc_cardinality: RelationJoin::cardinality
         attr_reader additional_filter: ::Hash[::String, untyped]
-        attr_reader foreign_key_nested_paths: ::Array[::String]
+        attr_reader foreign_key_nested_paths: ::Array[::Array[::String]]
       end
 
       class RelationJoin < RelationJoinSupertype


### PR DESCRIPTION
This build on top of #379 and is a bit faster in my testing.