### PR TITLE
Define initial schema for search highlights.

### DIFF
--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -2696,6 +2696,8 @@ object_types_by_name:
   AddressEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -2910,6 +2912,8 @@ object_types_by_name:
   ComponentEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -3126,6 +3130,8 @@ object_types_by_name:
   ElectricalPartEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -3431,6 +3437,8 @@ object_types_by_name:
   ManufacturerEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -3544,6 +3552,8 @@ object_types_by_name:
   MechanicalPartEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -3858,6 +3868,8 @@ object_types_by_name:
   NamedEntityEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -4078,6 +4090,8 @@ object_types_by_name:
   PartEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -4238,6 +4252,13 @@ object_types_by_name:
         resolver: list_records
       widgets_or_addresses:
         resolver: list_records
+  SearchHighlight:
+    graphql_fields_by_name:
+      path:
+        resolver: object_without_lookahead
+      snippets:
+        resolver: object_without_lookahead
+    graphql_only_return_type: true
   SizeListFilterInput:
     graphql_fields_by_name:
       count:
@@ -4342,6 +4363,8 @@ object_types_by_name:
   SponsorEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -4390,6 +4413,8 @@ object_types_by_name:
   StringEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -4639,6 +4664,8 @@ object_types_by_name:
   TeamEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -5479,6 +5506,8 @@ object_types_by_name:
   WidgetCurrencyEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -5519,6 +5548,8 @@ object_types_by_name:
   WidgetEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -5856,6 +5887,8 @@ object_types_by_name:
   WidgetOrAddressEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -6041,6 +6074,8 @@ object_types_by_name:
   WidgetWorkspaceEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:

--- a/config/schema/artifacts/schema.graphql
+++ b/config/schema/artifacts/schema.graphql
@@ -145,6 +145,11 @@ Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for mor
 """
 type AddressEdge {
   """
