### PR TITLE
Address steep `UndeclaredMethodDefinition` errors.

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -91,6 +91,5 @@ target :elasticgraph_gems do
     # For more detail: https://github.com/soutaro/steep/wiki/Release-Note-1.5#better-flow-sensitive-typing-analysis
     config[::Steep::Diagnostic::Ruby::UnreachableBranch] = :hint
     config[::Steep::Diagnostic::Ruby::UnreachableValueBranch] = :hint
-    config[::Steep::Diagnostic::Ruby::UndeclaredMethodDefinition] = :information
   end
 end

--- a/elasticgraph-datastore_core/sig/elastic_graph/datastore_core/index_definition.rbs
+++ b/elasticgraph-datastore_core/sig/elastic_graph/datastore_core/index_definition.rbs
@@ -35,6 +35,7 @@ module ElasticGraph
       def index_name_for_writes: (::Hash[::String, untyped], ?timestamp_field_path: ::String?) -> ::String
       def mappings_in_datastore: (DatastoreCore::_Client) -> ::Hash[::String, untyped]
       def related_rollover_indices: (DatastoreCore::_Client, ?only_if_exists: bool) -> ::Array[IndexDefinition::RolloverIndex]
+      def delete_from_datastore: (DatastoreCore::_Client) -> void
     end
 
     # Defines the full `_IndexDefinition` interface.

--- a/elasticgraph-datastore_core/sig/elastic_graph/datastore_core/index_definition/base.rbs
+++ b/elasticgraph-datastore_core/sig/elastic_graph/datastore_core/index_definition/base.rbs
@@ -12,6 +12,8 @@ module ElasticGraph
         @list_counts_field_paths_for_source: ::Hash[::String, ::Set[::String]]
         @max_result_window: ::Integer?
 
+        def to_s: () -> ::String
+
         private
 
         def identify_list_counts_field_paths_for_source: (::String) -> ::Set[::String]

--- a/elasticgraph-datastore_core/sig/elastic_graph/datastore_core/index_definition/rollover_index_template.rbs
+++ b/elasticgraph-datastore_core/sig/elastic_graph/datastore_core/index_definition/rollover_index_template.rbs
@@ -4,6 +4,7 @@ module ElasticGraph
       class RolloverIndexTemplate
         include IndexDefinition::Base
         include _IndexDefinition
+        include Support::_MemoizableDataClass
 
         def initialize: (**untyped) -> void
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/query_adapter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/query_adapter.rbs
@@ -27,6 +27,7 @@ module ElasticGraph
 
       class QueryAdapter < QueryAdapterSupertype
         include _QueryAdapter
+        include Support::_MemoizableDataClass
 
         class WithoutSchema
           include _QueryAdapter

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/datastore_response/document.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/datastore_response/document.rbs
@@ -25,6 +25,8 @@ module ElasticGraph
           ?decoded_cursor_factory: DecodedCursor::_Factory
         ) -> Document
 
+        def self.with_payload: (::Hash[::String, untyped]) -> Document
+
         def []: (::String) -> untyped
         def fetch: (::String) -> untyped
         def index_name: () -> ::String

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/relay_connection/array_adapter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/relay_connection/array_adapter.rbs
@@ -12,7 +12,6 @@ module ElasticGraph
           def initialize: (SchemaArtifacts::RuntimeMetadata::SchemaElementNames, ::GraphQL::Pagination::ArrayConnection[N]) -> void
 
           def self.build: [N] (::Array[N], ::Hash[::String, untyped], SchemaArtifacts::RuntimeMetadata::SchemaElementNames, ::GraphQL::Query::Context) -> ArrayAdapter[N]
-          def total_edge_count: () -> ::Integer
 
           @edges: ::Array[_RelayEdge[N]]?
           @nodes: ::Array[N]?

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/relay_connection/interfaces.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/relay_connection/interfaces.rbs
@@ -4,6 +4,7 @@ module ElasticGraph
       module RelayConnection
         interface _RelayConnection[N]
           def page_info: () -> _RelayPageInfo
