### PR TITLE
Remove `for_context` argument from `SchemaArtifacts::FromDisk`.

### DIFF
--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -1499,8 +1499,9 @@ enum_types_by_name:
           direction: desc
           field_path: widget.id
 graphql_extension_modules:
-- name: ElasticGraph::Apollo::GraphQL::EngineExtension
-  require_path: elastic_graph/apollo/graphql/engine_extension
+- extension_ref:
+    name: ElasticGraph::Apollo::GraphQL::EngineExtension
+    require_path: elastic_graph/apollo/graphql/engine_extension
 graphql_resolvers_by_name:
   apollo_entities:
     needs_lookahead: true

--- a/elasticgraph-admin/lib/elastic_graph/admin.rb
+++ b/elasticgraph-admin/lib/elastic_graph/admin.rb
@@ -22,7 +22,7 @@ module ElasticGraph
     # A factory method that builds an Admin instance from the given parsed YAML config.
     # `from_yaml_file(file_name, &block)` is also available (via `Support::FromYamlFile`).
     def self.from_parsed_yaml(parsed_yaml, &datastore_client_customization_block)
-      new(datastore_core: DatastoreCore.from_parsed_yaml(parsed_yaml, for_context: :admin, &datastore_client_customization_block))
+      new(datastore_core: DatastoreCore.from_parsed_yaml(parsed_yaml, &datastore_client_customization_block))
     end
 
     def initialize(datastore_core:, monotonic_clock: nil, clock: ::Time)

--- a/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
+++ b/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
@@ -421,8 +421,8 @@ module ElasticGraph
           expect(with_apollo_results.indices).to eq(without_apollo_results.indices)
           expect(with_apollo_results.index_templates).to eq(without_apollo_results.index_templates)
 
-          with_apollo_runtime_metadata = SchemaArtifacts::RuntimeMetadata::Schema.from_hash(with_apollo_results.runtime_metadata.to_dumpable_hash, for_context: :graphql)
-          without_apollo_runtime_metadata = SchemaArtifacts::RuntimeMetadata::Schema.from_hash(without_apollo_results.runtime_metadata.to_dumpable_hash, for_context: :graphql)
+          with_apollo_runtime_metadata = SchemaArtifacts::RuntimeMetadata::Schema.from_hash(with_apollo_results.runtime_metadata.to_dumpable_hash)
+          without_apollo_runtime_metadata = SchemaArtifacts::RuntimeMetadata::Schema.from_hash(without_apollo_results.runtime_metadata.to_dumpable_hash)
           expect(with_apollo_runtime_metadata.enum_types_by_name).to eq(without_apollo_runtime_metadata.enum_types_by_name)
           expect(with_apollo_runtime_metadata.object_types_by_name.except("_Entity", "_Service", "Query")).to eq(without_apollo_runtime_metadata.object_types_by_name.except("Query"))
         end
@@ -481,8 +481,8 @@ module ElasticGraph
         it "registers the GraphQL extension since the GraphQL endpoint will be buggy/broken if the extension is not loaded given the custom schema elements that have been added" do
           runtime_metadata = define_schema(with_apollo: true) { |s| define_some_types_on(s) }.runtime_metadata
 
