### PR TITLE
Optimize `GetRecordFieldValue` resolver: split `name_in_index` only once.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/get_record_field_value.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/get_record_field_value.rb
@@ -20,7 +20,6 @@ module ElasticGraph
         end
 
         def resolve(field:, object:, args:, context:, lookahead:)
-          field_name = field.name_in_index
           data =
             case object
             when DatastoreResponse::Document
@@ -29,7 +28,7 @@ module ElasticGraph
               object
             end
 
-          value = Support::HashUtil.fetch_value_at_path(data, field_name.split(".")) { nil }
+          value = Support::HashUtil.fetch_value_at_path(data, field.path_in_index) { nil }
           value = [] if value.nil? && field.type.list?
 
           if field.type.relay_connection?

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/field.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/field.rb
@@ -60,6 +60,10 @@ module ElasticGraph
           @name ||= @graphql_field.name
         end
 
+        def path_in_index
+          @path_in_index ||= name_in_index.split(".")
+        end
+
         # Returns an object that knows how this field joins to its relation.
         # Used by ElasticGraph::Resolvers::NestedRelationships.
         def relation_join


### PR DESCRIPTION
This was creating unnecessary garbage.