### PR TITLE
Remove support for `REPORT_BATCH_ITEM_FAILURES: false`.

### DIFF
--- a/elasticgraph-indexer_lambda/lib/elastic_graph/indexer_lambda/lambda_function.rb
+++ b/elasticgraph-indexer_lambda/lib/elastic_graph/indexer_lambda/lambda_function.rb
@@ -19,11 +19,7 @@ module ElasticGraph
         require "elastic_graph/indexer_lambda/sqs_processor"
 
         indexer = ElasticGraph::IndexerLambda.indexer_from_env
-        @sqs_processor = ElasticGraph::IndexerLambda::SqsProcessor.new(
-          indexer.processor,
-          logger: indexer.logger,
-          report_batch_item_failures: ENV["REPORT_BATCH_ITEM_FAILURES"] == "true"
-        )
+        @sqs_processor = ElasticGraph::IndexerLambda::SqsProcessor.new(indexer.processor, logger: indexer.logger)
       end
 
       def handle_request(event:, context:)

--- a/elasticgraph-indexer_lambda/lib/elastic_graph/indexer_lambda/sqs_processor.rb
+++ b/elasticgraph-indexer_lambda/lib/elastic_graph/indexer_lambda/sqs_processor.rb
@@ -16,9 +16,8 @@ module ElasticGraph
     #
     # @private
     class SqsProcessor
-      def initialize(indexer_processor, report_batch_item_failures:, logger:, s3_client: nil)
+      def initialize(indexer_processor, logger:, s3_client: nil)
         @indexer_processor = indexer_processor
-        @report_batch_item_failures = report_batch_item_failures
         @logger = logger
         @s3_client = s3_client
       end
@@ -30,7 +29,6 @@ module ElasticGraph
 
         if failures.any?
           failures_error = Indexer::IndexingFailuresError.for(failures: failures, events: events)
-          raise failures_error unless @report_batch_item_failures
           @logger.error(failures_error.message)
         end
 

--- a/elasticgraph-indexer_lambda/sig/elastic_graph/indexer_lambda/sqs_processor.rbs
+++ b/elasticgraph-indexer_lambda/sig/elastic_graph/indexer_lambda/sqs_processor.rbs
@@ -3,7 +3,6 @@ module ElasticGraph
     class SqsProcessor
       def initialize: (
         Indexer::Processor,
-        report_batch_item_failures: bool,
         logger: ::Logger,
         ?s3_client: Aws::S3::Client?
       ) -> void
@@ -13,7 +12,6 @@ module ElasticGraph
       private
 
       @indexer_processor: Indexer::Processor
-      @report_batch_item_failures: bool
       @logger: ::Logger
       @s3_client: Aws::S3::Client?
 


### PR DESCRIPTION
Batch item failures are strictly better. The only reason we allowed it to be configured is to enable safe migration. The upcoming 1.0 release is an ideal time to drop support for `REPORT_BATCH_ITEM_FAILURES: false`.