### PR TITLE
Update genre-based example queries to always return results.

### DIFF
--- a/config/site/examples/music/Rakefile
+++ b/config/site/examples/music/Rakefile
@@ -160,8 +160,6 @@ namespace :example_queries do
     "AccordionAndViolinStrictSearch",
     "AccordionOrViolinSearch",
     "AnyOfGotcha",
-    "BluegrassArtistAggregations",
-    "BluegrassArtistLifetimeSales",
     "FindArtist",
     "FindMarch2025Shows",
     "FindProlificArtists",
@@ -169,8 +167,7 @@ namespace :example_queries do
     "FindSeattleVenues",
     "FindUnnamedArtists",
     "FindU2OrRadiohead",
-    "PhraseSearch",
-    "SkaArtistHomeCountries"
+    "PhraseSearch"
   ].to_set
 
   desc "Validate that all example queries return non-empty results"

--- a/config/site/examples/music/queries/aggregations/BluegrassArtistAggregations.graphql
+++ b/config/site/examples/music/queries/aggregations/BluegrassArtistAggregations.graphql
@@ -2,7 +2,7 @@ query BluegrassArtistAggregations($cursor: Cursor) {
   artistAggregations(
     first: 10
     after: $cursor
-    filter: {bio: {description: {matchesQuery: {query: "bluegrass"}}}}
+    filter: {genres: {anySatisfy: {equalToAnyOf: [BLUEGRASS]}}}
   ) {
     pageInfo {
       hasNextPage

--- a/config/site/examples/music/queries/aggregations/BluegrassArtistLifetimeSales.graphql
+++ b/config/site/examples/music/queries/aggregations/BluegrassArtistLifetimeSales.graphql
@@ -1,6 +1,6 @@
 query BluegrassArtistLifetimeSales {
   artistAggregations(
-    filter: {bio: {description: {matchesQuery: {query: "bluegrass"}}}}
+    filter: {genres: {anySatisfy: {equalToAnyOf: [BLUEGRASS]}}}
   ) {
     nodes {
       groupedBy {

--- a/config/site/examples/music/queries/aggregations/SkaArtistHomeCountries.graphql
+++ b/config/site/examples/music/queries/aggregations/SkaArtistHomeCountries.graphql
@@ -1,6 +1,6 @@
 query SkaArtistHomeCountries {
   artistAggregations(
-    filter: {bio: {description: {matchesQuery: {query: "ska"}}}}
+    filter: {genres: {anySatisfy: {equalToAnyOf: [SKA]}}}
   ) {
     nodes {
       groupedBy {

--- a/elasticgraph/lib/elastic_graph/project_template/config/schema/artists.rb.tt
+++ b/elasticgraph/lib/elastic_graph/project_template/config/schema/artists.rb.tt
@@ -1,10 +1,32 @@
 # TODO: replace this file with one that defines the schema for your own dataset.
 ElasticGraph.define_schema do |schema|
+  schema.enum_type "MusicGenre" do |t|
+    t.value "ALTERNATIVE"
+    t.value "BLUES"
+    t.value "BLUEGRASS"
+    t.value "CLASSICAL"
+    t.value "COUNTRY"
+    t.value "ELECTRONIC"
+    t.value "FOLK"
+    t.value "HIP_HOP"
+    t.value "INDIE"
+    t.value "JAZZ"
+    t.value "METAL"
+    t.value "POP"
+    t.value "PUNK"
+    t.value "REGGAE"
+    t.value "RNB"
+    t.value "ROCK"
+    t.value "SKA"
+    t.value "SOUL"
+  end
+
   schema.object_type "Artist" do |t|
     t.field "id", "ID"
     t.field "name", "String"
     t.field "lifetimeSales", "JsonSafeLong"
     t.field "bio", "ArtistBio"
+    t.field "genres", "[MusicGenre!]!"
 
     t.field "albums", "[Album!]!" do |f|
       f.mapping type: "nested"

--- a/elasticgraph/lib/elastic_graph/project_template/lib/app_name/factories.rb
+++ b/elasticgraph/lib/elastic_graph/project_template/lib/app_name/factories.rb
@@ -18,6 +18,17 @@ FactoryBot.define do
 
     bio { build(:artist_bio) }
 
+    genres do
+      # Available genres from the MusicGenre enum
+      all_genres = %w[
+        ALTERNATIVE BLUES BLUEGRASS CLASSICAL COUNTRY ELECTRONIC FOLK HIP_HOP
+        INDIE JAZZ METAL POP PUNK REGGAE RNB ROCK SKA SOUL
+      ]
+
+      # Pick 1-3 random genres
+      Faker::Base.sample(all_genres, Faker::Number.between(from: 1, to: 3)).uniq
+    end
+
     albums do
       Faker::Number.between(from: 1, to: 6).times.map { build(:album) }
     end


### PR DESCRIPTION
The `bio.description` field is random lorem text, and as such, the example queries that search it for "ska" or "bluegrass" have not been matching any documents. Instead, I've introduced an `Artist.genres` field which should support consistent matches.

As a side benefit, the project template now includes an example of an enum type, which is worthwhile on its own.