-          expect(runtime_metadata.graphql_extension_modules).to include(
-            SchemaArtifacts::RuntimeMetadata::Extension.new(GraphQL::EngineExtension, "elastic_graph/apollo/graphql/engine_extension", {})
+          expect(runtime_metadata.graphql_extension_modules.map(&:extension_ref)).to include(
+            SchemaArtifacts::RuntimeMetadata::Extension.new(GraphQL::EngineExtension, "elastic_graph/apollo/graphql/engine_extension", {}).to_dumpable_hash
           )
         end
 

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core.rb
@@ -17,11 +17,11 @@ module ElasticGraph
     # @dynamic config, schema_artifacts, logger, client_customization_block
     attr_reader :config, :schema_artifacts, :logger, :client_customization_block
 
-    def self.from_parsed_yaml(parsed_yaml, for_context:, &client_customization_block)
+    def self.from_parsed_yaml(parsed_yaml, &client_customization_block)
       new(
         config: DatastoreCore::Config.from_parsed_yaml(parsed_yaml),
         logger: Support::Logger.from_parsed_yaml(parsed_yaml),
-        schema_artifacts: SchemaArtifacts.from_parsed_yaml(parsed_yaml, for_context: for_context),
+        schema_artifacts: SchemaArtifacts.from_parsed_yaml(parsed_yaml),
         client_customization_block: client_customization_block
       )
     end

--- a/elasticgraph-datastore_core/sig/elastic_graph/datastore_core.rbs
+++ b/elasticgraph-datastore_core/sig/elastic_graph/datastore_core.rbs
@@ -5,10 +5,7 @@ module ElasticGraph
     attr_reader schema_artifacts: schemaArtifacts
     attr_reader client_customization_block: (^(untyped) -> void)?
 
-    def self.from_parsed_yaml: (
-      parsedYamlSettings,
-      for_context: SchemaArtifacts::context
-    ) ?{ (untyped) -> void } -> DatastoreCore
+    def self.from_parsed_yaml: (parsedYamlSettings) ?{ (untyped) -> void } -> DatastoreCore
 
     def initialize: (
       config: Config,

--- a/elasticgraph-datastore_core/spec/spec_helper.rb
+++ b/elasticgraph-datastore_core/spec/spec_helper.rb
@@ -13,18 +13,8 @@
 require "elastic_graph/spec_support/builds_datastore_core"
 
 module ElasticGraph
-  module DatastoreCoreSpecHelpers
-    include BuildsDatastoreCore
-
-    def build_datastore_core(**options, &block)
-      # Default `for_context` to :admin since it is a more limited context.
-      options = {for_context: :admin}.merge(options)
-      super(**options, &block)
-    end
-  end
-
   RSpec.configure do |config|
-    config.include DatastoreCoreSpecHelpers, absolute_file_path: %r{/elasticgraph-datastore_core/}
+    config.include BuildsDatastoreCore, absolute_file_path: %r{/elasticgraph-datastore_core/}
   end
 end
 

--- a/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core_spec.rb
+++ b/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core_spec.rb
@@ -24,14 +24,14 @@ module ElasticGraph
 
     describe ".from_parsed_yaml" do
       it "can build an instance from a parsed settings YAML file" do
-        datastore_core = DatastoreCore.from_parsed_yaml(parsed_test_settings_yaml, for_context: :admin)
+        datastore_core = DatastoreCore.from_parsed_yaml(parsed_test_settings_yaml)
 
         expect(datastore_core).to be_an(DatastoreCore)
       end
 
       it "allows the datastore clients to be customized via the passed block" do
         customization_block = lambda { |conn| }
-        datastore_core = DatastoreCore.from_parsed_yaml(parsed_test_settings_yaml, for_context: :admin, &customization_block)
+        datastore_core = DatastoreCore.from_parsed_yaml(parsed_test_settings_yaml, &customization_block)
 
         expect(datastore_core.client_customization_block).to be(customization_block)
       end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -27,7 +27,7 @@ module ElasticGraph
     def self.from_parsed_yaml(parsed_yaml, &datastore_client_customization_block)
       new(
         config: GraphQL::Config.from_parsed_yaml(parsed_yaml),
-        datastore_core: DatastoreCore.from_parsed_yaml(parsed_yaml, for_context: :graphql, &datastore_client_customization_block)
+        datastore_core: DatastoreCore.from_parsed_yaml(parsed_yaml, &datastore_client_customization_block)
       )
     end
 
@@ -56,7 +56,7 @@ module ElasticGraph
 
       # Apply any extension modules that have been configured.
       @config.extension_modules.each { |mod| extend mod }
-      @runtime_metadata.graphql_extension_modules.each { |ext_mod| extend ext_mod.extension_class }
+      @runtime_metadata.graphql_extension_modules.each { |ext_mod| extend ext_mod.load_extension.extension_class }
     end
 
     # @private

--- a/elasticgraph-graphql/spec/acceptance/elasticgraph_graphql_acceptance_support.rb
+++ b/elasticgraph-graphql/spec/acceptance/elasticgraph_graphql_acceptance_support.rb
@@ -69,7 +69,7 @@ module ElasticGraph
 
         before(:context) do
           enum_types = ::GraphQL::Schema.from_definition(
-            stock_schema_artifacts(for_context: :graphql).graphql_schema_string
+            stock_schema_artifacts.graphql_schema_string
           ).types.values.select { |t| t.kind.enum? }
 
           # For each enum type, we want to override the values to be different, as a forcing function to make
@@ -270,7 +270,7 @@ module ElasticGraph
     def build(*args, **opts)
       raw_data = super
 
-      schema_artifacts = stock_schema_artifacts(for_context: :graphql)
+      schema_artifacts = stock_schema_artifacts
       json_schema_defs = schema_artifacts.json_schemas_for(schema_artifacts.latest_json_schema_version).fetch("$defs")
 
       if (typename = raw_data[:__typename])

--- a/elasticgraph-graphql/spec/spec_helper.rb
+++ b/elasticgraph-graphql/spec/spec_helper.rb
@@ -14,13 +14,6 @@ module ElasticGraph
   class GraphQL
     SPEC_ROOT = __dir__
   end
-
-  module GraphQLSpecHelpers
-    def build_datastore_core(**options, &block)
-      options = {for_context: :graphql}.merge(options)
-      super(**options, &block)
-    end
-  end
 end
 
 RSpec.configure do |config|
@@ -31,7 +24,6 @@ RSpec.configure do |config|
   config.when_first_matching_example_defined(:ensure_no_orphaned_types) { require_relative "support/ensure_no_orphaned_types" }
   config.when_first_matching_example_defined(:query_adapter) { require_relative "support/query_adapter" }
   config.when_first_matching_example_defined(:resolver) { require_relative "support/resolver" }
-  config.prepend ElasticGraph::GraphQLSpecHelpers, absolute_file_path: %r{/elasticgraph-graphql/}
 end
 
 RSpec::Matchers.define :take_less_than do |max_expected_duration|

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_adapter_spec.rb
@@ -131,7 +131,7 @@ module ElasticGraph
 
           context "with `sub_aggregations`" do
             before(:context) do
-              self.schema_artifacts = CommonSpecHelpers.stock_schema_artifacts(for_context: :graphql)
+              self.schema_artifacts = CommonSpecHelpers.stock_schema_artifacts
             end
 
             it "can build sub-aggregations" do

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/pagination_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/pagination_spec.rb
@@ -14,7 +14,7 @@ module ElasticGraph
       include_context "DatastoreQueryUnitSupport"
 
       before(:context) do
-        artifacts = CommonSpecHelpers.stock_schema_artifacts(for_context: :graphql)
+        artifacts = CommonSpecHelpers.stock_schema_artifacts
         @index_def_names = artifacts.indices.keys + artifacts.index_templates.keys
       end
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql_spec.rb
@@ -81,6 +81,7 @@ module ElasticGraph
             super() + "\n# #{extension_data.inspect}"
           end
         end
+        stub_const("ConfigExtensionModule", config_extension_module)
 
         runtime_metadata_extension_module = Module.new do
           define_method :runtime_metadata do
@@ -90,11 +91,14 @@ module ElasticGraph
             )
           end
         end
+        stub_const("RuntimeMetadataExtensionModule", runtime_metadata_extension_module)
 
         extended_graphql = build_graphql(
           extension_modules: [config_extension_module],
           schema_definition: lambda do |schema|
-            schema.register_graphql_extension runtime_metadata_extension_module, defined_at: __FILE__
+            # `defined_at` just needs a valid require path, but needs to be outside ElasticGraph
+            # to not mess with our code coverage measurement.
+            schema.register_graphql_extension runtime_metadata_extension_module, defined_at: "time"
             define_schema_elements(schema)
           end
         )

--- a/elasticgraph-health_check/lib/elastic_graph/health_check/envoy_extension.rb
+++ b/elasticgraph-health_check/lib/elastic_graph/health_check/envoy_extension.rb
@@ -19,7 +19,7 @@ module ElasticGraph
           begin
             http_path_segment = config.extension_settings.dig("health_check", "http_path_segment")
             http_path_segment ||= runtime_metadata
-              .graphql_extension_modules
+              .graphql_extension_modules.map(&:load_extension)
               .find { |ext_mod| ext_mod.extension_class == EnvoyExtension }
               &.config
               &.dig(:http_path_segment)

--- a/elasticgraph-indexer/lib/elastic_graph/indexer.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer.rb
@@ -22,7 +22,7 @@ module ElasticGraph
     def self.from_parsed_yaml(parsed_yaml, &datastore_client_customization_block)
       new(
         config: Indexer::Config.from_parsed_yaml(parsed_yaml),
-        datastore_core: DatastoreCore.from_parsed_yaml(parsed_yaml, for_context: :indexer, &datastore_client_customization_block)
+        datastore_core: DatastoreCore.from_parsed_yaml(parsed_yaml, &datastore_client_customization_block)
       )
     end
 

--- a/elasticgraph-indexer/spec/spec_helper.rb
+++ b/elasticgraph-indexer/spec/spec_helper.rb
@@ -33,10 +33,7 @@ module ElasticGraph
     def build_indexer(use_old_update_script: false, **options, &block)
       return super(**options, &block) unless use_old_update_script
 
-      schema_artifacts = SchemaArtifacts::FromDisk.new(
-        ::File.join(CommonSpecHelpers::REPO_ROOT, "config", "schema", "artifacts"),
-        :indexer
-      )
+      schema_artifacts = SchemaArtifacts::FromDisk.new(::File.join(CommonSpecHelpers::REPO_ROOT, "config", "schema", "artifacts"))
 
       schema_artifacts.runtime_metadata.object_types_by_name.each do |name, object_type|
         object_type.update_targets.map! do |update_target|

--- a/elasticgraph-indexer_autoscaler_lambda/lib/elastic_graph/indexer_autoscaler_lambda.rb
+++ b/elasticgraph-indexer_autoscaler_lambda/lib/elastic_graph/indexer_autoscaler_lambda.rb
@@ -23,7 +23,7 @@ module ElasticGraph
     # A factory method that builds a IndexerAutoscalerLambda instance from the given parsed YAML config.
     # `from_yaml_file(file_name, &block)` is also available (via `Support::FromYamlFile`).
     def self.from_parsed_yaml(parsed_yaml, &datastore_client_customization_block)
-      new(datastore_core: DatastoreCore.from_parsed_yaml(parsed_yaml, for_context: :indexer_autoscaler_lambda, &datastore_client_customization_block))
+      new(datastore_core: DatastoreCore.from_parsed_yaml(parsed_yaml, &datastore_client_customization_block))
     end
 
     # @dynamic datastore_core

--- a/elasticgraph-indexer_autoscaler_lambda/spec/support/builds_indexer_autoscaler.rb
+++ b/elasticgraph-indexer_autoscaler_lambda/spec/support/builds_indexer_autoscaler.rb
@@ -21,7 +21,6 @@ module ElasticGraph
       &customize_datastore_config
     )
       datastore_core = build_datastore_core(
-        for_context: :autoscaling,
         **datastore_core_options,
         &customize_datastore_config
       )

