### PR TITLE
Move API docs from `/docs` to `/api-docs`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,7 @@ config/site/doc/
 
 # Ignore Jekyll generated site artifacts
 config/site/_site
-config/site/src/docs
+config/site/src/api-docs
 config/site/src/_data/*_queries.yaml
 config/site/src/_data/content.yaml
 config/site/.jekyll-metadata

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,7 +176,7 @@ Then visit http://localhost:4000/elasticgraph/ in your browser. Local edits to t
 ### API Documentation
 
 ElasticGraph's Ruby code is documented using [YARD](https://yardoc.org/). You can view the rendered API docs in the context of the
-project website using the same `site:serve` rake task (just visit http://localhost:4000/elasticgraph/docs/main/). However, that task
+project website using the same `site:serve` rake task (just visit http://localhost:4000/elasticgraph/api-docs/main/). However, that task
 fully regenerates the documentation from scratch and it's not very quick. If you're working on multiple changes to the API documentation,
 you'll get a faster feedback loop using the `site:preview_docs:[gem name]` tasks. For example, to preview the docs of
 [elasticgraph-schema_definition](elasticgraph-schema_definition), run:

--- a/config/site/Rakefile
+++ b/config/site/Rakefile
@@ -17,11 +17,11 @@ module ElasticGraph
     SITE_CONFIG_DIR = ::Pathname.new(__dir__)
     REPO_ROOT = SITE_CONFIG_DIR.parent.parent
     SITE_SOURCE_DIR = SITE_CONFIG_DIR / "src"
-    DOCS_DIR = SITE_SOURCE_DIR / "docs"
-    ARCHIVED_DOCS_DIR = SITE_CONFIG_DIR / "archived_docs"
-    YARD_OUTPUT_DIR = DOCS_DIR / "main"
+    API_DOCS_DIR = SITE_SOURCE_DIR / "api-docs"
+    ARCHIVED_API_DOCS_DIR = SITE_CONFIG_DIR / "archived_docs"
+    YARD_OUTPUT_DIR = API_DOCS_DIR / "main"
     JEKYLL_SITE_DIR = SITE_CONFIG_DIR / "_site"
-    JEKYLL_DOCS_DIR = JEKYLL_SITE_DIR / "docs"
+    JEKYLL_API_DOCS_DIR = JEKYLL_SITE_DIR / "api-docs"
     JEKYLL_DATA_DIR = SITE_SOURCE_DIR / "_data"
     EXAMPLE_SCHEMA_FILES_BY_NAME = SITE_CONFIG_DIR.glob("examples/*/schema.rb").to_h do |file|
       [file.parent.basename.to_s, file]
@@ -140,7 +140,7 @@ module ElasticGraph
 
           extractor = ContentExtractor.new(
             jekyll_site_dir: JEKYLL_SITE_DIR,
-            docs_dir: DOCS_DIR
+            api_docs_dir: API_DOCS_DIR
           )
 
           content = extractor.extract_content
@@ -160,9 +160,9 @@ module ElasticGraph
           abort "Version argument is required (e.g., rake site:archive_docs[1.0.0])" unless args[:version]
 
           archive_name = "v#{args[:version]}.tar.gz"
-          archive_path = ARCHIVED_DOCS_DIR / archive_name
+          archive_path = ARCHIVED_API_DOCS_DIR / archive_name
 
-          FileUtils.mkdir_p(ARCHIVED_DOCS_DIR)
+          FileUtils.mkdir_p(ARCHIVED_API_DOCS_DIR)
 
           Dir.chdir(YARD_OUTPUT_DIR) do
             # --no-xattrs is necessary to ensure that apple-specific attributes are excluded from the archive.
@@ -174,14 +174,14 @@ module ElasticGraph
           puts "Documentation archive created at: #{archive_path}"
         end
 
-        desc "Unpack all documentation archives into src/docs"
+        desc "Unpack all documentation archives into src/api-docs"
         task :unpack_doc_archives do
           # Clean the docs directory
-          FileUtils.rm_rf(DOCS_DIR)
+          FileUtils.rm_rf(API_DOCS_DIR)
 
-          Dir.glob(ARCHIVED_DOCS_DIR / "*.tar.gz").sort.each do |archive|
+          Dir.glob(ARCHIVED_API_DOCS_DIR / "*.tar.gz").sort.each do |archive|
             version_name = File.basename(archive, ".tar.gz")
-            target_dir = DOCS_DIR / version_name
+            target_dir = API_DOCS_DIR / version_name
 
             # Remove existing directory if it exists
             FileUtils.rm_rf(target_dir)
