### PR TITLE
Revert "Use a more performant GraphQL visibility plugin."

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -135,12 +135,9 @@ module ElasticGraph
         {
           # We depend on this to avoid N+1 calls to the datastore.
           ::GraphQL::Dataloader => {},
-          # Here we opt-in to the old `GraphQL::Schema::Warden` visibility plugin.
-          # The new plugin, `GraphQL::Schema::Visibility`, causes a performance regression
-          # in ElasticGraph projects, and until that's fixed we want to stick with the old plugin.
-          #
-          # TODO: switch back to `::GraphQL::Schema::Visibility => {preload: true}` once the perf issue has been fixed.
-          ::GraphQL::Schema::Warden => {}
+          # This is new in the graphql-ruby 2.4 release, and will be required in the future.
+          # We pass `preload: true` because the way we handle the schema depends on it being preloaded.
+          ::GraphQL::Schema::Visibility => {preload: true}
         }
       end
     end

--- a/elasticgraph-graphql/sig/graphql_gem.rbs
+++ b/elasticgraph-graphql/sig/graphql_gem.rbs
@@ -173,9 +173,6 @@ module GraphQL
       def self.print_schema: (Schema, **untyped) -> ::String
     end
 
-    class Warden
-    end
-
     class Visibility
     end
   end


### PR DESCRIPTION
This reverts commit d83392cbf24d1177f268a5139e86893f56261848.

The performance issue that prompted that commit has been addresed in the GraphQL gem (in https://github.com/rmosolgo/graphql-ruby/pull/5325) and released in 2.5.3, which we recently upgraded to. So there's no reason to continue using the old `Warden` plugin.