### PR TITLE
Avoid logging `NestedRelationshipsMergedQueries` when no merging occurred.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships_source.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships_source.rb
@@ -96,15 +96,17 @@ module ElasticGraph
             fetch_via_single_query_with_merged_filters(id_sets) { attempt_count += 1 }
           end
 
-          @logger.info({
-            "message_type" => "NestedRelationshipsMergedQueries",
-            "field" => @join.field.description,
-            "optimized_attempt_count" => [attempt_count, MAX_OPTIMIZED_ATTEMPTS].min,
-            "degraded_to_separate_queries" => (attempt_count > MAX_OPTIMIZED_ATTEMPTS),
-            "id_set_count" => id_sets.size,
-            "total_id_count" => id_sets.reduce(:union).size,
-            "duration_ms" => duration_ms
-          })
+          if id_sets.size > 1
+            @logger.info({
+              "message_type" => "NestedRelationshipsMergedQueries",
+              "field" => @join.field.description,
+              "optimized_attempt_count" => [attempt_count, MAX_OPTIMIZED_ATTEMPTS].min,
+              "degraded_to_separate_queries" => (attempt_count > MAX_OPTIMIZED_ATTEMPTS),
+              "id_set_count" => id_sets.size,
+              "total_id_count" => id_sets.reduce(:union).size,
+              "duration_ms" => duration_ms
+            })
+          end
 
           id_sets.map { |id_set| responses_by_id_set.fetch(id_set) }
         end

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_source_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_source_spec.rb
@@ -283,14 +283,7 @@ module ElasticGraph
               expect(response1.map(&:id)).to contain_exactly("w3")
             }.to perform_datastore_search("main", 2).times.and perform_datastore_msearch("main", 2).time
 
-            expect(logged_jsons_of_type(merged_queries_message_type)).to match [a_hash_including({
-              "message_type" => merged_queries_message_type,
-              "field" => "Component.widget",
-              "optimized_attempt_count" => 1,
-              "degraded_to_separate_queries" => false,
-              "id_set_count" => 1,
-              "total_id_count" => 1
-            })]
+            expect(logged_jsons_of_type(merged_queries_message_type)).to be_empty
 
             expect(logged_jsons_of_type(comparison_results_message_type)).to match [a_hash_including({
               "message_type" => comparison_results_message_type,


### PR DESCRIPTION
Specifically, when there is only a single set of ids, we don't perform any merging, and logging a `NestedRelationshipsMergedQueries` message is confusing.