### PR TITLE
Fix failing doctest.

### DIFF
--- a/config/site/support/doctest_helper.rb
+++ b/config/site/support/doctest_helper.rb
@@ -119,7 +119,7 @@ module ElasticGraph
       # in this context, `eval` is being used and the file doesn't exist! So we have to stub it out here.
       extend ::RSpec::Mocks::ExampleMethods
       allow(::File).to receive(:read).and_wrap_original do |original, file_name|
-        if file_name.include?("(eval at")
+        if file_name.include?("(eval")
           ([file_name] * 10).join("\n")
         else
           original.call(file_name)


### PR DESCRIPTION
Apparently `file_name` is sometimes `(eval at ...)` and sometimes `(eval)`.

```
  1) Error:
Errno::ENOENT: No such file or directory @ rb_sysopen - (eval)
    config/site/support/doctest_helper.rb:125:in `read'
    config/site/support/doctest_helper.rb:125:in `call'
    config/site/support/doctest_helper.rb:125:in `block (3 levels) in <module:ElasticGraph>'
    bundle/ruby/3.2.0/gems/rspec-mocks-3.13.2/lib/rspec/mocks/message_expectation.rb:809:in `call'
    bundle/ruby/3.2.0/gems/rspec-mocks-3.13.2/lib/rspec/mocks/message_expectation.rb:621:in `invoke_incrementing_actual_calls_by'
    bundle/ruby/3.2.0/gems/rspec-mocks-3.13.2/lib/rspec/mocks/message_expectation.rb:474:in `invoke'
    bundle/ruby/3.2.0/gems/rspec-mocks-3.13.2/lib/rspec/mocks/proxy.rb:206:in `message_received'
    bundle/ruby/3.2.0/gems/rspec-mocks-3.13.2/lib/rspec/mocks/proxy.rb:358:in `message_received'
    bundle/ruby/3.2.0/gems/rspec-mocks-3.13.2/lib/rspec/mocks/method_double.rb:98:in `proxy_method_invoked'
    bundle/ruby/3.2.0/gems/rspec-mocks-3.13.2/lib/rspec/mocks/method_double.rb:74:in `block (2 levels) in define_proxy_method'
    elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/interface_verifier.rb:103:in `signature_code_for'
    elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/interface_verifier.rb:70:in `block in verify_methods'
    elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/interface_verifier.rb:67:in `each'
    elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/interface_verifier.rb:67:in `verify_methods'
    elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/interface_verifier.rb:40:in `verify'
    elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/extension.rb:53:in `verify_against'
    elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb:364:in `register_graphql_resolver'
    (eval):12:in `block in context'
    elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb:28:in `define_schema'
    (eval):10:in `context'
    bundle/ruby/3.2.0/gems/yard-doctest-0.1.17/lib/yard/doctest/example.rb:98:in `eval'
    config/site/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb:360
    bundle/ruby/3.2.0/gems/yard-doctest-0.1.17/lib/yard/doctest/example.rb:98:in `evaluate'
    config/site/support/doctest_helper.rb:182:in `evaluate'
    bundle/ruby/3.2.0/gems/yard-doctest-0.1.17/lib/yard/doctest/example.rb:67:in `evaluate_example'
    bundle/ruby/3.2.0/gems/yard-doctest-0.1.17/lib/yard/doctest/example.rb:52:in `block (4 levels) in generate'
    bundle/ruby/3.2.0/gems/yard-doctest-0.1.17/lib/yard/doctest/example.rb:49:in `each'
    bundle/ruby/3.2.0/gems/yard-doctest-0.1.17/lib/yard/doctest/example.rb:49:in `block (3 levels) in generate'
```