### PR TITLE
Refactor: make `copyable_code_snippet` usable with any `data` file.

### DIFF
--- a/config/site/Rakefile
+++ b/config/site/Rakefile
@@ -296,6 +296,12 @@ module ElasticGraph
           )
         end
 
+        desc "Validate that no code snippets are empty"
+        task :validate_no_empty_code_snippets do
+          require_relative "support/validate_no_empty_code_snippets"
+          ElasticGraph::ValidateNoEmptyCodeSnippets.new(JEKYLL_SITE_DIR).validate!
+        end
+
         desc "Validate that all pages have proper frontmatter with permalink"
         task :validate_page_frontmatter do
           require "yaml"
@@ -362,7 +368,7 @@ module ElasticGraph
         end
 
         desc "Perform validations of the website, including doc tests and doc coverage"
-        task validate: [:build, :validate_html_output, :docs_coverage, :doctest, :validate_page_frontmatter]
+        task validate: [:build, :validate_no_empty_code_snippets, :validate_html_output, :docs_coverage, :doctest, :validate_page_frontmatter]
 
         task build_css: :npm_install do
           require "rouge"

--- a/config/site/src/_includes/copyable_code_snippet.html
+++ b/config/site/src/_includes/copyable_code_snippet.html
@@ -4,15 +4,16 @@
   Parameters:
     language: The language for syntax highlighting (e.g., "graphql", "ruby", "shell")
     code: Raw code to display
-    music_query: Name of a query from site.data.music_queries (e.g. "filtering.FindArtist")
+    data: path to a code snippet available under `site.data` (e.g  "music_queries.filtering.FindArtist")
     font_size: Optional font size class (e.g., "text-xs", "text-sm", etc)
     style: Optional "dark" for dark background style
 {% endcomment %}
-{% if include.music_query %}
-  {% assign parts = include.music_query | split: "." %}
-  {% assign section = parts[0] %}
-  {% assign name = parts[1] %}
-  {% assign code = site.data.music_queries[section][name] %}
+{% if include.data %}
+  {% assign parts = include.data | split: "." %}
+  {% assign code = site.data %}
+  {% for part in parts %}
+    {% assign code = code[part] %}
+  {% endfor %}
 {% else %}
   {% assign code = include.code %}
 {% endif %}
@@ -44,7 +45,7 @@
         {% assign display_content = code %}
       {% endif %}
       <button onclick="copyToClipboard(this, {{ clipboard_content | jsonify | escape }})"
-        class="{% if include.style == 'dark' %}text-white hover:text-blue-300{% else %}text-gray-400 hover:text-blue-300{% endif %} transition-all cursor-pointer"
+        class="{% if include.style == 'dark' %}text-white hover:text-blue-300{% else %}text-gray-400 hover:text-blue-300{% endif %} transition-all cursor-pointer copy-to-clipboard"
         aria-label="Copy code">
         <span class="sr-only">Copy code</span>
         {% include icons/document-duplicate.svg %}

--- a/config/site/src/getting-started.md
+++ b/config/site/src/getting-started.md
@@ -69,7 +69,7 @@ This will:
 
 Run some example queries in GraphiQL to confirm it's working. Here's an example query to get you started:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.FindArtistsFormedIn90s" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.FindArtistsFormedIn90s" %}
 
 Visit the [Query API docs]({% link query-api.md %}) for other example queries that work against the example schema.
 

--- a/config/site/src/query-api/aggregations.md
+++ b/config/site/src/query-api/aggregations.md
@@ -8,7 +8,7 @@ menu_order: 3
 ElasticGraph offers a powerful aggregations API. Each indexed type gets a corresponding `*Aggregations` field.
 Here's a complete example:
 
