### PR TITLE
Remove `extension` from `extension_name` and `extension_config`.

### DIFF
--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -1502,27 +1502,27 @@ graphql_resolvers_by_name:
   get_record_field_value:
     needs_lookahead: false
     resolver_ref:
-      extension_name: ElasticGraph::GraphQL::Resolvers::GetRecordFieldValue
+      name: ElasticGraph::GraphQL::Resolvers::GetRecordFieldValue
       require_path: elastic_graph/graphql/resolvers/get_record_field_value
   list_records:
     needs_lookahead: true
     resolver_ref:
-      extension_name: ElasticGraph::GraphQL::Resolvers::ListRecords
+      name: ElasticGraph::GraphQL::Resolvers::ListRecords
       require_path: elastic_graph/graphql/resolvers/list_records
   nested_relationships:
     needs_lookahead: true
     resolver_ref:
-      extension_name: ElasticGraph::GraphQL::Resolvers::NestedRelationships
+      name: ElasticGraph::GraphQL::Resolvers::NestedRelationships
       require_path: elastic_graph/graphql/resolvers/nested_relationships
   object_with_lookahead:
     needs_lookahead: true
     resolver_ref:
-      extension_name: ElasticGraph::GraphQL::Resolvers::Object::WithLookahead
+      name: ElasticGraph::GraphQL::Resolvers::Object::WithLookahead
       require_path: elastic_graph/graphql/resolvers/object
   object_without_lookahead:
     needs_lookahead: false
     resolver_ref:
-      extension_name: ElasticGraph::GraphQL::Resolvers::Object::WithoutLookahead
+      name: ElasticGraph::GraphQL::Resolvers::Object::WithoutLookahead
       require_path: elastic_graph/graphql/resolvers/object
 index_definitions_by_name:
   addresses:
@@ -6325,94 +6325,94 @@ object_types_by_name:
 scalar_types_by_name:
   Boolean:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
       require_path: elastic_graph/graphql/scalar_coercion_adapters/no_op
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   Cursor:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::Cursor
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::Cursor
       require_path: elastic_graph/graphql/scalar_coercion_adapters/cursor
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   Date:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::Date
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::Date
       require_path: elastic_graph/graphql/scalar_coercion_adapters/date
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   DateTime:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::DateTime
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::DateTime
       require_path: elastic_graph/graphql/scalar_coercion_adapters/date_time
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   Float:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
       require_path: elastic_graph/graphql/scalar_coercion_adapters/no_op
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   ID:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
       require_path: elastic_graph/graphql/scalar_coercion_adapters/no_op
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   Int:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
       require_path: elastic_graph/graphql/scalar_coercion_adapters/no_op
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::Integer
+      name: ElasticGraph::Indexer::IndexingPreparers::Integer
       require_path: elastic_graph/indexer/indexing_preparers/integer
   JsonSafeLong:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::JsonSafeLong
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::JsonSafeLong
       require_path: elastic_graph/graphql/scalar_coercion_adapters/longs
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::Integer
+      name: ElasticGraph::Indexer::IndexingPreparers::Integer
       require_path: elastic_graph/indexer/indexing_preparers/integer
   LocalTime:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::LocalTime
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::LocalTime
       require_path: elastic_graph/graphql/scalar_coercion_adapters/local_time
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   LongString:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::LongString
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::LongString
       require_path: elastic_graph/graphql/scalar_coercion_adapters/longs
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::Integer
+      name: ElasticGraph::Indexer::IndexingPreparers::Integer
       require_path: elastic_graph/indexer/indexing_preparers/integer
   String:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
       require_path: elastic_graph/graphql/scalar_coercion_adapters/no_op
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   TimeZone:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::TimeZone
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::TimeZone
       require_path: elastic_graph/graphql/scalar_coercion_adapters/time_zone
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   Untyped:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::Untyped
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::Untyped
       require_path: elastic_graph/graphql/scalar_coercion_adapters/untyped
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::Untyped
+      name: ElasticGraph::Indexer::IndexingPreparers::Untyped
       require_path: elastic_graph/indexer/indexing_preparers/untyped
 schema_element_names:
   form: snake_case

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -1499,43 +1499,43 @@ enum_types_by_name:
           direction: desc
           field_path: widget.id
 graphql_extension_modules:
-- extension_name: ElasticGraph::Apollo::GraphQL::EngineExtension
+- name: ElasticGraph::Apollo::GraphQL::EngineExtension
   require_path: elastic_graph/apollo/graphql/engine_extension
 graphql_resolvers_by_name:
   apollo_entities:
     needs_lookahead: true
     resolver_ref:
-      extension_name: ElasticGraph::Apollo::GraphQL::EntitiesFieldResolver
+      name: ElasticGraph::Apollo::GraphQL::EntitiesFieldResolver
       require_path: elastic_graph/apollo/graphql/entities_field_resolver
   apollo_service:
     needs_lookahead: false
     resolver_ref:
-      extension_name: ElasticGraph::Apollo::GraphQL::ServiceFieldResolver
+      name: ElasticGraph::Apollo::GraphQL::ServiceFieldResolver
       require_path: elastic_graph/apollo/graphql/service_field_resolver
   get_record_field_value:
     needs_lookahead: false
     resolver_ref:
-      extension_name: ElasticGraph::GraphQL::Resolvers::GetRecordFieldValue
+      name: ElasticGraph::GraphQL::Resolvers::GetRecordFieldValue
       require_path: elastic_graph/graphql/resolvers/get_record_field_value
   list_records:
     needs_lookahead: true
     resolver_ref:
-      extension_name: ElasticGraph::GraphQL::Resolvers::ListRecords
+      name: ElasticGraph::GraphQL::Resolvers::ListRecords
       require_path: elastic_graph/graphql/resolvers/list_records
   nested_relationships:
     needs_lookahead: true
     resolver_ref:
-      extension_name: ElasticGraph::GraphQL::Resolvers::NestedRelationships
+      name: ElasticGraph::GraphQL::Resolvers::NestedRelationships
       require_path: elastic_graph/graphql/resolvers/nested_relationships
   object_with_lookahead:
     needs_lookahead: true
     resolver_ref:
-      extension_name: ElasticGraph::GraphQL::Resolvers::Object::WithLookahead
+      name: ElasticGraph::GraphQL::Resolvers::Object::WithLookahead
       require_path: elastic_graph/graphql/resolvers/object
   object_without_lookahead:
     needs_lookahead: false
     resolver_ref:
-      extension_name: ElasticGraph::GraphQL::Resolvers::Object::WithoutLookahead
+      name: ElasticGraph::GraphQL::Resolvers::Object::WithoutLookahead
       require_path: elastic_graph/graphql/resolvers/object
 index_definitions_by_name:
   addresses:
@@ -6367,129 +6367,129 @@ object_types_by_name:
 scalar_types_by_name:
   Boolean:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
       require_path: elastic_graph/graphql/scalar_coercion_adapters/no_op
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   Cursor:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::Cursor
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::Cursor
       require_path: elastic_graph/graphql/scalar_coercion_adapters/cursor
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   Date:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::Date
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::Date
       require_path: elastic_graph/graphql/scalar_coercion_adapters/date
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   DateTime:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::DateTime
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::DateTime
       require_path: elastic_graph/graphql/scalar_coercion_adapters/date_time
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   FieldSet:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
       require_path: elastic_graph/graphql/scalar_coercion_adapters/no_op
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   Float:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
       require_path: elastic_graph/graphql/scalar_coercion_adapters/no_op
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   ID:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
       require_path: elastic_graph/graphql/scalar_coercion_adapters/no_op
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   Int:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
       require_path: elastic_graph/graphql/scalar_coercion_adapters/no_op
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::Integer
+      name: ElasticGraph::Indexer::IndexingPreparers::Integer
       require_path: elastic_graph/indexer/indexing_preparers/integer
   JsonSafeLong:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::JsonSafeLong
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::JsonSafeLong
       require_path: elastic_graph/graphql/scalar_coercion_adapters/longs
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::Integer
+      name: ElasticGraph::Indexer::IndexingPreparers::Integer
       require_path: elastic_graph/indexer/indexing_preparers/integer
   LocalTime:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::LocalTime
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::LocalTime
       require_path: elastic_graph/graphql/scalar_coercion_adapters/local_time
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   LongString:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::LongString
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::LongString
       require_path: elastic_graph/graphql/scalar_coercion_adapters/longs
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::Integer
+      name: ElasticGraph::Indexer::IndexingPreparers::Integer
       require_path: elastic_graph/indexer/indexing_preparers/integer
   String:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
       require_path: elastic_graph/graphql/scalar_coercion_adapters/no_op
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   TimeZone:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::TimeZone
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::TimeZone
       require_path: elastic_graph/graphql/scalar_coercion_adapters/time_zone
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   Untyped:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::Untyped
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::Untyped
       require_path: elastic_graph/graphql/scalar_coercion_adapters/untyped
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::Untyped
+      name: ElasticGraph::Indexer::IndexingPreparers::Untyped
       require_path: elastic_graph/indexer/indexing_preparers/untyped
   _Any:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
       require_path: elastic_graph/graphql/scalar_coercion_adapters/no_op
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   federation__Policy:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
       require_path: elastic_graph/graphql/scalar_coercion_adapters/no_op
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   federation__Scope:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
       require_path: elastic_graph/graphql/scalar_coercion_adapters/no_op
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
   link__Import:
     coercion_adapter:
-      extension_name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
+      name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp
       require_path: elastic_graph/graphql/scalar_coercion_adapters/no_op
     indexing_preparer:
-      extension_name: ElasticGraph::Indexer::IndexingPreparers::NoOp
+      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
       require_path: elastic_graph/indexer/indexing_preparers/no_op
 schema_element_names:
   form: snake_case

--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -167,7 +167,7 @@ module ElasticGraph
     def named_graphql_resolvers
       @named_graphql_resolvers ||= runtime_metadata.graphql_resolvers_by_name.transform_values do |resolver|
         ext = resolver.load_resolver
-        (_ = ext.extension_class).new(elasticgraph_graphql: self, config: ext.extension_config)
+        (_ = ext.extension_class).new(elasticgraph_graphql: self, config: ext.config)
       end
     end
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/config.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/config.rb
@@ -44,9 +44,9 @@ module ElasticGraph
 
         extension_loader = SchemaArtifacts::RuntimeMetadata::ExtensionLoader.new(::Module.new)
         extension_mods = parsed_yaml.fetch("extension_modules", []).map do |mod_hash|
-          extension_loader.load(mod_hash.fetch("extension_name"), from: mod_hash.fetch("require_path"), config: {}).extension_class.tap do |mod|
+          extension_loader.load(mod_hash.fetch("name"), from: mod_hash.fetch("require_path"), config: {}).extension_class.tap do |mod|
             unless mod.instance_of?(::Module)
-              raise Errors::ConfigError, "`#{mod_hash.fetch("extension_name")}` is not a module, but all application extension modules must be modules."
+              raise Errors::ConfigError, "`#{mod_hash.fetch("name")}` is not a module, but all application extension modules must be modules."
             end
           end
         end
@@ -83,13 +83,13 @@ module ElasticGraph
 
         client_resolver_loader = SchemaArtifacts::RuntimeMetadata::ExtensionLoader.new(Client::DefaultResolver)
         extension = client_resolver_loader.load(
-          config.fetch("extension_name"),
+          config.fetch("name"),
           from: config.fetch("require_path"),
-          config: config.except("extension_name", "require_path")
+          config: config.except("name", "require_path")
         )
         extension_class = extension.extension_class # : ::Class
 
-        __skip__ = extension_class.new(extension.extension_config)
+        __skip__ = extension_class.new(extension.config)
       end
     end
   end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/config_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/config_spec.rb
@@ -19,7 +19,7 @@ module ElasticGraph
           "slow_query_latency_warning_threshold_in_ms" => 3200,
           "extension_modules" => [],
           "client_resolver" => {
-            "extension_name" => "ElasticGraph::GraphQL::ClientResolvers::ViaHTTPHeader",
+            "name" => "ElasticGraph::GraphQL::ClientResolvers::ViaHTTPHeader",
             "require_path" => "support/client_resolvers",
             "header_name" => "X-Client-Name"
           }
@@ -101,7 +101,7 @@ module ElasticGraph
               "default_page_size" => 27,
               "max_page_size" => 270,
               "client_resolver" => {
-                "extension_name" => "ElasticGraph::GraphQL::ClientResolvers::ViaHTTPHeader",
+                "name" => "ElasticGraph::GraphQL::ClientResolvers::ViaHTTPHeader",
                 "require_path" => "support/client_resolvers_typo",
                 "header_name" => "X-CLIENT-NAME"
               }
@@ -115,7 +115,7 @@ module ElasticGraph
               "default_page_size" => 27,
               "max_page_size" => 270,
               "client_resolver" => {
-                "extension_name" => "ElasticGraph::GraphQL::ClientResolvers::ViaHTTPHeaderTypo",
+                "name" => "ElasticGraph::GraphQL::ClientResolvers::ViaHTTPHeaderTypo",
                 "require_path" => "support/client_resolvers",
                 "header_name" => "X-CLIENT-NAME"
               }
@@ -129,7 +129,7 @@ module ElasticGraph
               "default_page_size" => 27,
               "max_page_size" => 270,
               "client_resolver" => {
-                "extension_name" => "ElasticGraph::GraphQL::ClientResolvers::Invalid",
+                "name" => "ElasticGraph::GraphQL::ClientResolvers::Invalid",
                 "require_path" => "support/client_resolvers",
                 "header_name" => "X-CLIENT-NAME"
               }
