### PR TITLE
Return a clear error when indices have not been configured.

### DIFF
--- a/elasticgraph-graphql/spec/acceptance/aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/aggregations_spec.rb
@@ -20,7 +20,7 @@ module ElasticGraph
       let(:grouped_by) { case_correctly("grouped_by") }
       let(:approximate_distinct_value_count) { case_correctly("approximate_distinct_value_count") }
 
-      it "returns empty aggregation results when querying a rollover index that does not yet have any concrete index (e.g. before the first document is indexed)" do
+      it "returns empty aggregation results when the indices have not been configured or no documents have been indexed" do
         allow(GraphQL::DatastoreQuery).to receive(:perform).and_wrap_original do |original, queries, &block|
           queries.each do |query|
             original_to_datastore_msearch_header = query.to_datastore_msearch_header
@@ -38,25 +38,9 @@ module ElasticGraph
         end
 
         # Test grouped_by
-        aggregations = group_widgets_by_tag
-        expect(aggregations).to eq [{
-          grouped_by => {"tag" => nil},
-          "count" => 0,
-          aggregated_values => {
-            "#{amount_cents}1" => {"sum" => 0},
-            "#{amount_cents}2" => {"sum" => 0}
-          }
-        }]
-
+        expect_indices_not_configured_error { group_widgets_by_tag(allow_errors: true) }
         # Test aggregated_values
-        aggregations = list_widgets_with_aggregations(all_amount_aggregations)
-        expect(aggregations).to contain_exactly({
-          aggregated_values => {
-            amount_cents => expected_aggregated_amounts_of([]),
-            "cost" => {amount_cents => expected_aggregated_amounts_of([])}
-          },
-          "count" => 0
-        })
+        expect_indices_not_configured_error { list_widgets_with_aggregations(all_amount_aggregations, allow_errors: true) }
       end
 
       it "returns aggregates (terms, date histogram) and nested aggregates" do
@@ -2369,8 +2353,8 @@ module ElasticGraph
       OPTS
     end
 
-    def group_widgets_by_tag
-      call_graphql_query(<<~QUERY).dig("data", case_correctly("widget_aggregations"), "nodes")
+    def group_widgets_by_tag(allow_errors: false)
+      response = call_graphql_query(<<~QUERY, allow_errors: allow_errors)
         query {
           widget_aggregations {
             nodes {
@@ -2384,6 +2368,10 @@ module ElasticGraph
           }
         }
       QUERY
+
+      return response if allow_errors
+
+      response.dig("data", case_correctly("widget_aggregations"), "nodes")
     end
 
     def widget_ungrouped_aggregated_values_for(field_selections)
@@ -2437,8 +2425,8 @@ module ElasticGraph
       QUERY
     end
 
-    def list_widgets_with_aggregations(widget_aggregation, **query_args)
-      call_graphql_query(<<~QUERY).dig("data", case_correctly("widget_aggregations"), "edges").map { |edge| edge["node"] }
+    def list_widgets_with_aggregations(widget_aggregation, allow_errors: false, **query_args)
+      response = call_graphql_query(<<~QUERY, allow_errors: allow_errors)
         query {
           widgets#{graphql_args(query_args)} {
             edges {
@@ -2485,6 +2473,10 @@ module ElasticGraph
           }
         }
       QUERY
+
+      return response if allow_errors
+
+      response.dig("data", case_correctly("widget_aggregations"), "edges").map { |edge| edge["node"] }
     end
 
     def group_components_by_position_x_and_y

--- a/elasticgraph-graphql/spec/acceptance/elasticgraph_graphql_acceptance_support.rb
+++ b/elasticgraph-graphql/spec/acceptance/elasticgraph_graphql_acceptance_support.rb
@@ -6,6 +6,7 @@
 #
 # frozen_string_literal: true
 
+require "elastic_graph/graphql/datastore_search_router"
 require "elastic_graph/schema_definition/schema_elements/type_namer"
 require "elastic_graph/spec_support/builds_admin"
 require "graphql"
@@ -43,6 +44,13 @@ module ElasticGraph
       # matcher in some tests which tries to assert which specific requests get made, since index definitions
       # have caching behavior that can make the presence or absence of that request slightly non-deterministic.
       pre_cache_index_state(graphql)
+    end
+
+    def expect_indices_not_configured_error
+      expect {
+        response = yield
+        expect(response.dig("errors").first).to include({"message" => GraphQL::DatastoreSearchRouter::INDICES_NOT_CONFIGURED_MESSAGE})
+      }.to log_warning(a_string_including(GraphQL::DatastoreSearchRouter::INDICES_NOT_CONFIGURED_MESSAGE))
     end
 
     def self.with_both_casing_forms(&block)

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/misc_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/misc_spec.rb
@@ -8,6 +8,7 @@
 
 require_relative "datastore_query_integration_support"
 require "elastic_graph/errors"
+require "elastic_graph/graphql/datastore_search_router"
 
 module ElasticGraph
   class GraphQL
@@ -117,7 +118,7 @@ module ElasticGraph
         end
       end
 
-      context "on a rollover index when no concrete indices yet exist (e.g. before indexing the first document)" do
+      context "when indices have not yet been configured", :builds_admin do
         let(:graphql) do
           build_graphql(schema_definition: lambda do |schema|
             schema.object_type "Widget" do |t|
@@ -130,7 +131,7 @@ module ElasticGraph
           end)
         end
 
-        it "returns an empty result" do
+        it "raises a `GraphQL::ExecutionError` indicating they need to be configured" do
           widgets_def = graphql.datastore_core.index_definitions_by_name.fetch(unique_index_name)
 
           query = graphql.datastore_query_builder.new_query(
@@ -141,8 +142,13 @@ module ElasticGraph
           index_names = main_datastore_client.list_indices_matching("*")
           expect(index_names).not_to include(a_string_including(unique_index_name))
 
-          results = perform_query(graphql, query)
+          expect { perform_query(graphql, query) }.to raise_error ::GraphQL::ExecutionError, DatastoreSearchRouter::INDICES_NOT_CONFIGURED_MESSAGE
 
+          admin = build_admin(datastore_core: graphql.datastore_core)
+          admin.cluster_configurator.configure_cluster(StringIO.new)
+
+          # ...but after configuring them, the error goes away (even though no documents have been indexed!)
+          results = perform_query(graphql, query)
           expect(results.to_a).to eq []
         end
       end


### PR DESCRIPTION
Previously, we'd silently return no results (which was ok) in most cases, but would return a 500 internal server error when executing a sub-aggregations query with aggregated values. We don't get back the sort of response the sub aggregations logic expects when there are no indices.

Now we return a clear error indicating the indices should be configured.