### PR TITLE
Update project template factories so they don't produce as much data.

### DIFF
--- a/elasticgraph/lib/elastic_graph/project_template/lib/app_name/factories.rb
+++ b/elasticgraph/lib/elastic_graph/project_template/lib/app_name/factories.rb
@@ -1,3 +1,4 @@
+require "digest/md5"
 require "factory_bot"
 require "faker"
 require_relative "shared_factories"
@@ -6,6 +7,9 @@ require_relative "shared_factories"
 FactoryBot.define do
   factory :artist, parent: :indexed_type_base do
     __typename { "Artist" }
+    # Prevent multiple artists with the same name by hashing the name to produce the id.
+    id { Digest::MD5.hexdigest(name) }
+
     name { Faker::Music.band }
 
     lifetimeSales do
@@ -15,11 +19,11 @@ FactoryBot.define do
     bio { build(:artist_bio) }
 
     albums do
-      Faker::Number.between(from: 1, to: 10).times.map { build(:album) }
+      Faker::Number.between(from: 1, to: 6).times.map { build(:album) }
     end
 
     tours do
-      Faker::Number.between(from: 0, to: 8).times.map { build(:tour, venueIds: venueIds) }
+      Faker::Number.between(from: 0, to: 4).times.map { build(:tour, venueIds: venueIds) }
     end
 
     transient do
@@ -37,10 +41,10 @@ FactoryBot.define do
   factory :album, parent: :hash_base do
     __typename { "Album" }
     name { Faker::Music.album }
-    releasedOn { Faker::Date.between(from: "1900-01-01", to: "2025-12-31").iso8601 }
+    releasedOn { Faker::Date.between(from: "1950-01-01", to: "2025-12-31").iso8601 }
     soldUnits { Faker::Number.between(from: 10000, to: 100_000_000) }
     tracks do
-      Faker::Number.between(from: 1, to: 20).times.map do |index|
+      Faker::Number.between(from: 1, to: 15).times.map do |index|
         build(:album_track, trackNumber: index + 1)
       end
     end
@@ -57,9 +61,9 @@ FactoryBot.define do
     __typename { "Tour" }
     name { "#{Faker::Music::RockBand.song} Tour" }
     shows do
-      start_date = Faker::Date.between(from: "1900-01-01", to: "2025-12-31")
+      start_date = Faker::Date.between(from: "1950-01-01", to: "2025-12-31")
 
-      Faker::Number.between(from: 3, to: 200).times.map do |index|
+      Faker::Number.between(from: 3, to: 30).times.map do |index|
         venue_id = Faker::Base.sample(venueIds)
         build(:show, date: start_date + index, venueId: venue_id)
       end
@@ -77,13 +81,16 @@ FactoryBot.define do
     venueId { nil }
 
     transient do
-      date { Faker::Date.between(from: "1900-01-01", to: "2025-12-31") }
+      date { Faker::Date.between(from: "1950-01-01", to: "2025-12-31") }
       startTime { Faker::Base.sample(%w[19:00:00Z 19:30:00Z 20:00:00Z 20:30:00Z]) }
     end
   end
 
   factory :venue, parent: :indexed_type_base do
     __typename { "Venue" }
+
+    # Prevent multiple venues with the same name by hashing the name to produce the id.
+    id { Digest::MD5.hexdigest(name) }
 
     name do
       # Some common music venue types


### PR DESCRIPTION
The original factories produced such a volume of data that a simple query to fetch every field returned ~5 MB of data. That wound up being a slow query (given how much data was being returned), and took longer to bootstrap.

In addition, I've updated the artist and venue factories to avoid producing multiple records with the same `name` as that is a bit confusing.