### PR TITLE
Remove dependabot entries that don't actually work.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,84 +19,9 @@ updates:
     directory: /config/site
     schedule:
       interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-admin
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-admin_lambda
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-apollo
-    schedule:
-      interval: weekly
-
+-
   - package-ecosystem: docker
     directory: /elasticgraph-apollo/apollo_tests_implementation
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-apollo/apollo_tests_implementation
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-datastore_core
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-elasticsearch
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-graphql
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-graphql_lambda
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-health_check
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-indexer
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-indexer_autoscaler_lambda
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-indexer_lambda
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-json_schema
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-lambda_support
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-local
     schedule:
       interval: weekly
 
@@ -107,46 +32,6 @@ updates:
 
   - package-ecosystem: docker
     directory: /elasticgraph-local/lib/elastic_graph/local/opensearch
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-opensearch
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-query_interceptor
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-query_registry
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-rack
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-schema_artifacts
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-schema_definition
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph-support
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: bundler
-    directory: /elasticgraph
     schedule:
       interval: weekly
 


### PR DESCRIPTION
Dependabot can't parse the nested `Gemfile` of each of the ElasticGraph gems. However, we don't need it to, as it's working on the root `Gemtfile` in the repository.