--- a/elasticgraph-query_interceptor/lib/elastic_graph/query_interceptor/graphql_extension.rb
+++ b/elasticgraph-query_interceptor/lib/elastic_graph/query_interceptor/graphql_extension.rb
@@ -15,7 +15,7 @@ module ElasticGraph
     module GraphQLExtension
       def datastore_query_adapters
         @datastore_query_adapters ||= begin
-          runtime_metadata_configs = runtime_metadata.graphql_extension_modules.filter_map do |ext_mod|
+          runtime_metadata_configs = runtime_metadata.graphql_extension_modules.map(&:load_extension).filter_map do |ext_mod|
             Support::HashUtil.stringify_keys(ext_mod.config) if ext_mod.extension_class == GraphQLExtension
           end
 

--- a/elasticgraph-query_interceptor/spec/unit/elastic_graph/query_interceptor/graphql_extension_spec.rb
+++ b/elasticgraph-query_interceptor/spec/unit/elastic_graph/query_interceptor/graphql_extension_spec.rb
@@ -115,10 +115,15 @@ module ElasticGraph
       end
 
       it "does not add interceptors if GraphQLExtension is not used" do
+        extension_mod = Module.new
+        stub_const("MyExtension", extension_mod)
+
         schema_artifacts = generate_schema_artifacts do |schema|
           schema.register_graphql_extension(
-            Module.new,
-            defined_at: __FILE__,
+            extension_mod,
+            # `defined_at` just needs a valid require path, but needs to be outside ElasticGraph
+            # to not mess with our code coverage measurement.
+            defined_at: "time",
             interceptors: interceptors
           )
         end

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/from_disk.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/from_disk.rb
@@ -17,7 +17,7 @@ require "yaml"
 module ElasticGraph
   module SchemaArtifacts
     # Builds a `SchemaArtifacts::FromDisk` instance using the provided YAML settings.
