### PR TITLE
Fix the rest of the queries which were not consistently getting results.

### DIFF
--- a/config/site/examples/music/Rakefile
+++ b/config/site/examples/music/Rakefile
@@ -154,15 +154,6 @@ module ExampleQueries
 end
 
 namespace :example_queries do
-  # Queries that are known to fail and will be fixed in a follow-up PR
-  allowed_failures = [
-    # TODO: Remove these once fixed
-    "FindMarch2025Shows",
-    "FindProlificArtists",
-    "FindSeattleVenues",
-    "FindUnnamedArtists"
-  ].to_set
-
   desc "Validate that all example queries return non-empty results"
   task :validate_results do
     queries_dir = Pathname.new(__dir__) / "queries"
@@ -171,7 +162,6 @@ namespace :example_queries do
     query_count = 0
     success_count = 0
     skip_count = 0
-    allowed_failure_count = 0
 
     Dir.glob(queries_dir / "**" / "*.graphql").sort.each do |query_file|
       query_count += 1
@@ -186,12 +176,7 @@ namespace :example_queries do
         skip_count += 1
         skipped_queries << [query_name, message]
       else
-        if allowed_failures.include?(query_name)
-          allowed_failure_count += 1
-          ExampleQueries::Output.skip("Known failing query - will be fixed in follow-up PR")
-        else
-          failed_queries << [query_name, message]
-        end
+        failed_queries << [query_name, message]
       end
     end
 
@@ -199,7 +184,6 @@ namespace :example_queries do
     puts "Total Queries: #{query_count}"
     puts "#{ExampleQueries::Output::GREEN}Successful: #{success_count}#{ExampleQueries::Output::RESET}"
     puts "#{ExampleQueries::Output::YELLOW}Skipped: #{skip_count}#{ExampleQueries::Output::RESET}"
-    puts "#{ExampleQueries::Output::YELLOW}Allowed Failures: #{allowed_failure_count}#{ExampleQueries::Output::RESET}"
     puts "#{ExampleQueries::Output::RED}Failed: #{failed_queries.size}#{ExampleQueries::Output::RESET}"
 
     if skipped_queries.any?