-{% include copyable_code_snippet.html language="graphql" music_query="aggregations.BluegrassArtistAggregations" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.aggregations.BluegrassArtistAggregations" %}
 
 Aggregation fields support [filtering]({% link query-api/filtering.md %}) and [pagination]({% link query-api/pagination.md %})
 but do _not_ support client-specified [sorting]({% link query-api/sorting.md %})[^1]. Under an aggregations field, each node

--- a/config/site/src/query-api/aggregations/aggregated-values.md
+++ b/config/site/src/query-api/aggregations/aggregated-values.md
@@ -8,7 +8,7 @@ menu_order: 1
 Aggregated values can be computed from all values of a particular field from all documents backing an aggregation node.
 Here's an example:
 
-{% include copyable_code_snippet.html language="graphql" music_query="aggregations.BluegrassArtistLifetimeSales" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.aggregations.BluegrassArtistLifetimeSales" %}
 
 This example query aggregates the values of the `Artist.lifetimeSales` field using all 4 of the standard numeric
 aggregated values: `min`, `max`, `avg`, and `sum`. These are qualified with `approximate` or `exact` to indicate
@@ -30,7 +30,7 @@ the level of precision they offer. The documentation for `approximateSum` and `e
 
 Besides these standard numeric aggregated values, ElasticGraph offers one more:
 
-{% include copyable_code_snippet.html language="graphql" music_query="aggregations.SkaArtistHomeCountries" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.aggregations.SkaArtistHomeCountries" %}
 
 The `approximateDistinctValueCount` field uses the [HyperLogLog++ algorithm](https://research.google.com/pubs/archive/40671.pdf)
 to provide an approximate count of distinct values for the field. In this case, it can give us an idea of how many countries ska

--- a/config/site/src/query-api/aggregations/counts.md
+++ b/config/site/src/query-api/aggregations/counts.md
@@ -7,7 +7,7 @@ menu_order: 2
 ---
 The aggregations API allows you to count documents within a grouping:
 
-{% include copyable_code_snippet.html language="graphql" music_query="aggregations.ArtistCountsByCountry" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.aggregations.ArtistCountsByCountry" %}
 
 This query, for example, returns a grouping for each country, and provides a count of how many artists
 call each country home.

--- a/config/site/src/query-api/aggregations/grouping.md
+++ b/config/site/src/query-api/aggregations/grouping.md
@@ -7,7 +7,7 @@ menu_order: 3
 ---
 When aggregating documents, the groupings are defined by `groupedBy`. Here's an example:
 
-{% include copyable_code_snippet.html language="graphql" music_query="aggregations.ArtistCountsByYearFormedAndHomeCountry" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.aggregations.ArtistCountsByYearFormedAndHomeCountry" %}
 
 In this case, we're grouping by multiple fields; a grouping will be returned for each
 combination of `Artist.bio.yearFormed` and `Artist.bio.homeCountry` found in the data.
@@ -18,33 +18,33 @@ In the example above, the grouping was performed on the raw values of the `group
 However, for `Date` fields it's generally more useful to group by _truncated_ values.
 Here's an example:
 
-{% include copyable_code_snippet.html language="graphql" music_query="aggregations.AlbumSalesByReleaseYear" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.aggregations.AlbumSalesByReleaseYear" %}
 
 In this case, we're truncating the `Album.releaseOn` dates to the year to give us one grouping per
 year rather than one grouping per distinct date. The `truncationUnit` argument supports `DAY`, `MONTH`,
 `QUARTER`, `WEEK` and `YEAR` values. In addition, an `offset` argument is supported, which can be used
 to shift what grouping a `Date` falls into. This is particularly useful when using `WEEK`:
 
-{% include copyable_code_snippet.html language="graphql" music_query="aggregations.AlbumSalesByReleaseWeek" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.aggregations.AlbumSalesByReleaseWeek" %}
 
 With no offset, grouped weeks run Monday to Sunday, but we can shift it using `offset`. In this case, the weeks have been
 shifted to run Sunday to Saturday.
 
 Finally, we can also group `Date` fields by what day of week they fall into using `asDayOfWeek` instead of `asDate`:
 
-{% include copyable_code_snippet.html language="graphql" music_query="aggregations.AlbumSalesByReleaseDayOfWeek" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.aggregations.AlbumSalesByReleaseDayOfWeek" %}
 
 ### DateTime Grouping
 
 `DateTime` fields offer a similar grouping API. `asDate` and `asDayOfWeek` work the same, but they accept an optional `timeZone`
 argument (default is "UTC"):
 
-{% include copyable_code_snippet.html language="graphql" music_query="aggregations.TourAttendanceByYear" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.aggregations.TourAttendanceByYear" %}
 
 Sub-day granualarities (`HOUR`, `MINUTE`, `SECOND`) are supported when you use `asDateTime` instead of `asDate`:
 
-{% include copyable_code_snippet.html language="graphql" music_query="aggregations.TourAttendanceByHour" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.aggregations.TourAttendanceByHour" %}
 
 Finally, you can group by the time of day (while ignoring the date) by using `asTimeOfDay`:
 
-{% include copyable_code_snippet.html language="graphql" music_query="aggregations.TourAttendanceByHourOfDay" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.aggregations.TourAttendanceByHourOfDay" %}

--- a/config/site/src/query-api/aggregations/sub-aggregations.md
+++ b/config/site/src/query-api/aggregations/sub-aggregations.md
@@ -17,12 +17,12 @@ ElasticGraph supports aggregations on these nested fields via `subAggregations`.
 to aggregate directly on the data of one of these fields. For example, this query returns the
 total sales for all albums of all artists:
 
-{% include copyable_code_snippet.html language="graphql" music_query="aggregations.TotalAlbumSales" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.aggregations.TotalAlbumSales" %}
 
 Sub-aggregations can also be performed under the groupings of an outer aggregation. For example,
 this query returns the total album sales grouped by the home country of the artist:
 
-{% include copyable_code_snippet.html language="graphql" music_query="aggregations.TotalAlbumSalesByArtistHomeCountry" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.aggregations.TotalAlbumSalesByArtistHomeCountry" %}
 
 Sub-aggregation nodes offer the standard set of aggregation operations:
 
@@ -36,19 +36,19 @@ Sub-aggregation nodes offer the standard set of aggregation operations:
 The data included in a sub-aggregation can be filtered. For example, this query gets the total
 sales of all albums released in the 21st century:
 
-{% include copyable_code_snippet.html language="graphql" music_query="aggregations.TwentyFirstCenturyAlbumSales" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.aggregations.TwentyFirstCenturyAlbumSales" %}
 
 ### Sub-Aggregation Limitations
 
 Sub-aggregation pagination support is limited. You can use `first` to request how many
 nodes are returned, but there is no `pageInfo` and you cannot request the next page of data:
 
-{% include copyable_code_snippet.html language="graphql" music_query="aggregations.AlbumSalesByReleaseMonth" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.aggregations.AlbumSalesByReleaseMonth" %}
 
 Sub-aggregation counts are approximate. Instead of `count`, ElasticGraph offers `countDetail`
 with multiple subfields:
 
-{% include copyable_code_snippet.html language="graphql" music_query="aggregations.AlbumCount" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.aggregations.AlbumCount" %}
 
 `approximateValue`
 : The (approximate) count of documents in this aggregation bucket.

--- a/config/site/src/query-api/filtering/comparison.md
+++ b/config/site/src/query-api/filtering/comparison.md
@@ -11,4 +11,4 @@ ElasticGraph offers a standard set of comparison filter predicates:
 
 Here's an example:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.FindArtistsFormedIn90s" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.FindArtistsFormedIn90s" %}

--- a/config/site/src/query-api/filtering/conjunctions.md
+++ b/config/site/src/query-api/filtering/conjunctions.md
@@ -12,14 +12,14 @@ ElasticGraph supports two conjunction predicates:
 By default, multiple filters are ANDed together. For example, this query finds artists
 formed after the year 2000 with `BLUES` as one of their genres:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.FindModernBluesArtists" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.FindModernBluesArtists" %}
 
 ### ORing subfilters with `anyOf`
 
 To instead find artists who were formed after the year 2000 OR play `BLUES` music, you
 can pass the sub-filters as a list-of-objects to `anyOf`:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.FindModernOrBluesArtists" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.FindModernOrBluesArtists" %}
 
 `anyOf` is available at all levels of the filtering structure so that you can OR
 sub-filters anywhere you like.
@@ -31,13 +31,13 @@ come in handy when you'd otherwise have a duplicate key collision on a filter in
 case where this comes in handy is when using `anySatisfy` to [filter on a
 list]({% link query-api/filtering/list.md %}). Consider this query:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.ArtistsWithPlatinum90sAlbum" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.ArtistsWithPlatinum90sAlbum" %}
 
 This query finds artists who released an album in the 90's that sold more than million copies.
 If you wanted to broaden the query to find artists with at least one 90's album and at least one
 platinum-selling album--without requiring it to be the same album--you could do this:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.ArtistsWith90sAlbumAndPlatinumAlbum" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.ArtistsWith90sAlbumAndPlatinumAlbum" %}
 
 GraphQL input objects don't allow duplicate keys, so
 `albums: {anySatisfy: {...}, anySatisfy: {...}}` isn't supported, but `allOf`
@@ -49,7 +49,7 @@ enables this use case.
 When using `allOf` or `anyOf`, be sure to pass the sub-filters as a list. If you instead
 pass them as an object, it won't work as expected. Consider this query:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.AnyOfGotcha" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.AnyOfGotcha" %}
 
 While this query will return results, it doesn't behave as it appears. The GraphQL
 spec mandates that list inputs [coerce non-list values into a list of one

--- a/config/site/src/query-api/filtering/date-time.md
+++ b/config/site/src/query-api/filtering/date-time.md
@@ -23,7 +23,7 @@ All three support the standard set of [equality]({% link query-api/filtering/equ
 [comparison]({% link query-api/filtering/comparison.md %}) predicates. When using comparison
 predicates to cover a range, it's usually simplest to pair `gte` with `lt`:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.Find2024Shows" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.Find2024Shows" %}
 
 In addition, `DateTime` fields support one more filtering operator:
 
@@ -31,4 +31,4 @@ In addition, `DateTime` fields support one more filtering operator:
 
 For example, you could use it to find shows that started between noon and 3 pm on any date:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.FindEarlyAfternoonShows" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.FindEarlyAfternoonShows" %}

--- a/config/site/src/query-api/filtering/equality.md
+++ b/config/site/src/query-api/filtering/equality.md
@@ -11,8 +11,8 @@ The most commonly used predicate supports equality filtering:
 
 Here's a basic example:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.FindU2OrRadiohead" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.FindU2OrRadiohead" %}
 
 Unlike the SQL `IN` operator, you can find records with `null` values if you put `null` in the list:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.FindUnnamedVenues" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.FindUnnamedVenues" %}

--- a/config/site/src/query-api/filtering/full-text-search.md
+++ b/config/site/src/query-api/filtering/full-text-search.md
@@ -13,7 +13,7 @@ ElasticGraph supports two full-text search filtering predicates:
 
 `matchesQuery` is the more lenient of the two predicates. It's designed to match broadly. Here's an example:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.AccordionOrViolinSearch" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.AccordionOrViolinSearch" %}
 
 This query will match artists with bios like:
 
@@ -26,16 +26,16 @@ Notably, the description needs `accordion` OR `violin`, but not both. In additio
 mentioned "viola" since it supports fuzzy matching by default and "viola" is only 2 edits away from "violin". Arguments
 are supported to control both aspects to make matching stricter:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.AccordionAndViolinStrictSearch" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.AccordionAndViolinStrictSearch" %}
 
 ### Matches Phrase
 
 `matchesPhrase` is even stricter: it requires all terms _in the provided order_ (`matchesQuery` doesn't care about order). It's particularly useful when you want to search on a particular multi-word expression:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.PhraseSearch" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.PhraseSearch" %}
 
 ### Bypassing matchesPhrase and matchesQuery
 
 In order to make a `matchesPhrase` or `matchesQuery` filter optional, you can supply `null` to the `MatchesQueryFilterInput` parameter, like this:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.OptionalMatchingFilter" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.OptionalMatchingFilter" %}

--- a/config/site/src/query-api/filtering/geographic.md
+++ b/config/site/src/query-api/filtering/geographic.md
@@ -11,4 +11,4 @@ The `GeoLocation` type supports a special predicate:
 
 Here's an example of this predicate:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.FindAsianVenues" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.FindAsianVenues" %}

--- a/config/site/src/query-api/filtering/list.md
+++ b/config/site/src/query-api/filtering/list.md
@@ -14,7 +14,7 @@ ElasticGraph supports a couple predicates for filtering on list fields:
 When filtering on a list field, use `anySatisfy` to find records with matching list elements.
 This query, for example, will find artists that released a platinum-selling album in the 1990s:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.ArtistsWithPlatinum90sAlbum" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.ArtistsWithPlatinum90sAlbum" %}
 
 {: .alert-warning}
 **Warning**{: .alert-title}
@@ -28,4 +28,4 @@ their albums will be returned--even ones that sold poorly or were released outsi
 
 If you'd rather filter on the _size_ of a list, use `count`:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.FindProlificArtists" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.FindProlificArtists" %}

--- a/config/site/src/query-api/filtering/negation.md
+++ b/config/site/src/query-api/filtering/negation.md
@@ -11,7 +11,7 @@ ElasticGraph supports a negation predicate:
 
 One of the more common use cases is to filter to non-null values:
 
-{% include copyable_code_snippet.html language="graphql" music_query="filtering.FindArtistsWithBios" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.FindArtistsWithBios" %}
 
 `not` is available at any level of a `filter`. All of these are equivalent:
 

--- a/config/site/src/query-api/overview.md
+++ b/config/site/src/query-api/overview.md
@@ -8,7 +8,7 @@ menu_order: 1
 
 ElasticGraph provides an extremely flexible GraphQL query API. As with every GraphQL API, you request the fields you want:
 
-{% include copyable_code_snippet.html language="graphql" music_query="basic.ListArtistAlbums" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.basic.ListArtistAlbums" %}
 
 If you're just getting started with GraphQL, we recommend you review the [graphql.org
 learning materials](https://graphql.org/learn/queries/).

--- a/config/site/src/query-api/pagination.md
+++ b/config/site/src/query-api/pagination.md
@@ -9,7 +9,7 @@ To provide pagination, ElasticGraph implements the [Relay GraphQL Cursor Connect
 Specification](https://relay.dev/graphql/connections.htm). Here's an example query showing
 pagination in action:
 
-{% include copyable_code_snippet.html language="graphql" music_query="pagination.PaginationExample" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.pagination.PaginationExample" %}
 
 This example uses `first:`, `after:`, and `pageInfo { hasNextPage, endCursor }` to implement forward pagination.
 If `pageInfo.hasNextPage` indicates there is another page, the client can pass `pageInfo.endCursor` as the
@@ -23,7 +23,7 @@ In addition, ElasticGraph offers some additional features beyond the Relay spec.
 As an extension to the Relay spec, ElasticGraph offers a `totalEdgeCount` field alongside `edges` and `pageInfo`.
 It can be used to get a total count of matching records:
 
-{% include copyable_code_snippet.html language="graphql" music_query="pagination.Count21stCenturyArtists" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.pagination.Count21stCenturyArtists" %}
 
 {: .alert-note}
 **Note**{: .alert-title}
@@ -35,4 +35,4 @@ As an alternative to `edges.node`, ElasticGraph offers `nodes`. This is recommen
 a per-node `cursor` (which is available under `edges`) since it removes an extra layer of nesting, providing a simpler
 response structure:
 
-{% include copyable_code_snippet.html language="graphql" music_query="pagination.PaginationNodes" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.pagination.PaginationNodes" %}

--- a/config/site/src/query-api/sorting.md
+++ b/config/site/src/query-api/sorting.md
@@ -7,7 +7,7 @@ menu_order: 4
 ---
 Use `orderBy:` on a root query field to control how the results are sorted:
 
-{% include copyable_code_snippet.html language="graphql" music_query="sorting.ListArtists" %}
+{% include copyable_code_snippet.html language="graphql" data="music_queries.sorting.ListArtists" %}
 
 This query, for example, would sort by `name` (ascending), with `bio.yearFormed` (descending) as a tie breaker.
 When no `orderBy:` argument is provided, ElasticGraph will sort according to the

--- a/config/site/support/validate_no_empty_code_snippets.rb
+++ b/config/site/support/validate_no_empty_code_snippets.rb
@@ -1,0 +1,45 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "nokogiri"
+
+module ElasticGraph
+  class ValidateNoEmptyCodeSnippets
+    def initialize(jekyll_site_dir)
+      @jekyll_site_dir = jekyll_site_dir
+    end
+
+    def validate!
+      buttons_by_file =
+        Dir.glob(File.join(@jekyll_site_dir, "**", "*.html")).to_h do |file|
+          content = File.read(file)
+          doc = Nokogiri::HTML(content)
+          [file, doc.css("button.copy-to-clipboard")]
+        end
+
+      if buttons_by_file.values.flatten.empty?
+        raise "No `button.copy-to-clipboard` elements found."
+      end
+
+      files_with_empty_snippets = buttons_by_file.filter_map do |file, buttons|
+        file unless buttons.all? do |button|
+          copied_code = button["onclick"][/\AcopyToClipboard\(this, (.+)\)\z/, 1]
+          /\A".+"\z/.match?(copied_code)
+        end
+      end
+
+      unless files_with_empty_snippets.empty?
+        abort <<~EOS
+          #{files_with_empty_snippets.size} HTML files have empty code snippets. Perhaps their `data=path.to.snippet` arguments in their markdown `copyable_code_snippet` includes are invalid?
+
+          #{files_with_empty_snippets.map.with_index(1) { |f, i| "  #{i}. #{f}" }.join("\n")}
+        EOS
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously, it only worked with `site.data.music_queries`. In addition, this adds validation. When the `data=` path fails to resolve to a valid string, the code snippet renders as `null`. The new validation will catch this issue when it occurs.