### PR TITLE
Bug fix: handle GraphQL exception during health checks.

### DIFF
--- a/elasticgraph-health_check/sig/elastic_graph/health_check/health_checker.rbs
+++ b/elasticgraph-health_check/sig/elastic_graph/health_check/health_checker.rbs
@@ -26,6 +26,7 @@ module ElasticGraph
       @indexed_document_types_by_name: ::Hash[::String, GraphQL::Schema::Type]
       @config: Config
 
+      def datastore_msearch: (::Array[GraphQL::DatastoreQuery]) -> ::Hash[GraphQL::DatastoreQuery, GraphQL::DatastoreResponse::SearchResponse]
       def build_recency_query_for: (::String, Config::DataRecencyCheck) -> GraphQL::DatastoreQuery
       def build_index_optimization_filter_for: (Config::DataRecencyCheck) -> ::Hash[::String, untyped]?
       def execute_in_parallel: (*::Proc) -> ::Array[untyped]


### PR DESCRIPTION
This specific GraphQL exception was introduced in #440. Before that, the `DatastoreSearchRouter` never raised `GraphQL::ExecutionError`. The GraphQL gem handles `GraphQL::ExecutionError` (it's how we add errors to a GraphQL response). In `elasticgraph-health_check` we are not running in a GraphQL context and need to handle the exception ourselves.