### PR TITLE
Test the website example queries from `config/docker_demo/test`.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,15 +54,17 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f # v1.227.0
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f # v1.227.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 2
 
-      - uses: KengoTODA/actions-setup-docker-compose@0169fb81f56cb44a908f67a3ec212f3579e2e4fe # main
+      - name: Setup Docker Compose
+        uses: KengoTODA/actions-setup-docker-compose@0169fb81f56cb44a908f67a3ec212f3579e2e4fe # main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -72,10 +74,11 @@ jobs:
           git config --global user.email "action@github.com"
           git config --global init.defaultBranch main
 
+      - name: Run Build Part
       # Note: the `10` argument on the end is a number of seconds to sleep after booting the datastore.
       # We've found that there is a minor race condition where the shards aren't fully ready for the tests
       # to hit them if we don't wait a bit after booting.
-      - run: script/ci_parts/${{ matrix.build_part }} ${{ matrix.datastore }} 10
+        run: script/ci_parts/${{ matrix.build_part }} ${{ matrix.datastore }} 10
 
   docker-demo:
     runs-on: ubuntu-latest
@@ -93,6 +96,12 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f # v1.227.0
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0

--- a/config/docker_demo/test
+++ b/config/docker_demo/test
@@ -1,11 +1,27 @@
 #!/usr/bin/env bash
 
 set -e
+set -x
 
 # Set default environment variables
 export OPENSEARCH_VERSION=${OPENSEARCH_VERSION:-2.19.1}
 export OPENSEARCH_IMAGE="elasticgraph-opensearch-demo:latest"
 export ELASTICGRAPH_IMAGE="elasticgraph-demo:latest"
+
+cleanup() {
+  local exit_code=$?
+  echo "Cleaning up..."
+  # Kill the logs process if it's running
+  if [ ! -z "${LOGS_PID+x}" ]; then
+    kill $LOGS_PID 2>/dev/null || true
+  fi
+  # Bring down containers
+  docker compose -f config/docker_demo/docker-compose.yaml down -v
+  exit $exit_code
+}
+
+# Set up cleanup trap for all exit scenarios
+trap cleanup EXIT
 
 if [ -z "${NO_BUILD+x}" ]; then
   echo "Building OpenSearch image..."
@@ -41,31 +57,18 @@ for i in {1..30}; do
   fi
   if [ $i -eq 30 ]; then
     echo "Timed out waiting for ElasticGraph"
-    kill $LOGS_PID
-    docker compose -f config/docker_demo/docker-compose.yaml down -v
     exit 1
   fi
   echo "Waiting... ($i/30)"
   sleep 2
 done
 