@@ -268,7 +268,7 @@ module ElasticGraph
           run_html_proofer.call(
             JEKYLL_SITE_DIR,
             # We are not in control of the generated YARD docs, and need to check them with more relaxed settings.
-            ignore_files: [/#{JEKYLL_DOCS_DIR}/o],
+            ignore_files: [%r{#{JEKYLL_API_DOCS_DIR}/.+/}o],
             # Needed so our internal URLs are resolved correctly.
             swap_urls: {%r{^/elasticgraph/} => "/"},
             # Our "Getting Started" page links to the locally booted ElasticGraph, which HTMLProofer can't resolve.
@@ -279,8 +279,8 @@ module ElasticGraph
           # We treat the YARD docs for previously released versions as being immutable, and have no plans to fix issues
           # like broken external links, etc.
           run_html_proofer.call(
-            JEKYLL_DOCS_DIR,
-            ignore_files: [/#{JEKYLL_DOCS_DIR / "main"}/o],
+            JEKYLL_API_DOCS_DIR,
+            ignore_files: [/#{JEKYLL_API_DOCS_DIR / "main"}/o, "#{JEKYLL_API_DOCS_DIR}/index.html"],
             ignore_urls: ["elasticgraph-rack/lib/elastic_graph/rack/graphiql/index.html"],
             check_external_hash: false,
             ignore_missing_alt: true,
@@ -290,7 +290,7 @@ module ElasticGraph
 
           # We use stricter settings for the newly generated YARD docs, since we can actually fix these.
           run_html_proofer.call(
-            JEKYLL_DOCS_DIR / "main",
+            JEKYLL_API_DOCS_DIR / "main",
             # YARD generates a bunch of anchor tags with no hrefs, which we can't do anything about.
             allow_missing_href: true
           )
@@ -311,7 +311,7 @@ module ElasticGraph
           pages = Dir.glob("#{src_dir}/**/*").reject do |file|
             # Skip directories, files in directories that don't contain pages, binary files, and specific file types
             File.directory?(file) ||
-              %w[/_data/ /docs/ /_includes/ /_layouts/ /_plugins/ /_config.yaml dc.yml /examples/ /assets/].any? { |dir| file.include?(dir) } ||
+              %w[/_data/ /api-docs/ /_includes/ /_layouts/ /_plugins/ /_config.yaml dc.yml /examples/ /assets/].any? { |dir| file.include?(dir) } ||
               %w[.js .css .png .jpg .jpeg .gif .ico .svg .woff .woff2 .ttf .eot .webmanifest .yaml .graphql].include?(File.extname(file).downcase)
           end
 

--- a/config/site/src/_includes/api_docs_nav.html
+++ b/config/site/src/_includes/api_docs_nav.html
@@ -10,7 +10,7 @@
       <div class="{{site.style.dropdown_pip}}"></div>
       <div class="relative py-1">
         {% for version in site.data.doc_versions.versions %}
-          <a href="{{ '/docs/' | append: version | relative_url }}"
+          <a href="{{ '/api-docs/' | append: version | relative_url }}"
               class="{{site.style.dropdown_item}}">
             {% if version == 'main' %}
               Development (main)

--- a/config/site/src/_plugins/doc_versions.rb
+++ b/config/site/src/_plugins/doc_versions.rb
@@ -9,11 +9,11 @@
 module Jekyll
   class DocVersions < Generator
     def generate(site)
-      # Get all subdirectories in src/docs
-      docs_dir = File.join(site.source, "docs")
-      versions = if Dir.exist?(docs_dir)
-        Dir.entries(docs_dir)
-          .select { |f| File.directory?(File.join(docs_dir, f)) && f !~ /^\./ }
+      # Get all subdirectories in src/api-docs
+      api_docs_dir = File.join(site.source, "api-docs")
+      versions = if Dir.exist?(api_docs_dir)
+        Dir.entries(api_docs_dir)
+          .select { |f| File.directory?(File.join(api_docs_dir, f)) && f !~ /^\./ }
           .sort_by { |v| (v == "main") ? "0" : Gem::Version.new(v.delete_prefix("v")) }
           .reverse
       else

--- a/config/site/src/api-docs.md
+++ b/config/site/src/api-docs.md
@@ -7,5 +7,5 @@ permalink: /api-docs/
 ## Available Versions
 
 {% for version in site.data.doc_versions.versions %}
-- {% if version == 'main' %}[Development (main)]{% else %}[Version {{ version }}]{% endif %}({{ '/docs/' | append: version | relative_url }}){% if version == site.data.doc_versions.latest_version %} (Latest){% endif %}
+- {% if version == 'main' %}[Development (main)]{% else %}[Version {{ version }}]{% endif %}({{ '/api-docs/' | append: version | relative_url }}){% if version == site.data.doc_versions.latest_version %} (Latest){% endif %}
 {% endfor %}

--- a/config/site/src/getting-started.md
+++ b/config/site/src/getting-started.md
@@ -131,7 +131,7 @@ Delete the `artist` schema definition:
 
 Then define your own schema in a Ruby file under `config/schema`.
 
-* Use the [schema definition API docs](/elasticgraph/docs/{{ site.data.doc_versions.latest_version }}/ElasticGraph/SchemaDefinition/API.html) as a reference.
+* Use the [schema definition API docs](/elasticgraph/api-docs/{{ site.data.doc_versions.latest_version }}/ElasticGraph/SchemaDefinition/API.html) as a reference.
 * Use our [AI Tools]({% link guides/ai-tools.md %}) together with an LLM such as [Goose](https://block.github.io/goose/) to translate a schema from an existing format such as protocol buffers, JSON schema, or SQL.
 * Run `bundle exec rake build` and deal with any errors that are reported.
 * Hint: search the project codebase for `TODO` comments to find things that need updating.

--- a/config/site/src/query-api/sorting.md
+++ b/config/site/src/query-api/sorting.md
@@ -11,4 +11,4 @@ Use `orderBy:` on a root query field to control how the results are sorted:
 
 This query, for example, would sort by `name` (ascending), with `bio.yearFormed` (descending) as a tie breaker.
 When no `orderBy:` argument is provided, ElasticGraph will sort according to the
-[default sort configured on the index]({{ '/docs/' | append: site.data.doc_versions.latest_version | append: '/ElasticGraph/SchemaDefinition/Indexing/Index.html#default_sort-instance_method' | relative_url }}).
+[default sort configured on the index]({{ '/api-docs/' | append: site.data.doc_versions.latest_version | append: '/ElasticGraph/SchemaDefinition/Indexing/Index.html#default_sort-instance_method' | relative_url }}).

--- a/config/site/support/content_extractor.rb
+++ b/config/site/support/content_extractor.rb
@@ -10,20 +10,20 @@ require "nokogiri"
 
 module ElasticGraph
   class ContentExtractor
-    def initialize(jekyll_site_dir:, docs_dir:)
+    def initialize(jekyll_site_dir:, api_docs_dir:)
       @jekyll_site_dir = jekyll_site_dir
-      @docs_dir = docs_dir
+      @api_docs_dir = api_docs_dir
     end
 
     def extract_content
       # Get the latest docs version
-      latest_docs_version = Dir.entries(@docs_dir).grep(/^v/)
+      latest_docs_version = Dir.entries(@api_docs_dir).grep(/^v/)
         .max_by { |v| Gem::Version.new(v.delete_prefix("v")) }
 
       puts "Indexing API docs from latest version: #{latest_docs_version}"
 
       # Extract docs content - without code blocks for search
-      api_docs_content = process_docs_directory(@docs_dir / latest_docs_version, latest_docs_version)
+      api_docs_content = process_docs_directory(@api_docs_dir / latest_docs_version, latest_docs_version)
       markdown_content = process_markdown_pages
 
       # Build the searchable content
@@ -127,9 +127,9 @@ module ElasticGraph
         title, content = extract_file_content(file)
         next if content.empty?
 
-        # Generate URL with /docs/version/ prefix
+        # Generate URL with /api-docs/version/ prefix
         relative_path = file.sub(dir.to_s, "")
-        url = "/docs/#{version}#{relative_path}"
+        url = "/api-docs/#{version}#{relative_path}"
 
         {
           "title" => "API Documentation - #{title}",
@@ -146,7 +146,7 @@ module ElasticGraph
         # Skip files we don't want to index
         next if file.include?("/css/") || file.include?("/js/")
         next if %w[frames.html file_list.html class_list.html method_list.html].include?(File.basename(file))
-        next if file.include?("/docs/") # Skip API docs, we handle those separately
+        next if file.include?("/api-docs/") # Skip API docs, we handle those separately
 
         # Get the rendered content
         content = File.read(file)

--- a/elasticgraph-admin/elasticgraph-admin.gemspec
+++ b/elasticgraph-admin/elasticgraph-admin.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "core" # used by script/update_codebase_overview

--- a/elasticgraph-admin_lambda/elasticgraph-admin_lambda.gemspec
+++ b/elasticgraph-admin_lambda/elasticgraph-admin_lambda.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "lambda" # used by script/update_codebase_overview

--- a/elasticgraph-apollo/elasticgraph-apollo.gemspec
+++ b/elasticgraph-apollo/elasticgraph-apollo.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "extension" # used by script/update_codebase_overview

--- a/elasticgraph-datastore_core/elasticgraph-datastore_core.gemspec
+++ b/elasticgraph-datastore_core/elasticgraph-datastore_core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "core" # used by script/update_codebase_overview

--- a/elasticgraph-elasticsearch/elasticgraph-elasticsearch.gemspec
+++ b/elasticgraph-elasticsearch/elasticgraph-elasticsearch.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "datastore_adapter" # used by script/update_codebase_overview

--- a/elasticgraph-graphql/elasticgraph-graphql.gemspec
+++ b/elasticgraph-graphql/elasticgraph-graphql.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "core" # used by script/update_codebase_overview

--- a/elasticgraph-graphql_lambda/elasticgraph-graphql_lambda.gemspec
+++ b/elasticgraph-graphql_lambda/elasticgraph-graphql_lambda.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "lambda" # used by script/update_codebase_overview

--- a/elasticgraph-health_check/elasticgraph-health_check.gemspec
+++ b/elasticgraph-health_check/elasticgraph-health_check.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "extension" # used by script/update_codebase_overview

--- a/elasticgraph-indexer/elasticgraph-indexer.gemspec
+++ b/elasticgraph-indexer/elasticgraph-indexer.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "core" # used by script/update_codebase_overview

--- a/elasticgraph-indexer_autoscaler_lambda/elasticgraph-indexer_autoscaler_lambda.gemspec
+++ b/elasticgraph-indexer_autoscaler_lambda/elasticgraph-indexer_autoscaler_lambda.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "lambda" # used by script/update_codebase_overview

--- a/elasticgraph-indexer_lambda/elasticgraph-indexer_lambda.gemspec
+++ b/elasticgraph-indexer_lambda/elasticgraph-indexer_lambda.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "lambda" # used by script/update_codebase_overview

--- a/elasticgraph-json_schema/elasticgraph-json_schema.gemspec
+++ b/elasticgraph-json_schema/elasticgraph-json_schema.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "core" # used by script/update_codebase_overview

--- a/elasticgraph-lambda_support/elasticgraph-lambda_support.gemspec
+++ b/elasticgraph-lambda_support/elasticgraph-lambda_support.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "lambda" # used by script/update_codebase_overview

--- a/elasticgraph-local/elasticgraph-local.gemspec
+++ b/elasticgraph-local/elasticgraph-local.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "local" # used by script/update_codebase_overview

--- a/elasticgraph-opensearch/elasticgraph-opensearch.gemspec
+++ b/elasticgraph-opensearch/elasticgraph-opensearch.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "datastore_adapter" # used by script/update_codebase_overview

--- a/elasticgraph-query_interceptor/elasticgraph-query_interceptor.gemspec
+++ b/elasticgraph-query_interceptor/elasticgraph-query_interceptor.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "extension" # used by script/update_codebase_overview

--- a/elasticgraph-query_registry/elasticgraph-query_registry.gemspec
+++ b/elasticgraph-query_registry/elasticgraph-query_registry.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "extension" # used by script/update_codebase_overview

--- a/elasticgraph-rack/elasticgraph-rack.gemspec
+++ b/elasticgraph-rack/elasticgraph-rack.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "local" # used by script/update_codebase_overview

--- a/elasticgraph-schema_artifacts/elasticgraph-schema_artifacts.gemspec
+++ b/elasticgraph-schema_artifacts/elasticgraph-schema_artifacts.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "core" # used by script/update_codebase_overview

--- a/elasticgraph-schema_definition/elasticgraph-schema_definition.gemspec
+++ b/elasticgraph-schema_definition/elasticgraph-schema_definition.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "local" # used by script/update_codebase_overview

--- a/elasticgraph-support/elasticgraph-support.gemspec
+++ b/elasticgraph-support/elasticgraph-support.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "core" # used by script/update_codebase_overview

--- a/elasticgraph/elasticgraph.gemspec
+++ b/elasticgraph/elasticgraph.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
     "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
-    "documentation_uri" => "https://block.github.io/elasticgraph/docs/v#{ElasticGraph::VERSION}/",
+    "documentation_uri" => "https://block.github.io/elasticgraph/api-docs/v#{ElasticGraph::VERSION}/",
     "homepage_uri" => "https://block.github.io/elasticgraph/",
     "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
     "gem_category" => "core" # used by script/update_codebase_overview


### PR DESCRIPTION
Our site features documentation beyond the YARD API docs, and it's clearer to use `/api-docs` as the path for the API docs. It also aligns with the way we label it at the website.

Note: ideally, we'd redirect from the `/docs` URLs to the new `/api-docs` URLs, but there's not an easy way to do that with Jekyll, and if we're going to break some links, now is the time to do it.