### PR TITLE
Make `build` the default rake task of new ElasticGraph projects.

### DIFF
--- a/elasticgraph/lib/elastic_graph/project_template/Rakefile.tt
+++ b/elasticgraph/lib/elastic_graph/project_template/Rakefile.tt
@@ -62,3 +62,6 @@ task build: ["schema_artifacts:dump", *standard_checks]
 
 desc "Check everything. Intended to be run on CI to check your project."
 task check: ["schema_artifacts:check", *standard_checks]
+
+# Make `rake` run `rake build` for convenience.
+task default: :build


### PR DESCRIPTION
It's quite convenient to be able to run `rake` without any arguments to run the primary build task.