### PR TITLE
Bump version to 1.0.0.pre.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,42 +1,42 @@
 PATH
   remote: elasticgraph-admin_lambda
   specs:
-    elasticgraph-admin_lambda (0.19.2.2.pre)
-      elasticgraph-admin (= 0.19.2.2.pre)
-      elasticgraph-lambda_support (= 0.19.2.2.pre)
+    elasticgraph-admin_lambda (1.0.0.pre)
+      elasticgraph-admin (= 1.0.0.pre)
+      elasticgraph-lambda_support (= 1.0.0.pre)
       rake (~> 13.2, >= 13.2.1)
 
 PATH
   remote: elasticgraph-admin
   specs:
-    elasticgraph-admin (0.19.2.2.pre)
-      elasticgraph-datastore_core (= 0.19.2.2.pre)
-      elasticgraph-indexer (= 0.19.2.2.pre)
-      elasticgraph-schema_artifacts (= 0.19.2.2.pre)
-      elasticgraph-support (= 0.19.2.2.pre)
+    elasticgraph-admin (1.0.0.pre)
+      elasticgraph-datastore_core (= 1.0.0.pre)
+      elasticgraph-indexer (= 1.0.0.pre)
+      elasticgraph-schema_artifacts (= 1.0.0.pre)
+      elasticgraph-support (= 1.0.0.pre)
       rake (~> 13.2, >= 13.2.1)
 
 PATH
   remote: elasticgraph-apollo
   specs:
-    elasticgraph-apollo (0.19.2.2.pre)
+    elasticgraph-apollo (1.0.0.pre)
       apollo-federation (~> 3.10, >= 3.10.1)
-      elasticgraph-graphql (= 0.19.2.2.pre)
-      elasticgraph-support (= 0.19.2.2.pre)
+      elasticgraph-graphql (= 1.0.0.pre)
+      elasticgraph-support (= 1.0.0.pre)
       graphql (~> 2.5.4)
 
 PATH
   remote: elasticgraph-datastore_core
   specs:
-    elasticgraph-datastore_core (0.19.2.2.pre)
-      elasticgraph-schema_artifacts (= 0.19.2.2.pre)
-      elasticgraph-support (= 0.19.2.2.pre)
+    elasticgraph-datastore_core (1.0.0.pre)
+      elasticgraph-schema_artifacts (= 1.0.0.pre)
+      elasticgraph-support (= 1.0.0.pre)
 
 PATH
   remote: elasticgraph-elasticsearch
   specs:
-    elasticgraph-elasticsearch (0.19.2.2.pre)
-      elasticgraph-support (= 0.19.2.2.pre)
+    elasticgraph-elasticsearch (1.0.0.pre)
+      elasticgraph-support (= 1.0.0.pre)
       elasticsearch (~> 9.0)
       faraday (~> 2.13)
       faraday-retry (~> 2.3, >= 2.3.1)
@@ -44,81 +44,81 @@ PATH
 PATH
   remote: elasticgraph-graphql_lambda
   specs:
-    elasticgraph-graphql_lambda (0.19.2.2.pre)
-      elasticgraph-graphql (= 0.19.2.2.pre)
-      elasticgraph-lambda_support (= 0.19.2.2.pre)
+    elasticgraph-graphql_lambda (1.0.0.pre)
+      elasticgraph-graphql (= 1.0.0.pre)
+      elasticgraph-lambda_support (= 1.0.0.pre)
 
 PATH
   remote: elasticgraph-graphql
   specs:
-    elasticgraph-graphql (0.19.2.2.pre)
+    elasticgraph-graphql (1.0.0.pre)
       base64 (~> 0.2)
-      elasticgraph-datastore_core (= 0.19.2.2.pre)
-      elasticgraph-schema_artifacts (= 0.19.2.2.pre)
+      elasticgraph-datastore_core (= 1.0.0.pre)
+      elasticgraph-schema_artifacts (= 1.0.0.pre)
       graphql (~> 2.5.4)
       graphql-c_parser (~> 1.1, >= 1.1.2)
 
 PATH
   remote: elasticgraph-health_check
   specs:
-    elasticgraph-health_check (0.19.2.2.pre)
-      elasticgraph-datastore_core (= 0.19.2.2.pre)
-      elasticgraph-graphql (= 0.19.2.2.pre)
-      elasticgraph-support (= 0.19.2.2.pre)
+    elasticgraph-health_check (1.0.0.pre)
+      elasticgraph-datastore_core (= 1.0.0.pre)
+      elasticgraph-graphql (= 1.0.0.pre)
+      elasticgraph-support (= 1.0.0.pre)
 
 PATH
   remote: elasticgraph-indexer_autoscaler_lambda
   specs:
-    elasticgraph-indexer_autoscaler_lambda (0.19.2.2.pre)
+    elasticgraph-indexer_autoscaler_lambda (1.0.0.pre)
       aws-sdk-cloudwatch (~> 1.112)
       aws-sdk-lambda (~> 1.148)
       aws-sdk-sqs (~> 1.93)
-      elasticgraph-datastore_core (= 0.19.2.2.pre)
-      elasticgraph-lambda_support (= 0.19.2.2.pre)
+      elasticgraph-datastore_core (= 1.0.0.pre)
+      elasticgraph-lambda_support (= 1.0.0.pre)
       ox (~> 2.14, >= 2.14.22)
 
 PATH
   remote: elasticgraph-indexer_lambda
   specs:
-    elasticgraph-indexer_lambda (0.19.2.2.pre)
+    elasticgraph-indexer_lambda (1.0.0.pre)
       aws-sdk-s3 (~> 1.183)
-      elasticgraph-indexer (= 0.19.2.2.pre)
-      elasticgraph-lambda_support (= 0.19.2.2.pre)
+      elasticgraph-indexer (= 1.0.0.pre)
+      elasticgraph-lambda_support (= 1.0.0.pre)
       ox (~> 2.14, >= 2.14.22)
 
 PATH
   remote: elasticgraph-indexer
   specs:
-    elasticgraph-indexer (0.19.2.2.pre)
-      elasticgraph-datastore_core (= 0.19.2.2.pre)
-      elasticgraph-json_schema (= 0.19.2.2.pre)
-      elasticgraph-schema_artifacts (= 0.19.2.2.pre)
-      elasticgraph-support (= 0.19.2.2.pre)
+    elasticgraph-indexer (1.0.0.pre)
+      elasticgraph-datastore_core (= 1.0.0.pre)
+      elasticgraph-json_schema (= 1.0.0.pre)
+      elasticgraph-schema_artifacts (= 1.0.0.pre)
+      elasticgraph-support (= 1.0.0.pre)
       hashdiff (~> 1.1, >= 1.1.2)
 
 PATH
   remote: elasticgraph-json_schema
   specs:
-    elasticgraph-json_schema (0.19.2.2.pre)
-      elasticgraph-support (= 0.19.2.2.pre)
+    elasticgraph-json_schema (1.0.0.pre)
+      elasticgraph-support (= 1.0.0.pre)
       json_schemer (~> 2.4)
 
 PATH
   remote: elasticgraph-lambda_support
   specs:
-    elasticgraph-lambda_support (0.19.2.2.pre)
-      elasticgraph-opensearch (= 0.19.2.2.pre)
+    elasticgraph-lambda_support (1.0.0.pre)
+      elasticgraph-opensearch (= 1.0.0.pre)
       faraday_middleware-aws-sigv4 (~> 1.0, >= 1.0.1)
 
 PATH
   remote: elasticgraph-local
   specs:
-    elasticgraph-local (0.19.2.2.pre)
-      elasticgraph-admin (= 0.19.2.2.pre)
-      elasticgraph-graphql (= 0.19.2.2.pre)
-      elasticgraph-indexer (= 0.19.2.2.pre)
-      elasticgraph-rack (= 0.19.2.2.pre)
-      elasticgraph-schema_definition (= 0.19.2.2.pre)
+    elasticgraph-local (1.0.0.pre)
+      elasticgraph-admin (= 1.0.0.pre)
+      elasticgraph-graphql (= 1.0.0.pre)
+      elasticgraph-indexer (= 1.0.0.pre)
+      elasticgraph-rack (= 1.0.0.pre)
+      elasticgraph-schema_definition (= 1.0.0.pre)
       rackup (~> 2.2, >= 2.2.1)
       rake (~> 13.2, >= 13.2.1)
       webrick (~> 1.9, >= 1.9.1)
@@ -126,8 +126,8 @@ PATH
 PATH
   remote: elasticgraph-opensearch
   specs:
-    elasticgraph-opensearch (0.19.2.2.pre)
-      elasticgraph-support (= 0.19.2.2.pre)
+    elasticgraph-opensearch (1.0.0.pre)
+      elasticgraph-support (= 1.0.0.pre)
       faraday (~> 2.13)
       faraday-retry (~> 2.3, >= 2.3.1)
       opensearch-ruby (~> 3.4)
