### PR TITLE
Add `request_all_fields` to `DatastoreQuery`.

### DIFF
--- a/elasticgraph-apollo/apollo_tests_implementation/lib/product_resolver.rb
+++ b/elasticgraph-apollo/apollo_tests_implementation/lib/product_resolver.rb
@@ -26,13 +26,7 @@ class ProductResolver
       monotonic_clock_deadline: context[:monotonic_clock_deadline],
       filters: [{"id" => {"equalToAnyOf" => [args.fetch("id")]}}],
       individual_docs_needed: true,
-      requested_fields: %w[
-        id sku package notes
-        variation.id
-        dimensions.size dimensions.weight dimensions.unit
-        createdBy.averageProductsCreatedPerYear createdBy.email createdBy.name createdBy.totalProductsCreated createdBy.yearsOfEmployment
-        research.study.caseNumber research.study.description research.outcome
-      ]
+      request_all_fields: true
     )
 
     @datastore_router.msearch([query]).fetch(query).documents.first

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/requested_fields_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/requested_fields_spec.rb
@@ -41,6 +41,15 @@ module ElasticGraph
 
         expect(results.size).to eq 0
       end
+
+      specify "returns all fields if passed `request_all_fields: true`" do
+        index_into(graphql, build(:widget))
+
+        results = search_datastore(request_all_fields: true)
+
+        expect(results.first.payload.keys).to include("name", "id", "options", "the_opts", "tags")
+        expect(results.first["options"].keys).to include("size", "the_sighs")
+      end
     end
   end
 end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/merge_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/merge_spec.rb
@@ -218,6 +218,30 @@ module ElasticGraph
         }.to avoid_logging_warnings
       end
 
+      it "sets `request_all_fields` to `true` if it is set on either query", covers: :request_all_fields do
+        merged = merge(
+          {request_all_fields: true},
+          {request_all_fields: false}
+        )
+        expect(merged.request_all_fields).to be true
+      end
+
+      it "sets `request_all_fields` to `true` if it is set on both queries", covers: :request_all_fields do
+        merged = merge(
+          {request_all_fields: true},
+          {request_all_fields: true}
+        )
+        expect(merged.request_all_fields).to be true
+      end
+
+      it "sets `request_all_fields` to `false` if it is set to false on both queries", covers: :request_all_fields do
+        merged = merge(
+          {request_all_fields: false},
+          {request_all_fields: false}
+        )
+        expect(merged.request_all_fields).to be false
+      end
+
       it "sets `individual_docs_needed` to `true` if it is set on either query", covers: :individual_docs_needed do
         merged = merge(
           {individual_docs_needed: true},
@@ -232,6 +256,22 @@ module ElasticGraph
           {individual_docs_needed: false}
         )
         expect(merged.individual_docs_needed).to be false
+      end
+
+      it "sets `individual_docs_needed` to `true` if specific fields are requested", covers: :individual_docs_needed do
+        merged = merge(
+          {individual_docs_needed: false},
+          {requested_fields: ["name"]}
+        )
+        expect(merged.individual_docs_needed).to be true
+      end
+
+      it "sets `individual_docs_needed` to `true` if all fields are requested", covers: :individual_docs_needed do
+        merged = merge(
+          {individual_docs_needed: false},
+          {request_all_fields: true}
+        )
+        expect(merged.individual_docs_needed).to be true
       end
 
       it "sets `total_document_count_needed` to `true` if it is set on either query", covers: :total_document_count_needed do

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/requested_fields_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/requested_fields_spec.rb
@@ -36,6 +36,12 @@ module ElasticGraph
 
         expect(datastore_body_of(query)[:_source]).to eq(false)
       end
+
+      it "passes `_source: true` when requesting all fields" do
+        query = new_query(requested_fields: [], request_all_fields: true)
+
+        expect(datastore_body_of(query)[:_source]).to eq(true)
+      end
     end
   end
 end


### PR DESCRIPTION
This is useful from extensions (such as a query interceptor) to have a way to request all fields, rather than having to individually enumerate them.