-    def self.from_parsed_yaml(parsed_yaml, for_context:)
+    def self.from_parsed_yaml(parsed_yaml)
       schema_artifacts = parsed_yaml.fetch("schema_artifacts") do
         raise Errors::ConfigError, "Config is missing required key `schema_artifacts`."
       end
@@ -30,11 +30,11 @@ module ElasticGraph
         raise Errors::ConfigError, "Config is missing required key `schema_artifacts.directory`."
       end
 
-      FromDisk.new(directory, for_context)
+      FromDisk.new(directory)
     end
 
     # Responsible for loading schema artifacts from disk.
-    class FromDisk < Support::MemoizableData.define(:artifacts_dir, :context)
+    class FromDisk < Support::MemoizableData.define(:artifacts_dir)
       include ArtifactsHelperMethods
 
       def graphql_schema_string
@@ -74,10 +74,7 @@ module ElasticGraph
       end
 
       def runtime_metadata
-        @runtime_metadata ||= RuntimeMetadata::Schema.from_hash(
-          parsed_yaml_from(RUNTIME_METADATA_FILE),
-          for_context: context
-        )
+        @runtime_metadata ||= RuntimeMetadata::Schema.from_hash(parsed_yaml_from(RUNTIME_METADATA_FILE))
       end
 
       private

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/graphql_extension.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/graphql_extension.rb
@@ -1,0 +1,40 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/schema_artifacts/runtime_metadata/extension_loader"
+
+module ElasticGraph
+  module SchemaArtifacts
+    module RuntimeMetadata
+      class GraphQLExtension < ::Data.define(:extension_ref)
+        def self.loader
+          @loader ||= ExtensionLoader.new(Module.new)
+        end
+
+        EXTENSION_REF = "extension_ref"
+
+        def load_extension
+          Extension.load_from_hash(extension_ref, via: GraphQLExtension.loader)
+        end
+
+        def self.from_hash(hash)
+          new(
+            extension_ref: hash.fetch(EXTENSION_REF)
+          )
+        end
+
+        def to_dumpable_hash
+          {
+            # Keys here are ordered alphabetically; please keep them that way.
+            EXTENSION_REF => extension_ref
+          }
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/from_disk.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/from_disk.rbs
@@ -16,15 +16,11 @@ module ElasticGraph
   end
 
   module SchemaArtifacts
-    def self.from_parsed_yaml: (
-      parsedYamlSettings,
-      for_context: context
-    ) ?{ (untyped) -> void } -> FromDisk
+    def self.from_parsed_yaml: (parsedYamlSettings) ?{ (untyped) -> void } -> FromDisk
 
     class FromDiskSupertype
       attr_reader artifacts_dir: ::String
-      attr_reader context: context
-      def initialize: (artifacs_dir: ::String, context: context) -> void
+      def initialize: (artifacs_dir: ::String) -> void
     end
 
     class FromDisk < FromDiskSupertype
@@ -32,8 +28,8 @@ module ElasticGraph
       include ArtifactsHelperMethods
 
       def self.new:
-        (artifacs_dir: ::String, context: context) -> instance
-      | (::String, context) -> instance
+        (artifacs_dir: ::String) -> instance
+      | (::String) -> instance
 
       private
 

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/graphql_extension.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/graphql_extension.rbs
@@ -1,0 +1,32 @@
+module ElasticGraph
+  module SchemaArtifacts
+    module RuntimeMetadata
+      class GraphQLExtensionSupertype
+        attr_reader extension_ref: ::Hash[::String, ::String]
+
+        def initialize: (
+          extension_ref: ::Hash[::String, ::String]
+        ) -> void
+
+        def with: (
+          ?extension_ref: ::Hash[::String, ::String]
+        ) -> instance
+
+        def self.new:
+          (extension_ref: ::Hash[::String, ::String]) -> instance
+          | (::Hash[::String, ::String]) -> instance
+      end
+
+      class GraphQLExtension < GraphQLExtensionSupertype
+        self.@loader: ExtensionLoader?
+        def self.loader: () -> ExtensionLoader
+
+        EXTENSION_REF: "extension_ref"
+
+        def load_extension: () -> Extension
+        def self.from_hash: (::Hash[::String, untyped]) -> GraphQLExtension
+        def to_dumpable_hash: () -> ::Hash[::String, untyped]
+      end
+    end
+  end
+end

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/schema.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/schema.rbs
@@ -1,7 +1,5 @@
 module ElasticGraph
   module SchemaArtifacts
