### PR TITLE
Infer `needs_lookahead` from `lookahead:` arg on resolver.

### DIFF
--- a/elasticgraph-apollo/sig/elastic_graph/apollo/graphql/entities_field_resolver.rbs
+++ b/elasticgraph-apollo/sig/elastic_graph/apollo/graphql/entities_field_resolver.rbs
@@ -2,7 +2,7 @@ module ElasticGraph
   module Apollo
     module GraphQL
       class EntitiesFieldResolver
-        include ::ElasticGraph::_GraphQLResolver
+        include ::ElasticGraph::_GraphQLResolverWithLookahead
 
         private
 

--- a/elasticgraph-apollo/sig/elastic_graph/apollo/graphql/service_field_resolver.rbs
+++ b/elasticgraph-apollo/sig/elastic_graph/apollo/graphql/service_field_resolver.rbs
@@ -2,7 +2,7 @@ module ElasticGraph
   module Apollo
     module GraphQL
       class ServiceFieldResolver
-        include ::ElasticGraph::_GraphQLResolver
+        include ::ElasticGraph::_GraphQLResolverWithLookahead
 
         private
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql.rbs
@@ -45,8 +45,8 @@ module ElasticGraph
     @resolver_query_adapter: Resolvers::QueryAdapter?
     def resolver_query_adapter: () -> Resolvers::QueryAdapter
 
-    @named_graphql_resolvers: ::Hash[::Symbol, _GraphQLResolver]?
-    def named_graphql_resolvers: () -> ::Hash[::Symbol, _GraphQLResolver]
+    @named_graphql_resolvers: ::Hash[::Symbol, _GraphQLResolverWithLookahead]?
+    def named_graphql_resolvers: () -> ::Hash[::Symbol, _GraphQLResolverWithLookahead]
 
     @datastore_query_adapters: ::Array[_QueryAdapter]?
     def datastore_query_adapters: () -> ::Array[_QueryAdapter]

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rbs
@@ -31,7 +31,7 @@ module ElasticGraph
         end
 
         class AggregatedValues < AggregatedValuesSupertype
-          include _GraphQLResolvable
+          include _GraphQLResolvableWithLookahead
         end
       end
     end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/grouped_by.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/grouped_by.rbs
@@ -26,7 +26,7 @@ module ElasticGraph
         end
 
         class GroupedBy < GroupedBySupertype
-          include _GraphQLResolvable
+          include _GraphQLResolvableWithLookahead
 
           private
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/sub_aggregations.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/sub_aggregations.rbs
@@ -33,7 +33,7 @@ module ElasticGraph
         end
 
         class SubAggregations < SubAggregationsSupertype
-          include _GraphQLResolvable
+          include _GraphQLResolvableWithLookahead
 
           private
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/get_record_field_value.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/get_record_field_value.rbs
@@ -2,7 +2,7 @@ module ElasticGraph
   class GraphQL
     module Resolvers
       class GetRecordFieldValue
-        include _GraphQLResolver
+        include _GraphQLResolverWithLookahead
       end
     end
   end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/graphql_adapter_builder.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/graphql_adapter_builder.rbs
@@ -5,12 +5,12 @@ module ElasticGraph
 
       class GraphQLAdapterBuilder
         @runtime_metadata: SchemaArtifacts::RuntimeMetadata::Schema
-        @named_resolvers: ::Hash[::Symbol, _GraphQLResolver]
+        @named_resolvers: ::Hash[::Symbol, _GraphQLResolverWithLookahead]
         @query_adapter: QueryAdapter
 
         def initialize: (
           runtime_metadata: SchemaArtifacts::RuntimeMetadata::Schema,
-          named_resolvers: ::Hash[::Symbol, _GraphQLResolver],
+          named_resolvers: ::Hash[::Symbol, _GraphQLResolverWithLookahead],
           query_adapter: QueryAdapter
         ) -> void
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/list_records.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/list_records.rbs
@@ -2,7 +2,7 @@ module ElasticGraph
   class GraphQL
     module Resolvers
       class ListRecords
-        include _GraphQLResolver
+        include _GraphQLResolverWithLookahead
       end
     end
   end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/nested_relationships.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/nested_relationships.rbs
@@ -2,7 +2,7 @@ module ElasticGraph
   class GraphQL
     module Resolvers
       class NestedRelationships
-        include _GraphQLResolver
+        include _GraphQLResolverWithLookahead
       end
     end
   end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/object.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/object.rbs
@@ -2,7 +2,7 @@ module ElasticGraph
   class GraphQL
     module Resolvers
       class Object
-        include _GraphQLResolver
+        include _GraphQLResolverWithLookahead
       end
     end
   end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/resolvable_value.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/resolvable_value.rbs
