### PR TITLE
Remove backwards compatibility with old version of the update script.

### DIFF
--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -1970,7 +1970,7 @@ scripts:
 
         // No timestamp values matched the params, so return `false`.
         return false;
-  update_index_data_38ea36e5b48fc1566d4142e9fc44b12e:
+  update_index_data_1fdfaf1c9261c96019decc89b515bd9a:
     context: update
     script:
       lang: painless
@@ -2008,30 +2008,10 @@ scripts:
          );
         }
 
-        // While the version in `__versions` is going to be used for the doc version in the future, for now
-        // we need to continue getting it from `__sourceVersions`. Both our old version and this versions of this
-        // script keep the value in `__sourceVersions` up-to-date, whereas the old script only writes it to
-        // `__sourceVersions`. Until we have completely migrated off of the old script for all ElasticGraph
-        // clusters, we need to keep using it.
-        //
-        // Later, after the old script is no longer used by any clusters, we'll stop using `__sourceVersions`.
-        Number _versionForSourceType = source.get("__sourceVersions")?.get(params.sourceType)?.get(sourceId);
-        Number _versionForRelationship = relationshipVersionsMap.get(sourceId);
+        Number maybeDocVersion = source.__versions.get(params.relationship)?.get(params.sourceId);
 
         // Our JSON schema requires event versions to be non-negative, so we can safely use Long.MIN_VALUE as a stand-in when the value is null.
-        long versionForSourceType = _versionForSourceType == null ? Long.MIN_VALUE : _versionForSourceType.longValue();
-        long versionForRelationship = _versionForRelationship == null ? Long.MIN_VALUE : _versionForRelationship.longValue();
-
-        // Pick the larger of the two versions as our doc version. Note that `Math.max` didn't work for me here for
-        // reasons I don't understand, but a simple ternary works fine.
-        //
-        // In theory, we could just use `versionForSourceType` as the `docVersion` (and not even check `__versions` at all)
-        // since both the old version and this version maintain the doc version in `__sourceVersions`. However, that would
-        // prevent this version of the script from being forward-compatible with the planned next version of this script.
-        // In the next version, we plan to stop writing to `__sourceVersions`, and as we can't deploy that change atomically,
-        // this version of the script will continue to run after that has begun to be used. So this version of the script
-        // must consider which version is greater here, and not simply trust either version value.
-        long docVersion = versionForSourceType > versionForRelationship ? versionForSourceType : versionForRelationship;
+        long docVersion = maybeDocVersion == null ? Long.MIN_VALUE : maybeDocVersion.longValue();
 
         if (docVersion >= eventVersion) {
           throw new IllegalArgumentException("ElasticGraph update was a no-op: [" +

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -2746,7 +2746,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: Address
   AddressAggregatedValues:
     graphql_fields_by_name:
@@ -2947,7 +2947,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: Component
   ComponentAggregatedValues:
     graphql_fields_by_name:
@@ -3176,7 +3176,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: ElectricalPart
   ElectricalPartAggregatedValues:
     graphql_fields_by_name:
@@ -3483,7 +3483,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: Manufacturer
   ManufacturerAggregatedValues:
     graphql_fields_by_name:
@@ -3594,7 +3594,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: MechanicalPart
   MechanicalPartAggregatedValues:
     graphql_fields_by_name:
@@ -4429,7 +4429,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: Sponsor
   SponsorAggregatedValues:
     graphql_fields_by_name:
@@ -4625,7 +4625,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: formed_on
       routing_value_source: league
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: Team
   TeamAggregatedValues:
     graphql_fields_by_name:
@@ -5409,7 +5409,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: created_at
       routing_value_source: workspace_id2
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: Widget
     - data_params:
         widget_cost:
@@ -5440,7 +5440,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: widget
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: Component
   WidgetAggregatedValues:
     graphql_fields_by_name:
@@ -5617,7 +5617,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: introduced_on
       routing_value_source: primary_continent
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: WidgetCurrency
   WidgetCurrencyAggregatedValues:
     graphql_fields_by_name:
@@ -6223,7 +6223,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: WidgetWorkspace
     - data_params:
         workspace_name:
@@ -6244,7 +6244,7 @@ object_types_by_name:
       relationship: workspace
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: Widget
   WidgetWorkspaceAggregatedValues:
     graphql_fields_by_name:
@@ -6420,4 +6420,4 @@ static_script_ids_by_scoped_name:
   field/as_day_of_week: field_as_day_of_week_f2b5c7d9e8f75bf2457b52412bfb6537
   field/as_time_of_day: field_as_time_of_day_ed82aba44fc66bff5635bec4305c1c66
   filter/by_time_of_day: filter_by_time_of_day_ea12d0561b24961789ab68ed38435612
-  update/index_data: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+  update/index_data: update_index_data_1fdfaf1c9261c96019decc89b515bd9a

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -1970,7 +1970,7 @@ scripts:
 
         // No timestamp values matched the params, so return `false`.
         return false;
-  update_index_data_38ea36e5b48fc1566d4142e9fc44b12e:
+  update_index_data_1fdfaf1c9261c96019decc89b515bd9a:
     context: update
     script:
       lang: painless
@@ -2008,30 +2008,10 @@ scripts:
          );
         }
 