-    type context = :admin | :graphql | :indexer | :indexer_autoscaler_lambda
-
     module RuntimeMetadata
       class SchemaSupertype
         attr_reader object_types_by_name: ::Hash[::String, ObjectType]
@@ -9,7 +7,7 @@ module ElasticGraph
         attr_reader enum_types_by_name: ::Hash[::String, Enum::Type]
         attr_reader index_definitions_by_name: ::Hash[::String, IndexDefinition]
         attr_reader schema_element_names: SchemaElementNames
-        attr_reader graphql_extension_modules: ::Array[Extension]
+        attr_reader graphql_extension_modules: ::Array[GraphQLExtension]
         attr_reader graphql_resolvers_by_name: ::Hash[::Symbol, GraphQLResolver]
         attr_reader static_script_ids_by_scoped_name: ::Hash[::String, ::String]
 
@@ -19,7 +17,7 @@ module ElasticGraph
           enum_types_by_name: ::Hash[::String, Enum::Type],
           index_definitions_by_name: ::Hash[::String, IndexDefinition],
           schema_element_names: SchemaElementNames,
-          graphql_extension_modules: ::Array[Extension],
+          graphql_extension_modules: ::Array[GraphQLExtension],
           graphql_resolvers_by_name: ::Hash[::Symbol, GraphQLResolver],
           static_script_ids_by_scoped_name: ::Hash[::String, ::String]) -> void
 
@@ -29,7 +27,7 @@ module ElasticGraph
           ?enum_types_by_name: ::Hash[::String, Enum::Type],
           ?index_definitions_by_name: ::Hash[::String, IndexDefinition],
           ?schema_element_names: SchemaElementNames,
-          ?graphql_extension_modules: ::Array[Extension],
+          ?graphql_extension_modules: ::Array[GraphQLExtension],
           ?graphql_resolvers_by_name: ::Hash[::Symbol, GraphQLResolver],
           ?static_script_ids_by_scoped_name: ::Hash[::String, ::String]) -> Schema
       end
@@ -44,7 +42,7 @@ module ElasticGraph
         GRAPHQL_RESOLVERS_BY_NAME: "graphql_resolvers_by_name"
         STATIC_SCRIPT_IDS_BY_NAME: "static_script_ids_by_scoped_name"
 
-        def self.from_hash: (::Hash[::String, untyped], for_context: context) -> Schema
+        def self.from_hash: (::Hash[::String, untyped]) -> Schema
         def to_dumpable_hash: () -> ::Hash[::String, untyped]
       end
     end

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/from_disk_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/from_disk_spec.rb
@@ -36,21 +36,21 @@ module ElasticGraph
         }.to raise_error Errors::ConfigError, a_string_including("foo")
       end
 
-      def from_parsed_yaml(parsed_yaml, for_context: :graphql)
-        SchemaArtifacts.from_parsed_yaml(parsed_yaml, for_context: for_context)
+      def from_parsed_yaml(parsed_yaml)
+        SchemaArtifacts.from_parsed_yaml(parsed_yaml)
       end
     end
 
     RSpec.describe FromDisk do
       it "loads each schema artifact from disk" do
-        artifacts = FromDisk.new(::File.join(CommonSpecHelpers::REPO_ROOT, "config", "schema", "artifacts"), :graphql)
+        artifacts = FromDisk.new(::File.join(CommonSpecHelpers::REPO_ROOT, "config", "schema", "artifacts"))
 
         expect_artifacts_to_load_and_be_valid(artifacts)
         expect(artifacts.datastore_scripts.values.first).to include("context", "script")
       end
 
       context "with multiple json schemas", :in_temp_dir do
-        let(:artifacts) { FromDisk.new(Dir.pwd, :indexer) }
+        let(:artifacts) { FromDisk.new(Dir.pwd) }
 
         before do
           ::FileUtils.mkdir_p(JSON_SCHEMAS_BY_VERSION_DIRECTORY)
@@ -81,7 +81,7 @@ module ElasticGraph
       end
 
       context "before any artifacts have been dumped", :in_temp_dir do
-        let(:artifacts) { FromDisk.new(Dir.pwd, :graphql) }
+        let(:artifacts) { FromDisk.new(Dir.pwd) }
 
         it "raises an error when accessing missing artifacts is attempted" do
           expect { artifacts.graphql_schema_string }.to raise_missing_artifacts_error
@@ -104,7 +104,7 @@ module ElasticGraph
       end
 
       describe "#index_mappings_by_index_def_name" do
