### PR TITLE
Improve release process: bump to pre-release version afterwards.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,7 @@ jobs:
             git commit -m "Archive docs for v${{ inputs.version }}"
           fi
 
-      - name: Bump the ElasticGraph version
+      - name: Bump the ElasticGraph version to release version
         run: |
           bundle exec rake bump_version[${{ inputs.version }}]
           if [[ ! "${{ inputs.version }}" =~ [a-zA-Z] ]]; then
@@ -92,6 +92,11 @@ jobs:
         with:
           await-release: ${{ ! inputs.dry-run }}
 
+      - name: Bump the ElasticGraph version to next pre-release version
+        run: |
+          unset GEM_RELEASE_PRETEND
+          bundle exec rake bump_version_to_next_prerelease
+
       # Note: this must come after we release the gem because it resets git back to the same SHA we started on
       # (before bumping the version), but the RubyGems release depends on the version having been bumped.
       - name: Create pull request for the version bump
@@ -101,6 +106,11 @@ jobs:
           branch: release-v${{ inputs.version }}
           title: "Release v${{ inputs.version }}"
           body: |
+            > [!NOTE]
+            > This PR bumps the ElasticGraph version twice in two separate commits. The released version does not show
+            > in the overall PR diff but is in the first commit. These two commits should not be squashed or rebased so
+            > that the tagged commit lands as-is in the base branch.
+
             - [ ] Confirm the [release action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) succeeded before merging
             - [ ] Confirm this version bump should be merged into [${{ github.ref_name }}](https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}) or change the base branch
             - [ ] Review and edit the [GitHub Draft Release](https://github.com/${{ github.repository }}/releases) (can be done after this PR is merged)

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@
 /*/Gemfile.lock
 /*/rbs_collection.lock.yaml
 
+config/release/bin
+config/release/bundle
+config/release/.bundle
+
 # Allows customization of the bundle for things like pry, debugger, etc.
 Gemfile-custom
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,6 +187,20 @@ bundle exec rake site:preview_docs:elasticgraph-schema_definition
 
 Then visit http://localhost:8808/. The preview task will rebuild the parts of the generated docs impacted by your edits, and is quite fast.
 
+## Releasing New Versions
+
+Project maintainers can release a new version using the [Release workflow](https://github.com/block/elasticgraph/actions/workflows/release.yaml).
+
+* Click "Run workflow"
+* Select a branch to release from
+* Specify a version number (based on our versioning policy)
+* Click "Run workflow"
+
+A "Dry Run" option is also available. It's primarily intended for use when testing changes to the Release workflow. It does the
+release actions which are reversible (e.g. bumping the version, pushing a branch, opening a PR, generating draft release notes)
+while skipping the one action that's not reversible (actually releasing to rubygems.org). When used, please remember to cleanup
+afterwards: close the PR and delete the draft release notes.
+
 ---
 
 ## Communications

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,42 +1,42 @@
 PATH
   remote: elasticgraph-admin_lambda
   specs:
-    elasticgraph-admin_lambda (0.19.1.1)
-      elasticgraph-admin (= 0.19.1.1)
-      elasticgraph-lambda_support (= 0.19.1.1)
+    elasticgraph-admin_lambda (0.19.1.2.pre)
+      elasticgraph-admin (= 0.19.1.2.pre)
+      elasticgraph-lambda_support (= 0.19.1.2.pre)
       rake (~> 13.2, >= 13.2.1)
 
 PATH
   remote: elasticgraph-admin
   specs:
-    elasticgraph-admin (0.19.1.1)
-      elasticgraph-datastore_core (= 0.19.1.1)
-      elasticgraph-indexer (= 0.19.1.1)
-      elasticgraph-schema_artifacts (= 0.19.1.1)
-      elasticgraph-support (= 0.19.1.1)
+    elasticgraph-admin (0.19.1.2.pre)
+      elasticgraph-datastore_core (= 0.19.1.2.pre)
+      elasticgraph-indexer (= 0.19.1.2.pre)
+      elasticgraph-schema_artifacts (= 0.19.1.2.pre)
+      elasticgraph-support (= 0.19.1.2.pre)
       rake (~> 13.2, >= 13.2.1)
 
 PATH
   remote: elasticgraph-apollo
   specs:
-    elasticgraph-apollo (0.19.1.1)
+    elasticgraph-apollo (0.19.1.2.pre)
       apollo-federation (~> 3.10)
-      elasticgraph-graphql (= 0.19.1.1)
-      elasticgraph-support (= 0.19.1.1)
+      elasticgraph-graphql (= 0.19.1.2.pre)
+      elasticgraph-support (= 0.19.1.2.pre)
       graphql (~> 2.4.15)
 
 PATH
   remote: elasticgraph-datastore_core
   specs:
-    elasticgraph-datastore_core (0.19.1.1)
-      elasticgraph-schema_artifacts (= 0.19.1.1)
-      elasticgraph-support (= 0.19.1.1)
+    elasticgraph-datastore_core (0.19.1.2.pre)
+      elasticgraph-schema_artifacts (= 0.19.1.2.pre)
+      elasticgraph-support (= 0.19.1.2.pre)
 
 PATH
   remote: elasticgraph-elasticsearch
   specs:
-    elasticgraph-elasticsearch (0.19.1.1)
-      elasticgraph-support (= 0.19.1.1)
+    elasticgraph-elasticsearch (0.19.1.2.pre)
+      elasticgraph-support (= 0.19.1.2.pre)
       elasticsearch (~> 8.17, >= 8.17.1)
       faraday (~> 2.12, >= 2.12.2)
       faraday-retry (~> 2.2, >= 2.2.1)
@@ -44,79 +44,79 @@ PATH
 PATH
   remote: elasticgraph-graphql_lambda
   specs:
-    elasticgraph-graphql_lambda (0.19.1.1)
-      elasticgraph-graphql (= 0.19.1.1)
-      elasticgraph-lambda_support (= 0.19.1.1)
+    elasticgraph-graphql_lambda (0.19.1.2.pre)
+      elasticgraph-graphql (= 0.19.1.2.pre)
+      elasticgraph-lambda_support (= 0.19.1.2.pre)
 
 PATH
   remote: elasticgraph-graphql
   specs:
-    elasticgraph-graphql (0.19.1.1)
-      elasticgraph-datastore_core (= 0.19.1.1)
-      elasticgraph-schema_artifacts (= 0.19.1.1)
+    elasticgraph-graphql (0.19.1.2.pre)
+      elasticgraph-datastore_core (= 0.19.1.2.pre)
+      elasticgraph-schema_artifacts (= 0.19.1.2.pre)
       graphql (~> 2.4.15)
 
 PATH
   remote: elasticgraph-health_check
   specs:
-    elasticgraph-health_check (0.19.1.1)
-      elasticgraph-datastore_core (= 0.19.1.1)
-      elasticgraph-graphql (= 0.19.1.1)
-      elasticgraph-support (= 0.19.1.1)
+    elasticgraph-health_check (0.19.1.2.pre)
+      elasticgraph-datastore_core (= 0.19.1.2.pre)
+      elasticgraph-graphql (= 0.19.1.2.pre)
+      elasticgraph-support (= 0.19.1.2.pre)
 
 PATH
   remote: elasticgraph-indexer_autoscaler_lambda
   specs:
-    elasticgraph-indexer_autoscaler_lambda (0.19.1.1)
+    elasticgraph-indexer_autoscaler_lambda (0.19.1.2.pre)
       aws-sdk-cloudwatch (~> 1.112)
       aws-sdk-lambda (~> 1.148)
       aws-sdk-sqs (~> 1.93)
-      elasticgraph-datastore_core (= 0.19.1.1)
-      elasticgraph-lambda_support (= 0.19.1.1)
+      elasticgraph-datastore_core (= 0.19.1.2.pre)
+      elasticgraph-lambda_support (= 0.19.1.2.pre)
       ox (~> 2.14, >= 2.14.22)
 
 PATH
   remote: elasticgraph-indexer_lambda
   specs:
-    elasticgraph-indexer_lambda (0.19.1.1)
+    elasticgraph-indexer_lambda (0.19.1.2.pre)
       aws-sdk-s3 (~> 1.182)
-      elasticgraph-indexer (= 0.19.1.1)
-      elasticgraph-lambda_support (= 0.19.1.1)
+      elasticgraph-indexer (= 0.19.1.2.pre)
+      elasticgraph-lambda_support (= 0.19.1.2.pre)
       ox (~> 2.14, >= 2.14.22)
 
 PATH
   remote: elasticgraph-indexer
   specs:
-    elasticgraph-indexer (0.19.1.1)
-      elasticgraph-datastore_core (= 0.19.1.1)
-      elasticgraph-json_schema (= 0.19.1.1)
-      elasticgraph-schema_artifacts (= 0.19.1.1)
-      elasticgraph-support (= 0.19.1.1)
+    elasticgraph-indexer (0.19.1.2.pre)
+      elasticgraph-datastore_core (= 0.19.1.2.pre)
+      elasticgraph-json_schema (= 0.19.1.2.pre)
+      elasticgraph-schema_artifacts (= 0.19.1.2.pre)
+      elasticgraph-support (= 0.19.1.2.pre)
       hashdiff (~> 1.1, >= 1.1.2)
 
 PATH
   remote: elasticgraph-json_schema
   specs:
-    elasticgraph-json_schema (0.19.1.1)
-      elasticgraph-support (= 0.19.1.1)
+    elasticgraph-json_schema (0.19.1.2.pre)
+      elasticgraph-support (= 0.19.1.2.pre)
       json_schemer (~> 2.4)
 
 PATH
   remote: elasticgraph-lambda_support
   specs:
-    elasticgraph-lambda_support (0.19.1.1)
-      elasticgraph-opensearch (= 0.19.1.1)
+    elasticgraph-lambda_support (0.19.1.2.pre)
+      elasticgraph-opensearch (= 0.19.1.2.pre)
       faraday_middleware-aws-sigv4 (~> 1.0, >= 1.0.1)
 
 PATH
   remote: elasticgraph-local
   specs:
-    elasticgraph-local (0.19.1.1)
-      elasticgraph-admin (= 0.19.1.1)
-      elasticgraph-graphql (= 0.19.1.1)
-      elasticgraph-indexer (= 0.19.1.1)
-      elasticgraph-rack (= 0.19.1.1)
-      elasticgraph-schema_definition (= 0.19.1.1)
+    elasticgraph-local (0.19.1.2.pre)
+      elasticgraph-admin (= 0.19.1.2.pre)
+      elasticgraph-graphql (= 0.19.1.2.pre)
+      elasticgraph-indexer (= 0.19.1.2.pre)
+      elasticgraph-rack (= 0.19.1.2.pre)
+      elasticgraph-schema_definition (= 0.19.1.2.pre)
       rackup (~> 2.2, >= 2.2.1)
       rake (~> 13.2, >= 13.2.1)
       webrick (~> 1.9, >= 1.9.1)
@@ -124,8 +124,8 @@ PATH
 PATH
   remote: elasticgraph-opensearch
   specs:
-    elasticgraph-opensearch (0.19.1.1)
-      elasticgraph-support (= 0.19.1.1)
+    elasticgraph-opensearch (0.19.1.2.pre)
+      elasticgraph-support (= 0.19.1.2.pre)
       faraday (~> 2.12, >= 2.12.2)
       faraday-retry (~> 2.2, >= 2.2.1)
       opensearch-ruby (~> 3.4)
@@ -133,55 +133,55 @@ PATH
 PATH
   remote: elasticgraph-query_interceptor
   specs:
-    elasticgraph-query_interceptor (0.19.1.1)
-      elasticgraph-graphql (= 0.19.1.1)
-      elasticgraph-schema_artifacts (= 0.19.1.1)
+    elasticgraph-query_interceptor (0.19.1.2.pre)
+      elasticgraph-graphql (= 0.19.1.2.pre)
+      elasticgraph-schema_artifacts (= 0.19.1.2.pre)
 
 PATH
   remote: elasticgraph-query_registry
   specs:
-    elasticgraph-query_registry (0.19.1.1)
-      elasticgraph-graphql (= 0.19.1.1)
-      elasticgraph-support (= 0.19.1.1)
+    elasticgraph-query_registry (0.19.1.2.pre)
+      elasticgraph-graphql (= 0.19.1.2.pre)
+      elasticgraph-support (= 0.19.1.2.pre)
       graphql (~> 2.4.15)
       rake (~> 13.2, >= 13.2.1)
 
 PATH
   remote: elasticgraph-rack
   specs:
-    elasticgraph-rack (0.19.1.1)
-      elasticgraph-graphql (= 0.19.1.1)
+    elasticgraph-rack (0.19.1.2.pre)
+      elasticgraph-graphql (= 0.19.1.2.pre)
       rack (~> 3.1, >= 3.1.12)
 
 PATH
   remote: elasticgraph-schema_artifacts
   specs:
-    elasticgraph-schema_artifacts (0.19.1.1)
-      elasticgraph-support (= 0.19.1.1)
+    elasticgraph-schema_artifacts (0.19.1.2.pre)
+      elasticgraph-support (= 0.19.1.2.pre)
 
 PATH
   remote: elasticgraph-schema_definition
   specs:
-    elasticgraph-schema_definition (0.19.1.1)
-      elasticgraph-graphql (= 0.19.1.1)
-      elasticgraph-indexer (= 0.19.1.1)
-      elasticgraph-json_schema (= 0.19.1.1)
-      elasticgraph-schema_artifacts (= 0.19.1.1)
-      elasticgraph-support (= 0.19.1.1)
+    elasticgraph-schema_definition (0.19.1.2.pre)
+      elasticgraph-graphql (= 0.19.1.2.pre)
+      elasticgraph-indexer (= 0.19.1.2.pre)
+      elasticgraph-json_schema (= 0.19.1.2.pre)
+      elasticgraph-schema_artifacts (= 0.19.1.2.pre)
+      elasticgraph-support (= 0.19.1.2.pre)
       graphql (~> 2.4.15)
       rake (~> 13.2, >= 13.2.1)
 
 PATH
   remote: elasticgraph-support
   specs:
-    elasticgraph-support (0.19.1.1)
+    elasticgraph-support (0.19.1.2.pre)
       logger (~> 1.6, >= 1.6.6)
 
 PATH
   remote: elasticgraph
   specs:
-    elasticgraph (0.19.1.1)
-      elasticgraph-support (= 0.19.1.1)
+    elasticgraph (0.19.1.2.pre)
+      elasticgraph-support (= 0.19.1.2.pre)
       thor (~> 1.3, >= 1.3.2)
 
 GEM
@@ -594,28 +594,28 @@ DEPENDENCIES
   aws_lambda_ric (~> 3.0)
   benchmark-ips (~> 2.14)
   coderay (~> 1.1, >= 1.1.3)
-  elasticgraph (= 0.19.1.1)!
-  elasticgraph-admin (= 0.19.1.1)!
-  elasticgraph-admin_lambda (= 0.19.1.1)!
-  elasticgraph-apollo (= 0.19.1.1)!
-  elasticgraph-datastore_core (= 0.19.1.1)!
-  elasticgraph-elasticsearch (= 0.19.1.1)!
-  elasticgraph-graphql (= 0.19.1.1)!
-  elasticgraph-graphql_lambda (= 0.19.1.1)!
-  elasticgraph-health_check (= 0.19.1.1)!
-  elasticgraph-indexer (= 0.19.1.1)!
-  elasticgraph-indexer_autoscaler_lambda (= 0.19.1.1)!
-  elasticgraph-indexer_lambda (= 0.19.1.1)!
-  elasticgraph-json_schema (= 0.19.1.1)!
-  elasticgraph-lambda_support (= 0.19.1.1)!
-  elasticgraph-local (= 0.19.1.1)!
-  elasticgraph-opensearch (= 0.19.1.1)!
-  elasticgraph-query_interceptor (= 0.19.1.1)!
-  elasticgraph-query_registry (= 0.19.1.1)!
-  elasticgraph-rack (= 0.19.1.1)!
-  elasticgraph-schema_artifacts (= 0.19.1.1)!
-  elasticgraph-schema_definition (= 0.19.1.1)!
-  elasticgraph-support (= 0.19.1.1)!
+  elasticgraph (= 0.19.1.2.pre)!
+  elasticgraph-admin (= 0.19.1.2.pre)!
+  elasticgraph-admin_lambda (= 0.19.1.2.pre)!
+  elasticgraph-apollo (= 0.19.1.2.pre)!
+  elasticgraph-datastore_core (= 0.19.1.2.pre)!
+  elasticgraph-elasticsearch (= 0.19.1.2.pre)!
+  elasticgraph-graphql (= 0.19.1.2.pre)!
+  elasticgraph-graphql_lambda (= 0.19.1.2.pre)!
+  elasticgraph-health_check (= 0.19.1.2.pre)!
+  elasticgraph-indexer (= 0.19.1.2.pre)!
+  elasticgraph-indexer_autoscaler_lambda (= 0.19.1.2.pre)!
+  elasticgraph-indexer_lambda (= 0.19.1.2.pre)!
+  elasticgraph-json_schema (= 0.19.1.2.pre)!
+  elasticgraph-lambda_support (= 0.19.1.2.pre)!
+  elasticgraph-local (= 0.19.1.2.pre)!
+  elasticgraph-opensearch (= 0.19.1.2.pre)!
+  elasticgraph-query_interceptor (= 0.19.1.2.pre)!
+  elasticgraph-query_registry (= 0.19.1.2.pre)!
+  elasticgraph-rack (= 0.19.1.2.pre)!
+  elasticgraph-schema_artifacts (= 0.19.1.2.pre)!
+  elasticgraph-schema_definition (= 0.19.1.2.pre)!
+  elasticgraph-support (= 0.19.1.2.pre)!
   factory_bot (~> 6.5, >= 6.5.1)
   faker (~> 3.5, >= 3.5.1)
   faraday (~> 2.12, >= 2.12.2)

--- a/config/release/Rakefile
+++ b/config/release/Rakefile
@@ -18,11 +18,31 @@ require "#{project_root}/script/list_eg_gems"
 # Load tasks from config/site/Rakefile
 load "#{project_root}/config/site/Rakefile"
 
-desc "Bumps the ElasticGraph version to the specified new version number"
-task :bump_version, [:version] do |_, args|
-  version = args.fetch(:version)
+# The `gem-release` gem is designed to support official SemVer with 3 version parts (+ an optional pre-release suffix).
+# Until we release 1.0.0, we're using 4 parts in our versions (+ an optional pre-release suffix).
+#
+# To make it compatible with our versioning scheme, we replace an internal regex here.
+#
+# Once we release 1.0.0, we can drop this workaround.
+::Gem::Release::Version::Number.class_eval do
+  remove_const :NUMBER
+
+  # standard:disable Lint/ConstantDefinitionInBlock
+  # This was changed from the original, which does not allow the extra version part we have:
+  #                 /^(\d+)\.?(\d+)?\.?(\d+)?(\-|\.)?(\w+)?\.?(\d+)?$/
+  NUMBER = /^(\d+)\.?(\d+)?\.?(\d+)?\.?(\d+)?(\-|\.)?(\w+)?\.?(\d+)?$/ # standard:disable Style/RedundantRegexpEscape
+  # standard:enable Lint/ConstantDefinitionInBlock
+end
+
+bump_version = lambda do |version:, message:|
   ::Dir.chdir(project_root) do
-    sh "bundle exec gem bump elasticgraph-support --file #{project_root}/elasticgraph-support/lib/elastic_graph/version.rb -v #{version} -m 'Release v#{version}.'"
+    opts = {
+      file: "#{project_root}/elasticgraph-support/lib/elastic_graph/version.rb",
+      version: version,
+      message: message
+    }
+
+    ::Gem::Release::Cmds::Runner.new(:bump, ["elasticgraph-support"], opts).run
 
     # We also want to commit an update to `Gemfile.lock` as part of the version bump.
     ::Bundler.with_unbundled_env do
@@ -31,6 +51,23 @@ task :bump_version, [:version] do |_, args|
       sh "git commit --amend --no-edit"
     end
   end
+end
+
+desc "Bumps the ElasticGraph version to the specified new version number"
+task :bump_version, [:version] do |_, args|
+  version = args.fetch(:version)
+  bump_version.call(version: version, message: "Release v#{version}.")
+end
+
+desc "Bumps the ElasticGraph version to the next pre-release version"
+task :bump_version_to_next_prerelease do
+  *main_parts, last_part = ElasticGraph::VERSION.split(".").filter_map do |part|
+    # ignore any pre-release parts.
+    Integer(part) unless part.match?(/[A-Za-z]/)
+  end
+
+  new_version = [*main_parts, last_part + 1, "pre"].join(".")
+  bump_version.call(version: new_version, message: "Bump version to v#{new_version}.")
 end
 
 desc "Releases ElasticGraph to rubygems.org and tags the release in git"

--- a/elasticgraph-support/lib/elastic_graph/version.rb
+++ b/elasticgraph-support/lib/elastic_graph/version.rb
@@ -8,7 +8,7 @@
 
 module ElasticGraph
   # The version of all ElasticGraph gems.
-  VERSION = "0.19.1.1"
+  VERSION = "0.19.1.2.pre"
 
   # Steep weirdly expects this here...
   # @dynamic self.define_schema


### PR DESCRIPTION
For example, when releasing `0.19.2.0`, this will create one more commit bumping the version to `0.19.2.1.pre` after the release has been tagged. The goal here is to bump the version to a version number which will never get released to rubygems.org because it is helpful when users want to update their project's `Gemfile` to use a development version.

To illustrate the problem, consider this `Gemfile` that is provided by `gem exec elasticgraph new`:

```ruby
source "https://rubygems.org"

elasticgraph_details = ["0.19.1.1"]

gem "elasticgraph-local", *elasticgraph_details
gem "elasticgraph-opensearch", *elasticgraph_details
gem "elasticgraph-query_registry", *elasticgraph_details

gem "httpx", "~> 1.3"

group :development do
  gem "factory_bot"
  gem "faker"
  gem "rspec"
  gem "standard"
end
```

Notably, it does not list out each individual ElasticGraph gem, relying on the dependencies which have been defined on them. This works great for released versions of ElasticGraph. However, a problem occurs when a user tries to use a development version, like this:

```diff
diff --git a/Gemfile b/Gemfile
index 770f8fc..4c38679 100644
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"

 # Gem details for the elasticgraph gems.
-elasticgraph_details = ["0.19.1.1"]
+elasticgraph_details = [git: "https://github.com/block/elasticgraph"]

 gem "elasticgraph-local", *elasticgraph_details
 gem "elasticgraph-opensearch", *elasticgraph_details
```

Bundler will pull the three listed gems from the GitHub repo, but it'll use the released version of all the other ElasticGraph gems, because we haven't told it to pull them from GitHub and rubygems.org has releases that match the dependency requirement (e.g. `= 0.19.1.1`).

Going forward, between releases, the ElasticGraph version will be a pre-release version for the _next_ version of ElasticGraph. We will never release this version to rubygems.org. With that in place, when a user updates their `Gemfile` to use a development version, bundler will no longer be able to find a released version on rubygems.org that matches the dependency requirement (e.g. `= 0.19.1.2.pre`), and it will pull them from GitHub instead, as intended.

To see an example of this in action, see:

https://github.com/block/elasticgraph/pull/404