### PR TITLE
Troubleshoot encoding errors from `SqsProcessor`.

### DIFF
--- a/elasticgraph-indexer_lambda/lib/elastic_graph/indexer_lambda/sqs_processor.rb
+++ b/elasticgraph-indexer_lambda/lib/elastic_graph/indexer_lambda/sqs_processor.rb
@@ -23,7 +23,7 @@ module ElasticGraph
         @s3_client = s3_client
 
         @logger.warn({
-          "message" => "SqsProcessorEncodingInfo",
+          "message_type" => "SqsProcessorEncodingInfo",
           "ENV" => ENV.slice("LANG", "LC_ALL", "LC_CTYPE", "LANGUAGE"),
           "default_external_encoding" => Encoding.default_external,
           "default_internal_encoding" => Encoding.default_internal,


### PR DESCRIPTION
I'm getting an `ArgumentError: invalid byte sequence in US-ASCII`  when upgrading a lambda from Ruby 3.2 to 3.4. This extra logging should help identify the problem.