### PR TITLE
Only update gem artifacts when `Gemfile.lock` changes.

### DIFF
--- a/.github/workflows/dependabot-gem-pr.yaml
+++ b/.github/workflows/dependabot-gem-pr.yaml
@@ -1,9 +1,11 @@
 # This workflow doesn't have access to secrets and has a read-only token
 # It exists to trigger `update-gem-version-artifacts.yaml` in a two-step process,
 # as recommended by https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544
-name: Dependabot PR Check
+name: Dependabot Gem PR Check
 on:
   pull_request
+    paths:
+      - "Gemfile.lock"
 
 jobs:
   check-dependabot:

--- a/.github/workflows/update-gem-version-artifacts.yaml
+++ b/.github/workflows/update-gem-version-artifacts.yaml
@@ -2,7 +2,7 @@ name: Update Gem Version Artifacts
 
 on:
   workflow_run:
-    workflows: ["Dependabot PR Check"]
+    workflows: ["Dependabot Gem PR Check"]
     types:
       - completed
 


### PR DESCRIPTION
Previously, it got run on any dependabot PR, even if it was updating a python package, an NPM package, or a GitHub action.