--- a/config/site/examples/music/queries/filtering/Find2024Shows.graphql
+++ b/config/site/examples/music/queries/filtering/Find2024Shows.graphql
@@ -1,17 +1,17 @@
-query FindMarch2025Shows {
+query Find2024Shows {
   artists(filter: {
     tours: {anySatisfy: {shows: {anySatisfy: {
       startedAt: {
-        gte: "2025-03-01T00:00:00Z"
-        lt: "2025-04-01T00:00:00Z"
+        gte: "2024-01-01T00:00:00Z"
+        lt: "2025-01-01T00:00:00Z"
 
         # Using gte/lt to fully cover the range is simpler than gte/lte:
-        # gte: "2025-03-01T00:00:00Z"
-        # lte: "2025-03-31T23:59:99.999Z"
+        # gte: "2024-01-01T00:00:00Z"
+        # lte: "2024-12-31T23:59:99.999Z"
 
         # ...and simpler than gt/lt:
-        # gt: "2025-02-28T23:59:99.999Z"
-        # lt: "2025-04-01T00:00:00Z"
+        # gt: "2023-12-31T23:59:99.999Z"
+        # lt: "2025-01-01T00:00:00Z"
       }
     }}}}
   }) {

--- a/config/site/examples/music/queries/filtering/FindAsianVenues.graphql
+++ b/config/site/examples/music/queries/filtering/FindAsianVenues.graphql
@@ -1,9 +1,9 @@
-query FindSeattleVenues {
+query FindAsianVenues {
   venues(filter: {
     location: {near: {
-      latitude: 47.621
-      longitude: -122.349
-      maxDistance: 10
+      latitude: 49.102271
+      longitude: 87.143660
+      maxDistance: 2000
       unit: MILE
     }}
   }) {

--- a/config/site/examples/music/queries/filtering/FindProlificArtists.graphql
+++ b/config/site/examples/music/queries/filtering/FindProlificArtists.graphql
@@ -1,6 +1,6 @@
 query FindProlificArtists {
   artists(filter: {
-    albums: {count: {gte: 20}}
+    albums: {count: {gte: 5}}
   }) {
     nodes {
       name

--- a/config/site/examples/music/queries/filtering/FindUnnamedVenues.graphql
+++ b/config/site/examples/music/queries/filtering/FindUnnamedVenues.graphql
@@ -1,12 +1,10 @@
-query FindUnnamedArtists {
-  artists(filter: {
+query FindUnnamedVenues {
+  venues(filter: {
     name: {equalToAnyOf: [null]}
   }) {
     nodes {
       name # will be null on all returned nodes
-      bio {
-        yearFormed
-      }
+      capacity
     }
   }
 }

--- a/config/site/src/query-api/filtering/date-time.md
+++ b/config/site/src/query-api/filtering/date-time.md
@@ -23,7 +23,7 @@ All three support the standard set of [equality]({% link query-api/filtering/equ
 [comparison]({% link query-api/filtering/comparison.md %}) predicates. When using comparison
 predicates to cover a range, it's usually simplest to pair `gte` with `lt`:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.FindMarch2025Shows" %}
+{% include copyable_code_snippet.html language="graphql" music_query="filtering.Find2024Shows" %}
 
 In addition, `DateTime` fields support one more filtering operator:
 

--- a/config/site/src/query-api/filtering/equality.md
+++ b/config/site/src/query-api/filtering/equality.md
@@ -15,4 +15,4 @@ Here's a basic example:
 
 Unlike the SQL `IN` operator, you can find records with `null` values if you put `null` in the list:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.FindUnnamedArtists" %}
+{% include copyable_code_snippet.html language="graphql" music_query="filtering.FindUnnamedVenues" %}

--- a/config/site/src/query-api/filtering/geographic.md
+++ b/config/site/src/query-api/filtering/geographic.md
@@ -11,4 +11,4 @@ The `GeoLocation` type supports a special predicate:
 
 Here's an example of this predicate:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.FindSeattleVenues" %}
+{% include copyable_code_snippet.html language="graphql" music_query="filtering.FindAsianVenues" %}

--- a/elasticgraph/lib/elastic_graph/project_template/lib/app_name/factories.rb
+++ b/elasticgraph/lib/elastic_graph/project_template/lib/app_name/factories.rb
@@ -163,9 +163,6 @@ FactoryBot.define do
   factory :venue, parent: :indexed_type_base do
     __typename { "Venue" }
 
-    # Prevent multiple venues with the same name by hashing the name to produce the id.
-    id { Digest::MD5.hexdigest(name) }
-
     name do
       # Some common music venue types
       venue_types = ["Theater", "Arena", "Music Hall", "Stadium", "Opera House", "Amphitheater"]

--- a/elasticgraph/lib/elastic_graph/project_template/lib/app_name/fake_data_batch_generator.rb.tt
+++ b/elasticgraph/lib/elastic_graph/project_template/lib/app_name/fake_data_batch_generator.rb.tt
@@ -3,7 +3,7 @@ require_relative "factories"
 module <%= ElasticGraph.setup_env.app_module %>
   module FakeDataBatchGenerator
     def self.generate(venues:)
-      venue_list = FactoryBot.build_list(:venue, venues)
+      venue_list = FactoryBot.build_list(:venue, venues - 1) + [FactoryBot.build(:venue, name: nil)]
       venue_ids = venue_list.map { |v| v.fetch(:id) }
 
       # Make one artist per unique name available via Faker.


### PR DESCRIPTION
- `FindMarch2025Shows`: expanded this to a whole year (2024).
- `FindProlificArtists`: lowered the required number of albums. Our factories generate between 1 and 6 albums by default.
- `FindSeattleVenues`: searched a much wider geographic area (all of Asia).
- `FindUnnamedArtists`: switched to `FindUnnamedVenues` and ensures a venue is created with no name.