### PR TITLE
Remove horizontal scrolling from website.

### DIFF
--- a/config/site/src/_layouts/base.html
+++ b/config/site/src/_layouts/base.html
@@ -56,7 +56,7 @@
   {% endif %}
 </head>
 
-<body class="{{ site.style.body }}">
+<body class="{{ site.style.body }} overflow-x-hidden">
   {% include navbar.html %}
   {{ content }}
   {% include footer.html %}


### PR DESCRIPTION
There's a weird extra column on the right that shouldn't be there and that the page allows you to scroll to. This removes it.

Before (after scrolling over):

<img width="196" alt="image" src="https://github.com/user-attachments/assets/8ac17315-6952-4534-a0e4-f43f63467966" />

After: 
<img width="150" alt="image" src="https://github.com/user-attachments/assets/0895e87a-384f-4080-902d-0ccbef4e9267" />
