### PR TITLE
Avoid enabling `:lookahead` on fields that don't need it.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter_builder.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter_builder.rb
@@ -79,8 +79,7 @@ module ElasticGraph
                       schema_field = context.fetch(:elastic_graph_schema).field_named(type_name, field_name)
                       # Convert args to the form they were defined in the schema, undoing the normalization
                       # the GraphQL gem does to convert them to Ruby keyword args form.
-                      # TODO: remove lookahead once we're no longer settings `extras([:lookahead])` on these fields.
-                      args = schema_field.args_to_schema_form(args.except(:lookahead))
+                      args = schema_field.args_to_schema_form(args)
 
                       result = resolver.resolve(field: schema_field, object: object, args: args, context: context)
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
@@ -39,6 +39,9 @@ module ElasticGraph
         @element_names = runtime_metadata.schema_element_names
         @config = config
         @runtime_metadata = runtime_metadata
+        resolvers_needing_lookahead = runtime_metadata.graphql_resolvers_by_name.filter_map do |name, resolver|
+          name if resolver.needs_lookahead
+        end.to_set
 
         @types_by_graphql_type = Hash.new do |hash, key|
           hash[key] = Type.new(
@@ -46,7 +49,8 @@ module ElasticGraph
             key,
             index_definitions_by_graphql_type[key.graphql_name] || [],
             runtime_metadata.object_types_by_name[key.graphql_name],
-            runtime_metadata.enum_types_by_name[key.graphql_name]
+            runtime_metadata.enum_types_by_name[key.graphql_name],
+            resolvers_needing_lookahead
           )
         end
 


### PR DESCRIPTION
In my benchmarking, this made some particularly slow queries about 20% faster.