### PR TITLE
Tolerate all indices being excluded when detecting unconfigured indices.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
@@ -136,6 +136,10 @@ module ElasticGraph
         ).to_s
       end
 
+      def excluding_indices?
+        search_index_expression.split(",").any? { |expr| expr.start_with?("-") }
+      end
+
       # Returns the name of the datastore cluster as a String where this query should be setn.
       # Unless exactly 1 cluster name is found, this method raises a Errors::ConfigError.
       def cluster_name

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_search_router.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_search_router.rb
@@ -80,11 +80,11 @@ module ElasticGraph
             [response["took"], queries_for_cluster.zip(ordered_responses)]
           end
 
-          queried_shard_count = server_took_and_results.reduce(0) do |outer_accum, (_, queries_and_responses)|
-            outer_accum + queries_and_responses.reduce(0) do |inner_accum, (_, response)|
+          queried_shard_count = server_took_and_results.reduce(0) do |outer_accum, (query, queries_and_responses)|
+            outer_accum + queries_and_responses.reduce(0) do |inner_accum, (query, response)|
               shards_total = response.dig("_shards", "total")
 
-              if shards_total == 0
+              if shards_total == 0 && !query.excluding_indices?
                 raise ::GraphQL::ExecutionError, INDICES_NOT_CONFIGURED_MESSAGE
               end
 

--- a/elasticgraph-graphql/spec/acceptance/search_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/search_spec.rb
@@ -640,7 +640,7 @@ module ElasticGraph
       end
 
       describe "`list` filtering behavior" do
-        it "supports filtering on scalar lists, nested object lists, and embedded object lists" do
+        it "supports filtering on scalar lists, nested object lists, and embedded object lists", :expect_index_exclusions do
           index_records(
             build(
               :team,
@@ -704,6 +704,11 @@ module ElasticGraph
               current_players: []
             )
           )
+
+          # Verify that if we filter on a rollover field with a range that excludes all indices, we get back no results rather than an
+          # "indices are not configured" error.
+          teams = query_teams_with(filter: {formed_on: {gt: "9999-01-01"}})
+          expect(teams).to eq []
 
           # Verify `any_satisfy: {...}` with all null predicates on a list-of-scalars field.
           results = query_teams_with(filter: {past_names: {any_satisfy: {equal_to_any_of: nil}}})


### PR DESCRIPTION
When a query filters on the rollover timestamp field in a way that causes no indices to be searched, the fact that the searched shard count is 0 is expected. It does not indicate that the indices are unconfigured.

This fixes an edge case bug with the recent change in #440.