### PR TITLE
Build against OpenSearch 2.19 instead of 2.7.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         datastore:
           - "elasticsearch:9.0.0"
           - "opensearch:3.0.0"
-          - "opensearch:2.7.0"
+          - "opensearch:2.19.0"
         include:
           # We have 4 build parts. The "primary" one is `run_each_gem_spec`, and we need that to be run on
           # every supported Ruby version and against every supported datastore. It's not necessary to run

--- a/elasticgraph-local/lib/elastic_graph/local/tested_datastore_versions.yaml
+++ b/elasticgraph-local/lib/elastic_graph/local/tested_datastore_versions.yaml
@@ -5,4 +5,4 @@ elasticsearch:
 - 9.0.0 # latest version as of 2025-04-23.
 opensearch:
 - 3.0.0 # latest version as of 2025-05-07.
-- 2.7.0 # lowest version ElasticGraph currently supports
+- 2.19.0 # lowest version ElasticGraph currently supports


### PR DESCRIPTION
This makes 2.19 the lower bound of what OpenSearch versions we officially support.