### PR TITLE
Improve the logging of hidden types.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -92,6 +92,7 @@ module ElasticGraph
         Schema.new(
           graphql_schema_string: graphql_schema_string,
           config: config,
+          logger: logger,
           runtime_metadata: runtime_metadata,
           index_definitions_by_graphql_type: @datastore_core.index_definitions_by_graphql_type,
           graphql_gem_plugins: graphql_gem_plugins,

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_details_tracker.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_details_tracker.rb
@@ -15,7 +15,6 @@ module ElasticGraph
     # Class used to track details of what happens during a single GraphQL query for the purposes of logging.
     # Here we use `Struct` instead of `Data` specifically because it is designed to be mutable.
     class QueryDetailsTracker < Struct.new(
-      :hidden_types,
       :shard_routing_values,
       :search_index_expressions,
       :query_counts_per_datastore_request,
@@ -26,7 +25,6 @@ module ElasticGraph
     )
       def self.empty
         new(
-          hidden_types: ::Set.new,
           shard_routing_values: ::Set.new,
           search_index_expressions: ::Set.new,
           query_counts_per_datastore_request: [],
@@ -42,12 +40,6 @@ module ElasticGraph
           shard_routing_values.merge(queries.flat_map { |q| q.shard_routing_values || [] })
           search_index_expressions.merge(queries.map(&:search_index_expression))
           query_counts_per_datastore_request << queries.size
-        end
-      end
-
-      def record_hidden_type(type)
-        mutex.synchronize do
-          hidden_types << type
         end
       end
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_executor.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_executor.rb
@@ -81,10 +81,6 @@ module ElasticGraph
           EOS
         end
 
-        unless query_tracker.hidden_types.empty?
-          @logger.warn "#{query_tracker.hidden_types.size} GraphQL types were hidden from the schema due to their backing indices being inaccessible: #{query_tracker.hidden_types.sort.join(", ")}"
-        end
-
         duration = @monotonic_clock.now_in_ms - start_time_in_ms
 
         # Note: I also wanted to log the sanitized query if `result` has `errors`, but `GraphQL::Query#sanitized_query`

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/base_classes.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/base_classes.rb
@@ -24,7 +24,6 @@ module ElasticGraph
 
         def self.visible?(context)
           if context[:elastic_graph_schema]&.type_named(graphql_name)&.hidden_from_queries?
-            context[:elastic_graph_query_tracker].record_hidden_type(graphql_name)
             return false
           end
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/query_details_tracker.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/query_details_tracker.rbs
@@ -1,7 +1,6 @@
 module ElasticGraph
   class GraphQL
     class QueryDetailsTrackerSupertype
-      attr_accessor hidden_types: ::Set[::String]
       attr_accessor shard_routing_values: ::Set[::String]
       attr_accessor search_index_expressions: ::Set[::String]
       attr_accessor query_counts_per_datastore_request: ::Array[::Integer]
@@ -11,7 +10,6 @@ module ElasticGraph
       attr_accessor mutex: ::Thread::Mutex
 
       def initialize: (
-        hidden_types: ::Set[::String],
         shard_routing_values: ::Set[::String],
         search_index_expressions: ::Set[::String],
         query_counts_per_datastore_request: ::Array[::Integer],
@@ -25,7 +23,6 @@ module ElasticGraph
     class QueryDetailsTracker < QueryDetailsTrackerSupertype
       def self.empty: () -> QueryDetailsTracker
       def record_datastore_queries_for_single_request: (::Array[DatastoreQuery]) -> void
-      def record_hidden_type: (::String) -> void
       def record_datastore_query_metrics: (
         client_duration_ms: ::Integer,
         server_duration_ms: ::Integer?,

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/schema.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/schema.rbs
@@ -8,6 +8,7 @@ module ElasticGraph
       def initialize: (
         graphql_schema_string: ::String,
         config: Config,
+        logger: Logger,
         runtime_metadata: SchemaArtifacts::RuntimeMetadata::Schema,
         index_definitions_by_graphql_type: ::Hash[::String, ::Array[DatastoreCore::_IndexDefinition]],
         graphql_gem_plugins: ::Hash[::Class, ::Hash[::Symbol, untyped]],
@@ -18,6 +19,7 @@ module ElasticGraph
       def type_named: (::String) -> Type
       def field_named: (::String, ::String) -> Field
       def indexed_document_types: () -> ::Array[Type]
+      def log_hidden_types: (Logger) -> void
     end
   end
 end

--- a/elasticgraph-graphql/spec/acceptance/hidden_types_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/hidden_types_spec.rb
@@ -29,7 +29,13 @@ module ElasticGraph
 
           expect {
             restricted_fields_by_type_name = fields_by_type_name_from(graphql_hiding_addresses_and_mechanical_parts)
-          }.to log_warning(a_string_including("2 GraphQL types were hidden", "Address", "MechanicalPart"))
+          }.to log_warning(a_string_including(
+            "4 GraphQL types were hidden",
+            "Address",
+            "MechanicalPart",
+            apply_derived_type_customizations("AddressAggregation"),
+            apply_derived_type_customizations("MechanicalPartAggregation")
+          ))
 
           hidden_types = (all_fields_by_type_name.keys - restricted_fields_by_type_name.keys)
 


### PR DESCRIPTION
- Log all hidden types, not just indexed hidden types.
- Log the hidden types once at boot time instead of once per query.