### PR TITLE
Implement and test top-level all_of

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_interpreter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_interpreter.rb
@@ -219,10 +219,14 @@ module ElasticGraph
         end
 
         def process_all_of_expression(bool_node, expressions, field_path)
-          # `all_of` represents an AND. AND is the default way that `process_filter_hash` combines
-          # filters so we just have to call it for each sub-expression.
+          # `all_of` represents an AND of multiple subexpressions.
+          # To achieve this, we build a new bool sub-filter for each subexpression and push it onto
+          # the parent’s `:filter` array. Each item in `:filter` is independently required (AND).
           expressions.each do |sub_expression|
-            process_filter_hash(bool_node, sub_expression, field_path)
+            sub_filter = build_bool_hash do |sub_bool_node|
+              process_filter_hash(sub_bool_node, sub_expression, field_path)
+            end
+            bool_node[:filter] << sub_filter if sub_filter
           end
         end
 


### PR DESCRIPTION
This is a follow up to the schema change in https://github.com/block/elasticgraph/pull/355. While this PR mostly updates the unit, integration, and acceptance tests, there is a key implementation change in the filter interpreter such that `all_of` filters will now build a new bool sub-filter for each subexpression and push it onto the parent’s `:filter` array. This ensures an ANDing across the subexpressions.

**Performance benchmarking**
Given the above change will result in an extra bool filter term, I performed benchmarking using the `test_es_query.rb` script adapted to an all_of query with nested any_satisfy blocks.

Results from current schema:
Average took value: 504ms
Median took value: 454ms
P99 took value: 1190ms

vs PR schema:
Average took value: 505ms
Median took value: 448ms
P99 took value: 1054ms

We can see there is no significant impact to performance with the additional bool filter terms.