### PR TITLE
Modernize success stories section on homepage

### DIFF
--- a/config/site/src/_includes/success_stories.html
+++ b/config/site/src/_includes/success_stories.html
@@ -1,93 +1,121 @@
 <!-- Success Stories Section -->
-<section class="py-16">
+<section class="py-20 bg-gradient-to-b from-gray-50 to-white dark:from-gray-900 dark:to-gray-800">
   <div class="container mx-auto px-4">
-    <h2
-      class="text-4xl font-bold text-gray-900 dark:text-gray-100 text-center mb-8">
-      Success Stories
-    </h2>
     <div class="max-w-4xl mx-auto">
-      <div class="p-8 rounded-lg shadow-lg text-center">
-        <h3 class="text-3xl font-semibold mb-6">
-          Scaling to support Square's Dashboard Reports
-        </h3>
-        <p class="text-lg mb-8">
-          ElasticGraph powers Square's new Dashboard reports. Switching to
-          ElasticGraph shaved multiple seconds off every page load, ultimately
-          giving businesses time back that was previously spent waiting for
-          reports to load.
-        </p>
-        <div class="flex flex-col md:flex-row justify-between gap-6">
-          <!-- Ingestion Performance Card -->
-          <div class="bg-gray-100 dark:bg-gray-700 p-6 rounded-lg md:w-1/3">
-            <h4 class="text-xl font-bold mb-4">Ingestion</h4>
-            <p
-              class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mb-2">
-              &lt; 400ms
-            </p>
-            <p class="text-sm text-gray-700 dark:text-gray-300">
-              p99 latency
-            </p>
-            <p
-              class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mt-4">
-              &lt; 1s
-            </p>
-            <p class="text-sm text-gray-700 dark:text-gray-300">
-              p99.99 latency
-            </p>
-            <p class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mt-4">
-              200k/s
-            </p>
-            <p class="text-sm text-gray-700 dark:text-gray-300">
-              documents ingested
-            </p>
+      <!-- Header -->
+      <div class="text-center mb-16">
+        <h2 class="text-4xl font-bold bg-gradient-to-r from-blue-600 to-blue-400 dark:from-blue-500 dark:to-blue-300 bg-clip-text text-transparent inline-block mb-4">
+          Success Stories
+        </h2>
+        <div class="h-1 w-20 bg-gradient-to-r from-blue-600 to-blue-400 dark:from-blue-500 dark:to-blue-300 mx-auto rounded-full"></div>
+      </div>
+
+      <!-- Main Content -->
+      <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl overflow-hidden transform transition-all duration-300 hover:shadow-2xl">
+        <!-- Square Logo and Title -->
+        <div class="p-8 border-b border-gray-100 dark:border-gray-700">
+          <div class="flex items-center justify-between">
+            <div>
+              <h3 class="text-3xl font-bold bg-gradient-to-br from-gray-900 to-gray-700 dark:from-gray-100 dark:to-gray-300 bg-clip-text text-transparent mb-2">
+                Square Dashboard Reports
+              </h3>
+              <p class="text-gray-600 dark:text-gray-400 text-lg">
+                Powering real-time analytics for millions of businesses
+              </p>
+            </div>
           </div>