-        // While the version in `__versions` is going to be used for the doc version in the future, for now
-        // we need to continue getting it from `__sourceVersions`. Both our old version and this versions of this
-        // script keep the value in `__sourceVersions` up-to-date, whereas the old script only writes it to
-        // `__sourceVersions`. Until we have completely migrated off of the old script for all ElasticGraph
-        // clusters, we need to keep using it.
-        //
-        // Later, after the old script is no longer used by any clusters, we'll stop using `__sourceVersions`.
-        Number _versionForSourceType = source.get("__sourceVersions")?.get(params.sourceType)?.get(sourceId);
-        Number _versionForRelationship = relationshipVersionsMap.get(sourceId);
+        Number maybeDocVersion = source.__versions.get(params.relationship)?.get(params.sourceId);
 
         // Our JSON schema requires event versions to be non-negative, so we can safely use Long.MIN_VALUE as a stand-in when the value is null.
-        long versionForSourceType = _versionForSourceType == null ? Long.MIN_VALUE : _versionForSourceType.longValue();
-        long versionForRelationship = _versionForRelationship == null ? Long.MIN_VALUE : _versionForRelationship.longValue();
-
-        // Pick the larger of the two versions as our doc version. Note that `Math.max` didn't work for me here for
-        // reasons I don't understand, but a simple ternary works fine.
-        //
-        // In theory, we could just use `versionForSourceType` as the `docVersion` (and not even check `__versions` at all)
-        // since both the old version and this version maintain the doc version in `__sourceVersions`. However, that would
-        // prevent this version of the script from being forward-compatible with the planned next version of this script.
-        // In the next version, we plan to stop writing to `__sourceVersions`, and as we can't deploy that change atomically,
-        // this version of the script will continue to run after that has begun to be used. So this version of the script
-        // must consider which version is greater here, and not simply trust either version value.
-        long docVersion = versionForSourceType > versionForRelationship ? versionForSourceType : versionForRelationship;
+        long docVersion = maybeDocVersion == null ? Long.MIN_VALUE : maybeDocVersion.longValue();
 
         if (docVersion >= eventVersion) {
           throw new IllegalArgumentException("ElasticGraph update was a no-op: [" +

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -2760,7 +2760,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: Address
   AddressAggregatedValues:
     graphql_fields_by_name:
@@ -2961,7 +2961,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: Component
   ComponentAggregatedValues:
     graphql_fields_by_name:
@@ -3208,7 +3208,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: ElectricalPart
   ElectricalPartAggregatedValues:
     graphql_fields_by_name:
@@ -3515,7 +3515,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: Manufacturer
   ManufacturerAggregatedValues:
     graphql_fields_by_name:
@@ -3626,7 +3626,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: MechanicalPart
   MechanicalPartAggregatedValues:
     graphql_fields_by_name:
@@ -4465,7 +4465,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: Sponsor
   SponsorAggregatedValues:
     graphql_fields_by_name:
@@ -4661,7 +4661,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: formed_on
       routing_value_source: league
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: Team
   TeamAggregatedValues:
     graphql_fields_by_name:
@@ -5445,7 +5445,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: created_at
       routing_value_source: workspace_id2
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: Widget
     - data_params:
         widget_cost:
@@ -5476,7 +5476,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: widget
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: Component
   WidgetAggregatedValues:
     graphql_fields_by_name:
@@ -5653,7 +5653,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: introduced_on
       routing_value_source: primary_continent
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: WidgetCurrency
   WidgetCurrencyAggregatedValues:
     graphql_fields_by_name:
@@ -6259,7 +6259,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: WidgetWorkspace
     - data_params:
         workspace_name:
@@ -6280,7 +6280,7 @@ object_types_by_name:
       relationship: workspace
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
-      script_id: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: Widget
   WidgetWorkspaceAggregatedValues:
     graphql_fields_by_name:
@@ -6498,4 +6498,4 @@ static_script_ids_by_scoped_name:
   field/as_day_of_week: field_as_day_of_week_f2b5c7d9e8f75bf2457b52412bfb6537
   field/as_time_of_day: field_as_time_of_day_ed82aba44fc66bff5635bec4305c1c66
   filter/by_time_of_day: filter_by_time_of_day_ea12d0561b24961789ab68ed38435612
-  update/index_data: update_index_data_38ea36e5b48fc1566d4142e9fc44b12e
+  update/index_data: update_index_data_1fdfaf1c9261c96019decc89b515bd9a

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/datastore_indexing_router.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/datastore_indexing_router.rb
@@ -207,14 +207,7 @@ module ElasticGraph
                 include_version =
                   if op.destination_index_def.use_updates_for_indexing?
                     # @type var op: Operation::Update
-                    {_source: {includes: [
-                      "__versions.#{op.update_target.relationship}",
-                      # The update_data script before ElasticGraph v0.8 used __sourceVersions[type] instead of __versions[relationship].
-                      # To be backwards-compatible we need to fetch the data at both paths.
-                      #
-                      # TODO: Drop this when we no longer need to maintain backwards-compatibility.
-                      "__sourceVersions.#{op.event.fetch("type")}"
-                    ]}}
+                    {_source: {includes: ["__versions.#{op.update_target.relationship}"]}}
                   else
                     {version: true, _source: false}
                   end
@@ -263,12 +256,7 @@ module ElasticGraph
               if op.destination_index_def.use_updates_for_indexing?
                 # @type var op: Operation::Update
                 versions = hits.filter_map do |hit|
-                  hit.dig("_source", "__versions", op.update_target.relationship, hit.fetch("_id")) ||
-                    # The update_data script before ElasticGraph v0.8 used __sourceVersions[type] instead of __versions[relationship].
-                    # To be backwards-compatible we need to fetch the data at both paths.
-                    #
-                    # TODO: Drop this when we no longer need to maintain backwards-compatibility.
-                    hit.dig("_source", "__sourceVersions", op.event.fetch("type"), hit.fetch("_id"))
+                  hit.dig("_source", "__versions", op.update_target.relationship, hit.fetch("_id"))
                 end
 
                 [op, versions.uniq]

--- a/elasticgraph-indexer/spec/integration/elastic_graph/indexer/processor_spec.rb
+++ b/elasticgraph-indexer/spec/integration/elastic_graph/indexer/processor_spec.rb
@@ -200,7 +200,7 @@ module ElasticGraph
       end
 
       # TODO: drop these backwards compatibility when we no longer need to maintain compatibility with the old version of the script.
-      context "on a system that's been using `use_updates_for_indexing: true` with the initial v0.8 update data script", use_updates_for_indexing: true do
+      context "on a system that's been using `use_updates_for_indexing: true` with the initial v0.9 update data script", use_updates_for_indexing: true do
         let(:component_id) { "c12" }
         let(:new_script_indexer) { build_indexer(use_old_update_script: false) }
         let(:old_script_indexer) { build_indexer(use_old_update_script: true) }
@@ -217,12 +217,10 @@ module ElasticGraph
             }.to change_name_and_version_metadata(
               from: {
                 "name" => "old",
-                "__sourceVersions" => {"Component" => {component_id => 1}},
                 "__versions" => {SELF_RELATIONSHIP_NAME => {component_id => 1}}
               },
               to: {
                 "name" => "new",
-                "__sourceVersions" => {"Component" => {component_id => 1}},
                 "__versions" => {SELF_RELATIONSHIP_NAME => {component_id => 2}}
               }
             )
@@ -240,7 +238,6 @@ module ElasticGraph
               },
               to: {
                 "name" => "new",
-                "__sourceVersions" => {"Component" => {component_id => 2}},
                 "__versions" => {SELF_RELATIONSHIP_NAME => {component_id => 2}}
               }
             )