-        let(:artifacts) { FromDisk.new(::File.join(CommonSpecHelpers::REPO_ROOT, "config", "schema", "artifacts"), :indexer) }
+        let(:artifacts) { FromDisk.new(::File.join(CommonSpecHelpers::REPO_ROOT, "config", "schema", "artifacts")) }
 
         it "returns the index mappings" do
           mappings = artifacts.index_mappings_by_index_def_name

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/graphql_extension_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/graphql_extension_spec.rb
@@ -1,0 +1,31 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/schema_artifacts/runtime_metadata/graphql_extension"
+
+module ElasticGraph
+  module SchemaArtifacts
+    module RuntimeMetadata
+      RSpec.describe GraphQLExtension do
+        it "loads extension lazily" do
+          graphql_extension = GraphQLExtension.new(
+            extension_ref: {
+              "name" => "ElasticGraph::Extensions::Valid",
+              "require_path" => "support/example_extensions/valid"
+            }
+          )
+
+          extension = graphql_extension.load_extension
+
+          expect(extension).to be_a(RuntimeMetadata::Extension)
+          expect(extension.extension_class).to be_a(::Module).and have_attributes(name: "ElasticGraph::Extensions::Valid")
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
@@ -278,8 +278,10 @@ module ElasticGraph
               "overrides" => {"any_of" => "or"}
             },
             "graphql_extension_modules" => [{
-              "name" => "ElasticGraph::SchemaArtifacts::GraphQLExtensionModule1",
-              "require_path" => "support/example_extensions/graphql_extension_modules"
+              "extension_ref" => {
+                "name" => "ElasticGraph::SchemaArtifacts::GraphQLExtensionModule1",
+                "require_path" => "support/example_extensions/graphql_extension_modules"
+              }
             }],
             "graphql_resolvers_by_name" => {
               "resolver1" => {
@@ -296,7 +298,7 @@ module ElasticGraph
             }
           )
 
-          expect(Schema.from_hash(hash, for_context: :graphql)).to eq schema
+          expect(Schema.from_hash(hash)).to eq schema
         end
 
         it "ignores object types that have no meaningful runtime metadata" do
@@ -323,7 +325,7 @@ module ElasticGraph
             "NoMetadata" => object_type_with
           })
 
-          schema = Schema.from_hash(schema.to_dumpable_hash, for_context: :graphql)
+          schema = Schema.from_hash(schema.to_dumpable_hash)
 
           expect(schema.object_types_by_name.keys).to contain_exactly(
             "UpdateTargetsOnly",
@@ -341,15 +343,13 @@ module ElasticGraph
             "NoValues" => enum_type_with(values_by_name: {})
           })
 
-          schema = Schema.from_hash(schema.to_dumpable_hash, for_context: :graphql)
+          schema = Schema.from_hash(schema.to_dumpable_hash)
 
           expect(schema.enum_types_by_name.keys).to contain_exactly("HasValues")
         end
 
         it "builds from a minimal hash" do
-          schema = Schema.from_hash({
-            "schema_element_names" => {"form" => "camelCase"}
-          }, for_context: :graphql)
+          schema = Schema.from_hash({"schema_element_names" => {"form" => "camelCase"}})
 
           expect(schema).to eq Schema.new(
             object_types_by_name: {},
@@ -361,14 +361,6 @@ module ElasticGraph
             graphql_resolvers_by_name: {},
             static_script_ids_by_scoped_name: {}
           )
-        end
-
-        it "only loads `graphql_extension_modules` for the `:graphql` context since the extension module gems may not be available in other contexts" do
-          schema = schema_with(graphql_extension_modules: [graphql_extension_module1])
-
-          expect(Schema.from_hash(schema.to_dumpable_hash, for_context: :admin).graphql_extension_modules).to eq []
-          expect(Schema.from_hash(schema.to_dumpable_hash, for_context: :indexer).graphql_extension_modules).to eq []
-          expect(Schema.from_hash(schema.to_dumpable_hash, for_context: :graphql).graphql_extension_modules).to eq [graphql_extension_module1]
         end
 
         it "dumps all hashes in alphabetical order for consistency" do

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
@@ -287,7 +287,8 @@ module ElasticGraph
       #       defined_at: query_registry_require_path
       #   end
       def register_graphql_extension(extension_module, defined_at:, **config)
-        @state.graphql_extension_modules << SchemaArtifacts::RuntimeMetadata::Extension.new(extension_module, defined_at, config)
+        extension = SchemaArtifacts::RuntimeMetadata::Extension.new(extension_module, defined_at, config)
+        @state.graphql_extension_modules << SchemaArtifacts::RuntimeMetadata::GraphQLExtension.new(extension.to_dumpable_hash)
         nil
       end
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/test_support.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/test_support.rb
@@ -94,7 +94,7 @@ module ElasticGraph
 
         artifacts_manager.dump_artifacts
 
-        SchemaArtifacts::FromDisk.new(tmp_dir, :graphql)
+        SchemaArtifacts::FromDisk.new(tmp_dir)
         # :nocov:
       end
 

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/state.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/state.rbs
@@ -18,7 +18,7 @@ module ElasticGraph
       attr_reader deleted_fields_by_type_name_and_old_field_name: ::Hash[::String, ::Hash[::String, SchemaElements::DeprecatedElement]]
       attr_accessor json_schema_version: ::Integer?
       attr_accessor json_schema_version_setter_location: ::Thread::Backtrace::Location?
-      attr_reader graphql_extension_modules: ::Array[SchemaArtifacts::RuntimeMetadata::Extension]
+      attr_reader graphql_extension_modules: ::Array[SchemaArtifacts::RuntimeMetadata::GraphQLExtension]
       attr_reader graphql_resolvers_by_name: ::Hash[::Symbol, SchemaArtifacts::RuntimeMetadata::GraphQLResolver]
       attr_accessor initially_registered_built_in_types: ::Set[::String]
       attr_accessor built_in_types_customization_blocks: ::Array[^(SchemaElements::graphQLType) -> void]

