### PR TITLE
Update Elasticsearch versions.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
           - "3.3"
           - "3.4"
         datastore:
-          - "elasticsearch:8.17.3"
+          - "elasticsearch:8.18.0"
           - "opensearch:2.19.1"
           - "opensearch:2.7.0"
         include:
@@ -40,13 +40,13 @@ jobs:
           # configuration here.
           - build_part: "run_misc_checks"
             ruby: "3.4"
-            datastore: "elasticsearch:8.17.3"
+            datastore: "elasticsearch:8.18.0"
           - build_part: "run_specs_with_vcr"
             ruby: "3.4"
-            datastore: "elasticsearch:8.17.3"
+            datastore: "elasticsearch:8.18.0"
           - build_part: "run_specs_file_by_file"
             ruby: "3.4"
-            datastore: "elasticsearch:8.17.3"
+            datastore: "elasticsearch:8.18.0"
 
     steps:
       - name: Harden Runner

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ PATH
   specs:
     elasticgraph-elasticsearch (0.19.2.1.pre)
       elasticgraph-support (= 0.19.2.1.pre)
-      elasticsearch (~> 9.0.0)
+      elasticsearch (~> 9.0)
       faraday (~> 2.13)
       faraday-retry (~> 2.3, >= 2.3.1)
 

--- a/elasticgraph-elasticsearch/elasticgraph-elasticsearch.gemspec
+++ b/elasticgraph-elasticsearch/elasticgraph-elasticsearch.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = [">= 3.2", "< 3.5"]
 
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "elasticsearch", "~> 9.0.0"
+  spec.add_dependency "elasticsearch", "~> 9.0"
   spec.add_dependency "faraday", "~> 2.13"
   spec.add_dependency "faraday-retry", "~> 2.3", ">= 2.3.1"
 end

--- a/elasticgraph-local/lib/elastic_graph/local/tested_datastore_versions.yaml
+++ b/elasticgraph-local/lib/elastic_graph/local/tested_datastore_versions.yaml
@@ -2,7 +2,7 @@
 # This file determines the versions the ElasticGraph CI build tests against, and is also
 # used to provide the default versions offered by the `elasticgraph-local` rake tasks.
 elasticsearch:
-- 8.17.3 # latest version as of 2025-03-10.
+- 8.18.0 # latest version as of 2025-04-23.
 opensearch:
 - 2.19.1 # latest version as of 2025-03-10.
 - 2.7.0 # lowest version ElasticGraph currently supports


### PR DESCRIPTION
* Change `elasticsearch` gem version constraint from `~> 9.0.0` to `~> 9.0`. We want to allow any 9.x version. This relaxes the constraint updated by GitHub actions in #501.
* Build against the recently released Elasticsearch 8.18.0.