@@ -258,7 +255,6 @@ module ElasticGraph
               process_batches([new_event], via: new_script_indexer)
             }.to leave_name_and_version_metadata_unchanged_from(
               "name" => "old",
-              "__sourceVersions" => {"Component" => {component_id => 1}},
               "__versions" => {SELF_RELATIONSHIP_NAME => {component_id => 1}}
             )
           end
@@ -286,7 +282,6 @@ module ElasticGraph
               process_batches([new_event], via: new_script_indexer)
             }.to leave_name_and_version_metadata_unchanged_from(
               "name" => "old",
-              "__sourceVersions" => {"Component" => {component_id => 2}},
               "__versions" => {SELF_RELATIONSHIP_NAME => {component_id => 2}}
             )
           end
@@ -302,7 +297,7 @@ module ElasticGraph
             )
           end
 
-          it "considers the max version from `__sourceVersions` and `__versions` to be the document's version when deciding whether to process an update" do
+          it "can go back and forth between old and new versions when processing updates" do
             expected_state1 = {
               "name" => "name1",
               "__versions" => {SELF_RELATIONSHIP_NAME => {component_id => 1}}
@@ -310,28 +305,24 @@ module ElasticGraph
 
             expected_state2 = {
               "name" => "name2",
-              "__versions" => {SELF_RELATIONSHIP_NAME => {component_id => 2}},
-              "__sourceVersions" => {"Component" => {component_id => 2}}
+              "__versions" => {SELF_RELATIONSHIP_NAME => {component_id => 2}}
             }
 
             expected_state3 = {
               "name" => "name3",
-              "__versions" => {SELF_RELATIONSHIP_NAME => {component_id => 3}},
-              "__sourceVersions" => {"Component" => {component_id => 2}}
+              "__versions" => {SELF_RELATIONSHIP_NAME => {component_id => 3}}
             }
 
             # 1) Successfully index using the new script...
             process_batches([build_component_event(name: "name1", version: 1)], via: new_script_indexer)
 
-            # 2) Then successfully index using the old script. Notably, the old script sets the version on `__sourceVersions`
-            #    but not on `__versions`, leaving `__versions` with an out-of-date value.
+            # 2) Then successfully index using the old script.
             expect {
               process_batches([build_component_event(name: "name2", version: 2)], via: old_script_indexer)
             }.to change_name_and_version_metadata(from: expected_state1, to: expected_state2)
 
             # 3) Then try to index using the new script with an event that doesn't have a greater version. It should
-            #    leave things unchanged. (Which requires it to use the version found in `__sourceVersions`, not the
-            #    version found in` __versions`).
+            #    leave things unchanged.
             expect {
               process_batches([build_component_event(name: "name3", version: 2)], via: new_script_indexer)
             }.to leave_name_and_version_metadata_unchanged_from(expected_state2)
@@ -359,7 +350,7 @@ module ElasticGraph
         def indexed_name_and_version_metadata
           results = search.dig("hits", "hits")
             .select { |h| h["_index"] == "components" }
-            .map { |h| h.dig("_source").slice("name", "__versions", "__sourceVersions") }
+            .map { |h| h.dig("_source").slice("name", "__versions") }
 
           expect(results.size).to eq(1)
           results.first

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/scripts/update/index_data.painless
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/scripts/update/index_data.painless
@@ -31,30 +31,10 @@ if (previousSourceIdsForRelationship.size() > 0) {
  );
 }
 
