### PR TITLE
Remove deprecated `TextFilterInput.matches`.

### DIFF
--- a/config/schema/artifacts/schema.graphql
+++ b/config/schema/artifacts/schema.graphql
@@ -11824,13 +11824,6 @@ input TextFilterInput {
   any_of: [TextFilterInput!]
 
   """
-  Matches records where the field value matches the provided value using full text search.
-
-  When `null` is passed, matches all documents.
-  """
-  matches: String @deprecated(reason: "Use `matches_query` instead.")
-
-  """
   Matches records where the field value has a phrase matching the provided phrase using
   full text search. This is stricter than `matches_query`: all terms must match
   and be in the same order as the provided phrase.

--- a/config/schema/artifacts_with_apollo/schema.graphql
+++ b/config/schema/artifacts_with_apollo/schema.graphql
@@ -12054,13 +12054,6 @@ input TextFilterInput {
   any_of: [TextFilterInput!]
 
   """
-  Matches records where the field value matches the provided value using full text search.
-
-  When `null` is passed, matches all documents.
-  """
-  matches: String @deprecated(reason: "Use `matches_query` instead.")
-
-  """
   Matches records where the field value has a phrase matching the provided phrase using
   full text search. This is stricter than `matches_query`: all terms must match
   and be in the same order as the provided phrase.

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_node_interpreter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_node_interpreter.rb
@@ -90,7 +90,6 @@ module ElasticGraph
             schema_names.gte => ->(field_name, value) { RangeQuery.new(field_name, :gte, value) },
             schema_names.lt => ->(field_name, value) { RangeQuery.new(field_name, :lt, value) },
             schema_names.lte => ->(field_name, value) { RangeQuery.new(field_name, :lte, value) },
-            schema_names.matches => ->(field_name, value) { BooleanQuery.must({match: {field_name => value}}) },
             schema_names.matches_query => ->(field_name, value) do
               allowed_edits_per_term = value.fetch(schema_names.allowed_edits_per_term).runtime_metadata.datastore_abbreviation
 

--- a/elasticgraph-graphql/spec/acceptance/search_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/search_spec.rb
@@ -463,11 +463,6 @@ module ElasticGraph
           case_correctly("widget_fee_currencies") => ["CAD", "USD"]
         }])
 
-        full_text_search_results = list_widgets_with(:name, filter: {"name_text" => {matches: "thing1"}}, order_by: [:name_ASC])
-        expect(full_text_search_results).to match([
-          string_hash_of(widget1, :id, :name)
-        ])
-
         full_text_query_search_results = list_widgets_with(:name, filter: {"name_text" => {matches_query: {query: "thing1"}}}, order_by: [:name_ASC])
         expect(full_text_query_search_results).to match([
           string_hash_of(widget1, :id, :name),

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/filtering_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/filtering_spec.rb
@@ -800,7 +800,7 @@ module ElasticGraph
         end
       end
 
-      specify "`matches` filters using full text search" do
+      specify "`matches_query` filters using full text search" do
         index_into(
           graphql,
           widget1 = build(:widget, name_text: "a blue thing"),
@@ -810,12 +810,12 @@ module ElasticGraph
           widget5 = build(:widget, name_text: "a blue device")
         )
 
-        results = search_with_filter("name_text", "matches", "blue thing")
+        results = search_with_filter("name_text", "matches_query", {"query" => "blue thing", "allowed_edits_per_term" => allowed_edits_per_term_of("NONE")})
 
         expect(results).to match_array(ids_of(widget1, widget2, widget4, widget5))
       end
 
-      specify "`matches` filters using full text search with flexible options" do
+      specify "`matches_query` filters using full text search with flexible options" do
         index_into(
           graphql,
           widget1 = build(:widget, name_text: "a blue thing"),
@@ -949,8 +949,8 @@ module ElasticGraph
           },
           "name_text" => {
             "any_of" => [
-              {"matches" => "red"},
-              {"matches" => "blue"}
+              {"matches_query" => {"query" => "red", "allowed_edits_per_term" => allowed_edits_per_term_of("NONE")}},
+              {"matches_query" => {"query" => "blue", "allowed_edits_per_term" => allowed_edits_per_term_of("NONE")}}
             ]
           }
         })
