### PR TITLE
Centralize the instantiation of `GraphQL::Query` objects.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -78,9 +78,7 @@ module ElasticGraph
           schema: schema,
           monotonic_clock: monotonic_clock,
           logger: logger,
-          slow_query_threshold_ms: @config.slow_query_latency_warning_threshold_in_ms,
-          datastore_search_router: datastore_search_router,
-          config: config
+          slow_query_threshold_ms: @config.slow_query_latency_warning_threshold_in_ms
         )
       end
     end
@@ -94,6 +92,7 @@ module ElasticGraph
           config: config,
           logger: logger,
           runtime_metadata: runtime_metadata,
+          datastore_search_router: datastore_search_router,
           index_definitions_by_graphql_type: @datastore_core.index_definitions_by_graphql_type,
           graphql_gem_plugins: graphql_gem_plugins,
           graphql_adapter: graphql_adapter

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_details_tracker.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_details_tracker.rb
@@ -6,10 +6,6 @@
 #
 # frozen_string_literal: true
 
-require "elastic_graph/graphql/client"
-require "elastic_graph/support/hash_util"
-require "graphql"
-
 module ElasticGraph
   class GraphQL
     # Class used to track details of what happens during a single GraphQL query for the purposes of logging.

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/query_executor.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/query_executor.rbs
@@ -5,9 +5,7 @@ module ElasticGraph
         schema: Schema,
         monotonic_clock: Support::MonotonicClock,
         logger: ::Logger,
-        slow_query_threshold_ms: ::Integer,
-        datastore_search_router: DatastoreSearchRouter,
-        config: Config
+        slow_query_threshold_ms: ::Integer
       ) -> void
 
       def execute: (

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/schema.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/schema.rbs
@@ -10,10 +10,20 @@ module ElasticGraph
         config: Config,
         logger: Logger,
         runtime_metadata: SchemaArtifacts::RuntimeMetadata::Schema,
+        datastore_search_router: DatastoreSearchRouter,
         index_definitions_by_graphql_type: ::Hash[::String, ::Array[DatastoreCore::_IndexDefinition]],
         graphql_gem_plugins: ::Hash[::Class, ::Hash[::Symbol, untyped]],
         graphql_adapter: Resolvers::graphQLAdapter
       ) -> void
+
+      def new_graphql_query: (
+        ::String?,
+        ?operation_name: ::String?,
+        ?variables: ::Hash[::String, untyped],
+        ?context: ::Hash[::Symbol, untyped],
+        ?document: ::GraphQL::Language::Nodes::Document?,
+        ?validate: bool
+      ) -> ::GraphQL::Query
 
       def type_from: (::GraphQL::Schema::_Type) -> Type
       def type_named: (::String) -> Type

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/client_data.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/client_data.rb
@@ -12,7 +12,7 @@ module ElasticGraph
       # @implements ClientData
       def self.from(schema, registered_query_strings)
         queries_by_original_string = registered_query_strings.to_h do |query_string|
-          [query_string, ::GraphQL::Query.new(schema.graphql_schema, query_string, validate: false)]
+          [query_string, schema.new_graphql_query(query_string, validate: false)]
         end
 
         canonical_query_strings = queries_by_original_string.values.map do |q|

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/graphql_extension.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/graphql_extension.rb
@@ -23,8 +23,6 @@ module ElasticGraph
             monotonic_clock: monotonic_clock,
             logger: logger,
             slow_query_threshold_ms: config.slow_query_latency_warning_threshold_in_ms,
-            datastore_search_router: datastore_search_router,
-            config: config,
             registry_directory: registry_config.path_to_registry,
             allow_unregistered_clients: registry_config.allow_unregistered_clients,
             allow_any_query_for_clients: registry_config.allow_any_query_for_clients
@@ -41,17 +39,13 @@ module ElasticGraph
         schema:,
         monotonic_clock:,
         logger:,
