### PR TITLE
Implement support for `page_info` under `sub_aggregations`.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/non_composite_grouping_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/non_composite_grouping_adapter.rb
@@ -124,7 +124,7 @@ module ElasticGraph
                 # a time breaker to ensure deterministic results, but don't particularly care which buckets
                 # come first.
                 [-b.fetch("doc_count"), b.fetch("key_values").map(&:to_s)]
-              end.first(size)
+              end.first(size + 1) # We add 1 so `page_info.has_next_page` detection works.
           end
 
           def missing_bucket_path_from(buckets_path)

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/sub_aggregations.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/sub_aggregations.rb
@@ -65,15 +65,21 @@ module ElasticGraph
                   sub_agg
                 end
 
-              # When we have a single ungrouped bucket, we never have any error on the `doc_count`.
-              # Our resolver logic expects it to be present, though.
-              [singleton_bucket.merge({"doc_count_error_upper_bound" => 0})]
+              [SINGLETON_BUCKET_DEFAULTS.merge(singleton_bucket)]
             end
           end
 
           BUCKET_ADAPTERS = [CompositeGroupingAdapter, NonCompositeGroupingAdapter].to_h do |adapter|
             [adapter.meta_name, adapter]
           end
+
+          SINGLETON_BUCKET_DEFAULTS = {
+            # When we have a single ungrouped bucket, we never have any error on the `doc_count`.
+            # Our resolver logic expects it to be present, though.
+            "doc_count_error_upper_bound" => 0,
+            # Our resolver logic expects a `key` as it gets used by the `PageInfo` resolver when that's requested.
+            "key" => {}
+          }
         end
       end
     end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/term_grouping.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/term_grouping.rb
@@ -33,7 +33,7 @@ module ElasticGraph
           clause_value = work_around_elasticsearch_bug(terms_subclause)
           {
             "terms" => clause_value.merge({
-              "size" => query.paginator.desired_page_size,
+              "size" => query.paginator.requested_page_size,
               "show_term_doc_count_error" => query.needs_doc_count_error
             })
           }

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/sub_aggregations.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/sub_aggregations.rbs
@@ -40,6 +40,7 @@ module ElasticGraph
           def extract_buckets: (::String, ::Hash[::String, untyped]) -> ::Array[::Hash[::String, untyped]]
 
           BUCKET_ADAPTERS: ::Hash[::String, groupingAdapter]
+          SINGLETON_BUCKET_DEFAULTS: ::Hash[::String, untyped]
         end
       end
     end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/sub_aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/sub_aggregations_spec.rb
@@ -992,7 +992,8 @@ module ElasticGraph
       end
 
       def terms(terms_hash, size: 50, show_term_doc_count_error: false)
-        terms_hash.merge({"size" => size, "show_term_doc_count_error" => show_term_doc_count_error})
+        # We add 1 to the size because we ask for one more from the datastore to detect `page_info.has_next_page`.
+        terms_hash.merge({"size" => size + 1, "show_term_doc_count_error" => show_term_doc_count_error})
       end
     end
   end


### PR DESCRIPTION
We don't truly support pagination under `sub_aggregations` (because OpenSearch and Elasticsearch throw exceptions when use a composite subaggregation under an outer terms or composite aggregation). That's why we didn't originally offer `page_info` under `sub_aggregations`. However, it's still useful to be able to request `has_next_page` to see if the response has all groupings or not.

Here's how the `page_info` fields work here:

- `has_previous_page` is always `false` because we don't offer a way to skip any nodes (so there is never a previous page).
- `has_next_page` is `true` if there are additional results we didn't return. This is detected by incrementing the size we request from the datastore.
- `end_cursor`/`start_cursor` cannot be used for anything (we don't accept a `before` or `after` argument on sub-aggregations) but the existing implementation encodes the grouping values based on the bucket key, and it works fine to keep that.