@@ -175,9 +175,9 @@ module ElasticGraph
           extension_modules = extension_modules_from(<<~YAML)
             extension_modules:
               - require_path: ./eg_extension_module1
-                extension_name: EgExtensionModule1
+                name: EgExtensionModule1
               - require_path: ./eg_extension_module2
-                extension_name: EgExtensionModule2
+                name: EgExtensionModule2
           YAML
 
           expect(extension_modules).to eq([::EgExtensionModule1, ::EgExtensionModule2])
@@ -188,7 +188,7 @@ module ElasticGraph
             extension_modules_from(<<~YAML)
               extension_modules:
                 - require_path: ./not_real
-                  extension_name: NotReal
+                  name: NotReal
             YAML
           }.to raise_error LoadError, a_string_including("not_real")
         end
@@ -198,7 +198,7 @@ module ElasticGraph
             extension_modules_from(<<~YAML)
               extension_modules:
                 - require: ./not_real
-                  extension_name: NotReal
+                  name: NotReal
             YAML
           }.to raise_error a_string_including("require_path")
 
@@ -213,7 +213,7 @@ module ElasticGraph
                 - require_path: ./eg_extension_module1
                   extension: EgExtensionModule1
             YAML
-          }.to raise_error a_string_including("extension_name")
+          }.to raise_error a_string_including("name")
         end
 
         it "raises a clear error if the named extension is not a module" do
@@ -226,7 +226,7 @@ module ElasticGraph
             extension_modules_from(<<~YAML)
               extension_modules:
                 - require_path: ./eg_extension_class1
-                  extension_name: EgExtensionClass1
+                  name: EgExtensionClass1
             YAML
           }.to raise_error a_string_including("not a module")
 
@@ -238,7 +238,7 @@ module ElasticGraph
             extension_modules_from(<<~YAML)
               extension_modules:
                 - require_path: ./eg_extension_object1
-                  extension_name: EgExtensionObject1
+                  name: EgExtensionObject1
             YAML
           }.to raise_error a_string_including("not a class or module")
         end

--- a/elasticgraph-health_check/lib/elastic_graph/health_check/envoy_extension.rb
+++ b/elasticgraph-health_check/lib/elastic_graph/health_check/envoy_extension.rb
@@ -21,7 +21,7 @@ module ElasticGraph
             http_path_segment ||= runtime_metadata
               .graphql_extension_modules
               .find { |ext_mod| ext_mod.extension_class == EnvoyExtension }
-              &.extension_config
+              &.config
               &.dig(:http_path_segment)
 
             if http_path_segment.nil?

--- a/elasticgraph-query_interceptor/README.md
+++ b/elasticgraph-query_interceptor/README.md
@@ -19,11 +19,11 @@ your interceptor when it is initialized.
 ``` yaml
 extension_modules:
 - require_path: elastic_graph/query_interceptor/graphql_extension
-  extension_name: ElasticGraph::QueryInterceptor::GraphQLExtension
+  name: ElasticGraph::QueryInterceptor::GraphQLExtension
 query_interceptor:
   interceptors:
   - require_path: ./my_app/example_interceptor
-    extension_name: MyApp::ExampleInterceptor
+    name: MyApp::ExampleInterceptor
     config: # Optional
       foo: bar
 ```

--- a/elasticgraph-query_interceptor/lib/elastic_graph/query_interceptor/config.rb
+++ b/elasticgraph-query_interceptor/lib/elastic_graph/query_interceptor/config.rb
@@ -16,21 +16,21 @@ module ElasticGraph
       def self.from_parsed_yaml(parsed_config_hash, parsed_runtime_metadata_hashes: [])
         interceptor_hashes = parsed_runtime_metadata_hashes.flat_map { |h| h["interceptors"] || [] }
 
-        if (extension_config = parsed_config_hash["query_interceptor"])
-          extra_keys = extension_config.keys - EXPECTED_KEYS
+        if (config = parsed_config_hash["query_interceptor"])
+          extra_keys = config.keys - EXPECTED_KEYS
 
           unless extra_keys.empty?
             raise Errors::ConfigError, "Unknown `query_interceptor` config settings: #{extra_keys.join(", ")}"
           end
 
-          interceptor_hashes += extension_config.fetch("interceptors")
+          interceptor_hashes += config.fetch("interceptors")
         end
 
         loader = SchemaArtifacts::RuntimeMetadata::ExtensionLoader.new(InterceptorInterface)
 
         interceptors = interceptor_hashes.map do |hash|
           empty_config = {}  # : ::Hash[::Symbol, untyped]