--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
@@ -290,7 +290,7 @@ module ElasticGraph
         does_not_match_warning_snippet = "does not match any type in your GraphQL schema"
 
         it "respects type name overrides for all types (both core and derived), except standard GraphQL ones like `Int`" do
-          original_types = graphql_types_defined_in(CommonSpecHelpers.stock_schema_artifacts(for_context: :graphql).graphql_schema_string)
+          original_types = graphql_types_defined_in(CommonSpecHelpers.stock_schema_artifacts.graphql_schema_string)
 
           # In this test, we evaluate our main test schema because it exercises such a wide variety of cases.
           ::File.write("schema.rb", <<~EOS)
@@ -341,7 +341,7 @@ module ElasticGraph
           derived_type_regex = /#{derived_type_suffixes.join("|")}\z/
 
           exclusions = SchemaElements::TypeNamer::TYPES_THAT_CANNOT_BE_OVERRIDDEN
-          schema_string = CommonSpecHelpers.stock_schema_artifacts(for_context: :graphql).graphql_schema_string
+          schema_string = CommonSpecHelpers.stock_schema_artifacts.graphql_schema_string
           original_core_types = graphql_types_defined_in(schema_string).reject do |t|
             t.start_with?("__") || derived_type_regex.match?(t) || exclusions.include?(t)
           end

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/enum_types_by_name_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/enum_types_by_name_spec.rb
@@ -155,7 +155,7 @@ module ElasticGraph
           end
         end
 
