### PR TITLE
Apply `rel=noopener` and `target=_blank` to appropriate links.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ config/site/doc/
 # Ignore Jekyll generated site artifacts
 config/site/_site
 config/site/src/api-docs
+config/site/src/config/site
 config/site/src/_data/*_queries.yaml
 config/site/src/_data/content.yaml
 config/site/.jekyll-metadata

--- a/config/site/src/_includes/footer.html
+++ b/config/site/src/_includes/footer.html
@@ -19,7 +19,7 @@
         </p>
         <p class="text-gray-700 dark:text-gray-300">
           Join our community and contribute on
-          <a href="{{ site.github_url }}" class="{{ site.style.link }} inline-flex items-center gap-1.25" rel="noopener">
+          <a href="{{ site.github_url }}" class="{{ site.style.link }} inline-flex items-center gap-1.25">
             GitHub
             <span class="w-4 h-4">
               {% include icons/github.svg %}
@@ -44,7 +44,7 @@
         <h4 class="text-lg font-semibold mb-4">Community</h4>
         <ul class="space-y-3" role="list">
           <li>
-            <a href="{{ site.github_url }}" class="{{ site.style.link }} inline-flex items-center gap-1.25" rel="noopener">
+            <a href="{{ site.github_url }}" class="{{ site.style.link }} inline-flex items-center gap-1.25">
               <span class="w-4 h-4">
                 {% include icons/github.svg %}
               </span>
@@ -52,13 +52,13 @@
             </a>
           </li>
           <li>
-            <a href="{{ site.discord_url }}" class="{{ site.style.link }} inline-flex items-center gap-1.25" rel="noopener">
+            <a href="{{ site.discord_url }}" class="{{ site.style.link }} inline-flex items-center gap-1.25">
               {% include icons/discord.svg %}
               <span>Discord</span>
             </a>
           </li>
           <li>
-            <a href="{{ site.github_url }}/discussions" class="{{ site.style.link }} inline-flex items-center gap-1.25" rel="noopener">
+            <a href="{{ site.github_url }}/discussions" class="{{ site.style.link }} inline-flex items-center gap-1.25">
               {% include icons/discussions.svg %}
               <span>Discussions</span>
             </a>
@@ -79,8 +79,7 @@
         <div class="flex items-center gap-4">
           {% if page.path %}
           <a href="{{ site.github_url }}/edit/main/config/site/src/{{ page.path }}"
-             class="{{ site.style.link }} inline-flex items-center gap-1.25"
-             rel="noopener">
+             class="{{ site.style.link }} inline-flex items-center gap-1.25">
             <span class="w-4 h-4">
               {% include icons/github.svg %}
             </span> 

--- a/config/site/src/_includes/navbar.html
+++ b/config/site/src/_includes/navbar.html
@@ -44,7 +44,7 @@
               {% include icons/moon.svg %}
             </span>
           </button>
-          <a href="{{ site.github_url }}" target="_blank" class="p-2 w-9 h-9 {{ site.style.navbar_link }} inline-flex items-center justify-center hover:bg-gray-300/50 dark:hover:bg-gray-700/50 rounded-md" rel="noopener">
+          <a href="{{ site.github_url }}" class="p-2 w-9 h-9 {{ site.style.navbar_link }} inline-flex items-center justify-center hover:bg-gray-300/50 dark:hover:bg-gray-700/50 rounded-md">
             {% include icons/github.svg %}
           </a>
           <a href="{% link about.md %}" class="text-base {{ site.style.navbar_link }}">About</a>
@@ -69,7 +69,7 @@
           </span>
           <span>Toggle Theme</span>
         </button>
-        <a href="{{ site.github_url }}" target="_blank" class="text-base {{ site.style.navbar_link }} inline-flex items-center space-x-2" rel="noopener">
+        <a href="{{ site.github_url }}" class="text-base {{ site.style.navbar_link }} inline-flex items-center space-x-2">
           <div class="w-5 h-5">
             {% include icons/github.svg %}
           </div>

--- a/config/site/src/_includes/testimonials.html
+++ b/config/site/src/_includes/testimonials.html
@@ -99,7 +99,7 @@
               <p class="text-gray-600 dark:text-gray-400 text-lg leading-relaxed mb-6">
                 Using ElasticGraph and loving it? We'd love to hear about your experience!
               </p>
-              <a href="{{ site.discord_url }}" target="_blank" rel="noopener"
+              <a href="{{ site.discord_url }}"
                  class="inline-flex items-center px-6 py-3 rounded-full text-white bg-gradient-to-r from-blue-500 to-cyan-500 hover:from-blue-600 hover:to-cyan-600 dark:from-blue-500 dark:to-cyan-500 dark:hover:from-blue-600 dark:hover:to-cyan-600 transition-all duration-200 shadow-md hover:shadow-lg">
                 <span>Share Feedback</span>
                 <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/config/site/src/_plugins/external_links.rb
+++ b/config/site/src/_plugins/external_links.rb
@@ -1,0 +1,40 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "nokogiri"
+
+module Jekyll
+  # Hook into the post_render event to modify links in the final HTML
+  Jekyll::Hooks.register :pages, :post_render do |page|
+    next unless page.output_ext == ".html"
+
+    doc = Nokogiri::HTML(page.output)
+    site_url = page.site.config.fetch("baseurl")
+
+    # Find all links
+    doc.css("a").each do |link|
+      href = link["href"]
+      next unless href
+
+      links_to_external_page = href.start_with?("http://", "https://") && !href.start_with?(site_url)
+      links_to_api_docs_without_nav = href.match?(%r{/api-docs/.+})
+      links_to_non_html_page = (href[/\.([^.]+)\z/, 1] || "html") != "html"
+
+      # Add `target=_blank rel=nokogiri` to any link that goes to a page that lacks our site nav, including:
+      # - All external links.
+      # - Pages under `/api-docs/` (except for `/api-docs/` itself) as the YARD-generated pages don't have the site nav.
+      # - Non-html resources.
+      if links_to_external_page || links_to_api_docs_without_nav || links_to_non_html_page
+        link["target"] = "_blank"
+        link["rel"] = "noopener"
+      end
+    end
+
+    page.output = doc.to_html
+  end
+end


### PR DESCRIPTION
Previously, we applied them haphazardly. Now we use a plugin to apply it consistently, to every single link that takes you to a page without the site nav. This includes:

- Links to external sites (like GitHub or Discord).
- Links to the YARD-generated API docs (which lacks the site nav).
- Links to non-HTML resources such as `llms-full.txt`.