@@ -135,16 +135,16 @@ PATH
 PATH
   remote: elasticgraph-query_interceptor
   specs:
-    elasticgraph-query_interceptor (0.19.2.2.pre)
-      elasticgraph-graphql (= 0.19.2.2.pre)
-      elasticgraph-schema_artifacts (= 0.19.2.2.pre)
+    elasticgraph-query_interceptor (1.0.0.pre)
+      elasticgraph-graphql (= 1.0.0.pre)
+      elasticgraph-schema_artifacts (= 1.0.0.pre)
 
 PATH
   remote: elasticgraph-query_registry
   specs:
-    elasticgraph-query_registry (0.19.2.2.pre)
-      elasticgraph-graphql (= 0.19.2.2.pre)
-      elasticgraph-support (= 0.19.2.2.pre)
+    elasticgraph-query_registry (1.0.0.pre)
+      elasticgraph-graphql (= 1.0.0.pre)
+      elasticgraph-support (= 1.0.0.pre)
       graphql (~> 2.5.4)
       graphql-c_parser (~> 1.1, >= 1.1.2)
       rake (~> 13.2, >= 13.2.1)
@@ -152,25 +152,25 @@ PATH
 PATH
   remote: elasticgraph-rack
   specs:
-    elasticgraph-rack (0.19.2.2.pre)
-      elasticgraph-graphql (= 0.19.2.2.pre)
+    elasticgraph-rack (1.0.0.pre)
+      elasticgraph-graphql (= 1.0.0.pre)
       rack (~> 3.1, >= 3.1.13)
 
 PATH
   remote: elasticgraph-schema_artifacts
   specs:
-    elasticgraph-schema_artifacts (0.19.2.2.pre)
-      elasticgraph-support (= 0.19.2.2.pre)
+    elasticgraph-schema_artifacts (1.0.0.pre)
+      elasticgraph-support (= 1.0.0.pre)
 
 PATH
   remote: elasticgraph-schema_definition
   specs:
-    elasticgraph-schema_definition (0.19.2.2.pre)
-      elasticgraph-graphql (= 0.19.2.2.pre)
-      elasticgraph-indexer (= 0.19.2.2.pre)
-      elasticgraph-json_schema (= 0.19.2.2.pre)
-      elasticgraph-schema_artifacts (= 0.19.2.2.pre)
-      elasticgraph-support (= 0.19.2.2.pre)
+    elasticgraph-schema_definition (1.0.0.pre)
+      elasticgraph-graphql (= 1.0.0.pre)
+      elasticgraph-indexer (= 1.0.0.pre)
+      elasticgraph-json_schema (= 1.0.0.pre)
+      elasticgraph-schema_artifacts (= 1.0.0.pre)
+      elasticgraph-support (= 1.0.0.pre)
       graphql (~> 2.5.4)
       graphql-c_parser (~> 1.1, >= 1.1.2)
       rake (~> 13.2, >= 13.2.1)
@@ -178,14 +178,14 @@ PATH
 PATH
   remote: elasticgraph-support
   specs:
-    elasticgraph-support (0.19.2.2.pre)
+    elasticgraph-support (1.0.0.pre)
       logger (~> 1.7)
 
 PATH
   remote: elasticgraph
   specs:
-    elasticgraph (0.19.2.2.pre)
-      elasticgraph-support (= 0.19.2.2.pre)
+    elasticgraph (1.0.0.pre)
+      elasticgraph-support (= 1.0.0.pre)
       thor (~> 1.3, >= 1.3.2)
 
 GEM
@@ -606,28 +606,28 @@ DEPENDENCIES
   aws_lambda_ric (~> 3.0)
   benchmark-ips (~> 2.14)
   coderay (~> 1.1, >= 1.1.3)
