### PR TITLE
Simplify the GraphQL query context.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_executor.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_executor.rb
@@ -61,13 +61,10 @@ module ElasticGraph
           operation_name: operation_name,
           client: client,
           context: context.merge({
-            logger: @logger,
             monotonic_clock_deadline: timeout_in_ms&.+(start_time_in_ms),
             elastic_graph_schema: @schema,
-            schema_element_names: @schema.element_names,
             elastic_graph_query_tracker: query_tracker,
-            datastore_search_router: @datastore_search_router,
-            nested_relationship_resolver_mode: @config.nested_relationship_resolver_mode
+            datastore_search_router: @datastore_search_router
           }.compact)
         )
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships_source.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships_source.rb
@@ -65,8 +65,9 @@ module ElasticGraph
           @join = join
           @filter_id_field_name_path = @join.filter_id_field_name.split(".")
           @context = context
-          @schema_element_names = @context.fetch(:schema_element_names)
-          @logger = context.fetch(:logger)
+          elastic_graph_schema = context.fetch(:elastic_graph_schema)
+          @schema_element_names = elastic_graph_schema.element_names
+          @logger = elastic_graph_schema.logger
           @monotonic_clock = monotonic_clock
           @mode = mode
         end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection.rb
@@ -20,7 +20,7 @@ module ElasticGraph
         def self.maybe_wrap(search_response, field:, context:, lookahead:, query:)
           return search_response unless field.type.relay_connection?
 
-          schema_element_names = context.fetch(:schema_element_names)
+          schema_element_names = context.fetch(:elastic_graph_schema).element_names
 
           unless field.type.unwrap_fully.indexed_aggregation?
             return SearchResponseAdapterBuilder.build_from(

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
@@ -25,7 +25,7 @@ module ElasticGraph
         scalar_types.to_set.union(introspection_types)
       )
 
-      attr_reader :element_names, :config, :graphql_schema, :runtime_metadata
+      attr_reader :element_names, :config, :logger, :graphql_schema, :runtime_metadata
 
       def initialize(
         graphql_schema_string:,
@@ -38,6 +38,7 @@ module ElasticGraph
       )
         @element_names = runtime_metadata.schema_element_names
         @config = config
+        @logger = logger
         @runtime_metadata = runtime_metadata
         resolvers_needing_lookahead = runtime_metadata.graphql_resolvers_by_name.filter_map do |name, resolver|
           name if resolver.needs_lookahead
@@ -69,7 +70,7 @@ module ElasticGraph
         # of loading the schema, before we execute the first query.
         @types_by_name = build_types_by_name
 
-        log_hidden_types(logger)
+        log_hidden_types
       end
 
       def type_from(graphql_type)
@@ -140,7 +141,7 @@ module ElasticGraph
         end.freeze
       end
 
-      def log_hidden_types(logger)
+      def log_hidden_types
         hidden_types = @types_by_name.values.select(&:hidden_from_queries?)
         return if hidden_types.empty?
 

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_source_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_source_spec.rb
@@ -407,9 +407,8 @@ module ElasticGraph
               query: instance_double(::GraphQL::Query),
               schema: graphql.schema.graphql_schema,
               values: {
-                logger: graphql.logger,
+                elastic_graph_schema: graphql.schema,
                 dataloader: dataloader,
-                schema_element_names: graphql.runtime_metadata.schema_element_names,
                 datastore_search_router: graphql.datastore_search_router,
                 elastic_graph_query_tracker: QueryDetailsTracker.empty
               }

--- a/elasticgraph-graphql/spec/support/query_adapter.rb
+++ b/elasticgraph-graphql/spec/support/query_adapter.rb
@@ -64,7 +64,6 @@ module QueryAdapterSpecSupport
     end
 
     def call(parent_type, field, object, args, context)
-      context[:schema_element_names] = @graphql.schema.element_names
       schema_field = @graphql.schema.field_named(parent_type.graphql_name, field.name)
 
       lookahead = args[:lookahead]

--- a/elasticgraph-graphql/spec/support/resolver.rb
+++ b/elasticgraph-graphql/spec/support/resolver.rb
@@ -24,13 +24,10 @@ module ResolverHelperMethods
         query: nil,
         schema: graphql.schema.graphql_schema,
         values: {
-          logger: graphql.logger,
           elastic_graph_schema: graphql.schema,
-          schema_element_names: graphql.runtime_metadata.schema_element_names,
           dataloader: dataloader,
           elastic_graph_query_tracker: query_details_tracker,
-          datastore_search_router: graphql.datastore_search_router,
-          nested_relationship_resolver_mode: graphql.config.nested_relationship_resolver_mode
+          datastore_search_router: graphql.datastore_search_router
         }
       )
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection_spec.rb
@@ -62,7 +62,7 @@ module ElasticGraph
 
             graphql = build_graphql(schema_artifacts: schema_artifacts)
             field = graphql.schema.field_named("Query", field_name)
-            context = {schema_element_names: graphql.runtime_metadata.schema_element_names}
+            context = {elastic_graph_schema: graphql.schema}
 
             lookahead = ::GraphQL::Execution::Lookahead.new(
               query: nil,


### PR DESCRIPTION
Previously, we had a large set of values we put into the query context. Most of them aren't needed. This removes the unneeded ones.