-          <!-- GraphQL API Latency Card -->
-          <div class="bg-gray-100 dark:bg-gray-700 p-6 rounded-lg md:w-1/3">
-            <h4 class="text-xl font-bold mb-4">Query</h4>
-            <p
-              class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mb-2">
-              &lt; 350ms
-            </p>
-            <p class="text-sm text-gray-700 dark:text-gray-300">
-              p99 latency
-            </p>
-            <p
-              class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mt-4">
-              &lt; 2.5s
-            </p>
-            <p class="text-sm text-gray-700 dark:text-gray-300">
-              p99.99 latency
-            </p>
-            <p class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mt-4">
-              > 500 QPS
-            </p>
-            <p class="text-sm text-gray-700 dark:text-gray-300">
-              throughput
-            </p>
-          </div>
-          <!-- Dataset Card -->
-          <div class="bg-gray-100 dark:bg-gray-700 p-6 rounded-lg md:w-1/3">
-            <h4 class="text-xl font-bold mb-4">Dataset</h4>
-            <p
-              class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mb-2">
-              100TB
-            </p>
-            <p class="text-sm text-gray-700 dark:text-gray-300">
-              indexed data
-            </p>
-            <p
-              class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mt-4">
-              &gt; 100B</p>
-            <p class="text-sm text-gray-700 dark:text-gray-300">
-              indexed documents
-            </p>
-            <p
-              class="text-3xl font-extrabold text-blue-600 dark:text-blue-400 mt-4">
-              &gt; 99.999%
-            </p>
-            <p class="text-sm text-gray-700 dark:text-gray-300">
-              availability
-            </p>
+        </div>
+
+        <!-- Success Story Description -->
+        <div class="p-8 bg-gradient-to-br from-blue-50/50 to-transparent dark:from-blue-900/20 dark:to-transparent">
+          <p class="text-lg text-gray-700 dark:text-gray-300 leading-relaxed mb-8">
+            ElasticGraph powers Square's new Dashboard reports. Switching to ElasticGraph
+            shaved multiple seconds off every page load, ultimately giving businesses time
+            back that was previously spent waiting for reports to load.
+          </p>
+
+          <!-- Metrics Grid -->
+          <div class="grid md:grid-cols-3 gap-6">
+            <!-- Ingestion Card -->
+            <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md hover:shadow-xl transition-shadow duration-300">
+              <div class="flex items-center space-x-3 mb-4">
+                <div class="p-2 bg-blue-100 dark:bg-blue-900/50 rounded-lg">
+                  <svg class="w-6 h-6 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3"></path>
+                  </svg>
+                </div>
+                <h4 class="text-xl font-semibold text-gray-900 dark:text-gray-100">Ingestion</h4>
+              </div>
+
+              <div class="space-y-4">
+                <div>
+                  <p class="text-3xl font-bold text-blue-600 dark:text-blue-400">&lt; 400ms</p>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">p99 latency</p>
+                </div>
+                <div>
+                  <p class="text-3xl font-bold text-blue-600 dark:text-blue-400">&lt; 1s</p>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">p99.99 latency</p>
+                </div>
+                <div>
+                  <p class="text-3xl font-bold text-blue-600 dark:text-blue-400">200k/s</p>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">documents ingested</p>
+                </div>
+              </div>
+            </div>
+
+            <!-- Query Card -->
+            <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md hover:shadow-xl transition-shadow duration-300">
+              <div class="flex items-center space-x-3 mb-4">
+                <div class="p-2 bg-green-100 dark:bg-green-900/50 rounded-lg">
+                  <svg class="w-6 h-6 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
+                  </svg>
+                </div>
+                <h4 class="text-xl font-semibold text-gray-900 dark:text-gray-100">Query</h4>
+              </div>
+
+              <div class="space-y-4">
+                <div>
+                  <p class="text-3xl font-bold text-green-600 dark:text-green-400">&lt; 350ms</p>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">p99 latency</p>
+                </div>
+                <div>
+                  <p class="text-3xl font-bold text-green-600 dark:text-green-400">&lt; 2.5s</p>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">p99.99 latency</p>
+                </div>
+                <div>
+                  <p class="text-3xl font-bold text-green-600 dark:text-green-400">&gt; 500 QPS</p>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">throughput</p>
+                </div>
+              </div>
+            </div>
+
+            <!-- Dataset Card -->
+            <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md hover:shadow-xl transition-shadow duration-300">
+              <div class="flex items-center space-x-3 mb-4">
+                <div class="p-2 bg-purple-100 dark:bg-purple-900/50 rounded-lg">
+                  <svg class="w-6 h-6 text-purple-600 dark:text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"></path>
+                  </svg>
+                </div>
+                <h4 class="text-xl font-semibold text-gray-900 dark:text-gray-100">Dataset</h4>
+              </div>
+
+              <div class="space-y-4">
+                <div>
+                  <p class="text-3xl font-bold text-purple-600 dark:text-purple-400">100TB</p>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">indexed data</p>
+                </div>
+                <div>
+                  <p class="text-3xl font-bold text-purple-600 dark:text-purple-400">&gt; 100B</p>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">indexed documents</p>
+                </div>
+                <div>
+                  <p class="text-3xl font-bold text-purple-600 dark:text-purple-400">&gt; 99.999%</p>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">availability</p>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
# Before
<img width="1112" alt="Screenshot 2025-03-28 at 3 31 40 PM" src="https://github.com/user-attachments/assets/670a03fb-7e60-4c48-8918-e1e224bfec71" />


# After

<img width="1102" alt="Screenshot 2025-03-28 at 3 31 36 PM" src="https://github.com/user-attachments/assets/5bddd642-db06-4aac-9709-e9894970e6c1" />
