### PR TITLE
Generate an `Artist` for each available artist name.

### DIFF
--- a/config/site/examples/music/Rakefile
+++ b/config/site/examples/music/Rakefile
@@ -160,13 +160,11 @@ namespace :example_queries do
     "AccordionAndViolinStrictSearch",
     "AccordionOrViolinSearch",
     "AnyOfGotcha",
-    "FindArtist",
     "FindMarch2025Shows",
     "FindProlificArtists",
     "FindRecentAccordionArtists",
     "FindSeattleVenues",
     "FindUnnamedArtists",
-    "FindU2OrRadiohead",
     "PhraseSearch"
   ].to_set
 

--- a/elasticgraph/lib/elastic_graph/project_template/Rakefile.tt
+++ b/elasticgraph/lib/elastic_graph/project_template/Rakefile.tt
@@ -43,7 +43,7 @@ ElasticGraph::Local::RakeTasks.new(
 
   # TODO: replace this with a fake data generator for your own dataset.
   tasks.define_fake_data_batch_for :artists do
-    <%= ElasticGraph.setup_env.app_module %>::FakeDataBatchGenerator.generate(artists: 100, venues: 10)
+    <%= ElasticGraph.setup_env.app_module %>::FakeDataBatchGenerator.generate(venues: 100)
   end
 end
 

--- a/elasticgraph/lib/elastic_graph/project_template/lib/app_name/factories.rb
+++ b/elasticgraph/lib/elastic_graph/project_template/lib/app_name/factories.rb
@@ -34,7 +34,10 @@ FactoryBot.define do
     end
 
     tours do
-      Faker::Number.between(from: 0, to: 4).times.map { build(:tour, venueIds: venueIds) }
+      Faker::Number.between(from: 0, to: 4).times.map do
+        song = Faker::Base.sample(albums.flat_map { |a| a.fetch(:tracks).map { |t| t.fetch(:name) } })
+        build(:tour, venueIds: venueIds, name: "The #{song} Tour")
+      end
     end
 
     transient do

--- a/elasticgraph/lib/elastic_graph/project_template/lib/app_name/fake_data_batch_generator.rb.tt
+++ b/elasticgraph/lib/elastic_graph/project_template/lib/app_name/fake_data_batch_generator.rb.tt
@@ -2,11 +2,15 @@ require_relative "factories"
 
 module <%= ElasticGraph.setup_env.app_module %>
   module FakeDataBatchGenerator
-    def self.generate(artists:, venues:)
+    def self.generate(venues:)
       venue_list = FactoryBot.build_list(:venue, venues)
       venue_ids = venue_list.map { |v| v.fetch(:id) }
 
-      artist_list = FactoryBot.build_list(:artist, artists, venueIds: venue_ids)
+      # Make one artist per unique name available via Faker.
+      artist_names = ::Faker::Base.translate("faker.music.bands") + ::Faker::Base.translate("faker.rock_band.name")
+      artist_list = artist_names.uniq.map do |name|
+        FactoryBot.build(:artist, name: name, venueIds: venue_ids)
+      end
 
       venue_list + artist_list
     end

--- a/elasticgraph/lib/elastic_graph/project_template/spec/project_spec.rb.tt
+++ b/elasticgraph/lib/elastic_graph/project_template/spec/project_spec.rb.tt
@@ -13,7 +13,11 @@ RSpec.describe "ElasticGraph project" do
 
   # TODO: update this spec as needed to generate example fake data for your dataset.
   it "generates a batch of valid records from `FakeDataBatchGenerator`" do
-    batch = <%= ElasticGraph.setup_env.app_module %>::FakeDataBatchGenerator.generate(artists: 20, venues: 5)
-    expect(batch.size).to eq(25)
+    batch = <%= ElasticGraph.setup_env.app_module %>::FakeDataBatchGenerator.generate(venues: 5)
+
+    expect(batch.map { |r| r.fetch(:__typename) }.tally).to match({
+      "Artist" => a_value > 100,
+      "Venue" => 5
+    })
   end
 end


### PR DESCRIPTION
Previously, we created a set number of artists (100) which produced an inconsistent set of artist names in the indexed dataset. That in turn meant that our example queries which filter on artist name would not produce consistent results--sometimes there would be an artist matching the name; sometimes there wouldn't be.

This fixes that by just mapping over all available artist names.