@@ -4,7 +4,7 @@ module ElasticGraph
       module ResolvableValue
         def self.new: (*Symbol) ?{ () [self: self] -> void } -> ResolvableValueClass
 
-        include _GraphQLResolvable
+        include _GraphQLResolvableWithLookahead
         attr_reader schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames
 
         private

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_executor_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_executor_spec.rb
@@ -416,7 +416,7 @@ module ElasticGraph
 
           before do
             # stub the `require` call that happens. If we allow it to load this file it'll mess with our reported code coverage
-            allow(SchemaArtifacts::RuntimeMetadata::GraphQLResolver.extension_loader).to receive(:require)
+            allow(SchemaArtifacts::RuntimeMetadata::GraphQLResolver.with_lookahead_loader).to receive(:require)
           end
 
           it "allows an injected resolver to resolve the custom field" do

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/graphql_resolver.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/graphql_resolver.rbs
@@ -21,8 +21,11 @@ module ElasticGraph
       end
 
       class GraphQLResolver < GraphQLResolverSupertype
-        self.@extension_loader: ExtensionLoader?
-        def self.extension_loader: () -> ExtensionLoader
+        self.@with_lookahead_loader: ExtensionLoader?
+        def self.with_lookahead_loader: () -> ExtensionLoader
+
+        self.@without_lookahead_loader: ExtensionLoader?
+        def self.without_lookahead_loader: () -> ExtensionLoader
 
         NEEDS_LOOKAHEAD: "needs_lookahead"
         RESOLVER_REF: "resolver_ref"
@@ -31,14 +34,18 @@ module ElasticGraph
         def self.from_hash: (::Hash[::String, untyped]) -> GraphQLResolver
         def to_dumpable_hash: () -> ::Hash[::String, untyped]
 
-        class Interface
-          include _GraphQLResolver
+        class InterfaceWithLookahead
+          include _GraphQLResolverWithLookahead
+        end
+
+        class InterfaceWithoutLookahead
+          include _GraphQLResolverWithoutLookahead
         end
       end
     end
   end
 
-  interface _GraphQLResolvable
+  interface _GraphQLResolvableWithLookahead
     def resolve: (
       field: ElasticGraph::GraphQL::Schema::Field,
       object: untyped,
@@ -48,12 +55,30 @@ module ElasticGraph
     ) -> untyped
   end
 
-  interface _GraphQLResolver
+  interface _GraphQLResolvableWithoutLookahead
+    def resolve: (
+      field: ElasticGraph::GraphQL::Schema::Field,
+      object: untyped,
+      context: ::GraphQL::Query::Context,
+      args: ::Hash[::String, untyped]
+    ) -> untyped
+  end
+
+  interface _GraphQLResolverWithLookahead
     def initialize: (
       elasticgraph_graphql: GraphQL,
       config: ::Hash[::String, untyped]
     ) -> void
 
-    include _GraphQLResolvable
+    include _GraphQLResolvableWithLookahead
+  end
+
+  interface _GraphQLResolverWithoutLookahead
+    def initialize: (
+      elasticgraph_graphql: GraphQL,
+      config: ::Hash[::String, untyped]
+    ) -> void
+
+    include _GraphQLResolvableWithoutLookahead
   end
 end

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/graphql_resolver_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/graphql_resolver_spec.rb
@@ -12,16 +12,56 @@ module ElasticGraph
   module SchemaArtifacts
     module RuntimeMetadata
       RSpec.describe GraphQLResolver do
-        it "loads a resolver dynamically" do
+        it "loads a resolver with lookahead dynamically" do
           resolver = GraphQLResolver.new(
-            needs_lookahead: false,
+            needs_lookahead: true,
             resolver_ref: {
-              "extension_name" => "ElasticGraph::GraphQLResolver1",
+              "extension_name" => "ElasticGraph::GraphQLResolverWithLookahead",
               "require_path" => "elastic_graph/spec_support/example_extensions/graphql_resolvers"
             }
           )
 