@@ -973,8 +973,8 @@ module ElasticGraph
             {
               "name_text" => {
                 "any_of" => [
-                  {"matches" => "blue"},
-                  {"matches" => "green"}
+                  {"matches_query" => {"query" => "blue", "allowed_edits_per_term" => allowed_edits_per_term_of("NONE")}},
+                  {"matches_query" => {"query" => "green", "allowed_edits_per_term" => allowed_edits_per_term_of("NONE")}}
                 ]
               }
             },
@@ -1037,7 +1037,6 @@ module ElasticGraph
         expect(search_with_filter("amount_cents", "gt", nil)).to eq ids_of(widget1, widget2)
         expect(search_with_filter("amount_cents", "gte", nil)).to eq ids_of(widget1, widget2)
         expect(search_with_filter("amount_cents", "any_of", nil)).to eq ids_of(widget1, widget2)
-        expect(search_with_filter("name_text", "matches", nil)).to eq ids_of(widget1, widget2)
         expect(search_with_filter("name_text", "matches_query", nil)).to eq ids_of(widget1, widget2)
         expect(search_with_filter("name_text", "matches_phrase", nil)).to eq ids_of(widget1, widget2)
         expect(search_with_freeform_filter({"id" => {}})).to eq ids_of(widget1, widget2)
@@ -1432,6 +1431,10 @@ module ElasticGraph
 
       def color_of(value_name)
         enum_value("ColorInput", value_name)
+      end
+
+      def allowed_edits_per_term_of(value_name)
+        enum_value("MatchesQueryAllowedEditsPerTermInput", value_name)
       end
     end
   end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/filtering_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/filtering_spec.rb
@@ -111,12 +111,6 @@ module ElasticGraph
         )
       end
 