-# Run a test query
-echo "Running test query..."
-QUERY='{"query": "{ artists { totalEdgeCount } }"}'
-RESPONSE=$(curl -s -X POST -H "Content-Type: application/json" -d "$QUERY" http://localhost:9000/graphql)
-
-# Check if we got a positive number back
-if echo "$RESPONSE" | grep -q '"totalEdgeCount":[1-9][0-9]*'; then
-  COUNT=$(echo "$RESPONSE" | grep -o '"totalEdgeCount":[0-9]*' | cut -d':' -f2)
-  echo "Successfully got $COUNT artists"
-else
-  echo "Failed to get positive artist count. Response:"
-  echo "$RESPONSE"
+# Run the example query validation
+echo "Running example query validation..."
+if ! bundle exec rake -f config/site/examples/music/Rakefile example_queries:validate_results; then
+  echo "Example query validation failed"
   docker compose -f config/docker_demo/docker-compose.yaml logs
-  docker compose -f config/docker_demo/docker-compose.yaml down -v
   exit 1
 fi
 
-# Clean up
-echo "Cleaning up..."
-docker compose -f config/docker_demo/docker-compose.yaml down -v
+echo "All tests passed successfully!"

--- a/config/site/examples/music/Rakefile
+++ b/config/site/examples/music/Rakefile
@@ -1,0 +1,230 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "graphql"
+require "json"
+require "net/http"
+require "pathname"
+require "yaml"
+
+module ExampleQueries
+  # Simple terminal output helpers
+  module Output
+    TICK = "✓"
+    CROSS = "✗"
+    SKIP = "-"
+    RESET = "\e[0m"
+    RED = "\e[31m"
+    GREEN = "\e[32m"
+    YELLOW = "\e[33m"
+    BOLD = "\e[1m"
+
+    def self.success(message)
+      puts "#{GREEN}#{TICK} #{message}#{RESET}"
+    end
+
+    def self.failure(message)
+      puts "#{RED}#{CROSS} #{message}#{RESET}"
+    end
+
+    def self.skip(message)
+      puts "#{YELLOW}#{SKIP} #{message}#{RESET}"
+    end
+
+    def self.header(message)
+      puts "\n#{BOLD}#{message}#{RESET}"
+    end
+
+    def self.format_error(error)
+      case error
+      when Hash
+        if error["message"]
+          "#{error["message"]}#{error["locations"] ? " at #{error["locations"].inspect}" : ""}"
+        else
+          error.inspect
+        end
+      else
+        error.to_s
+      end
+    end
+
+    def self.format_graphql_errors(errors)
+      errors.map { |e| "  - #{format_error(e)}" }.join("\n")
+    end
+
+    def self.format_data(data)
+      JSON.pretty_generate(data)
+        .lines
+        .map { |line| "    #{line}" }
+        .join
+    end
+  end
+
+  # Handles the validation of a single query
+  class QueryValidator
+    def initialize(query_file)
+      query_file = Pathname.new(query_file)
+      @query_name = query_file.basename(".graphql").to_s
+      @query = File.read(query_file)
+    end
+
+    def validate
+      Output.header("Testing #{@query_name}...")
+
+      # Parse the query to check for variable definitions
+      if query_requires_variables?
+        Output.skip("Skipping query that requires variables")
+        return [:skip, "Requires variables"]
+      end
+
+      uri = URI("http://localhost:9000/graphql")
+      http = Net::HTTP.new(uri.host, uri.port)
+      request = Net::HTTP::Post.new(uri.path, "Content-Type" => "application/json")
+      request.body = {
+        query: @query,
+        variables: {}  # Empty variables since we're skipping queries that need them
+      }.to_json
+
+      response = http.request(request)
+      result = JSON.parse(response.body)
+
+      if result["errors"]
+        Output.failure("Query returned errors:")
+        puts Output.format_graphql_errors(result["errors"])
+        return [:error, "GraphQL errors encountered"]
+      end
+
+      data = result["data"]
+      empty = data.empty? || data.values.any? do |value|
+        case value
+        when Hash
+          value["nodes"]&.empty? || value["edges"]&.empty?
+        when Array
+          value.empty?
+        else
+          value.nil?
+        end
+      end
+
+      if empty
+        Output.failure("Query returned empty results:")
+        puts Output.format_data(data)
+        return [:empty, "Empty results returned"]
+      end
+
+      Output.success("Query returned valid results")
+      [:success, nil]
+    rescue => e
+      Output.failure("Query execution failed:")
+      puts "  - #{e.message}"
+      [:error, e.message]
+    end
+
+    private
+
+    def query_requires_variables?
+      # Parse the query using the GraphQL gem
+      document = GraphQL.parse(@query)
+
+      # Look through all operation definitions in the document
+      document.definitions.any? do |definition|
+        next unless definition.is_a?(GraphQL::Language::Nodes::OperationDefinition)
+
+        # Check if any of the variables are required (non-null)
+        definition.variables.any? do |variable|
+          # A type is non-null if its last type component is non-null
+          last_type = variable.type
+          while last_type.respond_to?(:of_type)
+            last_type = last_type.of_type
+          end
+          last_type.is_a?(GraphQL::Language::Nodes::NonNullType)
+        end
+      end
+    rescue GraphQL::ParseError => e
+      Output.failure("Failed to parse query:")
+      puts "  - #{e.message}"
+      false
+    end
+  end
+end
+
+namespace :example_queries do
+  # Queries that are known to fail and will be fixed in a follow-up PR
+  allowed_failures = [
+    # TODO: Remove these once fixed
+    "AccordionAndViolinStrictSearch",
+    "AccordionOrViolinSearch",
+    "AnyOfGotcha",
+    "BluegrassArtistAggregations",
+    "BluegrassArtistLifetimeSales",
+    "FindArtist",
+    "FindMarch2025Shows",
+    "FindProlificArtists",
+    "FindRecentAccordionArtists",
+    "FindSeattleVenues",
+    "FindUnnamedArtists",
+    "FindU2OrRadiohead",
+    "PhraseSearch",
+    "SkaArtistHomeCountries"
+  ].to_set
+
+  desc "Validate that all example queries return non-empty results"
+  task :validate_results do
+    queries_dir = Pathname.new(__dir__) / "queries"
+    failed_queries = []
+    skipped_queries = []
+    query_count = 0
+    success_count = 0
+    skip_count = 0
+    allowed_failure_count = 0
+
+    Dir.glob(queries_dir / "**" / "*.graphql").sort.each do |query_file|
+      query_count += 1
+      validator = ExampleQueries::QueryValidator.new(query_file)
+      status, message = validator.validate
+      query_name = File.basename(query_file, ".graphql")
+
+      case status
+      when :success
+        success_count += 1
+      when :skip
+        skip_count += 1
+        skipped_queries << [query_name, message]
+      else
+        if allowed_failures.include?(query_name)
+          allowed_failure_count += 1
+          ExampleQueries::Output.skip("Known failing query - will be fixed in follow-up PR")
+        else
+          failed_queries << [query_name, message]
+        end
+      end
+    end
+
+    puts "\n#{ExampleQueries::Output::BOLD}Results Summary:#{ExampleQueries::Output::RESET}"
+    puts "Total Queries: #{query_count}"
+    puts "#{ExampleQueries::Output::GREEN}Successful: #{success_count}#{ExampleQueries::Output::RESET}"
+    puts "#{ExampleQueries::Output::YELLOW}Skipped: #{skip_count}#{ExampleQueries::Output::RESET}"
+    puts "#{ExampleQueries::Output::YELLOW}Allowed Failures: #{allowed_failure_count}#{ExampleQueries::Output::RESET}"
+    puts "#{ExampleQueries::Output::RED}Failed: #{failed_queries.size}#{ExampleQueries::Output::RESET}"
+
+    if skipped_queries.any?
+      puts "\n#{ExampleQueries::Output::YELLOW}#{ExampleQueries::Output::BOLD}Skipped Queries:#{ExampleQueries::Output::RESET}"
+      skipped_queries.each do |name, reason|
+        puts "- #{name}: #{reason}"
+      end
+    end
+
+    unless failed_queries.empty?
+      puts "\n#{ExampleQueries::Output::RED}#{ExampleQueries::Output::BOLD}Failed Queries:#{ExampleQueries::Output::RESET}"
+      failed_queries.each do |name, error|
+        puts "- #{name}: #{error}"
+      end
+      exit 1
+    end
+  end
+end

--- a/script/update_ci_yaml
+++ b/script/update_ci_yaml
@@ -144,15 +144,17 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f # v1.227.0
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f # v1.227.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 2
 
-      - uses: KengoTODA/actions-setup-docker-compose@0169fb81f56cb44a908f67a3ec212f3579e2e4fe # main
+      - name: Setup Docker Compose
+        uses: KengoTODA/actions-setup-docker-compose@0169fb81f56cb44a908f67a3ec212f3579e2e4fe # main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -162,10 +164,11 @@ jobs:
           git config --global user.email "action@github.com"
           git config --global init.defaultBranch main
 
+      - name: Run Build Part
       # Note: the `10` argument on the end is a number of seconds to sleep after booting the datastore.
       # We've found that there is a minor race condition where the shards aren't fully ready for the tests
       # to hit them if we don't wait a bit after booting.
-      - run: script/ci_parts/${{ matrix.build_part }} ${{ matrix.datastore }} 10
+        run: script/ci_parts/${{ matrix.build_part }} ${{ matrix.datastore }} 10
 
   docker-demo:
     runs-on: ubuntu-latest
@@ -183,6 +186,12 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f # v1.227.0
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0


### PR DESCRIPTION
Now that the website encourages users to boot our docker demo from the pages with example queries, I'd like to make sure the example queries return actual data. To enforce that, I've updated the CI build so that when the docker image is booted, we test each of our queries, validating that it the response was non-empty.

As it turns out, 14 of our 41 example queries do not consistently return data. For now, I've added these 14 to an `allowed_failures` set. In future PRs, I'll work through these and fix them.

See the #387 build for an example of the output when these new checks fail.