### PR TITLE
Offer more flexible extension interface verification.

### DIFF
--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/extension.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/extension.rb
@@ -45,6 +45,10 @@ module ElasticGraph
           }.reject { |_, v| v.empty? }
         end
 
+        def verify_against!(interface_def)
+          InterfaceVerifier.verify!(extension_class, against: interface_def, constant_name: extension_name)
+        end
+
         def verify_against(interface_def)
           InterfaceVerifier.verify(extension_class, against: interface_def, constant_name: extension_name)
         end

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/extension_loader.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/extension_loader.rb
@@ -45,7 +45,7 @@ module ElasticGraph
           require require_path
           extension_class = ::Object.const_get(constant_name)
           Extension.new(extension_class, require_path, {}, constant_name.delete_prefix("::")).tap do |ext|
-            ext.verify_against(@interface_def)
+            ext.verify_against!(@interface_def)
           end
         end
       end

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/interface_verifier.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/interface_verifier.rb
@@ -22,9 +22,18 @@ module ElasticGraph
       # called. But this verifies the interface to the extent that we can.
       module InterfaceVerifier
         class << self
+          def verify!(extension, against:, constant_name:)
+            problems = verify(extension, against:, constant_name:)
+
+            if problems.any?
+              raise Errors::InvalidExtensionError,
+                "Extension `#{constant_name}` does not implement the expected interface correctly. Problems:\n\n" \
+                "#{problems.join("\n")}"
+            end
+          end
+
           def verify(extension, against:, constant_name:)
-            # @type var problems: ::Array[::String]
-            problems = []
+            problems = [] # : ::Array[::String]
             problems.concat(verify_methods("class", extension.singleton_class, against.singleton_class))
 
             if extension.is_a?(::Module)
@@ -39,11 +48,7 @@ module ElasticGraph
               problems << "- Is not a class or module as expected"
             end
 
-            if problems.any?
-              raise Errors::InvalidExtensionError,
-                "Extension `#{constant_name}` does not implement the expected interface correctly. Problems:\n\n" \
-                "#{problems.join("\n")}"
-            end
+            problems
           end
 
           private

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/extension.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/extension.rbs
@@ -39,7 +39,8 @@ module ElasticGraph
         def self.load_from_hash: (::Hash[::String, untyped], via: ExtensionLoader) -> Extension
         def to_dumpable_hash: () -> ::Hash[::String, untyped]
 
-        def verify_against: (extensionClass) -> void
+        def verify_against!: (extensionClass) -> void
+        def verify_against: (extensionClass) -> ::Array[::String]
       end
     end
   end

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/interface_verifier.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/interface_verifier.rbs
@@ -2,7 +2,8 @@ module ElasticGraph
   module SchemaArtifacts
     module RuntimeMetadata
       module InterfaceVerifier
-        def self.verify: (extensionClass, against: extensionClass, constant_name: ::String) -> void
+        def self.verify!: (extensionClass, against: extensionClass, constant_name: ::String) -> void
+        def self.verify: (extensionClass, against: extensionClass, constant_name: ::String) -> ::Array[::String]
 
         private
 

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/extension_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/extension_spec.rb
@@ -40,8 +40,11 @@ module ElasticGraph
           )
 
           expect {
-            valid_extension.verify_against(ExampleInterfaceDef)
+            valid_extension.verify_against!(ExampleInterfaceDef)
           }.not_to raise_error
+          expect(
+            valid_extension.verify_against(ExampleInterfaceDef)
+          ).to be_empty
 
           invalid_extension = Extension.new(
             extension_class: Extensions::MissingInstanceMethod,
@@ -50,8 +53,11 @@ module ElasticGraph
           )
 
           expect {
-            invalid_extension.verify_against(ExampleInterfaceDef)
+            invalid_extension.verify_against!(ExampleInterfaceDef)
           }.to raise_error Errors::InvalidExtensionError, a_string_including("instance_method1")
+          expect(
+            invalid_extension.verify_against(ExampleInterfaceDef)
+          ).to include(a_string_including("instance_method1"))
         end
       end
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
@@ -326,7 +326,7 @@ module ElasticGraph
       #   end
       def register_graphql_resolver(name, klass, defined_at:, **resolver_config)
         resolver = SchemaArtifacts::RuntimeMetadata::Extension.new(klass, defined_at, resolver_config)
-        resolver.verify_against(GraphQL::Resolvers::Interface)
+        resolver.verify_against!(GraphQL::Resolvers::Interface)
         @state.graphql_resolvers_by_name[name] = resolver
         nil
       end


### PR DESCRIPTION
Previously, `verify`/`verify_against` would raise an error if there were any verification problems. I've renamed these methods to `verify!`/`verify_against!` and re-introduced a method with the old name that returns errors as an array of strings.

This affords more flexibility--for example, for a performance optimization I'm working on, I need to allow an extension to be registered with one of two interfaces.