-      it "builds a `match` must condition when given a `matches`: 'string' filter" do
-        query = new_query(filter: {"name_text" => {"matches" => "foo"}})
-
-        expect(datastore_body_of(query)).to query_datastore_with(bool: {must: [{match: {"name_text" => "foo"}}]})
-      end
-
       it "builds a `match` must condition when given a `matches_query`: 'MatchesQueryFilterInput' filter" do
         query = new_query(
           filter: {
@@ -348,15 +342,17 @@ module ElasticGraph
 
         it "builds an `exists` when the `equal_to_any_of: [nil]` part is among other filters" do
           query = new_query(filter: {
-            "name_text" => {"matches" => "foo"},
+            "name" => {"equal_to_any_of" => ["foo"]},
             "age" => {"equal_to_any_of" => [nil]},
             "currency" => {"equal_to_any_of" => ["USD"]}
           })
 
           expect(datastore_body_of(query)).to query_datastore_with({
             bool: {
-              filter: [{terms: {"currency" => ["USD"]}}],
-              must: [{match: {"name_text" => "foo"}}],
+              filter: [
+                {terms: {"name" => ["foo"]}},
+                {terms: {"currency" => ["USD"]}}
+              ],
               must_not: [{bool: {filter: [{exists: {"field" => "age"}}]}}]
             }
           })

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/shard_routing_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/shard_routing_spec.rb
@@ -69,7 +69,6 @@ module ElasticGraph
         expect(shard_routing_for(["name"], {"name" => {"gte" => "abc"}})).to search_all_shards
         expect(shard_routing_for(["name"], {"name" => {"lt" => "abc"}})).to search_all_shards
         expect(shard_routing_for(["name"], {"name" => {"lte" => "abc"}})).to search_all_shards
-        expect(shard_routing_for(["name"], {"name" => {"matches" => "abc"}})).to search_all_shards
         expect(shard_routing_for(["name"], {"name" => {"matches_query" => {"query" => "abc"}}})).to search_all_shards
         expect(shard_routing_for(["name"], {"name" => {"matches_phrase" => {"phrase" => "abc"}}})).to search_all_shards
       end
@@ -445,7 +444,6 @@ module ElasticGraph
           expect(shard_routing_for(["name"], {"name" => {"not" => {"gte" => "abc"}}})).to search_all_shards
           expect(shard_routing_for(["name"], {"name" => {"not" => {"lt" => "abc"}}})).to search_all_shards
           expect(shard_routing_for(["name"], {"name" => {"not" => {"lte" => "abc"}}})).to search_all_shards
-          expect(shard_routing_for(["name"], {"name" => {"not" => {"matches" => "abc"}}})).to search_all_shards
           expect(shard_routing_for(["name"], {"name" => {"not" => {"matches_query" => {"query" => "abc"}}}})).to search_all_shards
           expect(shard_routing_for(["name"], {"name" => {"not" => {"matches_phrase" => {"phrase" => "abc"}}}})).to search_all_shards
         end

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rb
@@ -137,7 +137,7 @@ module ElasticGraph
       SchemaElementNames = SchemaElementNamesDefinition.new(
         # Filter arg and operation names:
         :filter,
-        :equal_to_any_of, :gt, :gte, :lt, :lte, :matches, :matches_phrase, :matches_query, :any_of, :all_of, :not,
+        :equal_to_any_of, :gt, :gte, :lt, :lte, :matches_phrase, :matches_query, :any_of, :all_of, :not,
         :time_of_day, :any_satisfy,
         # Directives
         :eg_latency_slo, :ms,

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rbs
@@ -22,7 +22,6 @@ module ElasticGraph
         attr_reader gte: ::String
         attr_reader lt: ::String
         attr_reader lte: ::String
-        attr_reader matches: ::String
         attr_reader matches_query: ::String
         attr_reader matches_phrase: ::String
         attr_reader all_of: ::String

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
@@ -200,16 +200,6 @@ module ElasticGraph
         def register_standard_elastic_graph_types
           # This is a special filter on a `String` type, so we don't have a `Text` scalar to generate it from.
           schema_def_state.factory.build_standard_filter_input_types_for_index_leaf_type("String", name_prefix: "Text") do |t|
-            t.field names.matches, "String" do |f|
-              f.documentation <<~EOS
-                Matches records where the field value matches the provided value using full text search.
-
-                When `null` is passed, matches all documents.
-              EOS
-
-              f.directive "deprecated", reason: "Use `#{names.matches_query}` instead."
-            end
-
             t.field names.matches_query, schema_def_state.type_ref("MatchesQuery").as_filter_input.name do |f|
               f.documentation <<~EOS
                 Matches records where the field value matches the provided query using full text search.

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/built_in_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/built_in_types_spec.rb
@@ -695,12 +695,6 @@ module ElasticGraph
               """
               #{schema_elements.not}: TextFilterInput
               """
-              Matches records where the field value matches the provided value using full text search.
-
-              When `null` is passed, matches all documents.
-              """
-              #{schema_elements.matches}: String @deprecated(reason: "Use `#{schema_elements.matches_query}` instead.")
-              """
               Matches records where the field value matches the provided query using full text search.
               This is more lenient than `#{schema_elements.matches_phrase}`: the order of terms is ignored, and,
               by default, only one search term is required to be in the field value.
@@ -744,12 +738,6 @@ module ElasticGraph
               When `null` or an empty list is passed, matches all documents.
               """
               #{schema_elements.all_of}: [TextListElementFilterInput!]
-              """
-              Matches records where the field value matches the provided value using full text search.
-
-              When `null` is passed, matches all documents.
-              """
-              #{schema_elements.matches}: String @deprecated(reason: "Use `#{schema_elements.matches_query}` instead.")
               """
               Matches records where the field value matches the provided query using full text search.
               This is more lenient than `#{schema_elements.matches_phrase}`: the order of terms is ignored, and,


### PR DESCRIPTION
It's been deprecated for a while, and the upcoming 1.0.0 release is an ideal time to drop it.