+  Search highlights for this `Address`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
   The `Cursor` of this `Address`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `Address`.
   """
@@ -1147,6 +1152,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type ComponentEdge {
+  """
+  Search highlights for this `Component`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `Component`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `Component`.
@@ -2648,6 +2658,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type ElectricalPartEdge {
+  """
+  Search highlights for this `ElectricalPart`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `ElectricalPart`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `ElectricalPart`.
@@ -4338,6 +4353,11 @@ Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for mor
 """
 type ManufacturerEdge {
   """
+  Search highlights for this `Manufacturer`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
   The `Cursor` of this `Manufacturer`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `Manufacturer`.
   """
@@ -4801,6 +4821,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type MechanicalPartEdge {
+  """
+  Search highlights for this `MechanicalPart`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `MechanicalPart`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `MechanicalPart`.
@@ -5430,6 +5455,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type NamedEntityEdge {
+  """
+  Search highlights for this `NamedEntity`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `NamedEntity`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `NamedEntity`.
@@ -6646,6 +6676,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type PartEdge {
+  """
+  Search highlights for this `Part`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `Part`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `Part`.
@@ -8761,6 +8796,22 @@ type Query {
   ): WidgetOrAddressConnection
 }
 
+"""
+Provides information about why a document matched a search via highlighted snippets.
+"""
+type SearchHighlight {
+  """
+  Path to a leaf field containing one or more search highlight snippets. The returned list will contain a path segment for
+  each object layer of the schema, from the document root.
+  """
+  path: [String!]!
+
+  """
+  List of snippets containing search highlights from field values at this `path`.
+  """
+  snippets: [String!]!
+}
+
 enum Size {
   LARGE
   MEDIUM
@@ -9226,6 +9277,11 @@ Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for mor
 """
 type SponsorEdge {
   """
+  Search highlights for this `Sponsor`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
   The `Cursor` of this `Sponsor`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `Sponsor`.
   """
@@ -9579,6 +9635,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type StringEdge {
+  """
+  Search highlights for this `String`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `String`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `String`.
@@ -10336,6 +10397,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type TeamEdge {
+  """
+  Search highlights for this `Team`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `Team`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `Team`.
@@ -12582,6 +12648,11 @@ Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for mor
 """
 type WidgetCurrencyEdge {
   """
+  Search highlights for this `WidgetCurrency`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
   The `Cursor` of this `WidgetCurrency`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `WidgetCurrency`.
   """
@@ -12912,6 +12983,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type WidgetEdge {
+  """
+  Search highlights for this `Widget`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `Widget`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `Widget`.
@@ -13798,6 +13874,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type WidgetOrAddressEdge {
+  """
+  Search highlights for this `WidgetOrAddress`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `WidgetOrAddress`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `WidgetOrAddress`.
@@ -15068,6 +15149,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type WidgetWorkspaceEdge {
+  """
+  Search highlights for this `WidgetWorkspace`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `WidgetWorkspace`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `WidgetWorkspace`.

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -2710,6 +2710,8 @@ object_types_by_name:
   AddressEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -2924,6 +2926,8 @@ object_types_by_name:
   ComponentEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -3158,6 +3162,8 @@ object_types_by_name:
   ElectricalPartEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -3463,6 +3469,8 @@ object_types_by_name:
   ManufacturerEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -3576,6 +3584,8 @@ object_types_by_name:
   MechanicalPartEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -3890,6 +3900,8 @@ object_types_by_name:
   NamedEntityEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -4110,6 +4122,8 @@ object_types_by_name:
   PartEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -4274,6 +4288,13 @@ object_types_by_name:
         resolver: list_records
       widgets_or_addresses:
         resolver: list_records
+  SearchHighlight:
+    graphql_fields_by_name:
+      path:
+        resolver: object_without_lookahead
+      snippets:
+        resolver: object_without_lookahead
+    graphql_only_return_type: true
   SizeListFilterInput:
     graphql_fields_by_name:
       count:
@@ -4378,6 +4399,8 @@ object_types_by_name:
   SponsorEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -4426,6 +4449,8 @@ object_types_by_name:
   StringEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -4675,6 +4700,8 @@ object_types_by_name:
   TeamEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -5515,6 +5542,8 @@ object_types_by_name:
   WidgetCurrencyEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -5555,6 +5584,8 @@ object_types_by_name:
   WidgetEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -5892,6 +5923,8 @@ object_types_by_name:
   WidgetOrAddressEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:
@@ -6077,6 +6110,8 @@ object_types_by_name:
   WidgetWorkspaceEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
+      all_highlights:
+        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:

--- a/config/schema/artifacts_with_apollo/schema.graphql
+++ b/config/schema/artifacts_with_apollo/schema.graphql
@@ -178,6 +178,11 @@ Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for mor
 """
 type AddressEdge {
   """
+  Search highlights for this `Address`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
   The `Cursor` of this `Address`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `Address`.
   """
@@ -1180,6 +1185,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type ComponentEdge {
+  """
+  Search highlights for this `Component`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `Component`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `Component`.
@@ -2822,6 +2832,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type ElectricalPartEdge {
+  """
+  Search highlights for this `ElectricalPart`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `ElectricalPart`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `ElectricalPart`.
@@ -4527,6 +4542,11 @@ Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for mor
 """
 type ManufacturerEdge {
   """
+  Search highlights for this `Manufacturer`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
   The `Cursor` of this `Manufacturer`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `Manufacturer`.
   """
@@ -4990,6 +5010,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type MechanicalPartEdge {
+  """
+  Search highlights for this `MechanicalPart`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `MechanicalPart`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `MechanicalPart`.
@@ -5619,6 +5644,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type NamedEntityEdge {
+  """
+  Search highlights for this `NamedEntity`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `NamedEntity`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `NamedEntity`.
@@ -6835,6 +6865,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type PartEdge {
+  """
+  Search highlights for this `Part`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `Part`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `Part`.
@@ -8991,6 +9026,22 @@ type Query {
   ): WidgetOrAddressConnection
 }
 
+"""
+Provides information about why a document matched a search via highlighted snippets.
+"""
+type SearchHighlight @shareable {
+  """
+  Path to a leaf field containing one or more search highlight snippets. The returned list will contain a path segment for
+  each object layer of the schema, from the document root.
+  """
+  path: [String!]!
+
+  """
+  List of snippets containing search highlights from field values at this `path`.
+  """
+  snippets: [String!]!
+}
+
 enum Size {
   LARGE
   MEDIUM
@@ -9456,6 +9507,11 @@ Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for mor
 """
 type SponsorEdge {
   """
+  Search highlights for this `Sponsor`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
   The `Cursor` of this `Sponsor`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `Sponsor`.
   """
@@ -9809,6 +9865,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type StringEdge @shareable {
+  """
+  Search highlights for this `String`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `String`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `String`.
@@ -10566,6 +10627,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type TeamEdge {
+  """
+  Search highlights for this `Team`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `Team`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `Team`.
@@ -12812,6 +12878,11 @@ Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for mor
 """
 type WidgetCurrencyEdge {
   """
+  Search highlights for this `WidgetCurrency`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
   The `Cursor` of this `WidgetCurrency`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `WidgetCurrency`.
   """
@@ -13142,6 +13213,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type WidgetEdge {
+  """
+  Search highlights for this `Widget`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `Widget`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `Widget`.
@@ -14028,6 +14104,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type WidgetOrAddressEdge {
+  """
+  Search highlights for this `WidgetOrAddress`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `WidgetOrAddress`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `WidgetOrAddress`.
@@ -15298,6 +15379,11 @@ See the [Relay GraphQL Cursor Connections
 Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
 """
 type WidgetWorkspaceEdge {
+  """
+  Search highlights for this `WidgetWorkspace`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
   """
   The `Cursor` of this `WidgetWorkspace`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `WidgetWorkspace`.

--- a/elasticgraph-graphql/spec/acceptance/hidden_types_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/hidden_types_spec.rb
@@ -121,6 +121,7 @@ module ElasticGraph
               IntListFilterInput IntListElementFilterInput AggregationCountDetail
               LocalTimeGroupingOffsetInput LocalTimeGroupingTruncationUnitInput LocalTimeUnitInput MatchesQueryFilterInput
               MatchesPhraseFilterInput MatchesQueryAllowedEditsPerTermInput StringContainsFilterInput StringStartsWithFilterInput
+              SearchHighlight
             ]
 
           # The sub-aggregation types are quite complicated and we just add them all here.

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rb
@@ -143,6 +143,8 @@ module ElasticGraph
         :eg_latency_slo, :ms,
         # For sorting.
         :order_by,
+        # For search highlighting,
+        :all_highlights, :path, :snippets,
         # For aggregation
         :grouped_by, :count, :count_detail, :aggregated_values, :sub_aggregations,
         # Date/time grouping aggregation fields

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rbs
@@ -40,7 +40,10 @@ module ElasticGraph
         attr_reader ms: ::String
 
         attr_reader order_by: ::String
-        attr_reader ordered_by: ::String
+
+        attr_reader all_highlights: ::String
+        attr_reader path: ::String
+        attr_reader snippets: ::String
 
         attr_reader grouped_by: ::String
         attr_reader count: ::String

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
@@ -207,9 +207,9 @@ module ElasticGraph
         [single_value_filter, list_filter, fields_list_filter]
       end
 
-      def build_relay_pagination_types(type_name, include_total_edge_count: false, derived_indexed_types: [], support_pagination: true, &customize_connection)
+      def build_relay_pagination_types(type_name, include_total_edge_count: false, derived_indexed_types: [], support_pagination: true, support_highlights: true, &customize_connection)
         [
-          (edge_type_for(type_name) if support_pagination),
+          (edge_type_for(type_name, support_highlights) if support_pagination),
           connection_type_for(type_name, include_total_edge_count, derived_indexed_types, support_pagination, &customize_connection)
         ].compact
       end
@@ -431,7 +431,7 @@ module ElasticGraph
         end
       end
 
-      def edge_type_for(type_name)
+      def edge_type_for(type_name, support_highlights)
         type_ref = @state.type_ref(type_name)
         new_object_type type_ref.as_edge.name do |t|
           t.relay_pagination_type = true
@@ -455,6 +455,12 @@ module ElasticGraph
               The `Cursor` of this `#{type_name}`. This can be passed in the next query as
               a `before` or `after` argument to continue paginating from this `#{type_name}`.
             EOS
+          end
+
+          if support_highlights
+            t.field @state.schema_elements.all_highlights, "[SearchHighlight!]!" do |f|
+              f.documentation "Search highlights for this `#{type_name}`, indicating where in the indexed document the query matched."
+            end
           end
         end
       end

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_filtering_and_aggregation.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_filtering_and_aggregation.rb
@@ -36,7 +36,7 @@ module ElasticGraph
           indexed_agg_type = to_indexed_aggregation_type
           indexed_aggregation_pagination_types =
             if indexed_agg_type
-              schema_def_state.factory.build_relay_pagination_types(indexed_agg_type.name)
+              schema_def_state.factory.build_relay_pagination_types(indexed_agg_type.name, support_highlights: false)
             else
               [] # : ::Array[SchemaElements::ObjectType]
             end

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
@@ -151,6 +151,9 @@ module ElasticGraph
       #   `PageInfo` specification from the [Relay GraphQL Cursor Connections
       #   Specification](https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo).
       #
+      # SearchHighlight
+      # : Provides information about why a document matched a search via highlighted snippets.
+      #
       # @!attribute [rw] schema_def_api
       #   @private
       # @!attribute [rw] schema_def_state
@@ -463,6 +466,23 @@ module ElasticGraph
                 The `Cursor` of the last edge of the current page. This can be passed in the next query as
                 a `after` argument to paginate forwards.
               EOS
+            end
+          end
+
+          register_framework_object_type "SearchHighlight" do |t|
+            t.default_graphql_resolver = :object_without_lookahead
+
+            t.documentation "Provides information about why a document matched a search via highlighted snippets."
+
+            t.field names.path, "[String!]!" do |f|
+              f.documentation <<~EOS
+                Path to a leaf field containing one or more search highlight snippets. The returned list will contain a path segment for
+                each object layer of the schema, from the document root.
+              EOS
+            end
+
+            t.field names.snippets, "[String!]!" do |f|
+              f.documentation "List of snippets containing search highlights from field values at this `path`."
             end
           end
 

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/factory.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/factory.rbs
@@ -72,7 +72,8 @@ module ElasticGraph
         ::String,
         ?include_total_edge_count: bool,
         ?derived_indexed_types: ::Array[Indexing::DerivedIndexedType],
-        ?support_pagination: bool
+        ?support_pagination: bool,
+        ?support_highlights: bool
       ) ?{ (SchemaElements::ObjectType) -> void } -> ::Array[SchemaElements::ObjectType]
 
       def new_interface_type: (::String) { (SchemaElements::InterfaceType) -> void } -> SchemaElements::InterfaceType
@@ -137,7 +138,7 @@ module ElasticGraph
 
       def define_list_counts_filter_field_on: (SchemaElements::InputType) -> void
 
-      def edge_type_for: (::String) -> SchemaElements::ObjectType
+      def edge_type_for: (::String, bool) -> SchemaElements::ObjectType
       def connection_type_for: (
         ::String,
         bool,

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/built_in_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/built_in_types_spec.rb
@@ -921,6 +921,25 @@ module ElasticGraph
           EOS
         end
 
+        it "defines a `SearchHighlight` type" do
+          expect(type_named("SearchHighlight", include_docs: true)).to eq(<<~EOS.strip)
+            """
+            Provides information about why a document matched a search via highlighted snippets.
+            """
+            type SearchHighlight {
+              """
+              Path to a leaf field containing one or more search highlight snippets. The returned list will contain a path segment for
+              each object layer of the schema, from the document root.
+              """
+              #{schema_elements.path}: [String!]!
+              """
+              List of snippets containing search highlights from field values at this `path`.
+              """
+              #{schema_elements.snippets}: [String!]!
+            }
+          EOS
+        end
+
         it "defines a `PageInfo` type" do
           expect(type_named("PageInfo", include_docs: true)).to eq(<<~EOS.strip)
             """

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/paginated_collection_field_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/paginated_collection_field_spec.rb
@@ -60,8 +60,9 @@ module ElasticGraph
 
           expect(edge_type_from(result, "String")).to eq(<<~EOS.chomp)
             type StringEdge {
-              node: String
-              cursor: Cursor
+              #{schema_elements.node}: String
+              #{schema_elements.cursor}: Cursor
+              #{schema_elements.all_highlights}: [SearchHighlight!]!
             }
           EOS
         end
@@ -103,8 +104,9 @@ module ElasticGraph
 
           expect(edge_type_from(result, "WidgetOptions")).to eq(<<~EOS.chomp)
             type WidgetOptionsEdge {
-              node: WidgetOptions
-              cursor: Cursor
+              #{schema_elements.node}: WidgetOptions
+              #{schema_elements.cursor}: Cursor
+              #{schema_elements.all_highlights}: [SearchHighlight!]!
             }
           EOS
         end
@@ -156,6 +158,7 @@ module ElasticGraph
             type TimeOfDayEdge {
               #{schema_elements.node}: TimeOfDay
               #{schema_elements.cursor}: Cursor
+              #{schema_elements.all_highlights}: [SearchHighlight!]!
             }
           EOS
 

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/relay_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/relay_types_spec.rb
@@ -35,12 +35,16 @@ module ElasticGraph
               """
               The `Widget` of this edge.
               """
-              node: Widget
+              #{schema_elements.node}: Widget
               """
               The `Cursor` of this `Widget`. This can be passed in the next query as
               a `before` or `after` argument to continue paginating from this `Widget`.
               """
-              cursor: Cursor
+              #{schema_elements.cursor}: Cursor
+              """
+              Search highlights for this `Widget`, indicating where in the indexed document the query matched.
+              """
+              #{schema_elements.all_highlights}: [SearchHighlight!]!
             }
           EOS
         end
@@ -70,8 +74,9 @@ module ElasticGraph
 
           expect(edge_type_from(result, "Inventor")).to eq(<<~EOS.strip)
             type InventorEdge {
-              node: Inventor
-              cursor: Cursor
+              #{schema_elements.node}: Inventor
+              #{schema_elements.cursor}: Cursor
+              #{schema_elements.all_highlights}: [SearchHighlight!]!
             }
           EOS
         end

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/pruning_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/pruning_spec.rb
@@ -76,6 +76,7 @@ module ElasticGraph
           NonNumericAggregatedValues
           PageInfo
           Query
+          SearchHighlight
           StringListFilterInput
           TextListFilterInput
           TimeZoneListFilterInput


### PR DESCRIPTION
This includes the `all_highlights` field but not the `highlights` (it's easier to start with `all_highlights`). See #561 for the full plan.