### PR TITLE
Build against the just-released Elasticsearch 9.0.0.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
           - "3.3"
           - "3.4"
         datastore:
-          - "elasticsearch:8.18.0"
+          - "elasticsearch:9.0.0"
           - "opensearch:2.19.1"
           - "opensearch:2.7.0"
         include:
@@ -40,13 +40,13 @@ jobs:
           # configuration here.
           - build_part: "run_misc_checks"
             ruby: "3.4"
-            datastore: "elasticsearch:8.18.0"
+            datastore: "elasticsearch:9.0.0"
           - build_part: "run_specs_with_vcr"
             ruby: "3.4"
-            datastore: "elasticsearch:8.18.0"
+            datastore: "elasticsearch:9.0.0"
           - build_part: "run_specs_file_by_file"
             ruby: "3.4"
-            datastore: "elasticsearch:8.18.0"
+            datastore: "elasticsearch:9.0.0"
 
     steps:
       - name: Harden Runner

--- a/elasticgraph-local/lib/elastic_graph/local/elasticsearch/Dockerfile
+++ b/elasticgraph-local/lib/elastic_graph/local/elasticsearch/Dockerfile
@@ -1,3 +1,3 @@
 ARG VERSION=latest
-FROM elasticsearch:${VERSION}
+FROM docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
 RUN bin/elasticsearch-plugin install mapper-size analysis-icu

--- a/elasticgraph-local/lib/elastic_graph/local/elasticsearch/UI-Dockerfile
+++ b/elasticgraph-local/lib/elastic_graph/local/elasticsearch/UI-Dockerfile
@@ -1,2 +1,2 @@
 ARG VERSION=latest
-FROM kibana:${VERSION}
+FROM docker.elastic.co/kibana/kibana:${VERSION}

--- a/elasticgraph-local/lib/elastic_graph/local/tested_datastore_versions.yaml
+++ b/elasticgraph-local/lib/elastic_graph/local/tested_datastore_versions.yaml
@@ -2,7 +2,7 @@
 # This file determines the versions the ElasticGraph CI build tests against, and is also
 # used to provide the default versions offered by the `elasticgraph-local` rake tasks.
 elasticsearch:
-- 8.18.0 # latest version as of 2025-04-23.
+- 9.0.0 # latest version as of 2025-04-23.
 opensearch:
 - 2.19.1 # latest version as of 2025-03-10.
 - 2.7.0 # lowest version ElasticGraph currently supports

--- a/elasticgraph-local/spec/acceptance/rake_tasks_spec.rb
+++ b/elasticgraph-local/spec/acceptance/rake_tasks_spec.rb
@@ -95,7 +95,7 @@ module ElasticGraph
       describe "elasticsearch/opensearch tasks" do
         it "times out if booting takes too long" do
           expect {
-            run_rake "elasticsearch:example:8.8.1:daemon", daemon_timeout: 0.1, port: 9615
+            run_rake "elasticsearch:example:9.0.0:daemon", daemon_timeout: 0.1, port: 9615
           }.to raise_error a_string_including("Timed out after 0.1 seconds.")
         end
       end
@@ -123,7 +123,7 @@ module ElasticGraph
               t.index_document_sizes = true
               t.schema_element_name_form = :snake_case
               t.env_port_mapping = {"example" => port}
-              t.elasticsearch_versions = ["8.7.1", "8.8.1"]
+              t.elasticsearch_versions = ["8.18.0", "9.0.0"]
               t.opensearch_versions = ["2.7.0"]
               t.output = output
               t.daemon_timeout = daemon_timeout


### PR DESCRIPTION
It appears that elastic.co is not publishing 9.x images to dockerhub, as 9.0.0 is not listed here:

https://hub.docker.com/_/elasticsearch/tags

They are, however, publishing to their own docker registry (docker.elastic.co), so we can specifically pull from there.

This should also fix the CI build. We recently (in #501) upgraded the Elasticsearch gem version to 9.0.0 and while that appeared to work initially, we're now getting CI build failures:

```json
{
  "error": {
    "root_cause": [
      {
        "type": "media_type_header_exception",
        "reason": "Invalid media-type value on headers [Accept, Content-Type]"
      }
    ],
    "type": "media_type_header_exception",
    "reason": "Invalid media-type value on headers [Accept, Content-Type]",
    "caused_by": {
      "type": "status_exception",
      "reason": "Accept version must be either version 8 or 7, but found 9. Accept=application/vnd.elasticsearch+json; compatible-with=9"
    }
  },
  "status": 400
}
```

Upgrading Elasticsearch itself to 9.0.0 should fix compatibility, and is preferrable to downgrading both.