### PR TITLE
Update ci.yaml to validate/lint workflows.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,6 +169,30 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/elasticgraph-demo:${{ github.sha }}
             ghcr.io/${{ github.repository_owner }}/elasticgraph-demo:latest
 
+  lint-workflows:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install action-validator with asdf
+        uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3.0.2
+        with:
+          tool_versions: |
+            action-validator 0.5.1
+
+      - name: Lint Actions
+        run: |
+          find .github/workflows -type f \( -iname \*.yaml -o -iname \*.yml \) \
+            | xargs -I {} action-validator --verbose {}
+
   # An extra job that runs after all the others and provides a single summary status.
   # This is used by our branch protection rule to block merge until all CI checks passed,
   # without requiring us to individually list each CI check in the branch protection rule.
@@ -178,7 +202,7 @@ jobs:
     if: ${{ always() }} # so it runs even if the workflow was cancelled
     runs-on: ubuntu-latest
     name: All CI Checks Passed
-    needs: [ci-check, docker-demo]
+    needs: [ci-check, docker-demo, lint-workflows]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1


### PR DESCRIPTION
This uses https://github.com/mpalmer/action-validator to validate/lint our GitHub action workflows.

Confirmed it properly fails when there's an invalid workflow file via #490.