### PR TITLE
Update FilterValueSetExtractor to handle allOf

### DIFF
--- a/elasticgraph-graphql/sig/elastic_graph/graphql/filtering/filter_value_set_extractor.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/filtering/filter_value_set_extractor.rbs
@@ -48,6 +48,13 @@ module ElasticGraph
           negate: bool
         ) -> setType[S]
 
+        def filter_value_set_for_all_of: (
+          ::Array[::Hash[::String, untyped]],
+          ::Array[::String],
+          ::Array[::String],
+          negate: bool
+        ) -> setType[S]
+
         def filter_value_set_for_field_filter: (
           ::String,
           untyped


### PR DESCRIPTION
## Problem
FilterValueSetExtractor currently doesn't properly support the `all_of` operator for shard routing and index selection optimizations. This is a critical component that implements the set algebra necessary to properly target a subset of shards or indices based on provided filters. Without proper `all_of` support, we can't safely release general purpose `all_of` operator functionality.

## Solution
Added support for `all_of` in FilterValueSetExtractor with proper handling of
- Set intersection for routing fields
- Non-routing field detection
- Empty filter cases
- Nested operator scenarios

The `filter_value_set_for_all_of` method
   - Returns `@all_values_set` for empty `all_of: []` (matches everything)
   - Returns `UnboundedSetWithExclusions` when non-routing fields are present
   - Performs set intersection for routing field values

## How Tested
Unit tests added to
   - `shard_routing_spec.rb`
   - `search_index_expression_spec.rb`