-          expect(resolver.load_resolver.extension_class).to be GraphQLResolver1
+          expect(resolver.load_resolver.extension_class).to be GraphQLResolverWithLookahead
+        end
+
+        it "loads a resolver without lookahead dynamically" do
+          resolver = GraphQLResolver.new(
+            needs_lookahead: false,
+            resolver_ref: {
+              "extension_name" => "ElasticGraph::GraphQLResolverWithoutLookahead",
+              "require_path" => "elastic_graph/spec_support/example_extensions/graphql_resolvers"
+            }
+          )
+
+          expect(resolver.load_resolver.extension_class).to be GraphQLResolverWithoutLookahead
+        end
+
+        it "raises an error if `needs_lookahead` is true for a resolver without lookahead" do
+          resolver = GraphQLResolver.new(
+            needs_lookahead: true,
+            resolver_ref: {
+              "extension_name" => "ElasticGraph::GraphQLResolverWithoutLookahead",
+              "require_path" => "elastic_graph/spec_support/example_extensions/graphql_resolvers"
+            }
+          )
+
+          expect {
+            resolver.load_resolver
+          }.to raise_error Errors::InvalidExtensionError
+        end
+
+        it "raises an error if `needs_lookahead` is false for a resolver with lookahead" do
+          resolver = GraphQLResolver.new(
+            needs_lookahead: false,
+            resolver_ref: {
+              "extension_name" => "ElasticGraph::GraphQLResolverWithLookahead",
+              "require_path" => "elastic_graph/spec_support/example_extensions/graphql_resolvers"
+            }
+          )
+
+          expect {
+            resolver.load_resolver
+          }.to raise_error Errors::InvalidExtensionError
         end
       end
     end

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
@@ -146,7 +146,7 @@ module ElasticGraph
             graphql_resolvers_by_name: {
               resolver1: graphql_resolver_with(
                 needs_lookahead: true,
-                resolver_ref: graphql_resolver1(limit: 10).to_dumpable_hash
+                resolver_ref: graphql_resolver_with_lookahead(limit: 10).to_dumpable_hash
               )
             },
             static_script_ids_by_scoped_name: {
@@ -285,7 +285,7 @@ module ElasticGraph
               "resolver1" => {
                 "needs_lookahead" => true,
                 "resolver_ref" => {
-                  "extension_name" => "ElasticGraph::GraphQLResolver1",
+                  "extension_name" => "ElasticGraph::GraphQLResolverWithLookahead",
                   "require_path" => "elastic_graph/spec_support/example_extensions/graphql_resolvers",
                   "extension_config" => {"limit" => 10}
                 }

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
@@ -326,10 +326,17 @@ module ElasticGraph
       #   end
       def register_graphql_resolver(name, klass, defined_at:, **resolver_config)
         extension = SchemaArtifacts::RuntimeMetadata::Extension.new(klass, defined_at, resolver_config)
-        extension.verify_against!(SchemaArtifacts::RuntimeMetadata::GraphQLResolver::Interface)
+
+        needs_lookahead =
+          if extension.verify_against(SchemaArtifacts::RuntimeMetadata::GraphQLResolver::InterfaceWithLookahead).empty?
+            true
+          else
+            extension.verify_against!(SchemaArtifacts::RuntimeMetadata::GraphQLResolver::InterfaceWithoutLookahead)
+            false
+          end
 
         resolver = SchemaArtifacts::RuntimeMetadata::GraphQLResolver.new(
-          needs_lookahead: true,
+          needs_lookahead: needs_lookahead,
           resolver_ref: extension.to_dumpable_hash
         )
 

--- a/spec_support/lib/elastic_graph/spec_support/example_extensions/graphql_resolvers.rb
+++ b/spec_support/lib/elastic_graph/spec_support/example_extensions/graphql_resolvers.rb
@@ -7,7 +7,7 @@
 # frozen_string_literal: true
 
 module ElasticGraph
-  class GraphQLResolver1
+  class GraphQLResolverWithLookahead
     def initialize(elasticgraph_graphql:, config:)
     end
 
@@ -15,11 +15,11 @@ module ElasticGraph
     end
   end
 
-  class GraphQLResolver2
+  class GraphQLResolverWithoutLookahead
     def initialize(elasticgraph_graphql:, config:)
     end
 
-    def resolve(field:, object:, args:, context:, lookahead:)
+    def resolve(field:, object:, args:, context:)
     end
   end
 
@@ -27,7 +27,7 @@ module ElasticGraph
     def initialize(elasticgraph_graphql:, config:)
     end
 
-    def resolve(field:, object:, args:, context:)
+    def resolve(field:, object:, args:)
     end
   end
 end

--- a/spec_support/lib/elastic_graph/spec_support/runtime_metadata_support.rb
+++ b/spec_support/lib/elastic_graph/spec_support/runtime_metadata_support.rb
@@ -190,8 +190,12 @@ module ElasticGraph
           Extension.new(GraphQLExtensionModule1, "support/example_extensions/graphql_extension_modules", {})
         end
 
-        def graphql_resolver1(**config)
-          Extension.new(GraphQLResolver1, "elastic_graph/spec_support/example_extensions/graphql_resolvers", config)
+        def graphql_resolver_with_lookahead(**config)
+          Extension.new(GraphQLResolverWithLookahead, "elastic_graph/spec_support/example_extensions/graphql_resolvers", config)
+        end
+
+        def graphql_resolver_without_lookahead(**config)
+          Extension.new(GraphQLResolverWithoutLookahead, "elastic_graph/spec_support/example_extensions/graphql_resolvers", config)
         end
       end
     end


### PR DESCRIPTION
This builds on #409, and paves the way for further optimizations.