### PR TITLE
Add dark mode toggle to navbar and mobile menu

### DIFF
--- a/config/site/src/_includes/icons/moon.svg
+++ b/config/site/src/_includes/icons/moon.svg
@@ -1,0 +1,3 @@
+<svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+</svg>

--- a/config/site/src/_includes/icons/sun.svg
+++ b/config/site/src/_includes/icons/sun.svg
@@ -1,0 +1,3 @@
+<svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+</svg>

--- a/config/site/src/_includes/navbar.html
+++ b/config/site/src/_includes/navbar.html
@@ -30,6 +30,15 @@
                           bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200
                           focus:outline-none focus:ring-2 focus:ring-blue-500">
           </form>
+          <!-- Theme Toggle Button -->
+          <button onclick="toggleTheme()" class="p-2 rounded-md hover:bg-gray-300 dark:hover:bg-gray-700" aria-label="Toggle theme">
+            <span class="hidden dark:block {{ site.style.link }}">
+              {% include icons/sun.svg %}
+            </span>
+            <span class="block dark:hidden {{ site.style.link }}">
+              {% include icons/moon.svg %}
+            </span>
+          </button>
           <a href="{{ site.github_url }}" target="_blank" class="text-base {{ site.style.link }} inline-flex items-center space-x-2" rel="noopener">
             {% include icons/github.svg %}
             <span>GitHub</span>
@@ -46,6 +55,16 @@
         <a href="{% link query-api.md %}" class="text-base {{ site.style.link }}">Query API</a>
         <a href="{% link guides.md %}" class="text-base {{ site.style.link }}">Guides</a>
         <a href="{% link api-docs.md %}" class="text-base {{ site.style.link }}">API Docs</a>
+        <!-- Mobile Theme Toggle -->
+        <button onclick="toggleTheme()" class="flex items-center space-x-2 text-base {{ site.style.link }}">
+          <span class="hidden dark:block">
+            {% include icons/sun.svg %}
+          </span>
+          <span class="block dark:hidden">
+            {% include icons/moon.svg %}
+          </span>
+          <span>Toggle Theme</span>
+        </button>
         <a href="{{ site.github_url }}" target="_blank" class="text-base {{ site.style.link }} inline-flex items-center space-x-2" rel="noopener">
           {% include icons/github.svg %}
           <span>GitHub</span>

--- a/config/site/src/_layouts/base.html
+++ b/config/site/src/_layouts/base.html
@@ -9,6 +9,29 @@
   <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
   <link rel="stylesheet" href="{{ '/assets/css/highlight.css' | relative_url }}">
   <script>
+    // Theme toggle functionality
+    function initTheme() {
+      // On page load or when changing themes, best to add inline in `head` to avoid FOUC
+      if (localStorage.getItem('theme') === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      } else {
+        document.documentElement.setAttribute('data-theme', 'light');
+      }
+    }
+
+    // Initialize theme on page load
+    initTheme();
+
+    function toggleTheme() {
+      if (document.documentElement.getAttribute('data-theme') === 'dark') {
+        document.documentElement.setAttribute('data-theme', 'light');
+        localStorage.setItem('theme', 'light');
+      } else {
+        document.documentElement.setAttribute('data-theme', 'dark');
+        localStorage.setItem('theme', 'dark');
+      }
+    }
+
     function copyToClipboard(button, text) {
       navigator.clipboard.writeText(text).then(() => {
         const message = button.parentElement.querySelector('[data-copy-message]');

--- a/config/site/src/assets/css/tailwind.css
+++ b/config/site/src/assets/css/tailwind.css
@@ -2,6 +2,9 @@
 
 @plugin '@tailwindcss/typography';
 
+/* Update`dark` variant to use `data-theme="dark"` as recommended by Tailwind */
+@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
+
 /*
   The default border color has changed to `currentColor` in Tailwind CSS v4,
   so we've added these compatibility styles to make sure everything still

--- a/config/site/tailwind.config.js
+++ b/config/site/tailwind.config.js
@@ -1,7 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["./src/**/*.{html,md}"],
-  darkMode: 'class',
   theme: {
     extend: {
       spacing: {


### PR DESCRIPTION
Follows the pattern recommended by Tailwind for a 3-way toggle (system default, dark, light).
https://tailwindcss.com/docs/dark-mode


<img width="442" alt="Screenshot 2025-03-27 at 2 52 12 PM" src="https://github.com/user-attachments/assets/2d70029e-6d4c-4f76-b3cc-9fa172b47af5" />
<img width="1578" alt="Screenshot 2025-03-27 at 2 51 59 PM" src="https://github.com/user-attachments/assets/e754df0d-9bd0-4502-bad6-17ec483e4226" />