-  elasticgraph (= 0.19.2.2.pre)!
-  elasticgraph-admin (= 0.19.2.2.pre)!
-  elasticgraph-admin_lambda (= 0.19.2.2.pre)!
-  elasticgraph-apollo (= 0.19.2.2.pre)!
-  elasticgraph-datastore_core (= 0.19.2.2.pre)!
-  elasticgraph-elasticsearch (= 0.19.2.2.pre)!
-  elasticgraph-graphql (= 0.19.2.2.pre)!
-  elasticgraph-graphql_lambda (= 0.19.2.2.pre)!
-  elasticgraph-health_check (= 0.19.2.2.pre)!
-  elasticgraph-indexer (= 0.19.2.2.pre)!
-  elasticgraph-indexer_autoscaler_lambda (= 0.19.2.2.pre)!
-  elasticgraph-indexer_lambda (= 0.19.2.2.pre)!
-  elasticgraph-json_schema (= 0.19.2.2.pre)!
-  elasticgraph-lambda_support (= 0.19.2.2.pre)!
-  elasticgraph-local (= 0.19.2.2.pre)!
-  elasticgraph-opensearch (= 0.19.2.2.pre)!
-  elasticgraph-query_interceptor (= 0.19.2.2.pre)!
-  elasticgraph-query_registry (= 0.19.2.2.pre)!
-  elasticgraph-rack (= 0.19.2.2.pre)!
-  elasticgraph-schema_artifacts (= 0.19.2.2.pre)!
-  elasticgraph-schema_definition (= 0.19.2.2.pre)!
-  elasticgraph-support (= 0.19.2.2.pre)!
+  elasticgraph (= 1.0.0.pre)!
+  elasticgraph-admin (= 1.0.0.pre)!
+  elasticgraph-admin_lambda (= 1.0.0.pre)!
+  elasticgraph-apollo (= 1.0.0.pre)!
+  elasticgraph-datastore_core (= 1.0.0.pre)!
+  elasticgraph-elasticsearch (= 1.0.0.pre)!
+  elasticgraph-graphql (= 1.0.0.pre)!
+  elasticgraph-graphql_lambda (= 1.0.0.pre)!
+  elasticgraph-health_check (= 1.0.0.pre)!
+  elasticgraph-indexer (= 1.0.0.pre)!
+  elasticgraph-indexer_autoscaler_lambda (= 1.0.0.pre)!
+  elasticgraph-indexer_lambda (= 1.0.0.pre)!
+  elasticgraph-json_schema (= 1.0.0.pre)!
+  elasticgraph-lambda_support (= 1.0.0.pre)!
+  elasticgraph-local (= 1.0.0.pre)!
+  elasticgraph-opensearch (= 1.0.0.pre)!
+  elasticgraph-query_interceptor (= 1.0.0.pre)!
+  elasticgraph-query_registry (= 1.0.0.pre)!
+  elasticgraph-rack (= 1.0.0.pre)!
+  elasticgraph-schema_artifacts (= 1.0.0.pre)!
+  elasticgraph-schema_definition (= 1.0.0.pre)!
+  elasticgraph-support (= 1.0.0.pre)!
   factory_bot (~> 6.5, >= 6.5.1)
   faker (~> 3.5, >= 3.5.1)
   faraday (~> 2.13)

--- a/config/release/Rakefile
+++ b/config/release/Rakefile
@@ -18,22 +18,6 @@ require "#{project_root}/script/list_eg_gems"
 # Load tasks from config/site/Rakefile
 load "#{project_root}/config/site/Rakefile"
 
-# The `gem-release` gem is designed to support official SemVer with 3 version parts (+ an optional pre-release suffix).
-# Until we release 1.0.0, we're using 4 parts in our versions (+ an optional pre-release suffix).
-#
-# To make it compatible with our versioning scheme, we replace an internal regex here.
-#
-# Once we release 1.0.0, we can drop this workaround.
-::Gem::Release::Version::Number.class_eval do
-  remove_const :NUMBER
-
-  # standard:disable Lint/ConstantDefinitionInBlock
-  # This was changed from the original, which does not allow the extra version part we have:
-  #                 /^(\d+)\.?(\d+)?\.?(\d+)?(\-|\.)?(\w+)?\.?(\d+)?$/
-  NUMBER = /^(\d+)\.?(\d+)?\.?(\d+)?\.?(\d+)?(\-|\.)?(\w+)?\.?(\d+)?$/ # standard:disable Style/RedundantRegexpEscape
-  # standard:enable Lint/ConstantDefinitionInBlock
-end
-
 bump_version = lambda do |version:, message:|
   ::Dir.chdir(project_root) do
     opts = {

--- a/elasticgraph-support/lib/elastic_graph/version.rb
+++ b/elasticgraph-support/lib/elastic_graph/version.rb
@@ -8,7 +8,7 @@
 
 module ElasticGraph
   # The version of all ElasticGraph gems.
-  VERSION = "0.19.2.2.pre"
+  VERSION = "1.0.0.pre"
 
   # Steep weirdly expects this here...
   # @dynamic self.define_schema


### PR DESCRIPTION
The next release will be 1.0.0. This allows us to cleanup a hack in `config/release/Rakefile` now that we have a more conventional version number (e.g. 3 parts + `.pre` instead of 4 parts + `.pre`).