### PR TITLE
Document the new `contains` and `startsWith` filter predicates.

### DIFF
--- a/config/site/examples/music/queries/filtering/ArtistsPrefixedWithThe.graphql
+++ b/config/site/examples/music/queries/filtering/ArtistsPrefixedWithThe.graphql
@@ -1,0 +1,15 @@
+query ArtistsPrefixedWithThe {
+  artists(filter: {
+    name: {
+      startsWith: {
+        anyPrefixOf: ["The "]
+      }
+    }
+  }) {
+    edges {
+      node {
+        name
+      }
+    }
+  }
+}

--- a/config/site/examples/music/queries/filtering/ArtistsPrefixedWithTheCaseInsensitive.graphql
+++ b/config/site/examples/music/queries/filtering/ArtistsPrefixedWithTheCaseInsensitive.graphql
@@ -1,0 +1,16 @@
+query ArtistsPrefixedWithTheCaseInsensitive {
+  artists(filter: {
+    name: {
+      startsWith: {
+        anyPrefixOf: ["the "]
+        ignoreCase: true
+      }
+    }
+  }) {
+    edges {
+      node {
+        name
+      }
+    }
+  }
+}

--- a/config/site/examples/music/queries/filtering/AverageSongLengthForYouAndEye.graphql
+++ b/config/site/examples/music/queries/filtering/AverageSongLengthForYouAndEye.graphql
@@ -1,0 +1,33 @@
+query AverageSongLengthForYouAndEye {
+  artistAggregations {
+    nodes {
+      subAggregations {
+        albums {
+          nodes {
+            subAggregations {
+              tracks(filter: {
+                name: {
+                  contains: {
+                    allSubstringsOf: ["You", "Eye"]
+                  }
+                }
+              }) {
+                nodes {
+                  groupedBy {
+                    name
+                  }
+
+                  aggregatedValues {
+                    lengthInSeconds {
+                      approximateAvg
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/config/site/examples/music/queries/filtering/AverageSongLengthForYouOrEye.graphql
+++ b/config/site/examples/music/queries/filtering/AverageSongLengthForYouOrEye.graphql
@@ -1,0 +1,34 @@
+query AverageSongLengthForYouOrEye {
+  artistAggregations {
+    nodes {
+      subAggregations {
+        albums {
+          nodes {
+            subAggregations {
+              tracks(filter: {
+                name: {
+                  contains: {
+                    anySubstringOf: ["you", "eye"]
+                    ignoreCase: true
+                  }
+                }
+              }) {
+                nodes {
+                  groupedBy {
+                    name
+                  }
+
+                  aggregatedValues {
+                    lengthInSeconds {
+                      approximateAvg
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/config/site/src/_includes/filtering_predicate_definitions/any_satisfy.md
+++ b/config/site/src/_includes/filtering_predicate_definitions/any_satisfy.md
@@ -2,8 +2,3 @@
 : Matches records where any of the list elements match the provided sub-filter.
 
   When `null` or an empty object is passed, matches all documents.
-
-[`count`]({% link query-api/filtering/list.md %}#filtering-on-the-list-size-with-count)
-: Used to filter on the number of non-null elements in this list field.
-
-  When `null` or an empty object is passed, matches all documents.

--- a/config/site/src/_includes/filtering_predicate_definitions/contains.md
+++ b/config/site/src/_includes/filtering_predicate_definitions/contains.md
@@ -1,0 +1,4 @@
+[`contains`]({% link query-api/filtering/substring.md %})
+: Matches documents using substring filtering.
+
+  When `null` is passed, matches all documents.

--- a/config/site/src/_includes/filtering_predicate_definitions/count.md
+++ b/config/site/src/_includes/filtering_predicate_definitions/count.md
@@ -1,0 +1,4 @@
+[`count`]({% link query-api/filtering/list.md %}#filtering-on-the-list-size-with-count)
+: Used to filter on the number of non-null elements in this list field.
+
+  When `null` or an empty object is passed, matches all documents.

--- a/config/site/src/_includes/filtering_predicate_definitions/starts_with.md
+++ b/config/site/src/_includes/filtering_predicate_definitions/starts_with.md
@@ -1,0 +1,4 @@
+[`startsWith`]({% link query-api/filtering/string-prefix.md %})
+: Matches documents using prefix filtering.
+
+  When `null` is passed, matches all documents.

--- a/config/site/src/query-api/aggregations.md
+++ b/config/site/src/query-api/aggregations.md
@@ -3,7 +3,7 @@ layout: query-api
 title: 'ElasticGraph Query API: Aggregations'
 permalink: "/query-api/aggregations/"
 nav_title: Aggregations
-menu_order: 3
+menu_order: 30
 ---
 ElasticGraph offers a powerful aggregations API. Each indexed type gets a corresponding `*Aggregations` field.
 Here's a complete example:

--- a/config/site/src/query-api/aggregations/aggregated-values.md
+++ b/config/site/src/query-api/aggregations/aggregated-values.md
@@ -3,7 +3,7 @@ layout: query-api
 title: 'ElasticGraph Query API: Aggregated Values'
 permalink: "/query-api/aggregations/aggregated-values/"
 nav_title: Aggregated Values
-menu_order: 1
+menu_order: 10
 ---
 Aggregated values can be computed from all values of a particular field from all documents backing an aggregation node.
 Here's an example:

--- a/config/site/src/query-api/aggregations/counts.md
+++ b/config/site/src/query-api/aggregations/counts.md
@@ -3,7 +3,7 @@ layout: query-api
 title: 'ElasticGraph Query API: Aggregation Counts'
 permalink: "/query-api/aggregations/counts/"
 nav_title: Counts
-menu_order: 2
+menu_order: 20
 ---
 The aggregations API allows you to count documents within a grouping:
 

--- a/config/site/src/query-api/aggregations/grouping.md
+++ b/config/site/src/query-api/aggregations/grouping.md
@@ -3,7 +3,7 @@ layout: query-api
 title: 'ElasticGraph Query API: Aggregation Grouping'
 permalink: "/query-api/aggregations/grouping/"
 nav_title: Grouping
-menu_order: 3
+menu_order: 30
 ---
 When aggregating documents, the groupings are defined by `groupedBy`. Here's an example:
 

--- a/config/site/src/query-api/aggregations/sub-aggregations.md
+++ b/config/site/src/query-api/aggregations/sub-aggregations.md
@@ -3,7 +3,7 @@ layout: query-api
 title: 'ElasticGraph Query API: Sub-Aggregations'
 permalink: "/query-api/aggregations/sub-aggregations/"
 nav_title: Sub-Aggregations
-menu_order: 4
+menu_order: 40
 ---
 The example schema used throughout this guide has a number of lists-of-object fields nested
 within the overall `Artist` type:

--- a/config/site/src/query-api/filtering.md
+++ b/config/site/src/query-api/filtering.md
@@ -3,7 +3,7 @@ layout: query-api
 title: 'ElasticGraph Query API: Filtering'
 permalink: "/query-api/filtering/"
 nav_title: Filtering
-menu_order: 2
+menu_order: 20
 ---
 Use `filter:` on a root query field to narrow down the returned results:
 

--- a/config/site/src/query-api/filtering/available-predicates.md
+++ b/config/site/src/query-api/filtering/available-predicates.md
@@ -3,7 +3,7 @@ layout: query-api
 title: 'ElasticGraph Query API: Available Filter Predicates'
 permalink: "/query-api/filtering/available-predicates/"
 nav_title: Available Predicates
-menu_order: 1
+menu_order: 10
 hide_try_queries_tip: true
 ---
 ElasticGraph offers a variety of filtering predicates:
@@ -15,10 +15,13 @@ ElasticGraph offers a variety of filtering predicates:
 {% endcomment %}
 
 {% include filtering_predicate_definitions/conjunctions.md %}
-{% include filtering_predicate_definitions/list.md %}
+{% include filtering_predicate_definitions/any_satisfy.md %}
+{% include filtering_predicate_definitions/contains.md %}
+{% include filtering_predicate_definitions/count.md %}
 {% include filtering_predicate_definitions/equality.md %}
 {% include filtering_predicate_definitions/comparison.md %}
 {% include filtering_predicate_definitions/fulltext.md %}
 {% include filtering_predicate_definitions/near.md %}
 {% include filtering_predicate_definitions/not.md %}
+{% include filtering_predicate_definitions/starts_with.md %}
 {% include filtering_predicate_definitions/time_of_day.md %}

--- a/config/site/src/query-api/filtering/comparison.md
+++ b/config/site/src/query-api/filtering/comparison.md
@@ -3,7 +3,7 @@ layout: query-api
 title: 'ElasticGraph Query API: Comparison Filtering'
 permalink: "/query-api/filtering/comparison/"
 nav_title: Comparison
-menu_order: 3
+menu_order: 30
 ---
 ElasticGraph offers a standard set of comparison filter predicates:
 

--- a/config/site/src/query-api/filtering/conjunctions.md
+++ b/config/site/src/query-api/filtering/conjunctions.md
@@ -3,7 +3,7 @@ layout: query-api
 title: 'ElasticGraph Query API: Filter Conjunctions'
 permalink: "/query-api/filtering/conjunctions/"
 nav_title: Conjunctions
-menu_order: 8
+menu_order: 80
 ---
 ElasticGraph supports two conjunction predicates:
 

--- a/config/site/src/query-api/filtering/date-time.md
+++ b/config/site/src/query-api/filtering/date-time.md
@@ -3,7 +3,7 @@ layout: query-api
 title: 'ElasticGraph Query API: DateTime Filtering'
 permalink: "/query-api/filtering/date-time/"
 nav_title: DateTime
-menu_order: 4
+menu_order: 40
 ---
 ElasticGraph supports three different date/time types:
 

--- a/config/site/src/query-api/filtering/equality.md
+++ b/config/site/src/query-api/filtering/equality.md
@@ -3,7 +3,7 @@ layout: query-api
 title: 'ElasticGraph Query API: Equality Filtering'
 permalink: "/query-api/filtering/equality/"
 nav_title: Equality
-menu_order: 2
+menu_order: 20
 ---
 The most commonly used predicate supports equality filtering:
 

--- a/config/site/src/query-api/filtering/full-text-search.md
+++ b/config/site/src/query-api/filtering/full-text-search.md
@@ -3,7 +3,7 @@ layout: query-api
 title: 'ElasticGraph Query API: Full Text Search'
 permalink: "/query-api/filtering/full-text-search/"
 nav_title: Full Text Search
-menu_order: 5
+menu_order: 50
 ---
 ElasticGraph supports two full-text search filtering predicates:
 

--- a/config/site/src/query-api/filtering/geographic.md
+++ b/config/site/src/query-api/filtering/geographic.md
@@ -3,7 +3,7 @@ layout: query-api
 title: 'ElasticGraph Query API: Geographic Filtering'
 permalink: "/query-api/filtering/geographic/"
 nav_title: Geographic
-menu_order: 6
+menu_order: 60
 ---
 The `GeoLocation` type supports a special predicate:
 

--- a/config/site/src/query-api/filtering/list.md
+++ b/config/site/src/query-api/filtering/list.md
@@ -3,11 +3,12 @@ layout: query-api
 title: 'ElasticGraph Query API: List Filtering'
 permalink: "/query-api/filtering/list/"
 nav_title: List
-menu_order: 8
+menu_order: 80
 ---
 ElasticGraph supports a couple predicates for filtering on list fields:
 
-{% include filtering_predicate_definitions/list.md %}
+{% include filtering_predicate_definitions/any_satisfy.md %}
+{% include filtering_predicate_definitions/count.md %}
 
 ### Filtering on list elements with `anySatisfy`
 

--- a/config/site/src/query-api/filtering/negation.md
+++ b/config/site/src/query-api/filtering/negation.md
@@ -3,7 +3,7 @@ layout: query-api
 title: 'ElasticGraph Query API: Filter Negation'
 permalink: "/query-api/filtering/negation/"
 nav_title: Negation
-menu_order: 7
+menu_order: 70
 ---
 ElasticGraph supports a negation predicate:
 

--- a/config/site/src/query-api/filtering/string-prefix.md
+++ b/config/site/src/query-api/filtering/string-prefix.md
@@ -1,0 +1,19 @@
+---
+layout: query-api
+title: 'ElasticGraph Query API: String Prefix Filtering'
+permalink: "/query-api/filtering/string-prefix/"
+nav_title: String Prefix
+menu_order: 47
+---
+
+ElasticGraph offers a predicate to support string prefix filtering:
+
+{% include filtering_predicate_definitions/starts_with.md %}
+
+Here's a basic example:
+
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.ArtistsPrefixedWithThe" %}
+
+By default, prefix searching is case-sensitive. To make it case-insensitive, pass `ignoreCase: true`:
+
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.ArtistsPrefixedWithTheCaseInsensitive" %}

--- a/config/site/src/query-api/filtering/substring.md
+++ b/config/site/src/query-api/filtering/substring.md
@@ -1,0 +1,36 @@
+---
+layout: query-api
+title: 'ElasticGraph Query API: Substring Filtering'
+permalink: "/query-api/filtering/substring/"
+nav_title: Substring
+menu_order: 43
+---
+
+ElasticGraph offers a predicate to support substring filtering:
+
+{% include filtering_predicate_definitions/contains.md %}
+
+The `contains` operator accepts an object with multiple options. Here's an example using `anySubstringOf` and `ignoreCase`:
+
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.AverageSongLengthForYouOrEye" %}
+
+This matches tracks with names that case-insensitively contain "you" or "eye" such as:
+
+* _Brown Eyed Girl_
+* _In Your Eyes_
+* _We Will Rock You_
+* _With or Without You_
+
+ElasticGraph also offers `allSubstringsOf`:
+
+{% include copyable_code_snippet.html language="graphql" data="music_queries.filtering.AverageSongLengthForYouAndEye" %}
+
+This query is case-sensitive (since there's no `ignoreCase: true`) and only matches tracks with names that contain "You" and "Eye" such as _In Your Eyes_.
+The following tracks only contain "You" or "Eye" (but not both) and would not be returned:
+
+* _Brown Eyed Girl_
+* _We Will Rock You_
+* _With or Without You_
+
+{: .alert-tip}
+When searching on a single substring, `anySubstringOf` and `allSubstringsOf` behave the same, so feel free to use either.

--- a/config/site/src/query-api/overview.md
+++ b/config/site/src/query-api/overview.md
@@ -3,7 +3,7 @@ layout: query-api
 title: 'ElasticGraph Query API: Overview'
 permalink: "/query-api/overview/"
 nav_title: Overview
-menu_order: 1
+menu_order: 10
 ---
 
 ElasticGraph provides an extremely flexible GraphQL query API. As with every GraphQL API, you request the fields you want:

--- a/config/site/src/query-api/pagination.md
+++ b/config/site/src/query-api/pagination.md
@@ -3,7 +3,7 @@ layout: query-api
 title: 'ElasticGraph Query API: Pagination'
 permalink: "/query-api/pagination/"
 nav_title: Pagination
-menu_order: 5
+menu_order: 50
 ---
 To provide pagination, ElasticGraph implements the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm). Here's an example query showing

--- a/config/site/src/query-api/sorting.md
+++ b/config/site/src/query-api/sorting.md
@@ -3,7 +3,7 @@ layout: query-api
 title: 'ElasticGraph Query API: Sorting'
 permalink: "/query-api/sorting/"
 nav_title: Sorting
-menu_order: 4
+menu_order: 40
 ---
 Use `orderBy:` on a root query field to control how the results are sorted:
 


### PR DESCRIPTION
As part of this, I've renumbered the nav menu items to be multiples of 10, in order to leave gaps so that I can more eaasily add new nav menu items in the middle.