-          ext = loader.load(hash.fetch("extension_name"), from: hash.fetch("require_path"), config: empty_config)
+          ext = loader.load(hash.fetch("name"), from: hash.fetch("require_path"), config: empty_config)
           config = hash["config"] || {} # : ::Hash[::String, untyped]
           InterceptorData.new(klass: ext.extension_class, config: config)
         end

--- a/elasticgraph-query_interceptor/lib/elastic_graph/query_interceptor/graphql_extension.rb
+++ b/elasticgraph-query_interceptor/lib/elastic_graph/query_interceptor/graphql_extension.rb
@@ -16,7 +16,7 @@ module ElasticGraph
       def datastore_query_adapters
         @datastore_query_adapters ||= begin
           runtime_metadata_configs = runtime_metadata.graphql_extension_modules.filter_map do |ext_mod|
-            Support::HashUtil.stringify_keys(ext_mod.extension_config) if ext_mod.extension_class == GraphQLExtension
+            Support::HashUtil.stringify_keys(ext_mod.config) if ext_mod.extension_class == GraphQLExtension
           end
 
           interceptors = Config

--- a/elasticgraph-query_interceptor/spec/unit/elastic_graph/query_interceptor/config_spec.rb
+++ b/elasticgraph-query_interceptor/spec/unit/elastic_graph/query_interceptor/config_spec.rb
@@ -45,9 +45,9 @@ module ElasticGraph
         end
 
         config = Config.from_parsed_yaml({"query_interceptor" => {"interceptors" => [
-          {"extension_name" => "Interceptor1", "require_path" => "./interceptor1"},
-          {"extension_name" => "Interceptor2", "require_path" => "./interceptor2", "config" => {"foo" => "bar"}},
-          {"extension_name" => "Interceptor3", "require_path" => "./interceptor3"}
+          {"name" => "Interceptor1", "require_path" => "./interceptor1"},
+          {"name" => "Interceptor2", "require_path" => "./interceptor2", "config" => {"foo" => "bar"}},
+          {"name" => "Interceptor3", "require_path" => "./interceptor3"}
         ]}})
 
         expect(config.interceptors).to eq [
@@ -65,7 +65,7 @@ module ElasticGraph
 
         expect {
           Config.from_parsed_yaml({"query_interceptor" => {"interceptors" => [
-            {"extension_name" => "InvalidInterceptor", "require_path" => "./invalid_interceptor"}
+            {"name" => "InvalidInterceptor", "require_path" => "./invalid_interceptor"}
           ]}})
         }.to raise_error Errors::InvalidExtensionError, a_string_including("Missing instance methods:", "intercept")
       end

--- a/elasticgraph-query_interceptor/spec/unit/elastic_graph/query_interceptor/graphql_extension_spec.rb
+++ b/elasticgraph-query_interceptor/spec/unit/elastic_graph/query_interceptor/graphql_extension_spec.rb
@@ -17,11 +17,11 @@ module ElasticGraph
       let(:interceptors) do
         [
           {
-            "extension_name" => "MyApp::HideNonPublicThings",
+            "name" => "MyApp::HideNonPublicThings",
             "require_path" => "./hide_non_public_things"
           },
           {
-            "extension_name" => "MyApp::FilterOnUser",
+            "name" => "MyApp::FilterOnUser",
             "require_path" => "./filter_on_user",
             "config" => {"header" => "USER-NAME", "key" => "user"}
           }

--- a/elasticgraph-query_registry/README.md
+++ b/elasticgraph-query_registry/README.md
@@ -87,7 +87,7 @@ Next, configure this library in your ElasticGraph config YAML files:
 graphql:
   extension_modules:
   - require_path: elastic_graph/query_registry/graphql_extension
-    extension_name: ElasticGraph::QueryRegistry::GraphQLExtension
+    name: ElasticGraph::QueryRegistry::GraphQLExtension
 query_registry:
   allow_unregistered_clients: false
   allow_any_query_for_clients:

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/extension.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/extension.rb
@@ -16,41 +16,41 @@ module ElasticGraph
       # code base) that implements a standard interface to plug in custom functionality.
       #
       # Extensions are serialized using two fields:
-      # - `extension_name`: the Ruby constant of the extension
+      # - `name`: the Ruby constant of the extension
       # - `require_path`: file path to `require` to load the extension
       #
       # However, an `Extension` instance represents a loaded, resolved extension.
       # We eagerly load extensions (and validate them in the `ExtensionLoader`) in
       # order to surface any issues with the extension as soon as possible. We don't
       # want to defer errors if we can detect any issues with the extension at boot time.
-      Extension = ::Data.define(:extension_class, :require_path, :extension_config, :extension_name) do
+      Extension = ::Data.define(:extension_class, :require_path, :config, :name) do
         # @implements Extension
-        def initialize(extension_class:, require_path:, extension_config:, extension_name: extension_class.name.to_s)
-          super(extension_class:, require_path:, extension_config:, extension_name:)
+        def initialize(extension_class:, require_path:, config:, name: extension_class.name.to_s)
+          super(extension_class:, require_path:, config:, name:)
         end
 
         # Loads an extension using a serialized hash, via the provided `ExtensionLoader`.
         def self.load_from_hash(hash, via:)
-          config = Support::HashUtil.symbolize_keys(hash["extension_config"] || {}) # : ::Hash[::Symbol, untyped]
-          via.load(hash.fetch("extension_name"), from: hash.fetch("require_path"), config: config)
+          config = Support::HashUtil.symbolize_keys(hash["config"] || {}) # : ::Hash[::Symbol, untyped]
+          via.load(hash.fetch("name"), from: hash.fetch("require_path"), config: config)
         end
 
         # The serialized form of an extension.
         def to_dumpable_hash
           # Keys here are ordered alphabetically; please keep them that way.
           {
-            "extension_config" => Support::HashUtil.stringify_keys(extension_config),
-            "extension_name" => extension_name,
+            "config" => Support::HashUtil.stringify_keys(config),
+            "name" => name,
             "require_path" => require_path
           }.reject { |_, v| v.empty? }
         end
 
         def verify_against!(interface_def)
-          InterfaceVerifier.verify!(extension_class, against: interface_def, constant_name: extension_name)
+          InterfaceVerifier.verify!(extension_class, against: interface_def, constant_name: name)
         end
 
         def verify_against(interface_def)
-          InterfaceVerifier.verify(extension_class, against: interface_def, constant_name: extension_name)
+          InterfaceVerifier.verify(extension_class, against: interface_def, constant_name: name)
         end
       end
     end

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/extension_loader.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/extension_loader.rb
@@ -36,7 +36,7 @@ module ElasticGraph
               raise Errors::InvalidExtensionError, "Extension `#{constant_name}` cannot be loaded from `#{from}`, " \
                 "since it has already been loaded from `#{extension.require_path}`."
             end
-          end.with(extension_config: config)
+          end.with(config: config)
         end
 
         private

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/scalar_type.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/scalar_type.rb
@@ -22,12 +22,12 @@ module ElasticGraph
         end
 
         DEFAULT_COERCION_ADAPTER_REF = {
-          "extension_name" => "ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp",
+          "name" => "ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp",
           "require_path" => "elastic_graph/graphql/scalar_coercion_adapters/no_op"
         }
 
         DEFAULT_INDEXING_PREPARER_REF = {
-          "extension_name" => "ElasticGraph::Indexer::IndexingPreparers::NoOp",
+          "name" => "ElasticGraph::Indexer::IndexingPreparers::NoOp",
           "require_path" => "elastic_graph/indexer/indexing_preparers/no_op"
         }
 

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/extension.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/extension.rbs
@@ -6,21 +6,21 @@ module ElasticGraph
       class ExtensionSupertype
         attr_reader extension_class: extensionClass
         attr_reader require_path: ::String
-        attr_reader extension_config: ::Hash[::Symbol, untyped]
-        attr_reader extension_name: ::String
+        attr_reader config: ::Hash[::Symbol, untyped]
+        attr_reader name: ::String
 
         def initialize: (
           extension_class: extensionClass,
           require_path: ::String,
-          extension_config: ::Hash[::Symbol, untyped],
-          extension_name: ::String
+          config: ::Hash[::Symbol, untyped],
+          name: ::String
         ) -> void
 
         def with: (
           ?extension_class: extensionClass,
           ?require_path: ::String,
-          ?extension_config: ::Hash[::Symbol, untyped],
-          ?extension_name: ::String
+          ?config: ::Hash[::Symbol, untyped],
+          ?name: ::String
         ) -> Extension
       end
 
@@ -28,12 +28,12 @@ module ElasticGraph
         def initialize: (
           extension_class: extensionClass,
           require_path: ::String,
-          extension_config: ::Hash[::Symbol, untyped],
-          ?extension_name: ::String
+          config: ::Hash[::Symbol, untyped],
+          ?name: ::String
         ) -> void
 
         def self.new:
-          (extension_class: extensionClass, require_path: ::String, extension_config: ::Hash[::Symbol, untyped], ?extension_name: ::String) -> Extension
+          (extension_class: extensionClass, require_path: ::String, config: ::Hash[::Symbol, untyped], ?name: ::String) -> Extension
           | (extensionClass, ::String, ::Hash[::Symbol, untyped], ?::String) -> Extension
 
         def self.load_from_hash: (::Hash[::String, untyped], via: ExtensionLoader) -> Extension

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/extension_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/extension_spec.rb
@@ -22,8 +22,8 @@ module ElasticGraph
           hash = extension.to_dumpable_hash
 
           expect(hash).to eq({
-            "extension_config" => {"foo" => "bar"},
-            "extension_name" => "ElasticGraph::Extensions::Valid",
+            "config" => {"foo" => "bar"},
+            "name" => "ElasticGraph::Extensions::Valid",
             "require_path" => "support/example_extensions/valid"
           })
 
@@ -36,7 +36,7 @@ module ElasticGraph
           valid_extension = Extension.new(
             extension_class: Extensions::Valid,
             require_path: "support/example_extensions/valid",
-            extension_config: {}
+            config: {}
           )
 
           expect {
@@ -49,7 +49,7 @@ module ElasticGraph
           invalid_extension = Extension.new(
             extension_class: Extensions::MissingInstanceMethod,
             require_path: "support/example_extensions/missing_instance_method",
-            extension_config: {}
+            config: {}
           )
 
           expect {

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/graphql_resolver_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/graphql_resolver_spec.rb
@@ -16,7 +16,7 @@ module ElasticGraph
           resolver = GraphQLResolver.new(
             needs_lookahead: true,
             resolver_ref: {
-              "extension_name" => "ElasticGraph::GraphQLResolverWithLookahead",
+              "name" => "ElasticGraph::GraphQLResolverWithLookahead",
               "require_path" => "elastic_graph/spec_support/example_extensions/graphql_resolvers"
             }
           )
@@ -28,7 +28,7 @@ module ElasticGraph
           resolver = GraphQLResolver.new(
             needs_lookahead: false,
             resolver_ref: {
-              "extension_name" => "ElasticGraph::GraphQLResolverWithoutLookahead",
+              "name" => "ElasticGraph::GraphQLResolverWithoutLookahead",
               "require_path" => "elastic_graph/spec_support/example_extensions/graphql_resolvers"
             }
           )
@@ -40,7 +40,7 @@ module ElasticGraph
           resolver = GraphQLResolver.new(
             needs_lookahead: true,
             resolver_ref: {
-              "extension_name" => "ElasticGraph::GraphQLResolverWithoutLookahead",
+              "name" => "ElasticGraph::GraphQLResolverWithoutLookahead",
               "require_path" => "elastic_graph/spec_support/example_extensions/graphql_resolvers"
             }
           )
@@ -54,7 +54,7 @@ module ElasticGraph
           resolver = GraphQLResolver.new(
             needs_lookahead: false,
             resolver_ref: {
-              "extension_name" => "ElasticGraph::GraphQLResolverWithLookahead",
+              "name" => "ElasticGraph::GraphQLResolverWithLookahead",
               "require_path" => "elastic_graph/spec_support/example_extensions/graphql_resolvers"
             }
           )

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
@@ -205,21 +205,21 @@ module ElasticGraph
             "scalar_types_by_name" => {
               "ScalarType1" => {
                 "coercion_adapter" => {
-                  "extension_name" => "ElasticGraph::SchemaArtifacts::ScalarCoercionAdapter1",
+                  "name" => "ElasticGraph::SchemaArtifacts::ScalarCoercionAdapter1",
                   "require_path" => "support/example_extensions/scalar_coercion_adapters"
                 },
                 "indexing_preparer" => {
-                  "extension_name" => "ElasticGraph::SchemaArtifacts::IndexingPreparer1",
+                  "name" => "ElasticGraph::SchemaArtifacts::IndexingPreparer1",
                   "require_path" => "support/example_extensions/indexing_preparers"
                 }
               },
               "ScalarType2" => {
                 "coercion_adapter" => {
-                  "extension_name" => "ElasticGraph::SchemaArtifacts::ScalarCoercionAdapter2",
+                  "name" => "ElasticGraph::SchemaArtifacts::ScalarCoercionAdapter2",
                   "require_path" => "support/example_extensions/scalar_coercion_adapters"
                 },
                 "indexing_preparer" => {
-                  "extension_name" => "ElasticGraph::SchemaArtifacts::IndexingPreparer2",
+                  "name" => "ElasticGraph::SchemaArtifacts::IndexingPreparer2",
                   "require_path" => "support/example_extensions/indexing_preparers"
                 }
               }
@@ -278,16 +278,16 @@ module ElasticGraph
               "overrides" => {"any_of" => "or"}
             },
             "graphql_extension_modules" => [{
-              "extension_name" => "ElasticGraph::SchemaArtifacts::GraphQLExtensionModule1",
+              "name" => "ElasticGraph::SchemaArtifacts::GraphQLExtensionModule1",
               "require_path" => "support/example_extensions/graphql_extension_modules"
             }],
             "graphql_resolvers_by_name" => {
               "resolver1" => {
                 "needs_lookahead" => true,
                 "resolver_ref" => {
-                  "extension_name" => "ElasticGraph::GraphQLResolverWithLookahead",
+                  "name" => "ElasticGraph::GraphQLResolverWithLookahead",
                   "require_path" => "elastic_graph/spec_support/example_extensions/graphql_resolvers",
-                  "extension_config" => {"limit" => 10}
+                  "config" => {"limit" => 10}
                 }
               }
             },

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
@@ -276,7 +276,7 @@ module ElasticGraph
       #
       # @param extension_module [Module] GraphQL extension module
       # @param defined_at [String] the `require` path of the extension module
-      # @param extension_config [Hash<Symbol, Object>] configuration options for the extension module
+      # @param config [Hash<Symbol, Object>] configuration options for the extension module
       # @return [void]
       #
       # @example Register `elasticgraph-query_registry` extension module
@@ -286,8 +286,8 @@ module ElasticGraph
       #     schema.register_graphql_extension ElasticGraph::QueryRegistry::GraphQLExtension,
       #       defined_at: query_registry_require_path
       #   end
-      def register_graphql_extension(extension_module, defined_at:, **extension_config)
-        @state.graphql_extension_modules << SchemaArtifacts::RuntimeMetadata::Extension.new(extension_module, defined_at, extension_config)
+      def register_graphql_extension(extension_module, defined_at:, **config)
+        @state.graphql_extension_modules << SchemaArtifacts::RuntimeMetadata::Extension.new(extension_module, defined_at, config)
         nil
       end
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/scalar_type.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/scalar_type.rb
@@ -112,7 +112,7 @@ module ElasticGraph
         #   end
         def coerce_with(adapter_name, defined_at:)
           self.runtime_metadata = runtime_metadata.with(coercion_adapter_ref: {
-            "extension_name" => adapter_name,
+            "name" => adapter_name,
             "require_path" => defined_at
           }).tap(&:load_coercion_adapter) # verify the adapter is valid.
         end
@@ -140,7 +140,7 @@ module ElasticGraph
         #   end
         def prepare_for_indexing_with(preparer_name, defined_at:)
           self.runtime_metadata = runtime_metadata.with(indexing_preparer_ref: {
-            "extension_name" => preparer_name,
+            "name" => preparer_name,
             "require_path" => defined_at
           }).tap(&:load_indexing_preparer) # verify the preparer is valid.
         end

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/scalar_types_by_name_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/scalar_types_by_name_spec.rb
@@ -23,7 +23,7 @@ module ElasticGraph
         end
 
         expect(metadata).to eq scalar_type_with(coercion_adapter_ref: {
-          "extension_name" => "ExampleScalarCoercionAdapter",
+          "name" => "ExampleScalarCoercionAdapter",
           "require_path" => "support/example_extensions/scalar_coercion_adapter"
         })
       end
@@ -38,7 +38,7 @@ module ElasticGraph
         end
 
         expect(metadata).to eq scalar_type_with(indexing_preparer_ref: {
-          "extension_name" => "ExampleIndexingPreparer",
+          "name" => "ExampleIndexingPreparer",
           "require_path" => "support/example_extensions/indexing_preparer"
         })
       end
@@ -85,7 +85,7 @@ module ElasticGraph
         end
 
         expect(metadata.coercion_adapter_ref).to eq({
-          "extension_name" => "ExampleScalarCoercionAdapter",
+          "name" => "ExampleScalarCoercionAdapter",
           "require_path" => "support/example_extensions/scalar_coercion_adapter"
         })
       end

--- a/spec_support/lib/elastic_graph/spec_support/runtime_metadata_support.rb
+++ b/spec_support/lib/elastic_graph/spec_support/runtime_metadata_support.rb
@@ -149,7 +149,7 @@ module ElasticGraph
         end
 
         DEFAULT_RESOLVER_REF = {
-          "extension_name" => "ElasticGraph::GraphQL::Resolvers::GetRecordFieldValue",
+          "name" => "ElasticGraph::GraphQL::Resolvers::GetRecordFieldValue",
           "require_path" => "elastic_graph/graphql/resolvers/get_record_field_value"
         }
 


### PR DESCRIPTION
`extension.extension_name` and `extension.extension_config` are excessive and verbose.