### PR TITLE
Revert "Return a clear error when indices have not been configured."

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_search_router.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_search_router.rb
@@ -28,8 +28,6 @@ module ElasticGraph
         @config = config
       end
 
-      INDICES_NOT_CONFIGURED_MESSAGE = "The datastore indices have not been configured. They must be configured before ElasticGraph can serve queries."
-
       # Sends the datastore a multi-search request based on the given queries.
       # Returns a hash of responses keyed by the query.
       def msearch(queries, query_tracker: QueryDetailsTracker.empty)
@@ -82,13 +80,7 @@ module ElasticGraph
 
           queried_shard_count = server_took_and_results.reduce(0) do |outer_accum, (_, queries_and_responses)|
             outer_accum + queries_and_responses.reduce(0) do |inner_accum, (_, response)|
-              shards_total = response.dig("_shards", "total")
-
-              if shards_total == 0
-                raise ::GraphQL::ExecutionError, INDICES_NOT_CONFIGURED_MESSAGE
-              end
-
-              inner_accum + (shards_total || 0)
+              inner_accum + (response.dig("_shards", "total") || 0)
             end
           end
 

--- a/elasticgraph-graphql/spec/acceptance/elasticgraph_graphql_acceptance_support.rb
+++ b/elasticgraph-graphql/spec/acceptance/elasticgraph_graphql_acceptance_support.rb
@@ -6,7 +6,6 @@
 #
 # frozen_string_literal: true
 
-require "elastic_graph/graphql/datastore_search_router"
 require "elastic_graph/schema_definition/schema_elements/type_namer"
 require "elastic_graph/spec_support/builds_admin"
 require "graphql"
@@ -44,13 +43,6 @@ module ElasticGraph
       # matcher in some tests which tries to assert which specific requests get made, since index definitions
       # have caching behavior that can make the presence or absence of that request slightly non-deterministic.
       pre_cache_index_state(graphql)
-    end
-
-    def expect_indices_not_configured_error
-      expect {
-        response = yield
-        expect(response.dig("errors").first).to include({"message" => GraphQL::DatastoreSearchRouter::INDICES_NOT_CONFIGURED_MESSAGE})
-      }.to log_warning(a_string_including(GraphQL::DatastoreSearchRouter::INDICES_NOT_CONFIGURED_MESSAGE))
     end
 
     def self.with_both_casing_forms(&block)

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
@@ -185,21 +185,6 @@ module ElasticGraph
           )
         end
 
-        it "raises `::GraphQL::ExecutionError` if a search queries no shards as that indicates the indices have not been configured" do
-          allow(main_datastore_client).to receive(:msearch).and_return("took" => 10, "responses" => [
-            empty_response,
-            DatastoreResponse::SearchResponse::RAW_EMPTY.merge(
-              "took" => 5, "_shards" => {"total" => 0, "successful" => 0, "skipped" => 0, "failed" => 0}, "status" => 200
-            )
-          ])
-
-          expect {
-            router.msearch([query1, query2])
-          }.to raise_error ::GraphQL::ExecutionError, a_string_including(
-            "The datastore indices have not been configured. They must be configured before ElasticGraph can serve queries."
-          )
-        end
-
         it "logs warning if a query has failed shards" do
           shard_failure_bits = {
             "_shards" => {


### PR DESCRIPTION
This reverts commit 2b1fa5ad50db7c1c9daf75af34b9a18c8b4ce3b8.

This apparently applies more broadly than it should, as we're getting this in some cases when we aren't expecting it.