### PR TITLE
Fix build.

### DIFF
--- a/config/site/src/guides/guiding-principles.md
+++ b/config/site/src/guides/guiding-principles.md
@@ -23,7 +23,7 @@ These are the "north stars" that guide ElasticGraph development. They guide the 
   [elasticgraph-health_check](https://github.com/block/elasticgraph/tree/main/elasticgraph-health_check),
   [elasticgraph-query_interceptor](https://github.com/block/elasticgraph/tree/main/elasticgraph-query_interceptor),
   [elasticgraph-query_registry](https://github.com/block/elasticgraph/tree/main/elasticgraph-query_registry),
-  and the various [AWS lambda components](https://github.com/block/elasticgraph/blob/main/CODEBASE_OVERVIEW.md#aws-lambda-integration-libraries-5-gems).
+  and the various [AWS lambda components](https://github.com/block/elasticgraph/blob/main/CODEBASE_OVERVIEW.md).
   In addition, extensions are designed to apply hermetically: when applied to one instance of `ElasticGraph::GraphQL`, `ElasticGraph::Indexer`,
   or `ElasticGraph::SchemaDefinition::API`, they don't apply to any other instances of those classes.
 


### PR DESCRIPTION
It's currently failing with:

```
For the Links > External check, the following failures were found:

* At /home/runner/work/elasticgraph/elasticgraph/config/site/_site/guides/guiding-principles/index.html:470:

  External link https://github.com/block/elasticgraph/blob/main/CODEBASE_OVERVIEW.md#aws-lambda-integration-libraries-5-gems failed: https://github.com/block/elasticgraph/blob/main/CODEBASE_OVERVIEW.md exists, but the hash 'aws-lambda-integration-libraries-5-gems' does not (status code 200)
```

When I visit that link, the hash works, but for some reason the build check is consistently failing. The easiest fix is to remove the hash.