+          def total_edge_count: () -> ::Integer?
           def edges: () -> ::Array[_RelayEdge[N]]
           def nodes: () -> ::Array[N]
         end

--- a/elasticgraph-indexer/sig/elastic_graph/indexer/failed_event_error.rbs
+++ b/elasticgraph-indexer/sig/elastic_graph/indexer/failed_event_error.rbs
@@ -8,6 +8,7 @@ module ElasticGraph
       attr_reader id: ::String
       attr_reader full_id: ::String
       attr_reader op: ::String
+      attr_reader type: ::String
       attr_reader version: ::Integer
       attr_reader record: ::Hash[::String, untyped]?
 

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/field_type/object.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/field_type/object.rbs
@@ -25,6 +25,7 @@ module ElasticGraph
 
         class Object < ObjectSuperType
           include _FieldType
+          include Support::_MemoizableDataClass
 
           @to_mapping: ::Hash[::String, untyped]?
           @to_json_schema: ::Hash[::String, untyped]?

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/mixins/supports_default_value.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/mixins/supports_default_value.rbs
@@ -4,6 +4,7 @@ module ElasticGraph
       module SupportsDefaultValue
         NO_DEFAULT_PROVIDED: Module
         @default_value: untyped
+        def initialize: (*untyped, **untyped) ?{ (*untyped, **untyped) -> untyped } -> void
         def default: (untyped) -> void
         def default_value_sdl: () -> ::String?
       end

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/mixins/verifies_graphql_name.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/mixins/verifies_graphql_name.rbs
@@ -2,6 +2,7 @@ module ElasticGraph
   module SchemaDefinition
     module Mixins
       module VerifiesGraphQLName: _NamedElement
+        def initialize: (*untyped, **untyped) ?{ (*untyped, **untyped) -> untyped } -> void
         def self.verify_name!: (::String) -> void
       end
     end

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/results.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/results.rbs
@@ -7,6 +7,7 @@ module ElasticGraph
 
     class Results < ResultsSupertype
       include _SchemaArtifacts
+      include Support::_MemoizableDataClass
 
       def json_schema_version_setter_location: () -> ::Thread::Backtrace::Location?
       def json_schema_field_metadata_by_type_and_field_name: () -> ::Hash[::String, ::Hash[::String, Indexing::JSONSchemaFieldMetadata]]

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/argument.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/argument.rbs
@@ -16,6 +16,7 @@ module ElasticGraph
         include Mixins::HasDocumentation
         include Mixins::HasDirectives
 
+        def to_sdl: () -> ::String
         def value_type: () -> TypeReference
       end
     end

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/interface_type.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/interface_type.rbs
@@ -14,6 +14,10 @@ module ElasticGraph
 
         def initialize: (State, ::String) { (InterfaceType) -> void } -> void
         def interface_fields_by_name: () -> ::Hash[::String, Field]
+
+        private
+
+        def resolve_subtypes: () -> ::Set[SchemaElements::TypeWithSubfields]
       end
     end
   end

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/type_reference.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/type_reference.rbs
@@ -11,6 +11,7 @@ module ElasticGraph
       end
 
       class TypeReference < TypeReferenceSupertype
+        include Support::_MemoizableDataClass
         extend ::Forwardable
         def type_namer: () -> TypeNamer
         def fully_unwrapped: () -> TypeReference

--- a/elasticgraph-support/sig/elastic_graph/support/memoizable_data.rbs
+++ b/elasticgraph-support/sig/elastic_graph/support/memoizable_data.rbs
@@ -11,6 +11,7 @@ module ElasticGraph
     end
 
     interface _MemoizableDataClass
+      def after_initialize: () -> void
     end
   end
 end


### PR DESCRIPTION
This allows us to enable this new diagnostic.