### PR TITLE
Update `PhraseSearch` to a phrase that should always find matches.

### DIFF
--- a/config/site/examples/music/queries/filtering/PhraseSearch.graphql
+++ b/config/site/examples/music/queries/filtering/PhraseSearch.graphql
@@ -3,7 +3,7 @@ query PhraseSearch {
     bio: {
       description:{
         matchesPhrase: {
-          phrase: "pioneers in jazz"
+          phrase: "unique musical identity"
         }
       }
     }


### PR DESCRIPTION
The phrase "pioneers in jazz" was generated dynamically in our factories as "pioneers in #{genre}". I'm not sure how many random genres there are but apparently there are enough that "pioneers in jazz" may not show up on any artist bio descriptions.

Instead, we can search in "unique musical identity" -- this phrase from our `bio.description` generator is static and should _always_ show up.