-        slow_query_threshold_ms:,
-        datastore_search_router:,
-        config:
+        slow_query_threshold_ms:
       )
         super(
           schema: schema,
           monotonic_clock: monotonic_clock,
           logger: logger,
-          slow_query_threshold_ms: slow_query_threshold_ms,
-          datastore_search_router: datastore_search_router,
-          config: config
+          slow_query_threshold_ms: slow_query_threshold_ms
         )
 
         @registry = Registry.build_from_directory(

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/query_validators/for_registered_client.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/query_validators/for_registered_client.rb
@@ -16,7 +16,6 @@ module ElasticGraph
       # Query validator implementation used for registered clients.
       class ForRegisteredClient < ::Data.define(
         :schema,
-        :graphql_schema,
         :allow_any_query_for_clients,
         :client_data_by_client_name,
         :client_cache_mutex,
@@ -25,7 +24,6 @@ module ElasticGraph
         def initialize(schema:, client_names:, allow_any_query_for_clients:, provide_query_strings_for_client:)
           super(
             schema: schema,
-            graphql_schema: schema.graphql_schema,
             allow_any_query_for_clients: allow_any_query_for_clients,
             client_cache_mutex: ::Mutex.new,
             provide_query_strings_for_client: provide_query_strings_for_client,
@@ -107,8 +105,7 @@ module ElasticGraph
         end
 
         def prepare_query_for_execution(query, variables:, operation_name:, context:)
-          ::GraphQL::Query.new(
-            graphql_schema,
+          schema.new_graphql_query(
             # Here we pass `document` instead of query string, so that we don't have to re-parse the query.
             # However, when the document is nil, we still need to pass the query string.
             query.document ? nil : query.query_string,

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/rake_tasks.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/rake_tasks.rb
@@ -57,7 +57,7 @@ module ElasticGraph
         require "elastic_graph/query_registry/variable_dumper"
         require "yaml"
 
-        variable_dumper = VariableDumper.new(graphql.schema.graphql_schema)
+        variable_dumper = VariableDumper.new(graphql.schema)
 
         @registered_queries_by_client_dir.glob(query_glob) do |file|
           dumped_variables = variable_dumper.dump_variables_for_query(file.read)

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/registry.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/registry.rb
@@ -68,8 +68,7 @@ module ElasticGraph
           end
 
         validator.build_and_validate_query(query_string, client: client, variables: variables, operation_name: operation_name, context: context) do
-          ::GraphQL::Query.new(
-            @graphql_schema,
+          @schema.new_graphql_query(
             query_string,
             variables: variables,
             operation_name: operation_name,
@@ -81,7 +80,7 @@ module ElasticGraph
       private
 
       def initialize(schema, client_names:, allow_unregistered_clients:, allow_any_query_for_clients:, &provide_query_strings_for_client)
-        @graphql_schema = schema.graphql_schema
+        @schema = schema
         allow_any_query_for_clients_set = allow_any_query_for_clients.to_set
 
         @registered_client_validator = QueryValidators::ForRegisteredClient.new(

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/variable_dumper.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/variable_dumper.rb
@@ -24,14 +24,15 @@ module ElasticGraph
     # When the structure of variables changes, we can then tell the engineer that they need to verify
     # that it won't break the client.
     class VariableDumper
-      def initialize(graphql_schema)
-        @graphql_schema = graphql_schema
+      def initialize(schema)
+        @schema = schema
+        @graphql_schema = schema.graphql_schema
       end
 
       # Returns a hash of operations from the given query string. For each operation, the value
       # is a hash of variables.
       def dump_variables_for_query(query_string)
-        query = ::GraphQL::Query.new(@graphql_schema, query_string, validate: false)
+        query = @schema.new_graphql_query(query_string, validate: false)
 
         if query.document.nil?
           # If the query was unparsable, we don't know anything about the variables and must just return an empty hash.

--- a/elasticgraph-query_registry/sig/elastic_graph/query_registry/graphql_extension.rbs
+++ b/elasticgraph-query_registry/sig/elastic_graph/query_registry/graphql_extension.rbs
@@ -12,9 +12,7 @@ module ElasticGraph
         schema: GraphQL::Schema,
         monotonic_clock: Support::MonotonicClock,
         logger: ::Logger,
-        slow_query_threshold_ms: ::Integer,
-        datastore_search_router: GraphQL::DatastoreSearchRouter,
-        config: GraphQL::Config
+        slow_query_threshold_ms: ::Integer
       ) -> void
 
       private

--- a/elasticgraph-query_registry/sig/elastic_graph/query_registry/query_validator.rbs
+++ b/elasticgraph-query_registry/sig/elastic_graph/query_registry/query_validator.rbs
@@ -15,7 +15,7 @@ module ElasticGraph
 
       private
 
-      @graphql_schema: ::GraphQL::Schema
+      @schema: GraphQL::Schema
       @schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames
       @var_dumper: VariableDumper
       @var_incompat_detector: VariableBackwardIncompatibilityDetector

--- a/elasticgraph-query_registry/sig/elastic_graph/query_registry/query_validators/for_registered_client.rbs
+++ b/elasticgraph-query_registry/sig/elastic_graph/query_registry/query_validators/for_registered_client.rbs
@@ -3,7 +3,6 @@ module ElasticGraph
     module QueryValidators
       class ForRegisteredClientSupertype
         attr_reader schema: GraphQL::Schema
-        attr_reader graphql_schema: ::GraphQL::Schema
         attr_reader allow_any_query_for_clients: ::Set[::String]
         attr_reader client_cache_mutex: ::Thread::Mutex
         attr_reader provide_query_strings_for_client: ^(::String) -> ::Array[::String]
@@ -11,7 +10,6 @@ module ElasticGraph
 
         def initialize: (
           schema: GraphQL::Schema,
-          graphql_schema: ::GraphQL::Schema,
           allow_any_query_for_clients: ::Set[::String],
           client_cache_mutex: ::Thread::Mutex,
           provide_query_strings_for_client: ^(::String) -> ::Array[::String],

--- a/elasticgraph-query_registry/sig/elastic_graph/query_registry/registry.rbs
+++ b/elasticgraph-query_registry/sig/elastic_graph/query_registry/registry.rbs
@@ -26,7 +26,7 @@ module ElasticGraph
 
       private
 
-      @graphql_schema: ::GraphQL::Schema
+      @schema: GraphQL::Schema
       @registered_client_validator: QueryValidators::ForRegisteredClient
       @unregistered_client_validator: QueryValidators::ForUnregisteredClient
     end

--- a/elasticgraph-query_registry/sig/elastic_graph/query_registry/variable_dumper.rbs
+++ b/elasticgraph-query_registry/sig/elastic_graph/query_registry/variable_dumper.rbs
@@ -5,7 +5,7 @@ module ElasticGraph
       type enumTypeInfo = {"type" => ::String, "values" => ::Array[::String]}
       type typeInfo = ::String | objectTypeInfo | enumTypeInfo
 
-      def initialize: (::GraphQL::Schema) -> void
+      def initialize: (GraphQL::Schema) -> void
       def dump_variables_for_query: (::String) -> ::Hash[::String, ::Hash[::String, typeInfo]]
       def dump_variables_for_operations: (
         ::Array[::GraphQL::Language::Nodes::OperationDefinition]
@@ -13,6 +13,7 @@ module ElasticGraph
 
       private
 
+      @schema: GraphQL::Schema
       @graphql_schema: ::GraphQL::Schema
       def variables_for_op: (::GraphQL::Language::Nodes::OperationDefinition) -> ::Hash[::String, typeInfo]
       def type_info: (::GraphQL::Schema::_Type) -> typeInfo

--- a/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/query_validator_spec.rb
+++ b/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/query_validator_spec.rb
@@ -14,7 +14,7 @@ module ElasticGraph
   module QueryRegistry
     RSpec.describe QueryValidator do
       let(:schema) { build_graphql.schema }
-      let(:variable_dumper) { VariableDumper.new(schema.graphql_schema) }
+      let(:variable_dumper) { VariableDumper.new(schema) }
 
       describe "#validate" do
         it "returns no errors when given a valid named query with no arguments" do

--- a/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/variable_dumper_spec.rb
+++ b/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/variable_dumper_spec.rb
@@ -12,7 +12,7 @@ require "elastic_graph/query_registry/variable_dumper"
 module ElasticGraph
   module QueryRegistry
     RSpec.describe VariableDumper do
-      let(:dumper) { VariableDumper.new(build_graphql.schema.graphql_schema) }
+      let(:dumper) { VariableDumper.new(build_graphql.schema) }
 
       describe "#dump_variables_for_query" do
         it "returns an empty hash for a valid query that has no variables" do


### PR DESCRIPTION
Previously, we instantiated them from 7 different places. I'm working on a change that impacts how they are instantiated, and it's useful to have that centralized. `ElasticGraph::GraphQL::Schema#new_graphql_query` makes sense as a useful abstraction to offer, anyway.