### PR TITLE
NestedRelationshipsSource: avoid comparisons when optimized can't apply.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships_source.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships_source.rb
@@ -72,6 +72,8 @@ module ElasticGraph
         end
 
         def fetch(id_sets)
+          return fetch_original(id_sets) unless can_merge_filters?
+
           case @mode
           when :original
             fetch_original(id_sets)
@@ -89,8 +91,6 @@ module ElasticGraph
         private
 
         def fetch_optimized(id_sets)
-          return fetch_via_separate_queries(id_sets) unless can_merge_filters?
-
           attempt_count = 0
           duration_ms, responses_by_id_set = time_duration do
             fetch_via_single_query_with_merged_filters(id_sets) { attempt_count += 1 }


### PR DESCRIPTION
Specifically, when a query needs the total document count or has aggregation queries, we aren't able to merge queries and the optimized logic can't apply. Previously, if the `nested_relationship_resolver_mode` was set to `comparison`, we would perform a comparison no matter what, even if there was nothing to compare. This resulted in confusing log output and wasted time.