### PR TITLE
Use a more performant GraphQL visibility plugin.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -135,9 +135,12 @@ module ElasticGraph
         {
           # We depend on this to avoid N+1 calls to the datastore.
           ::GraphQL::Dataloader => {},
-          # This is new in the graphql-ruby 2.4 release, and will be required in the future.
-          # We pass `preload: true` because the way we handle the schema depends on it being preloaded.
-          ::GraphQL::Schema::Visibility => {preload: true}
+          # Here we opt-in to the old `GraphQL::Schema::Warden` visibility plugin.
+          # The new plugin, `GraphQL::Schema::Visibility`, causes a performance regression
+          # in ElasticGraph projects, and until that's fixed we want to stick with the old plugin.
+          #
+          # TODO: switch back to `::GraphQL::Schema::Visibility => {preload: true}` once the perf issue has been fixed.
+          ::GraphQL::Schema::Warden => {}
         }
       end
     end

--- a/elasticgraph-graphql/sig/graphql_gem.rbs
+++ b/elasticgraph-graphql/sig/graphql_gem.rbs
@@ -173,6 +173,9 @@ module GraphQL
       def self.print_schema: (Schema, **untyped) -> ::String
     end
 
+    class Warden
+    end
+
     class Visibility
     end
   end


### PR DESCRIPTION
We've observed that the new `GraphQL::Schema::Visibility` plugin causes a large performance degradation. `GraphQL::Schema::Warden` does not have this issue, so until it's fixed we'll stick with it.

```
ruby 3.3.4 (2024-07-09 revision be1089c8ec) [arm64-darwin23]
Warming up --------------------------------------
    Using Visibility    10.000 i/100ms
        Using Warden   248.000 i/100ms
Calculating -------------------------------------
    Using Visibility    102.340 (± 2.0%) i/s    (9.77 ms/i) -    520.000 in   5.082553s
        Using Warden      2.471k (± 4.9%) i/s  (404.71 μs/i) -     12.400k in   5.030776s

Comparison:
        Using Warden:     2470.9 i/s
    Using Visibility:      102.3 i/s - 24.14x  slower
```

Edit: see https://github.com/rmosolgo/graphql-ruby/issues/5324 for details on this issue.