### PR TITLE
Cap the parallelism when using flatware to run specs.

### DIFF
--- a/script/flatware_rspec
+++ b/script/flatware_rspec
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# This script runs all specs from all the elasticgraph gems. Any arguments passed to this script
+# will be appended to the `rspec` command.
+
+# Print a trace of simple commands.
+# Verbose form of `set -x`.
+set -o xtrace
+
+# Avoid a connection issue if a prior run was interrupted. More info:
+# https://github.com/briandunn/flatware/issues/68
+rm -f flatware-sink
+
+# Limit the number of workers to 8. On some really beefy CI worker hosts, we've seen
+# flatware default to 96 workers (due to the host having 96 vCPUs!), but that's overkill,
+# and using too many workers can perform worse.
+#
+# In addition, using too many parallel processes can overwhelm the locally booted datastore,
+# because we have to create a separate set of indices for each process. The datastore tends
+# to run into limits when we use 16 processes. 8 processes seems to work better
+#
+# Note: `Etc.nprocessors` is what flatware uses internally for the default number of workers.
+worker_count=$(ruby -retc -e "puts [8, Etc.nprocessors].min")
+
+bundle exec flatware rspec -w $worker_count "$@"

--- a/script/run_gem_specs
+++ b/script/run_gem_specs
@@ -30,12 +30,8 @@ pushd $gem
   cp ../Gemfile.lock Gemfile.lock
   BUNDLE_GEMFILE=Gemfile bundle check || (rm -rf Gemfile.lock && bundle install)
   if [[ "$gem" == "elasticgraph-graphql" || "$gem" == "elasticgraph-indexer" || "$gem" == "elasticgraph-schema_definition" ]]; then
-    # Avoid a connection issue if a prior run was interrupted. More info:
-    # https://github.com/briandunn/flatware/issues/68
-    rm -f flatware-sink
-
     # These gems have larger test suites that take longer, and therefore benefit from being run in parallel with flatware.
-    BUNDLE_GEMFILE=Gemfile bundle exec flatware rspec --backtrace --format progress
+    BUNDLE_GEMFILE=Gemfile ../script/flatware_rspec --backtrace --format progress
   else
     # The rest of the gems have small enough test suites that flatware is likely to be a net negative.
     BUNDLE_GEMFILE=Gemfile bundle exec rspec --backtrace --format progress

--- a/script/run_specs
+++ b/script/run_specs
@@ -17,15 +17,4 @@ set -o xtrace
 # - The specific gems we want to exclude are ones we are OK excluding all of.
 spec_dirs=$(script/list_eg_gems.rb | grep -v elasticgraph-local)
 
-# Avoid a connection issue if a prior run was interrupted. More info:
-# https://github.com/briandunn/flatware/issues/68
-rm -f flatware-sink
-
-# Limit the number of workers to 16. On some really beefy CI worker hosts, we've seen
-# flatware default to 96 workers (due to the host having 96 vCPUs!), but that's overkill,
-# and using too many workers can perform worse.
-#
-# Note: `Etc.nprocessors` is what flatware uses internally for the default number of workers.
-worker_count=$(ruby -retc -e "puts [16, Etc.nprocessors].min")
-
-bundle exec flatware rspec $spec_dirs -w $worker_count "$@"
+script/flatware_rspec $spec_dirs "$@"


### PR DESCRIPTION
Running 16 processes in parallel tends to overwhelm the datastore, given that we create a separate set of indices for each process. In my testing, 8 processes winds up being just as fast (if not faster) and runs into fewer problems.