-        runtime_metadata = SchemaArtifacts::RuntimeMetadata::Schema.from_hash(results.runtime_metadata.to_dumpable_hash, for_context: :admin)
+        runtime_metadata = SchemaArtifacts::RuntimeMetadata::Schema.from_hash(results.runtime_metadata.to_dumpable_hash)
         expect(runtime_metadata.enum_types_by_name.keys).to contain_exactly(
           "DateGroupingGranularity", "DateGroupingGranularityInput",
           "DateGroupingTruncationUnit", "DateGroupingTruncationUnitInput",

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/graphql_extension_modules_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/graphql_extension_modules_spec.rb
@@ -28,8 +28,12 @@ module ElasticGraph
         end.runtime_metadata
 
         expect(metadata.graphql_extension_modules).to eq [
-          SchemaArtifacts::RuntimeMetadata::Extension.new(extension_module1, __FILE__, {}),
-          SchemaArtifacts::RuntimeMetadata::Extension.new(extension_module2, __FILE__, {})
+          SchemaArtifacts::RuntimeMetadata::GraphQLExtension.new(
+            SchemaArtifacts::RuntimeMetadata::Extension.new(extension_module1, __FILE__, {}).to_dumpable_hash
+          ),
+          SchemaArtifacts::RuntimeMetadata::GraphQLExtension.new(
+            SchemaArtifacts::RuntimeMetadata::Extension.new(extension_module2, __FILE__, {}).to_dumpable_hash
+          )
         ]
       end
     end

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/object_type_metadata_support.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/object_type_metadata_support.rb
@@ -15,7 +15,7 @@ module ElasticGraph
 
       def object_types_by_name(**options, &block)
         runtime_metadata = define_schema(**options, &block).runtime_metadata
-        runtime_metadata = SchemaArtifacts::RuntimeMetadata::Schema.from_hash(runtime_metadata.to_dumpable_hash, for_context: :admin)
+        runtime_metadata = SchemaArtifacts::RuntimeMetadata::Schema.from_hash(runtime_metadata.to_dumpable_hash)
         runtime_metadata.object_types_by_name
       end
 

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/pruning_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/pruning_spec.rb
@@ -31,7 +31,7 @@ module ElasticGraph
           end
         end
 
-        runtime_metadata = SchemaArtifacts::RuntimeMetadata::Schema.from_hash(results.runtime_metadata.to_dumpable_hash, for_context: :admin)
+        runtime_metadata = SchemaArtifacts::RuntimeMetadata::Schema.from_hash(results.runtime_metadata.to_dumpable_hash)
 
         # Note: this list has greatly grown over time. When you make a change causing a new type to be dumped, this'll fail
         # and force you to consider if that new type should be dumped or not. Add types to this as needed for ones that we

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/schema_elements/type_namer_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/schema_elements/type_namer_spec.rb
@@ -277,7 +277,7 @@ module ElasticGraph
           describe "properties of an overall schema (using the full test schema for completeness)" do
             attr_reader :schema
             before(:context) do
-              @schema = ::GraphQL::Schema.from_definition(CommonSpecHelpers.stock_schema_artifacts(for_context: :graphql).graphql_schema_string)
+              @schema = ::GraphQL::Schema.from_definition(CommonSpecHelpers.stock_schema_artifacts.graphql_schema_string)
             end
 
             let(:input_types) { schema.types.values.select { |type| type.kind.input_object? } }

--- a/spec_support/lib/elastic_graph/spec_support/builds_admin.rb
+++ b/spec_support/lib/elastic_graph/spec_support/builds_admin.rb
@@ -16,7 +16,7 @@ module ElasticGraph
     extend CommonSpecHelpers
 
     def build_admin(datastore_core: nil, **options, &customize_datastore_config)
-      Admin.new(datastore_core: datastore_core || build_datastore_core(for_context: :admin, **options, &customize_datastore_config))
+      Admin.new(datastore_core: datastore_core || build_datastore_core(**options, &customize_datastore_config))
     end
   end
 

--- a/spec_support/lib/elastic_graph/spec_support/builds_datastore_core.rb
+++ b/spec_support/lib/elastic_graph/spec_support/builds_datastore_core.rb
@@ -16,7 +16,6 @@ require "stringio"
 module ElasticGraph
   module BuildsDatastoreCore
     def build_datastore_core(
-      for_context:,
       client_customization_block: nil,
       clients_by_name: nil,
       config: nil,
@@ -66,9 +65,9 @@ module ElasticGraph
         elsif schema_artifacts_directory
           # Deal with the relative nature of paths in config, ensuring we can run the specs while being
           # in the repo root and also while being in a gem directory.
-          SchemaArtifacts::FromDisk.new(schema_artifacts_directory.sub("config", "#{CommonSpecHelpers::REPO_ROOT}/config"), for_context)
+          SchemaArtifacts::FromDisk.new(schema_artifacts_directory.sub("config", "#{CommonSpecHelpers::REPO_ROOT}/config"))
         else
-          stock_schema_artifacts(for_context: for_context)
+          stock_schema_artifacts
         end
 
       if clients_by_name.nil? && respond_to?(:stubbed_datastore_client)

--- a/spec_support/lib/elastic_graph/spec_support/builds_graphql.rb
+++ b/spec_support/lib/elastic_graph/spec_support/builds_graphql.rb
@@ -33,7 +33,7 @@ module ElasticGraph
       &customize_datastore_config
     )
       GraphQL.new(
-        datastore_core: datastore_core || build_datastore_core(for_context: :graphql, **datastore_core_options, &customize_datastore_config),
+        datastore_core: datastore_core || build_datastore_core(**datastore_core_options, &customize_datastore_config),
         config: GraphQL::Config.new(
           max_page_size: max_page_size,
           default_page_size: default_page_size,

--- a/spec_support/lib/elastic_graph/spec_support/builds_indexer.rb
+++ b/spec_support/lib/elastic_graph/spec_support/builds_indexer.rb
@@ -25,7 +25,7 @@ module ElasticGraph
       &customize_datastore_config
     )
       Indexer.new(
-        datastore_core: datastore_core || build_datastore_core(for_context: :indexer, **datastore_core_options, &customize_datastore_config),
+        datastore_core: datastore_core || build_datastore_core(**datastore_core_options, &customize_datastore_config),
         config: Indexer::Config.new(
           latency_slo_thresholds_by_timestamp_in_ms: latency_slo_thresholds_by_timestamp_in_ms,
           skip_derived_indexing_type_updates: skip_derived_indexing_type_updates.transform_values(&:to_set)

--- a/spec_support/lib/elastic_graph/spec_support/runtime_metadata_support.rb
+++ b/spec_support/lib/elastic_graph/spec_support/runtime_metadata_support.rb
@@ -187,7 +187,8 @@ module ElasticGraph
         end
 
         def graphql_extension_module1
-          Extension.new(GraphQLExtensionModule1, "support/example_extensions/graphql_extension_modules", {})
+          extension = Extension.new(GraphQLExtensionModule1, "support/example_extensions/graphql_extension_modules", {})
+          GraphQLExtension.new(extension_ref: extension.to_dumpable_hash)
         end
 
         def graphql_resolver_with_lookahead(**config)

--- a/spec_support/spec_helper.rb
+++ b/spec_support/spec_helper.rb
@@ -279,11 +279,10 @@ module ElasticGraph
       @test_settings_file
     end
 
-    def self.stock_schema_artifacts(for_context:)
-      @stock_schema_artifacts ||= {}
-      @stock_schema_artifacts[for_context] ||= begin
+    def self.stock_schema_artifacts
+      @stock_schema_artifacts ||= begin
         require "elastic_graph/schema_artifacts/from_disk"
-        SchemaArtifacts.from_parsed_yaml(parsed_test_settings_yaml, for_context: for_context)
+        SchemaArtifacts.from_parsed_yaml(parsed_test_settings_yaml)
       end
     end
 
@@ -317,8 +316,8 @@ module ElasticGraph
       raise_error(::SystemExit, *args, &block).and output(/./).to_stderr
     end
 
-    def stock_schema_artifacts(for_context:)
-      CommonSpecHelpers.stock_schema_artifacts(for_context: for_context)
+    def stock_schema_artifacts
+      CommonSpecHelpers.stock_schema_artifacts
     end
 
     def parsed_test_settings_yaml


### PR DESCRIPTION
Previously, it was used to deal with `graphql_extension_modules` in the runtime metadata. In non-graphql contexts, we could not count on these extension modules being avilable to load. The `for_context` argument indicated whether or not we were in a GraphQL context and should load them or not.

However, this setup was suboptimal: it "infected" lots of places with the extra `for_context` argument (e.g. each callsite, and each of their callsites, etc...) and it makes things harder to reason about when the runtime metadata loads differently for one context vs another.

Instead, I've added a layer of indirection (a new `GraphQLExtension` class) which holds a reference to an unloaded extension, and allows the extension to be loaded on demand. That allows `elasticgraph-graphql` to load the extension when needed, while avoiding loading it in other contexts, without the need for the `for_context` argument. It also aligns with how we deal with our other extension modules in runtime metadata -- they are also loaded lazily on demand rather than eagerly when loading `runtime_metadata.yaml`.