-// While the version in `__versions` is going to be used for the doc version in the future, for now
-// we need to continue getting it from `__sourceVersions`. Both our old version and this versions of this
-// script keep the value in `__sourceVersions` up-to-date, whereas the old script only writes it to
-// `__sourceVersions`. Until we have completely migrated off of the old script for all ElasticGraph
-// clusters, we need to keep using it.
-//
-// Later, after the old script is no longer used by any clusters, we'll stop using `__sourceVersions`.
-Number _versionForSourceType = source.get("__sourceVersions")?.get(params.sourceType)?.get(sourceId);
-Number _versionForRelationship = relationshipVersionsMap.get(sourceId);
+Number maybeDocVersion = source.__versions.get(params.relationship)?.get(params.sourceId);
 
 // Our JSON schema requires event versions to be non-negative, so we can safely use Long.MIN_VALUE as a stand-in when the value is null.
-long versionForSourceType = _versionForSourceType == null ? Long.MIN_VALUE : _versionForSourceType.longValue();
-long versionForRelationship = _versionForRelationship == null ? Long.MIN_VALUE : _versionForRelationship.longValue();
-
-// Pick the larger of the two versions as our doc version. Note that `Math.max` didn't work for me here for
-// reasons I don't understand, but a simple ternary works fine.
-//
-// In theory, we could just use `versionForSourceType` as the `docVersion` (and not even check `__versions` at all)
-// since both the old version and this version maintain the doc version in `__sourceVersions`. However, that would
-// prevent this version of the script from being forward-compatible with the planned next version of this script.
-// In the next version, we plan to stop writing to `__sourceVersions`, and as we can't deploy that change atomically,
-// this version of the script will continue to run after that has begun to be used. So this version of the script
-// must consider which version is greater here, and not simply trust either version value.
-long docVersion = versionForSourceType > versionForRelationship ? versionForSourceType : versionForRelationship;
+long docVersion = maybeDocVersion == null ? Long.MIN_VALUE : maybeDocVersion.longValue();
 
 if (docVersion >= eventVersion) {
   throw new IllegalArgumentException("ElasticGraph update was a no-op: [" +

--- a/elasticgraph-support/lib/elastic_graph/constants.rb
+++ b/elasticgraph-support/lib/elastic_graph/constants.rb
@@ -125,7 +125,7 @@ module ElasticGraph
   #
   # Note: this constant is automatically kept up-to-date by our `schema_artifacts:dump` rake task.
   # @private
-  INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_38ea36e5b48fc1566d4142e9fc44b12e"
+  INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_1fdfaf1c9261c96019decc89b515bd9a"
 
   # The id of the old version of the update data script before ElasticGraph v0.9. For now, we are maintaining
   # backwards compatibility with how it recorded event versions, and we have test coverage for that which relies
@@ -133,7 +133,7 @@ module ElasticGraph
   #
   # TODO: Drop this when we no longer need to maintain backwards-compatibility.
   # @private
-  OLD_INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_9b97090d5c97c4adc82dc7f4c2b89bc5"
+  OLD_INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_7b4f66599e5dd7658f5c15c44b2d998b"
 
   # When an update script has a no-op result we often want to communicate more information about
   # why it was a no-op back to ElatsicGraph from the script. The only way to do that is to throw

--- a/spec_support/lib/elastic_graph/spec_support/cluster_configuration_manager.rb
+++ b/spec_support/lib/elastic_graph/spec_support/cluster_configuration_manager.rb
@@ -8,7 +8,6 @@
 
 require "elastic_graph/admin"
 require "elastic_graph/spec_support/builds_admin"
-require "elastic_graph/support/hash_util"
 require "yaml"
 
 module ElasticGraph
@@ -36,53 +35,11 @@ module ElasticGraph
       self.state_file_name = state_file_name
 
       # Also make our old datastore scripts available to call from our tests for backwards-compatibility testing.
-      # We also need to add the `__sourceVersions` field back that some tests rely on but which we don't want
-      # generated in our `datastore_config.yaml` anymore.
       #
       # TODO: Drop this when we no longer need to maintain backwards-compatibility.
       # standard:disable Lint/NestedMethodDefinition
       def (@admin.schema_artifacts).datastore_scripts
         super.merge(::YAML.safe_load_file(::File.join(__dir__, "old_datastore_scripts.yaml")))
-      end
-
-      def (@admin.schema_artifacts).indices
-        datastore_config = super
-
-        overrides = datastore_config.transform_values do |index_config|
-          {
-            "mappings" => {
-              "properties" => {
-                "__sourceVersions" => {
-                  "type" => "object",
-                  "dynamic" => "false"
-                }
-              }
-            }
-          }
-        end
-
-        Support::HashUtil.deep_merge(datastore_config, overrides)
-      end
-
-      def (@admin.schema_artifacts).index_templates
-        datastore_config = super
-
-        overrides = datastore_config.transform_values do |index_config|
-          {
-            "template" => {
-              "mappings" => {
-                "properties" => {
-                  "__sourceVersions" => {
-                    "type" => "object",
-                    "dynamic" => "false"
-                  }
-                }
-              }
-            }
-          }
-        end
-
-        Support::HashUtil.deep_merge(datastore_config, overrides)
       end
       # standard:enable Lint/NestedMethodDefinition
     end

--- a/spec_support/lib/elastic_graph/spec_support/old_datastore_scripts.yaml
+++ b/spec_support/lib/elastic_graph/spec_support/old_datastore_scripts.yaml
@@ -1,7 +1,7 @@
 ---
-# Copied from config/schema/artifacts/datastore_scripts.yaml#L196-L264 in ElasticGraph v0.8.0.0.
+# Copied from config/schema/artifacts/datastore_scripts.yaml#L196-L264 in ElasticGraph v0.9.0.0.
 # TODO: Drop this when we no longer need to maintain backwards-compatibility.
-update_index_data_9b97090d5c97c4adc82dc7f4c2b89bc5:
+update_index_data_7b4f66599e5dd7658f5c15c44b2d998b:
   context: update
   script:
     lang: painless
@@ -19,14 +19,6 @@ update_index_data_9b97090d5c97c4adc82dc7f4c2b89bc5:
         source.__versions[params.relationship] = [:];
       }
 
-      if (source.__sourceVersions == null) {
-        source.__sourceVersions = [:];
-      }
-
-      if (source.__sourceVersions[params.sourceType] == null) {
-        source.__sourceVersions[params.sourceType] = [:];
-      }
-
       // While the version in `__versions` is going to be used for the doc version in the future, for now
       // we need to continue getting it from `__sourceVersions`. Both our old version and this versions of this
       // script keep the value in `__sourceVersions` up-to-date, whereas the old script only writes it to
@@ -35,7 +27,7 @@ update_index_data_9b97090d5c97c4adc82dc7f4c2b89bc5:
       //
       // Later, after the old script is no longer used by any clusters, we'll stop using `__sourceVersions`.
       // TODO: switch to `__versions` when we no longer need to maintain compatibility with the old version of the script.
-      Number _versionForSourceType = source.__sourceVersions.get(params.sourceType)?.get(params.sourceId);
+      Number _versionForSourceType = source.get("__sourceVersions")?.get(params.sourceType)?.get(params.sourceId);
       Number _versionForRelationship = source.__versions.get(params.relationship)?.get(params.sourceId);
 
       // Our JSON schema requires event versions to be non-negative, so we can safely use Long.MIN_VALUE as a stand-in when the value is null.
@@ -62,11 +54,4 @@ update_index_data_9b97090d5c97c4adc82dc7f4c2b89bc5:
         source.putAll(params.data);
         source.id = params.id;
         source.__versions[params.relationship][params.sourceId] = eventVersion;
-
-        // To continue to be backwards compatible with the old version of this script, we need to write the version to
-        // `__sourceVersions` since that's where it looks. In addition, we need to use `params.version` (which can be
-        // double) rather than `eventVersion` (a long) to mirror how the old version of this script behaved (which didn't
-        // do any casting).
-        // TODO: drop this when we no longer need to maintain compatibility with the old version of the script.
-        source.__sourceVersions[params.sourceType][params.sourceId] = params.version;
       }


### PR DESCRIPTION
In ElasticGraph v0.9.0.0 (an internal release inside Block), we began migrating off of `__sourceVersions[sourceType]` for the internal bookkeeping performed by the indexing update script. However, for backwards compatibility with indices which had been written to using older versions of ElasticGraph, we kept reading the `__sourceVersions[sourceType]` field even as we stopped writing to it.

This removes that backwards compatibility, in preparation for ElasticGraph v1.0.0.