### PR TITLE
Update project template: use standard datastore port (9200).

### DIFF
--- a/config/docker_demo/Dockerfile
+++ b/config/docker_demo/Dockerfile
@@ -59,7 +59,7 @@ RUN <<EOS
   ELASTICGRAPH_GEMS_PATH=/app bundle exec elasticgraph new demo --datastore opensearch
 
   # Configure OpenSearch connection
-  sed -i 's/localhost:9293/opensearch:9200/g' demo/config/settings/local.yaml
+  sed -i 's/localhost/opensearch/g' demo/config/settings/local.yaml
 
   # Clean up unnecessary files
   rm -rf .git

--- a/elasticgraph/lib/elastic_graph/project_template/README.md.tt
+++ b/elasticgraph/lib/elastic_graph/project_template/README.md.tt
@@ -64,7 +64,7 @@ bundle exec rake boot_locally
 open http://localhost:9000/
 
 # You can also visit <%= ElasticGraph.setup_env.datastore_ui_name %> via:
-open http://localhost:19293/
+open http://localhost:19200/
 ```
 
 ### Run Build Tasks
@@ -119,7 +119,7 @@ You can pass an arg (note quotes) to seed more batches of data:
 ### Using <%= ElasticGraph.setup_env.datastore_ui_name %>
 
 After running `bundle exec rake boot_locally` and opening <%= ElasticGraph.setup_env.datastore_ui_name %>
-`open http://localhost:19293/` click "Dev Tools" to open the <%= ElasticGraph.setup_env.datastore_name %> console.
+`open http://localhost:19200/` click "Dev Tools" to open the <%= ElasticGraph.setup_env.datastore_name %> console.
 
 Here are some queries to get you started:
 

--- a/elasticgraph/lib/elastic_graph/project_template/config/settings/local.yaml.tt
+++ b/elasticgraph/lib/elastic_graph/project_template/config/settings/local.yaml.tt
@@ -5,7 +5,7 @@ datastore:
   clusters:
     main:
       backend: <%= ElasticGraph.setup_env.datastore %>
-      url: http://localhost:9293
+      url: http://localhost:9200
       settings: {}
   index_definitions:
     # TODO: replace the `artists:` and `venues:` keys with the indices from your dataset


### PR DESCRIPTION
9200 is the standard port used by OpenSearch/Elasticsearch. We've been using 9293 (for no reason, really), but it's harder to remember, and requires a work around in our `Dockerfile`.

Instead, we can use the standard port.