### PR TITLE
Prefer using `filter` over `must` in boolean queries.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/boolean_query.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/boolean_query.rb
@@ -13,14 +13,13 @@ module ElasticGraph
       # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html
       #
       # It is composed of:
-      #   1) The occurrence type (:must, :filter, :should, or :must_not)
+      #   1) The occurrence type (:filter, :should, or :must_not)
       #   2) A list of query clauses evaluated by the given occurrence type
       #   3) An optional flag indicating whether the occurrence should be negated
+      #
+      # Note: since we never do anything with the score, we always prefer `filter` over `must`. If we ever
+      # decide to do something with the score (such as sorting by it), then we'll want to introduce `must`.
       class BooleanQuery < ::Data.define(:occurrence, :clauses)
-        def self.must(*clauses)
-          new(:must, clauses)
-        end
-
         def self.filter(*clauses)
           new(:filter, clauses)
         end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/filtering/boolean_query.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/filtering/boolean_query.rbs
@@ -3,7 +3,7 @@ module ElasticGraph
     module Filtering
       type queryClause = RangeQuery | BooleanQuery
       type stringOrSymbolHash = ::Hash[(::String | ::Symbol), untyped]
-      type occurrence = :must | :must_not | :filter | :should
+      type occurrence = :must_not | :filter | :should
 
       class BooleanQuerySupertype
         attr_reader occurrence: occurrence
@@ -21,7 +21,6 @@ module ElasticGraph
       end
 
       class BooleanQuery < BooleanQuerySupertype
-        def self.must: (*stringOrSymbolHash) -> BooleanQuery
         def self.filter: (*stringOrSymbolHash) -> BooleanQuery
         def self.should: (*stringOrSymbolHash) -> BooleanQuery
         def merge_into: (stringOrSymbolHash) -> void

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/filtering_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/filtering_spec.rb
@@ -111,7 +111,7 @@ module ElasticGraph
         )
       end
 
-      it "builds a `match` must condition when given a `matches_query`: 'MatchesQueryFilterInput' filter" do
+      it "builds a `match` filter condition when given a `matches_query`: 'MatchesQueryFilterInput' filter" do
         query = new_query(
           filter: {
             "name_text" => {
@@ -124,10 +124,10 @@ module ElasticGraph
           }
         )
 
-        expect(datastore_body_of(query)).to query_datastore_with(bool: {must: [{match: {"name_text" => {query: "foo", fuzziness: "AUTO", operator: "OR"}}}]})
+        expect(datastore_body_of(query)).to query_datastore_with(bool: {filter: [{match: {"name_text" => {query: "foo", fuzziness: "AUTO", operator: "OR"}}}]})
       end
 
-      it "builds a `match` must condition with specified fuzziness when given a `matches_query`: 'MatchesQueryFilterInput' filter" do
+      it "builds a `match` filter condition with specified fuzziness when given a `matches_query`: 'MatchesQueryFilterInput' filter" do
         query = new_query(
           filter: {
             "name_text" => {
@@ -139,7 +139,7 @@ module ElasticGraph
             }
           }
         )
-        expect(datastore_body_of(query)).to query_datastore_with(bool: {must: [{match: {"name_text" => {query: "foo", fuzziness: "0", operator: "OR"}}}]})
+        expect(datastore_body_of(query)).to query_datastore_with(bool: {filter: [{match: {"name_text" => {query: "foo", fuzziness: "0", operator: "OR"}}}]})
 
         query = new_query(
           filter: {
@@ -152,7 +152,7 @@ module ElasticGraph
             }
           }
         )
-        expect(datastore_body_of(query)).to query_datastore_with(bool: {must: [{match: {"name_text" => {query: "foo", fuzziness: "1", operator: "OR"}}}]})
+        expect(datastore_body_of(query)).to query_datastore_with(bool: {filter: [{match: {"name_text" => {query: "foo", fuzziness: "1", operator: "OR"}}}]})
 
         query = new_query(
           filter: {
@@ -165,7 +165,7 @@ module ElasticGraph
             }
           }
         )
-        expect(datastore_body_of(query)).to query_datastore_with(bool: {must: [{match: {"name_text" => {query: "foo", fuzziness: "2", operator: "OR"}}}]})
+        expect(datastore_body_of(query)).to query_datastore_with(bool: {filter: [{match: {"name_text" => {query: "foo", fuzziness: "2", operator: "OR"}}}]})
 
         query = new_query(
           filter: {
@@ -178,10 +178,10 @@ module ElasticGraph
             }
           }
         )
-        expect(datastore_body_of(query)).to query_datastore_with(bool: {must: [{match: {"name_text" => {query: "foo", fuzziness: "AUTO", operator: "OR"}}}]})
+        expect(datastore_body_of(query)).to query_datastore_with(bool: {filter: [{match: {"name_text" => {query: "foo", fuzziness: "AUTO", operator: "OR"}}}]})
       end
 
-      it "builds a `match` must condition with specified operator when given a `matches_query`: 'MatchesQueryFilterInput' filter" do
+      it "builds a `match` filter condition with specified operator when given a `matches_query`: 'MatchesQueryFilterInput' filter" do
         query = new_query(
           filter: {
             "name_text" => {
@@ -194,13 +194,13 @@ module ElasticGraph
           }
         )
 
-        expect(datastore_body_of(query)).to query_datastore_with(bool: {must: [{match: {"name_text" => {query: "foo", fuzziness: "AUTO", operator: "AND"}}}]})
+        expect(datastore_body_of(query)).to query_datastore_with(bool: {filter: [{match: {"name_text" => {query: "foo", fuzziness: "AUTO", operator: "AND"}}}]})
       end
 
-      it "builds a `match_phrase_prefix` must condition when given a `matches_phrase`: 'MatchesPhraseFilterInput' filter" do
+      it "builds a `match_phrase_prefix` filter condition when given a `matches_phrase`: 'MatchesPhraseFilterInput' filter" do
         query = new_query(filter: {"name_text" => {"matches_phrase" => {"phrase" => "foo"}}})
 
-        expect(datastore_body_of(query)).to query_datastore_with(bool: {must: [{match_phrase_prefix: {"name_text" => {query: "foo"}}}]})
+        expect(datastore_body_of(query)).to query_datastore_with(bool: {filter: [{match_phrase_prefix: {"name_text" => {query: "foo"}}}]})
       end
 
       it "builds a `terms` condition on a nested path when given a deeply nested (3 levels) `equal_to_any_of: [...]` filter" do


### PR DESCRIPTION
As explained by the Elasticsearch docs[^1], `filter` and `must` are nearly identical. The difference has to do with scoring and caching:

* Clauses under `must` contribute to the relevance score, and are not considered for caching.
* Clauses under `filter` ignore relevance scoring and are considered for caching.

We don't do anything with the relevance score (for example, we _always_ sort by a concrete field, and don't expose an API to interact with the score), so our current use of `must` isn't doing anything for us, other than preventing Elasticsearch/OpenSearch from applying caching.

Switching to `filter` should be a bit more performant, with no difference in observable query behavior.

[^1]: https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-bool-query