### PR TITLE
Introduce `internal_filters` vs `client_filters` on `DatastoreQuery`.

### DIFF
--- a/elasticgraph-apollo/apollo_tests_implementation/lib/product_resolver.rb
+++ b/elasticgraph-apollo/apollo_tests_implementation/lib/product_resolver.rb
@@ -24,7 +24,7 @@ class ProductResolver
     query = @datastore_query_builder.new_query(
       search_index_definitions: [@product_index_def],
       monotonic_clock_deadline: context[:monotonic_clock_deadline],
-      filters: [{"id" => {"equalToAnyOf" => [args.fetch("id")]}}],
+      client_filters: [{"id" => {"equalToAnyOf" => [args.fetch("id")]}}],
       individual_docs_needed: true,
       request_all_fields: true
     )

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/entities_field_resolver.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/entities_field_resolver.rb
@@ -166,7 +166,7 @@ module ElasticGraph
               query.merge_with(
                 document_pagination: {first: representations.length},
                 requested_fields: additional_requested_fields_for(representations),
-                filters: [filter]
+                internal_filters: [filter]
               )
             end
 
@@ -242,7 +242,7 @@ module ElasticGraph
               # In the case of representations which don't query Id, we ask for 2 documents so that
               # if something weird is going on and it matches more than 1, we can detect that and return an error.
               document_pagination: {first: 2},
-              filters: [build_filter_for_hash(fields)]
+              internal_filters: [build_filter_for_hash(fields)]
             )
           end
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/query_adapter/filters.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/query_adapter/filters.rbs
@@ -18,7 +18,7 @@ module ElasticGraph
 
         private
 
-        def build_automatic_filter: (filter_from_args: ::Hash[::String, untyped]?, query: DatastoreQuery) -> ::Hash[::String, untyped]?
+        def build_automatic_filter: (client_filter: ::Hash[::String, untyped]?, query: DatastoreQuery) -> ::Hash[::String, untyped]?
         def exclude_incomplete_docs_filter: () -> ::Hash[::String, untyped]
         def search_could_hit_incomplete_docs?: (DatastoreCore::_IndexDefinition, ::Hash[::String, untyped]) -> bool
 

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/aggregation_pagination_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/aggregation_pagination_spec.rb
@@ -118,7 +118,7 @@ module ElasticGraph
             document_pagination: {first: 0}, # make sure we don't ask for any documents, just aggregations.
             aggregations: [aggregation_query],
             total_document_count_needed: groupings.empty?,
-            filters: [({"name" => {"equal_to_any_of" => ids_of(filter_to)}} if filter_to)].compact
+            client_filters: [({"name" => {"equal_to_any_of" => ids_of(filter_to)}} if filter_to)].compact
           )
 
           connection = Aggregation::Resolvers::RelayConnectionBuilder.build_from_search_response(

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/datastore_query_integration_support.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/datastore_query_integration_support.rb
@@ -24,7 +24,7 @@ module ElasticGraph
 
       let(:graphql) { build_graphql }
 
-      def search_datastore(index_def_name: "widgets", aggregations: [], graphql: self.graphql, filter: nil, filters: [], **options, &before_msearch)
+      def search_datastore(index_def_name: "widgets", aggregations: [], graphql: self.graphql, **options, &before_msearch)
         index_def = graphql.datastore_core.index_definitions_by_name.fetch(index_def_name)
 
         query = graphql.datastore_query_builder.new_query(
@@ -32,7 +32,6 @@ module ElasticGraph
           requested_fields: ["id"],
           sort: index_def.default_sort_clauses,
           aggregations: aggregations.to_h { |agg| [agg.name, agg] },
-          filters: filters + [filter].compact,
           **options
         )
 

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/filtering_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/filtering_spec.rb
@@ -1199,8 +1199,7 @@ module ElasticGraph
         )
 
         expect(
-          ids_of(search_datastore(filter:
-            {"any_of" => [{"amount_cents" => {"equal_to_any_of" => [nil]}}]}).to_a)
+          ids_of(search_datastore(client_filters: [{"any_of" => [{"amount_cents" => {"equal_to_any_of" => [nil]}}]}]).to_a)
         ).to eq ids_of(widget2)
       end
 
@@ -1526,11 +1525,11 @@ module ElasticGraph
       end
 
       def search_with_freeform_filter(filter, **options)
-        ids_of(search_datastore(filter: filter, sort: [], **options).to_a)
+        ids_of(search_datastore(client_filters: [filter], sort: [], **options).to_a)
       end
 
       def search_with_filter(field, operator, value)
-        ids_of(search_datastore(filter: {field => {operator => value}}, sort: []).to_a)
+        ids_of(search_datastore(client_filters: [{field => {operator => value}}], sort: []).to_a)
       end
 
       def enum_value(type_name, value_name)

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/pagination_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/pagination_spec.rb
@@ -178,7 +178,7 @@ module ElasticGraph
         response = search_datastore(
           sort: sort,
           document_pagination: document_pagination,
-          filter: ({"id" => {"equal_to_any_of" => ids_of(filter_to)}} if filter_to)
+          client_filters: [({"id" => {"equal_to_any_of" => ids_of(filter_to)}} if filter_to)].compact
         ) { |q| query = q }
 
         adapter = Resolvers::RelayConnection::SearchResponseAdapterBuilder.build_from(

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/sub_aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/sub_aggregations_spec.rb
@@ -77,7 +77,7 @@ module ElasticGraph
           nested_sub_aggregation_of(path_in_index: ["seasons_nested"], query: sub_aggregation_query_of(name: "seasons_nested", first: 5))
         ])
 
-        results = search_datastore_aggregations(query, index_def_name: "teams", filter: {"league" => {"equal_to_any_of" => []}})
+        results = search_datastore_aggregations(query, index_def_name: "teams", client_filters: [{"league" => {"equal_to_any_of" => []}}])
 
         expect(results).to eq [{
           "doc_count" => 0,
@@ -93,7 +93,7 @@ module ElasticGraph
           nested_sub_aggregation_of(path_in_index: ["seasons_nested"], query: sub_aggregation_query_of(name: "seasons_nested", first: 5))
         ])
 
-        results = search_datastore_aggregations(query, index_def_name: "teams", filter: {"formed_on" => {"equal_to_any_of" => []}})
+        results = search_datastore_aggregations(query, index_def_name: "teams", client_filters: [{"formed_on" => {"equal_to_any_of" => []}}])
 
         expect(results).to eq [{
           "doc_count" => 0,
@@ -109,7 +109,7 @@ module ElasticGraph
           nested_sub_aggregation_of(path_in_index: ["seasons_nested"], query: sub_aggregation_query_of(name: "seasons_nested", first: 5))
         ])
 
-        results = search_datastore_aggregations(query, index_def_name: "teams", filter: {"formed_on" => {"gt" => "7890-01-01"}})
+        results = search_datastore_aggregations(query, index_def_name: "teams", client_filters: [{"formed_on" => {"gt" => "7890-01-01"}}])
 
         expect(results).to eq [{
           "doc_count" => 0,

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_optimizer_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_optimizer_spec.rb
@@ -36,7 +36,7 @@ module ElasticGraph
             computations: [computation_of("amountMoney", "amount", :sum)]
           )
 
-          base_query = new_query(filters: [{"age" => {"equal_to_any_of" => [0]}}])
+          base_query = new_query(client_filters: [{"age" => {"equal_to_any_of" => [0]}}])
 
           by_size = with_aggs(base_query, [by_size_agg])
           by_color = with_aggs(base_query, [by_color_agg])
@@ -77,7 +77,7 @@ module ElasticGraph
             computations: [computation_of("amountMoney", "amount", :sum)]
           )
 
-          base_query = new_query(filters: [{"age" => {"equal_to_any_of" => [0]}}])
+          base_query = new_query(client_filters: [{"age" => {"equal_to_any_of" => [0]}}])
 
           by_size = with_aggs(base_query, [by_size_agg])
           by_color = with_aggs(base_query, [by_color_agg])
@@ -103,8 +103,8 @@ module ElasticGraph
         end
 
         it "can merge non-aggregation queries that are identical as well" do
-          q1 = new_query(filters: [{"age" => {"equal_to_any_of" => [0]}}])
-          q2 = new_query(filters: [{"age" => {"equal_to_any_of" => [0]}}])
+          q1 = new_query(client_filters: [{"age" => {"equal_to_any_of" => [0]}}])
+          q2 = new_query(client_filters: [{"age" => {"equal_to_any_of" => [0]}}])
           expect(q1).to eq(q2)
 
           results_by_query = optimize_queries(q1, q2)
@@ -122,8 +122,8 @@ module ElasticGraph
 
         it "keeps queries separate when they have non-aggregation differences" do
           optimize_queries(
-            base_query = new_query(filters: [{"age" => {"equal_to_any_of" => [0]}}], individual_docs_needed: true),
-            alt_filter = base_query.with(filters: [{"age" => {"equal_to_any_of" => [1]}}]),
+            base_query = new_query(client_filters: [{"age" => {"equal_to_any_of" => [0]}}], individual_docs_needed: true),
+            alt_filter = base_query.with(client_filters: [{"age" => {"equal_to_any_of" => [1]}}]),
             alt_pagination = base_query.with(document_pagination: {first: 1}),
             alt_individual_docs_needed = base_query.with(individual_docs_needed: !base_query.individual_docs_needed),
             alt_sort = base_query.with(sort: [{"age" => {"order" => "desc"}}]),
@@ -156,14 +156,14 @@ module ElasticGraph
             groupings: [field_term_grouping_of("options", "color")]
           )
 
-          base_query = new_query(filters: [{"age" => {"equal_to_any_of" => [0]}}])
+          base_query = new_query(client_filters: [{"age" => {"equal_to_any_of" => [0]}}])
 
           by_size = base_query.with(
-            filters: [{"age" => {"equal_to_any_of" => [0]}}],
+            client_filters: [{"age" => {"equal_to_any_of" => [0]}}],
             aggregations: {by_size_agg.name => by_size_agg}
           )
           by_color = base_query.with(
-            filters: [{"age" => {"equal_to_any_of" => [1]}}],
+            client_filters: [{"age" => {"equal_to_any_of" => [1]}}],
             aggregations: {by_color_agg.name => by_color_agg}
           )
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/datastore_query_unit_support.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/datastore_query_unit_support.rb
@@ -24,13 +24,12 @@ module ElasticGraph
         end
       end
 
-      def new_query(aggregations: {}, filter: nil, filters: [], types: ["Widget"], **options)
+      def new_query(aggregations: {}, types: ["Widget"], **options)
         aggregations = aggregations.to_h { |agg| [agg.name, agg] } if aggregations.is_a?(::Array)
 
         builder.new_query(
           aggregations: aggregations,
           search_index_definitions: types.flat_map { |t| graphql.datastore_core.index_definitions_by_graphql_type.fetch(t) },
-          filters: filters + [filter].compact,
           **options
         )
       end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/filtering_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/filtering_spec.rb
@@ -19,19 +19,19 @@ module ElasticGraph
       end
 
       it "builds a `nil` datastore body when given no filters (passed as `nil`)" do
-        query = new_query(filter: nil)
+        query = new_query(client_filter: nil)
 
         expect(datastore_body_of(query)).to not_filter_datastore_at_all
       end
 
       it "builds a `nil` datastore body when given no filters (passed as an empty hash)" do
-        query = new_query(filter: {})
+        query = new_query(client_filter: {})
 
         expect(datastore_body_of(query)).to not_filter_datastore_at_all
       end
 
       it "ignores unknown filtering operators and logs a warning" do
-        query = new_query(filter: {"name" => {"like" => "abc"}})
+        query = new_query(client_filter: {"name" => {"like" => "abc"}})
 
         expect {
           expect(datastore_body_of(query)).to not_filter_datastore_at_all
@@ -39,7 +39,7 @@ module ElasticGraph
       end
 
       it "ignores malformed filters and logs a warning" do
-        query = new_query(filter: {"name" => [7]})
+        query = new_query(client_filter: {"name" => [7]})
 
         expect {
           expect(datastore_body_of(query)).to not_filter_datastore_at_all
@@ -47,63 +47,63 @@ module ElasticGraph
       end
 
       it "takes advantage of ids query when filtering on id" do
-        query = new_query(filter: {"id" => {"equal_to_any_of" => ["testid"]}})
+        query = new_query(client_filter: {"id" => {"equal_to_any_of" => ["testid"]}})
 
         expect(datastore_body_of(query)).to filter_datastore_with(ids: {values: ["testid"]})
       end
 
       it "deduplicates the `id` to a unique set of values when given duplicates in an `equal_to_any_of: [...]` filter" do
-        query = new_query(filter: {"id" => {"equal_to_any_of" => ["a", "b", "a"]}})
+        query = new_query(client_filter: {"id" => {"equal_to_any_of" => ["a", "b", "a"]}})
 
         expect(datastore_body_of(query)).to filter_datastore_with(ids: {values: ["a", "b"]})
       end
 
       it "builds a `terms` condition when given an `equal_to_any_of: [...]` filter" do
-        query = new_query(filter: {"age" => {"equal_to_any_of" => [25, 30]}})
+        query = new_query(client_filter: {"age" => {"equal_to_any_of" => [25, 30]}})
 
         expect(datastore_body_of(query)).to filter_datastore_with(terms: {"age" => [25, 30]})
       end
 
       it "deduplicates the `terms` to a unique set of values when given duplicates in an `equal_to_any_of: [...]` filter" do
-        query = new_query(filter: {"age" => {"equal_to_any_of" => [25, 30, 25]}})
+        query = new_query(client_filter: {"age" => {"equal_to_any_of" => [25, 30, 25]}})
 
         expect(datastore_body_of(query)).to filter_datastore_with(terms: {"age" => [25, 30]})
       end
 
       it "builds a `range` condition when given an `gt: scalar` filter" do
-        query = new_query(filter: {"age" => {"gt" => 25}})
+        query = new_query(client_filter: {"age" => {"gt" => 25}})
 
         expect(datastore_body_of(query)).to filter_datastore_with(range: {"age" => {gt: 25}})
       end
 
       it "builds a `range` condition when given an `gte: scalar` filter" do
-        query = new_query(filter: {"age" => {"gte" => 25}})
+        query = new_query(client_filter: {"age" => {"gte" => 25}})
 
         expect(datastore_body_of(query)).to filter_datastore_with(range: {"age" => {gte: 25}})
       end
 
       it "builds a `range` condition when given an `lt: scalar` filter" do
-        query = new_query(filter: {"age" => {"lt" => 25}})
+        query = new_query(client_filter: {"age" => {"lt" => 25}})
 
         expect(datastore_body_of(query)).to filter_datastore_with(range: {"age" => {lt: 25}})
       end
 
       it "builds a `range` condition when given an `lte: scalar` filter" do
-        query = new_query(filter: {"age" => {"lte" => 25}})
+        query = new_query(client_filter: {"age" => {"lte" => 25}})
 
         expect(datastore_body_of(query)).to filter_datastore_with(range: {"age" => {lte: 25}})
       end
 
       it "merges multiple `range` clauses that are on the same field" do
-        query1 = new_query(filter: {"age" => {"gt" => 10, "lte" => 25}})
+        query1 = new_query(client_filter: {"age" => {"gt" => 10, "lte" => 25}})
         expect(datastore_body_of(query1)).to filter_datastore_with(range: {"age" => {gt: 10, lte: 25}})
 
-        query2 = new_query(filter: {"age" => {"gt" => 10, "lte" => 25, "gte" => 20, "lt" => 50}})
+        query2 = new_query(client_filter: {"age" => {"gt" => 10, "lte" => 25, "gte" => 20, "lt" => 50}})
         expect(datastore_body_of(query2)).to filter_datastore_with(range: {"age" => {gt: 10, gte: 20, lt: 50, lte: 25}})
       end
 
       it "leaves multiple `range` clauses that are on different fields unmerged" do
-        query = new_query(filter: {"age" => {"gt" => 10}, "height" => {"lte" => 120}})
+        query = new_query(client_filter: {"age" => {"gt" => 10}, "height" => {"lte" => 120}})
 
         expect(datastore_body_of(query)).to filter_datastore_with(
           {range: {"age" => {gt: 10}}},
@@ -113,7 +113,7 @@ module ElasticGraph
 
       it "builds a `match` filter condition when given a `matches_query`: 'MatchesQueryFilterInput' filter" do
         query = new_query(
-          filter: {
+          client_filter: {
             "name_text" => {
               "matches_query" => {
                 "query" => "foo",
@@ -129,7 +129,7 @@ module ElasticGraph
 
       it "builds a `match` filter condition with specified fuzziness when given a `matches_query`: 'MatchesQueryFilterInput' filter" do
         query = new_query(
-          filter: {
+          client_filter: {
             "name_text" => {
               "matches_query" => {
                 "query" => "foo",
@@ -142,7 +142,7 @@ module ElasticGraph
         expect(datastore_body_of(query)).to query_datastore_with(bool: {filter: [{match: {"name_text" => {query: "foo", fuzziness: "0", operator: "OR"}}}]})
 
         query = new_query(
-          filter: {
+          client_filter: {
             "name_text" => {
               "matches_query" => {
                 "query" => "foo",
@@ -155,7 +155,7 @@ module ElasticGraph
         expect(datastore_body_of(query)).to query_datastore_with(bool: {filter: [{match: {"name_text" => {query: "foo", fuzziness: "1", operator: "OR"}}}]})
 
         query = new_query(
-          filter: {
+          client_filter: {
             "name_text" => {
               "matches_query" => {
                 "query" => "foo",
@@ -168,7 +168,7 @@ module ElasticGraph
         expect(datastore_body_of(query)).to query_datastore_with(bool: {filter: [{match: {"name_text" => {query: "foo", fuzziness: "2", operator: "OR"}}}]})
 
         query = new_query(
-          filter: {
+          client_filter: {
             "name_text" => {
               "matches_query" => {
                 "query" => "foo",
@@ -183,7 +183,7 @@ module ElasticGraph
 
       it "builds a `match` filter condition with specified operator when given a `matches_query`: 'MatchesQueryFilterInput' filter" do
         query = new_query(
-          filter: {
+          client_filter: {
             "name_text" => {
               "matches_query" => {
                 "query" => "foo",
@@ -198,25 +198,25 @@ module ElasticGraph
       end
 
       it "builds a `match_phrase_prefix` filter condition when given a `matches_phrase`: 'MatchesPhraseFilterInput' filter" do
-        query = new_query(filter: {"name_text" => {"matches_phrase" => {"phrase" => "foo"}}})
+        query = new_query(client_filter: {"name_text" => {"matches_phrase" => {"phrase" => "foo"}}})
 
         expect(datastore_body_of(query)).to query_datastore_with(bool: {filter: [{match_phrase_prefix: {"name_text" => {query: "foo"}}}]})
       end
 
       it "builds a `terms` condition on a nested path when given a deeply nested (3 levels) `equal_to_any_of: [...]` filter" do
-        query = new_query(filter: {"options" => {"color" => {"red" => {"equal_to_any_of" => [100, 200]}}}})
+        query = new_query(client_filter: {"options" => {"color" => {"red" => {"equal_to_any_of" => [100, 200]}}}})
 
         expect(datastore_body_of(query)).to filter_datastore_with(terms: {"options.color.red" => [100, 200]})
       end
 
       it "builds a `terms` condition on a nested path when given a nested (2 levels) `equal_to_any_of: [...]` filter" do
-        query = new_query(filter: {"options" => {"size" => {"equal_to_any_of" => [10]}}})
+        query = new_query(client_filter: {"options" => {"size" => {"equal_to_any_of" => [10]}}})
 
         expect(datastore_body_of(query)).to filter_datastore_with(terms: {"options.size" => [10]})
       end
 
       it "supports an `equal_to_any_of` operator on multiple fields, converting them to multiple `terms` conditions" do
-        query = new_query(filter: {"age" => {"equal_to_any_of" => [25, 30]}, "size" => {"equal_to_any_of" => [10]}})
+        query = new_query(client_filter: {"age" => {"equal_to_any_of" => [25, 30]}, "size" => {"equal_to_any_of" => [10]}})
 
         expect(datastore_body_of(query)).to filter_datastore_with(
           {terms: {"age" => [25, 30]}},
@@ -226,27 +226,27 @@ module ElasticGraph
 
       describe "`contains`" do
         it "is ignored if it is empty in any form" do
-          query = new_query(filter: {"name" => {"contains" => nil}})
+          query = new_query(client_filter: {"name" => {"contains" => nil}})
           expect(datastore_body_of(query)).to not_filter_datastore_at_all
 
-          query = new_query(filter: {"name" => {"contains" => {}}})
+          query = new_query(client_filter: {"name" => {"contains" => {}}})
           expect(datastore_body_of(query)).to not_filter_datastore_at_all
 
-          query = new_query(filter: {"name" => {"contains" => {"ignore_case" => true}}})
+          query = new_query(client_filter: {"name" => {"contains" => {"ignore_case" => true}}})
           expect(datastore_body_of(query)).to not_filter_datastore_at_all
 
-          query = new_query(filter: {"name" => {"contains" => {"any_substring_of" => nil}}})
+          query = new_query(client_filter: {"name" => {"contains" => {"any_substring_of" => nil}}})
           expect(datastore_body_of(query)).to not_filter_datastore_at_all
 
-          query = new_query(filter: {"name" => {"contains" => {"all_substrings_of" => nil}}})
+          query = new_query(client_filter: {"name" => {"contains" => {"all_substrings_of" => nil}}})
           expect(datastore_body_of(query)).to not_filter_datastore_at_all
 
-          query = new_query(filter: {"name" => {"contains" => {"any_substring_of" => nil, "all_substrings_of" => nil, "ignore_case" => true}}})
+          query = new_query(client_filter: {"name" => {"contains" => {"any_substring_of" => nil, "all_substrings_of" => nil, "ignore_case" => true}}})
           expect(datastore_body_of(query)).to not_filter_datastore_at_all
         end
 
         it "translates each `all_substrings_of` value to a wildcard query, which are all ANDed together" do
-          query = new_query(filter: {"name" => {"contains" => {"all_substrings_of" => ["foo", "bar", " "]}}})
+          query = new_query(client_filter: {"name" => {"contains" => {"all_substrings_of" => ["foo", "bar", " "]}}})
 
           expect(datastore_body_of(query)).to filter_datastore_with(
             {wildcard: {"name" => {value: "*foo*", case_insensitive: false}}},
@@ -256,7 +256,7 @@ module ElasticGraph
         end
 
         it "translates each `any_substring_of` value to a wildcard query under a `should` clause to OR them together" do
-          query = new_query(filter: {"name" => {"contains" => {"any_substring_of" => ["foo", "bar", " "]}}})
+          query = new_query(client_filter: {"name" => {"contains" => {"any_substring_of" => ["foo", "bar", " "]}}})
 
           expect(datastore_body_of(query)).to filter_datastore_with({bool: {
             minimum_should_match: 1,
@@ -269,7 +269,7 @@ module ElasticGraph
         end
 
         it "supports `all_substrings_of` and `any_substring_of` on the same filter" do
-          query = new_query(filter: {"name" => {"contains" => {"any_substring_of" => ["foo", "bar"], "all_substrings_of" => ["bazz"]}}})
+          query = new_query(client_filter: {"name" => {"contains" => {"any_substring_of" => ["foo", "bar"], "all_substrings_of" => ["bazz"]}}})
 
           expect(datastore_body_of(query)).to filter_datastore_with(
             {wildcard: {"name" => {value: "*bazz*", case_insensitive: false}}},
@@ -284,21 +284,21 @@ module ElasticGraph
         end
 
         it "returns a query that matches no documents when `any_substring_of` is empty" do
-          query = new_query(filter: {"name" => {"contains" => {"any_substring_of" => []}}})
+          query = new_query(client_filter: {"name" => {"contains" => {"any_substring_of" => []}}})
 
           expect(datastore_body_of(query)).to query_datastore_with(always_false_condition)
 
-          query = new_query(filter: {"name" => {"contains" => {"any_substring_of" => [], "all_substrings_of" => ["foo"]}}})
+          query = new_query(client_filter: {"name" => {"contains" => {"any_substring_of" => [], "all_substrings_of" => ["foo"]}}})
 
           expect(datastore_body_of(query)).to query_datastore_with(always_false_condition)
         end
 
         it "ignores `all_substrings_of: []`" do
-          query = new_query(filter: {"name" => {"contains" => {"all_substrings_of" => []}}})
+          query = new_query(client_filter: {"name" => {"contains" => {"all_substrings_of" => []}}})
 
           expect(datastore_body_of(query)).to not_filter_datastore_at_all
 
-          query = new_query(filter: {"name" => {"contains" => {"any_substring_of" => ["foo"], "all_substrings_of" => []}}})
+          query = new_query(client_filter: {"name" => {"contains" => {"any_substring_of" => ["foo"], "all_substrings_of" => []}}})
 
           expect(datastore_body_of(query)).to filter_datastore_with(
             {wildcard: {"name" => {value: "*foo*", case_insensitive: false}}}
@@ -306,13 +306,13 @@ module ElasticGraph
         end
 
         it "avoids an unneeded `should` clause when `any_substring_of` has only one value, preserving the possibility of caching" do
-          query = new_query(filter: {"name" => {"contains" => {"any_substring_of" => ["foo"]}}})
+          query = new_query(client_filter: {"name" => {"contains" => {"any_substring_of" => ["foo"]}}})
 
           expect(datastore_body_of(query)).to filter_datastore_with(
             {wildcard: {"name" => {value: "*foo*", case_insensitive: false}}}
           )
 
-          query = new_query(filter: {"name" => {"contains" => {"any_substring_of" => ["foo"], "all_substrings_of" => ["bar", "bazz"]}}})
+          query = new_query(client_filter: {"name" => {"contains" => {"any_substring_of" => ["foo"], "all_substrings_of" => ["bar", "bazz"]}}})
 
           expect(datastore_body_of(query)).to filter_datastore_with(
             {wildcard: {"name" => {value: "*bar*", case_insensitive: false}}},
@@ -322,14 +322,14 @@ module ElasticGraph
         end
 
         it "uses a single wildcard of `*` when given an empty string" do
-          query = new_query(filter: {"name" => {"contains" => {"all_substrings_of" => ["foo", ""]}}})
+          query = new_query(client_filter: {"name" => {"contains" => {"all_substrings_of" => ["foo", ""]}}})
 
           expect(datastore_body_of(query)).to filter_datastore_with(
             {wildcard: {"name" => {value: "*foo*", case_insensitive: false}}},
             {wildcard: {"name" => {value: "*", case_insensitive: false}}}
           )
 
-          query = new_query(filter: {"name" => {"contains" => {"any_substring_of" => [""]}}})
+          query = new_query(client_filter: {"name" => {"contains" => {"any_substring_of" => [""]}}})
 
           expect(datastore_body_of(query)).to filter_datastore_with(
             {wildcard: {"name" => {value: "*", case_insensitive: false}}}
@@ -337,19 +337,19 @@ module ElasticGraph
         end
 
         it "honors `ignore_case` and defaults it to false" do
-          query = new_query(filter: {"name" => {"contains" => {"any_substring_of" => ["foo"], "all_substrings_of" => ["bar"]}}})
+          query = new_query(client_filter: {"name" => {"contains" => {"any_substring_of" => ["foo"], "all_substrings_of" => ["bar"]}}})
           expect(datastore_body_of(query)).to filter_datastore_with(
             {wildcard: {"name" => {value: "*bar*", case_insensitive: false}}},
             {wildcard: {"name" => {value: "*foo*", case_insensitive: false}}}
           )
 
-          query = new_query(filter: {"name" => {"contains" => {"any_substring_of" => ["foo"], "all_substrings_of" => ["bar"], "ignore_case" => true}}})
+          query = new_query(client_filter: {"name" => {"contains" => {"any_substring_of" => ["foo"], "all_substrings_of" => ["bar"], "ignore_case" => true}}})
           expect(datastore_body_of(query)).to filter_datastore_with(
             {wildcard: {"name" => {value: "*bar*", case_insensitive: true}}},
             {wildcard: {"name" => {value: "*foo*", case_insensitive: true}}}
           )
 
-          query = new_query(filter: {"name" => {"contains" => {"any_substring_of" => ["foo"], "all_substrings_of" => ["bar"], "ignore_case" => false}}})
+          query = new_query(client_filter: {"name" => {"contains" => {"any_substring_of" => ["foo"], "all_substrings_of" => ["bar"], "ignore_case" => false}}})
           expect(datastore_body_of(query)).to filter_datastore_with(
             {wildcard: {"name" => {value: "*bar*", case_insensitive: false}}},
             {wildcard: {"name" => {value: "*foo*", case_insensitive: false}}}
@@ -359,24 +359,24 @@ module ElasticGraph
 
       describe "`starts_with`" do
         it "is ignored if it is empty in any form" do
-          query = new_query(filter: {"name" => {"starts_with" => nil}})
+          query = new_query(client_filter: {"name" => {"starts_with" => nil}})
           expect(datastore_body_of(query)).to not_filter_datastore_at_all
 
-          query = new_query(filter: {"name" => {"starts_with" => {}}})
+          query = new_query(client_filter: {"name" => {"starts_with" => {}}})
           expect(datastore_body_of(query)).to not_filter_datastore_at_all
 
-          query = new_query(filter: {"name" => {"starts_with" => {"ignore_case" => true}}})
+          query = new_query(client_filter: {"name" => {"starts_with" => {"ignore_case" => true}}})
           expect(datastore_body_of(query)).to not_filter_datastore_at_all
 
-          query = new_query(filter: {"name" => {"starts_with" => {"any_prefix_of" => nil}}})
+          query = new_query(client_filter: {"name" => {"starts_with" => {"any_prefix_of" => nil}}})
           expect(datastore_body_of(query)).to not_filter_datastore_at_all
 
-          query = new_query(filter: {"name" => {"starts_with" => {"any_prefix_of" => nil, "ignore_case" => true}}})
+          query = new_query(client_filter: {"name" => {"starts_with" => {"any_prefix_of" => nil, "ignore_case" => true}}})
           expect(datastore_body_of(query)).to not_filter_datastore_at_all
         end
 
         it "translates each `any_prefix_of` value to a prefix query under a `should` clause to OR them together" do
-          query = new_query(filter: {"name" => {"starts_with" => {"any_prefix_of" => ["foo", "bar", " "]}}})
+          query = new_query(client_filter: {"name" => {"starts_with" => {"any_prefix_of" => ["foo", "bar", " "]}}})
 
           expect(datastore_body_of(query)).to filter_datastore_with({bool: {
             minimum_should_match: 1,
@@ -389,13 +389,13 @@ module ElasticGraph
         end
 
         it "returns a query that matches no documents when `any_prefix_of` is empty" do
-          query = new_query(filter: {"name" => {"starts_with" => {"any_prefix_of" => []}}})
+          query = new_query(client_filter: {"name" => {"starts_with" => {"any_prefix_of" => []}}})
 
           expect(datastore_body_of(query)).to query_datastore_with(always_false_condition)
         end
 
         it "avoids an unneeded `should` clause when `any_prefix_of` has only one value, preserving the possibility of caching" do
-          query = new_query(filter: {"name" => {"starts_with" => {"any_prefix_of" => ["foo"]}}})
+          query = new_query(client_filter: {"name" => {"starts_with" => {"any_prefix_of" => ["foo"]}}})
 
           expect(datastore_body_of(query)).to filter_datastore_with(
             {prefix: {"name" => {value: "foo", case_insensitive: false}}}
@@ -403,7 +403,7 @@ module ElasticGraph
         end
 
         it "honors `ignore_case` and defaults it to false" do
-          query = new_query(filter: {"name" => {"starts_with" => {"any_prefix_of" => ["foo", "bar"]}}})
+          query = new_query(client_filter: {"name" => {"starts_with" => {"any_prefix_of" => ["foo", "bar"]}}})
           expect(datastore_body_of(query)).to filter_datastore_with({bool: {
             minimum_should_match: 1,
             should: [
@@ -412,7 +412,7 @@ module ElasticGraph
             ]
           }})
 
-          query = new_query(filter: {"name" => {"starts_with" => {"any_prefix_of" => ["foo", "bar"], "ignore_case" => true}}})
+          query = new_query(client_filter: {"name" => {"starts_with" => {"any_prefix_of" => ["foo", "bar"], "ignore_case" => true}}})
           expect(datastore_body_of(query)).to filter_datastore_with({bool: {
             minimum_should_match: 1,
             should: [
@@ -421,7 +421,7 @@ module ElasticGraph
             ]
           }})
 
-          query = new_query(filter: {"name" => {"starts_with" => {"any_prefix_of" => ["foo", "bar"], "ignore_case" => false}}})
+          query = new_query(client_filter: {"name" => {"starts_with" => {"any_prefix_of" => ["foo", "bar"], "ignore_case" => false}}})
           expect(datastore_body_of(query)).to filter_datastore_with({bool: {
             minimum_should_match: 1,
             should: [
@@ -434,7 +434,7 @@ module ElasticGraph
 
       describe "`equal_to_any_of` with `[nil]`" do
         it "builds a `must_not` `exists` condition when given an `equal_to_any_of: [nil]` filter" do
-          query = new_query(filter: {"age" => {"equal_to_any_of" => [nil]}})
+          query = new_query(client_filter: {"age" => {"equal_to_any_of" => [nil]}})
 
           expect(datastore_body_of(query)).to query_datastore_with({
             bool: {must_not: [
@@ -444,7 +444,7 @@ module ElasticGraph
         end
 
         it "builds a `must_not` `exists` condition when given an `equal_to_any_of: [nil, nil]` filter" do
-          query = new_query(filter: {"age" => {"equal_to_any_of" => [nil, nil]}})
+          query = new_query(client_filter: {"age" => {"equal_to_any_of" => [nil, nil]}})
 
           expect(datastore_body_of(query)).to query_datastore_with({
             bool: {must_not: [
@@ -454,7 +454,7 @@ module ElasticGraph
         end
 
         it "handles `equal_to_any_of: [nil, non_nil_values, ...]` by ORing together multiple conditions (for a field that's not `id`)" do
-          query = new_query(filter: {"age" => {"equal_to_any_of" => [nil, 25, 40]}})
+          query = new_query(client_filter: {"age" => {"equal_to_any_of" => [nil, 25, 40]}})
 
           expect(datastore_body_of(query)).to filter_datastore_with({
             bool: {minimum_should_match: 1, should: [
@@ -465,7 +465,7 @@ module ElasticGraph
         end
 
         it "handles `equal_to_any_of: [nil, non_nil_values, ...]` by ORing together multiple conditions (for the `id` field)" do
-          query = new_query(filter: {"id" => {"equal_to_any_of" => [nil, 25, 40]}})
+          query = new_query(client_filter: {"id" => {"equal_to_any_of" => [nil, 25, 40]}})
 
           expect(datastore_body_of(query)).to filter_datastore_with({
             bool: {minimum_should_match: 1, should: [
@@ -476,7 +476,7 @@ module ElasticGraph
         end
 
         it "builds an `exists` condition when given a `not` equal_to_any_of filter" do
-          query = new_query(filter: {"not" => {"age" => {"equal_to_any_of" => [nil]}}})
+          query = new_query(client_filter: {"not" => {"age" => {"equal_to_any_of" => [nil]}}})
 
           expect(datastore_body_of(query)).to query_datastore_with({
             bool: {filter: [{exists: {"field" => "age"}}]}
@@ -484,7 +484,7 @@ module ElasticGraph
         end
 
         it "builds an `exists` condition when given `equal_to_any_of: [nil]` filter, and does not drop other boolean occurrences" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "age" => {"equal_to_any_of" => [nil]},
             "color" => {"equal_to_any_of" => %w[blue green]}
           })
@@ -496,7 +496,7 @@ module ElasticGraph
         end
 
         it "builds an `exists` condition when given `equal_to_any_of: [nil]` filter, and combines must_not occurrences" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "age" => {"equal_to_any_of" => [nil]},
             "color" => {"not" => {"equal_to_any_of" => %w[blue green]}}
           })
@@ -510,7 +510,7 @@ module ElasticGraph
         end
 
         it "builds an `exists` condition when given a `not` `equal_to_any_of` filter, and combines it with other boolean occurrences" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "not" => {"age" => {"equal_to_any_of" => [nil]}},
             "color" => {"equal_to_any_of" => %w[blue green]}
           })
@@ -524,7 +524,7 @@ module ElasticGraph
         end
 
         it "builds an `exists` condition when given a `not` `equal_to_any_of` filter, and does not drop other negated boolean occurrences" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "age" => {"not" => {"equal_to_any_of" => [nil]}},
             "color" => {"not" => {"equal_to_any_of" => %w[blue green]}}
           })
@@ -536,7 +536,7 @@ module ElasticGraph
         end
 
         it "builds an `exists` when `equal_to_any_of: [nil]` is the only filter and nested in `any_of`" do
-          query = new_query(filter: {"any_of" => [
+          query = new_query(client_filter: {"any_of" => [
             {"age" => {"equal_to_any_of" => [nil]}}
           ]})
 
@@ -549,7 +549,7 @@ module ElasticGraph
         end
 
         it "builds an `exists` when the `equal_to_any_of: [nil]` part is among other filters" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "name" => {"equal_to_any_of" => ["foo"]},
             "age" => {"equal_to_any_of" => [nil]},
             "currency" => {"equal_to_any_of" => ["USD"]}
@@ -569,7 +569,7 @@ module ElasticGraph
 
       describe "`all_of` operator" do
         it "produces a separate bool subfilter for each clause" do
-          query = new_query(filter: {"all_of" => [
+          query = new_query(client_filter: {"all_of" => [
             {"color" => {"equal_to_any_of" => ["RED"]}},
             {"size" => {"gt" => 10}}
           ]})
@@ -595,7 +595,7 @@ module ElasticGraph
         end
 
         it "allows ANDing two subfilters on the same field" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "all_of" => [
               {"color" => {"equal_to_any_of" => ["RED"]}},
               {"color" => {"not" => {"equal_to_any_of" => ["GREEN"]}}}
@@ -631,7 +631,7 @@ module ElasticGraph
         end
 
         it "allows an AND of multiple OR subfilters (i.e. allOf of anyOfs)" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "all_of" => [
               {
                 "any_of" => [
@@ -673,7 +673,7 @@ module ElasticGraph
         end
 
         it "can be used to wrap multiple `any_satisfy` expressions to require multiple sub-filters to be satisfied by a list element" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "tags" => {"all_of" => [
               {"any_satisfy" => {"equal_to_any_of" => ["a", "b"]}},
               {"any_satisfy" => {"equal_to_any_of" => ["c", "d"]}}
@@ -689,7 +689,7 @@ module ElasticGraph
         end
 
         it "handles `not` within `all_of` operator" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "all_of" => [
               {"amount_cents" => {"gt" => 50}},
               {"not" => {"tags" => {"any_satisfy" => {"equal_to_any_of" => ["foo"]}}}}
@@ -717,7 +717,7 @@ module ElasticGraph
         end
 
         it "handles empty predicates" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "all_of" => [
               {},
               {"amount_cents" => {"gt" => 50}}
@@ -730,7 +730,7 @@ module ElasticGraph
             ]
           })
 
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "all_of" => [
               {"amount_cents" => {}},
               {"amount_cents" => {"gt" => 50}}
@@ -745,7 +745,7 @@ module ElasticGraph
         end
 
         it "handles not with empty predicate" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "all_of" => [
               {"not" => {}},
               {"amount_cents" => {"gt" => 50}}
@@ -773,13 +773,13 @@ module ElasticGraph
         end
 
         it "is treated as `true` when `null` is passed" do
-          query = new_query(filter: {"tags" => {"all_of" => nil}})
+          query = new_query(client_filter: {"tags" => {"all_of" => nil}})
 
           expect(datastore_body_of(query)).to not_filter_datastore_at_all
         end
 
         it "is treated as `true` when `[]` is passed" do
-          query = new_query(filter: {"tags" => {"all_of" => []}})
+          query = new_query(client_filter: {"tags" => {"all_of" => []}})
 
           expect(datastore_body_of(query)).to not_filter_datastore_at_all
         end
@@ -788,12 +788,12 @@ module ElasticGraph
       describe "`any_satisfy` operator" do
         context "on a list-of-scalars field" do
           it "returns the body of the sub-filters because the semantics indicated by `any_satisfy` is what the datastore automatically provides on list fields" do
-            query1 = new_query(filter: {
+            query1 = new_query(client_filter: {
               "tags" => {"any_satisfy" => {"equal_to_any_of" => ["a", "b"]}},
               "ages" => {"any_satisfy" => {"gt" => 30}}
             })
 
-            query2 = new_query(filter: {
+            query2 = new_query(client_filter: {
               "tags" => {"equal_to_any_of" => ["a", "b"]},
               "ages" => {"gt" => 30}
             })
@@ -802,7 +802,7 @@ module ElasticGraph
           end
 
           it "merges multiple range operators into a single clause to force a single value to satisfy all (rather than separate values satisfying each)" do
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "ages" => {"any_satisfy" => {"gt" => 30, "lt" => 60}}
             })
 
@@ -816,7 +816,7 @@ module ElasticGraph
             let(:graphql) { build_graphql(schema_element_name_form: :snake_case) }
 
             it "rejects a query that produces multiple query clauses under `any_satisfy` because the datastore does not require a single value to match them all" do
-              query = new_query(filter: {
+              query = new_query(client_filter: {
                 # We don't expect users to send us a filter like this, but if they did, we can't support it.
                 "ages" => {"any_satisfy" => {"gt" => 30, "equal_to_any_of" => [50]}}
               })
@@ -833,7 +833,7 @@ module ElasticGraph
             let(:graphql) { build_graphql(schema_element_name_form: :camelCase) }
 
             it "rejects a query that produces multiple query clauses under `any_satisfy` because the datastore does not require a single value to match them all" do
-              query = new_query(filter: {
+              query = new_query(client_filter: {
                 # We don't expect users to send us a filter like this, but if they did, we can't support it.
                 "ages" => {"anySatisfy" => {"gt" => 30, "equalToAnyOf" => [50]}}
               })
@@ -847,7 +847,7 @@ module ElasticGraph
           end
 
           it "still allows multiple query clauses under `any_satisfy: {any_of: [...]}}` because that has OR semantics" do
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "ages" => {"any_satisfy" => {"any_of" => [{"gt" => 30}, {"equal_to_any_of" => [50]}]}}
             })
 
@@ -858,7 +858,7 @@ module ElasticGraph
           end
 
           it "does not allow `any_of` alongside another filter because that would also produce multiple query clauses that we can't support" do
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "ages" => {"any_satisfy" => {"any_of" => [{"gt" => 30}], "equal_to_any_of" => [50]}}
             })
 
@@ -870,7 +870,7 @@ module ElasticGraph
           end
 
           it "returns the standard always false filter for `any_satisfy: {any_of: []}`" do
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "ages" => {"any_satisfy" => {"any_of" => []}}
             })
 
@@ -878,7 +878,7 @@ module ElasticGraph
           end
 
           it "applies no filtering when given `any_satisfy: {}`" do
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "ages" => {"any_satisfy" => {}}
             })
 
@@ -888,7 +888,7 @@ module ElasticGraph
 
         context "on a list-of-nested-objects field" do
           it "builds a `nested` filter" do
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "people" => {"friends" => {"any_satisfy" => {"age" => {"gt" => 30}}}}
             })
 
@@ -901,7 +901,7 @@ module ElasticGraph
           end
 
           it "correctly builds a `nested` filter when `any_satisfy: {not: ...}` is used" do
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "people" => {"friends" => {"any_satisfy" => {"not" => {"age" => {"gt" => 30}}}}}
             })
 
@@ -914,7 +914,7 @@ module ElasticGraph
           end
 
           it "correctly builds a `nested` filter when `any_satisfy: {field: {any_satisfy: ...}}}` is used" do
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "line_items" => {"any_satisfy" => {"tags" => {"any_satisfy" => {"equal_to_any_of" => ["a"]}}}}
             })
 
@@ -927,7 +927,7 @@ module ElasticGraph
           end
 
           it "correctly builds a `nested` filter when `any_satisfy: {any_of: [{field: ...}]}` is used" do
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "line_items" => {"any_satisfy" => {"any_of" => [{"name" => {"equal_to_any_of" => ["a"]}}]}}
             })
 
@@ -943,7 +943,7 @@ module ElasticGraph
           end
 
           it "builds an empty filter when given `any_satisfy: {field: {}}`" do
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "line_items" => {"any_satisfy" => {"name" => {}}}
             })
 
@@ -951,7 +951,7 @@ module ElasticGraph
           end
 
           it "builds an empty filter when given `any_satisfy: {field: {predicate: nil}}`" do
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "line_items" => {"any_satisfy" => {"name" => {"equal_to_any_of" => nil}}}
             })
 
@@ -964,7 +964,7 @@ module ElasticGraph
       # and that translation happens as the query is being built, so we use `__counts` in our example filters here.
       describe "`count` operator on a list" do
         it "builds a query on the hidden `#{LIST_COUNTS_FIELD}` field where we have indexed list counts" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "past_names" => {LIST_COUNTS_FIELD => {"gt" => 10}}
           })
 
@@ -974,7 +974,7 @@ module ElasticGraph
         end
 
         it "correctly references a list field embedded on an object field" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "details" => {"uniform_colors" => {LIST_COUNTS_FIELD => {"gt" => 10}}}
           })
 
@@ -984,7 +984,7 @@ module ElasticGraph
         end
 
         it "correctly references a list field under a list-of-nested-objects field" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "seasons_nested" => {"any_satisfy" => {"notes" => {LIST_COUNTS_FIELD => {"gt" => 10}}}}
           })
 
@@ -997,7 +997,7 @@ module ElasticGraph
         end
 
         it "treats a filter on a `count` schema field like a filter on any other schema field" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "past_names" => {"count" => {"gt" => 10}}
           })
 
@@ -1008,28 +1008,28 @@ module ElasticGraph
 
         describe "including an extra must_not exists filter for a predicate that matches zero in order to match documents indexed before the list field got defined" do
           it "correctly detects when an `lt` expression could match zero" do
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"lt" => 10}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with_must_not_exists_or(range: {
               "#{LIST_COUNTS_FIELD}.past_names" => {lt: 10}
             })
 
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"lt" => 1}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with_must_not_exists_or(range: {
               "#{LIST_COUNTS_FIELD}.past_names" => {lt: 1}
             })
 
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"lt" => 0}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with(range: {
               "#{LIST_COUNTS_FIELD}.past_names" => {lt: 0}
             })
 
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"lt" => -1}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with(range: {
@@ -1038,28 +1038,28 @@ module ElasticGraph
           end
 
           it "correctly detects when an `lte` expression could match zero" do
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"lte" => 10}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with_must_not_exists_or(range: {
               "#{LIST_COUNTS_FIELD}.past_names" => {lte: 10}
             })
 
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"lte" => 1}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with_must_not_exists_or(range: {
               "#{LIST_COUNTS_FIELD}.past_names" => {lte: 1}
             })
 
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"lte" => 0}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with_must_not_exists_or(range: {
               "#{LIST_COUNTS_FIELD}.past_names" => {lte: 0}
             })
 
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"lte" => -1}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with(range: {
@@ -1068,28 +1068,28 @@ module ElasticGraph
           end
 
           it "correctly detects when an `gt` expression could match zero" do
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"gt" => -10}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with_must_not_exists_or(range: {
               "#{LIST_COUNTS_FIELD}.past_names" => {gt: -10}
             })
 
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"gt" => -1}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with_must_not_exists_or(range: {
               "#{LIST_COUNTS_FIELD}.past_names" => {gt: -1}
             })
 
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"gt" => 0}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with(range: {
               "#{LIST_COUNTS_FIELD}.past_names" => {gt: 0}
             })
 
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"gt" => 1}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with(range: {
@@ -1098,28 +1098,28 @@ module ElasticGraph
           end
 
           it "correctly detects when an `gte` expression could match zero" do
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"gte" => -10}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with_must_not_exists_or(range: {
               "#{LIST_COUNTS_FIELD}.past_names" => {gte: -10}
             })
 
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"gte" => -1}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with_must_not_exists_or(range: {
               "#{LIST_COUNTS_FIELD}.past_names" => {gte: -1}
             })
 
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"gte" => 0}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with_must_not_exists_or(range: {
               "#{LIST_COUNTS_FIELD}.past_names" => {gte: 0}
             })
 
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"gte" => 1}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with(range: {
@@ -1128,14 +1128,14 @@ module ElasticGraph
           end
 
           it "correctly detects when an `equal_to_any_of` could match zero" do
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"equal_to_any_of" => [3, 0, 5]}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with_must_not_exists_or(terms: {
               "#{LIST_COUNTS_FIELD}.past_names" => [3, 0, 5]
             })
 
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"equal_to_any_of" => [3, 5]}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with(terms: {
@@ -1144,21 +1144,21 @@ module ElasticGraph
           end
 
           it "correct detects when an expression with multiple predicates could match zero" do
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"gte" => 0, "lt" => 10}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with_must_not_exists_or(range: {
               "#{LIST_COUNTS_FIELD}.past_names" => {gte: 0, lt: 10}
             })
 
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"gte" => 1, "lt" => 10}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with(range: {
               "#{LIST_COUNTS_FIELD}.past_names" => {gte: 1, lt: 10}
             })
 
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "past_names" => {LIST_COUNTS_FIELD => {"gte" => 0, "lt" => 0}}
             })
             expect(datastore_body_of(query)).to filter_datastore_with(range: {
@@ -1167,33 +1167,33 @@ module ElasticGraph
           end
 
           it "treats `count` filter predicates that have a `nil` or `{}` value as `true`" do
-            query = new_query(filter: {"past_names" => {LIST_COUNTS_FIELD => nil}})
+            query = new_query(client_filter: {"past_names" => {LIST_COUNTS_FIELD => nil}})
             expect(datastore_body_of(query)).to not_filter_datastore_at_all
 
-            query = new_query(filter: {"past_names" => {LIST_COUNTS_FIELD => {}}})
+            query = new_query(client_filter: {"past_names" => {LIST_COUNTS_FIELD => {}}})
             expect(datastore_body_of(query)).to not_filter_datastore_at_all
 
-            query = new_query(filter: {"past_names" => {LIST_COUNTS_FIELD => {"gt" => nil}}})
+            query = new_query(client_filter: {"past_names" => {LIST_COUNTS_FIELD => {"gt" => nil}}})
             expect(datastore_body_of(query)).to not_filter_datastore_at_all
 
-            query = new_query(filter: {"past_names" => {LIST_COUNTS_FIELD => {"gte" => nil}}})
+            query = new_query(client_filter: {"past_names" => {LIST_COUNTS_FIELD => {"gte" => nil}}})
             expect(datastore_body_of(query)).to not_filter_datastore_at_all
 
-            query = new_query(filter: {"past_names" => {LIST_COUNTS_FIELD => {"lt" => nil}}})
+            query = new_query(client_filter: {"past_names" => {LIST_COUNTS_FIELD => {"lt" => nil}}})
             expect(datastore_body_of(query)).to not_filter_datastore_at_all
 
-            query = new_query(filter: {"past_names" => {LIST_COUNTS_FIELD => {"lte" => nil}}})
+            query = new_query(client_filter: {"past_names" => {LIST_COUNTS_FIELD => {"lte" => nil}}})
             expect(datastore_body_of(query)).to not_filter_datastore_at_all
 
-            query = new_query(filter: {"past_names" => {LIST_COUNTS_FIELD => {"equal_to_any_of" => nil}}})
+            query = new_query(client_filter: {"past_names" => {LIST_COUNTS_FIELD => {"equal_to_any_of" => nil}}})
             expect(datastore_body_of(query)).to not_filter_datastore_at_all
 
-            query = new_query(filter: {"past_names" => {LIST_COUNTS_FIELD => {"gt" => nil, "lt" => 10}}})
+            query = new_query(client_filter: {"past_names" => {LIST_COUNTS_FIELD => {"gt" => nil, "lt" => 10}}})
             expect(datastore_body_of(query)).to filter_datastore_with_must_not_exists_or(range: {
               "#{LIST_COUNTS_FIELD}.past_names" => {lt: 10}
             })
 
-            query = new_query(filter: {"past_names" => {LIST_COUNTS_FIELD => {"gt" => 10, "lt" => nil}}})
+            query = new_query(client_filter: {"past_names" => {LIST_COUNTS_FIELD => {"gt" => 10, "lt" => nil}}})
             expect(datastore_body_of(query)).to filter_datastore_with(range: {
               "#{LIST_COUNTS_FIELD}.past_names" => {gt: 10}
             })
@@ -1237,7 +1237,7 @@ module ElasticGraph
 
           datastore_abbreviations_by_distance_unit.each do |distance_unit, datastore_abbreviation|
             it "supports filtering using the `#{distance_unit}` distance unit" do
-              query = new_query(filter: {"address_location" => {"near" => {
+              query = new_query(client_filter: {"address_location" => {"near" => {
                 "latitude" => 37.5,
                 "longitude" => 67.5,
                 "max_distance" => 500,
@@ -1287,7 +1287,7 @@ module ElasticGraph
         specify "the `near` filter implementation doesn't fail due to a lack of a `DistanceUnit` type" do
           expect(graphql.runtime_metadata.enum_types_by_name.keys).to exclude("DistanceUnit")
 
-          query = new_query(filter: {"id" => {"equal_to_any_of" => ["a"]}})
+          query = new_query(client_filter: {"id" => {"equal_to_any_of" => ["a"]}})
 
           expect(datastore_body_of(query)).to filter_datastore_with({ids: {values: ["a"]}})
         end
@@ -1295,7 +1295,7 @@ module ElasticGraph
 
       describe "`time_of_day` operator" do
         it "uses a `script` query, passing along the `gte` param" do
-          query = new_query(filter: {"timestamps" => {"created_at" => {"time_of_day" => {"gte" => "07:00:00"}}}})
+          query = new_query(client_filter: {"timestamps" => {"created_at" => {"time_of_day" => {"gte" => "07:00:00"}}}})
 
           expect_script_query_with_params(query, {
             field: "timestamps.created_at",
@@ -1304,7 +1304,7 @@ module ElasticGraph
         end
 
         it "uses a `script` query, passing along the `gt` param" do
-          query = new_query(filter: {"timestamps" => {"created_at" => {"time_of_day" => {"gt" => "07:00:00"}}}})
+          query = new_query(client_filter: {"timestamps" => {"created_at" => {"time_of_day" => {"gt" => "07:00:00"}}}})
 
           expect_script_query_with_params(query, {
             field: "timestamps.created_at",
@@ -1313,7 +1313,7 @@ module ElasticGraph
         end
 
         it "uses a `script` query, passing along the `lte` param" do
-          query = new_query(filter: {"timestamps" => {"created_at" => {"time_of_day" => {"lte" => "07:00:00"}}}})
+          query = new_query(client_filter: {"timestamps" => {"created_at" => {"time_of_day" => {"lte" => "07:00:00"}}}})
 
           expect_script_query_with_params(query, {
             field: "timestamps.created_at",
@@ -1322,7 +1322,7 @@ module ElasticGraph
         end
 
         it "uses a `script` query, passing along the `lt` param" do
-          query = new_query(filter: {"timestamps" => {"created_at" => {"time_of_day" => {"lt" => "07:00:00"}}}})
+          query = new_query(client_filter: {"timestamps" => {"created_at" => {"time_of_day" => {"lt" => "07:00:00"}}}})
 
           expect_script_query_with_params(query, {
             field: "timestamps.created_at",
@@ -1331,7 +1331,7 @@ module ElasticGraph
         end
 
         it "uses a `script` query, passing along the `equal_to_any_of` param" do
-          query = new_query(filter: {"timestamps" => {"created_at" => {"time_of_day" => {"equal_to_any_of" => ["07:00:00", "08:00:00"]}}}})
+          query = new_query(client_filter: {"timestamps" => {"created_at" => {"time_of_day" => {"equal_to_any_of" => ["07:00:00", "08:00:00"]}}}})
 
           expect_script_query_with_params(query, {
             field: "timestamps.created_at",
@@ -1340,7 +1340,7 @@ module ElasticGraph
         end
 
         it "uses a `script` query, passing along the `time_zone` param" do
-          query = new_query(filter: {"timestamps" => {"created_at" => {"time_of_day" => {
+          query = new_query(client_filter: {"timestamps" => {"created_at" => {"time_of_day" => {
             "time_zone" => "America/Los_Angeles",
             # We have to include at least one comparison operator so that the filter is included in the datastore body.
             "gt" => "08:00:00"
@@ -1354,7 +1354,7 @@ module ElasticGraph
         end
 
         it "omits the filter from the query payload when no operators are provided" do
-          query = new_query(filter: {"timestamps" => {"created_at" => {"time_of_day" => {"time_zone" => "America/Los_Angeles"}}}})
+          query = new_query(client_filter: {"timestamps" => {"created_at" => {"time_of_day" => {"time_zone" => "America/Los_Angeles"}}}})
 
           expect(datastore_body_of(query)).to not_filter_datastore_at_all
         end
@@ -1373,7 +1373,7 @@ module ElasticGraph
           end
 
           it "recognizes the alternate schema element names but uses our standard names in the script params because the script expects that" do
-            query = new_query(filter: {"timestamps" => {"created_at" => {"time_part" => {
+            query = new_query(client_filter: {"timestamps" => {"created_at" => {"time_part" => {
               "tz" => "America/Los_Angeles",
               "greater" => "01:00:00",
               "lesser" => "02:00:00",
@@ -1417,7 +1417,7 @@ module ElasticGraph
       end
 
       it "supports an `any_of` operator" do
-        query = new_query(filter: {
+        query = new_query(client_filter: {
           "any_of" => [
             {
               "transaction_type" => {"equal_to_any_of" => ["CARD"]},
@@ -1465,7 +1465,7 @@ module ElasticGraph
       end
 
       it "handles `any_of` used at nested cousin nodes correctly" do
-        query = new_query(filter: {
+        query = new_query(client_filter: {
           "cost" => {
             "any_of" => [
               {"currency" => {"equal_to_any_of" => ["USD"]}},
@@ -1510,11 +1510,11 @@ module ElasticGraph
 
       describe "`not`" do
         it "negates the inner filter expression, regardless of where the `not` goes" do
-          body_for_inner_not = datastore_body_of(new_query(filter: {"age" => {"not" => {
+          body_for_inner_not = datastore_body_of(new_query(client_filter: {"age" => {"not" => {
             "equal_to_any_of" => [25, 30]
           }}}))
 
-          body_for_outer_not = datastore_body_of(new_query(filter: {"not" => {"age" => {
+          body_for_outer_not = datastore_body_of(new_query(client_filter: {"not" => {"age" => {
             "equal_to_any_of" => [25, 30]
           }}}))
 
@@ -1522,12 +1522,12 @@ module ElasticGraph
         end
 
         it "can negate multiple inner filter predicates" do
-          body_for_inner_not = datastore_body_of(new_query(filter: {"age" => {"not" => {
+          body_for_inner_not = datastore_body_of(new_query(client_filter: {"age" => {"not" => {
             "gte" => 30,
             "lt" => 25
           }}}))
 
-          body_for_outer_not = datastore_body_of(new_query(filter: {"not" => {"age" => {
+          body_for_outer_not = datastore_body_of(new_query(client_filter: {"not" => {"age" => {
             "gte" => 30,
             "lt" => 25
           }}}))
@@ -1538,7 +1538,7 @@ module ElasticGraph
         end
 
         it "negates a complex compound inner filter expression" do
-          query = new_query(filter: {"not" => {
+          query = new_query(client_filter: {"not" => {
             "any_of" => [
               {
                 "transaction_type" => {"equal_to_any_of" => ["CARD"]},
@@ -1586,12 +1586,12 @@ module ElasticGraph
         end
 
         it "works correctly when included alongside other filtering operators" do
-          body_for_inner_not = datastore_body_of(new_query(filter: {"age" => {
+          body_for_inner_not = datastore_body_of(new_query(client_filter: {"age" => {
             "not" => {"equal_to_any_of" => [15, 30]},
             "gte" => 20
           }}))
 
-          body_for_outer_not = datastore_body_of(new_query(filter: {
+          body_for_outer_not = datastore_body_of(new_query(client_filter: {
             "not" => {
               "age" => {"equal_to_any_of" => [15, 30]}
             },
@@ -1607,7 +1607,7 @@ module ElasticGraph
         end
 
         it "works correctly when included alongside an `any_of`" do
-          body_for_inner_not = datastore_body_of(new_query(filter: {"age" => {
+          body_for_inner_not = datastore_body_of(new_query(client_filter: {"age" => {
             "not" => {"equal_to_any_of" => [15, 50]},
             "any_of" => [
               {"gt" => 35},
@@ -1615,7 +1615,7 @@ module ElasticGraph
             ]
           }}))
 
-          body_for_outer_not = datastore_body_of(new_query(filter: {
+          body_for_outer_not = datastore_body_of(new_query(client_filter: {
             "not" => {
               "age" => {"equal_to_any_of" => [15, 50]}
             },
@@ -1627,7 +1627,7 @@ module ElasticGraph
             }
           }))
 
-          # The location of the `filter: [{bool: }]` wrapper differs between `body_for_inner_not` and `body_for_outer_not` but does not impact behavior.
+          # The location of the `client_filter: [{bool: }]` wrapper differs between `body_for_inner_not` and `body_for_outer_not` but does not impact behavior.
           # These two queries yield the same results - confirmed by the integration test "`not` works correctly when included alongside an `any_of`",
           # so even though the behavior is the same, we must assert on the two payloads separately.
           expect(body_for_inner_not).to query_datastore_with({bool: {filter: [{bool: {
@@ -1658,26 +1658,26 @@ module ElasticGraph
         end
 
         it "returns the standard always false filter when set to nil" do
-          body_for_inner_not = datastore_body_of(new_query(filter: {"age" => {"not" => nil}}))
-          body_for_outer_not = datastore_body_of(new_query(filter: {"not" => {"age" => nil}}))
+          body_for_inner_not = datastore_body_of(new_query(client_filter: {"age" => {"not" => nil}}))
+          body_for_outer_not = datastore_body_of(new_query(client_filter: {"not" => {"age" => nil}}))
 
           expect(body_for_inner_not).to eq(body_for_outer_not).and query_datastore_with(always_false_condition)
         end
 
         it "returns the standard always false filter when set to an emptyPredicate" do
-          body_for_inner_not = datastore_body_of(new_query(filter: {"age" => {"not" => {}}}))
-          body_for_outer_not = datastore_body_of(new_query(filter: {"not" => {"age" => {}}}))
+          body_for_inner_not = datastore_body_of(new_query(client_filter: {"age" => {"not" => {}}}))
+          body_for_outer_not = datastore_body_of(new_query(client_filter: {"not" => {"age" => {}}}))
 
           expect(body_for_inner_not).to eq(body_for_outer_not).and query_datastore_with(always_false_condition)
         end
 
         it "returns the standard always false filter when set to nil alongside other filters" do
-          body_for_inner_not = datastore_body_of(new_query(filter: {"age" => {
+          body_for_inner_not = datastore_body_of(new_query(client_filter: {"age" => {
             "not" => nil,
             "gt" => 25
           }}))
 
-          body_for_outer_not = datastore_body_of(new_query(filter: {
+          body_for_outer_not = datastore_body_of(new_query(client_filter: {
             "not" => nil,
             "age" => {
               "gt" => 25
@@ -1688,14 +1688,14 @@ module ElasticGraph
         end
 
         it "returns the standard always false filter when set to nil alongside other filters inside `any_of`" do
-          body_for_inner_not = datastore_body_of(new_query(filter: {"age" => {
+          body_for_inner_not = datastore_body_of(new_query(client_filter: {"age" => {
             "any_of" => [
               {"not" => nil},
               {"gt" => 25}
             ]
           }}))
 
-          body_for_outer_not = datastore_body_of(new_query(filter: {
+          body_for_outer_not = datastore_body_of(new_query(client_filter: {
             "any_of" => [
               {"not" => nil},
               {
@@ -1715,8 +1715,8 @@ module ElasticGraph
         end
 
         it "returns the standard always false filter when the inner filter evaluates to true" do
-          body_for_inner_not = datastore_body_of(new_query(filter: {"age" => {"not" => {"equal_to_any_of" => nil}}}))
-          body_for_outer_not = datastore_body_of(new_query(filter: {"not" => {"age" => {"equal_to_any_of" => nil}}}))
+          body_for_inner_not = datastore_body_of(new_query(client_filter: {"age" => {"not" => {"equal_to_any_of" => nil}}}))
+          body_for_outer_not = datastore_body_of(new_query(client_filter: {"not" => {"age" => {"equal_to_any_of" => nil}}}))
 
           expect(body_for_inner_not).to eq(body_for_outer_not).and query_datastore_with(always_false_condition)
         end
@@ -1729,14 +1729,14 @@ module ElasticGraph
             ]
           }
 
-          query1 = new_query(filter: {"not" => {"not" => inner_filter}})
-          query2 = new_query(filter: inner_filter)
+          query1 = new_query(client_filter: {"not" => {"not" => inner_filter}})
+          query2 = new_query(client_filter: inner_filter)
 
           expect(datastore_body_of(query1)).to eq(datastore_body_of(query2))
         end
 
         specify "`not: {all_of: [...]}` returns only the documents that are unmatched by `all_of: [...]`" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "not" => {
               "all_of" => [
                 {"age" => {"equal_to_any_of" => [25, 30]}},
@@ -1758,7 +1758,7 @@ module ElasticGraph
 
       describe "behavior of empty/null filter values" do
         it "treats filtering predicates that are empty no-ops on root fields as `true`" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "age" => {"gt" => nil},
             "name" => {"equal_to_any_of" => ["Jane"]},
             "height" => {"gte" => nil, "lt" => nil},
@@ -1769,7 +1769,7 @@ module ElasticGraph
         end
 
         it "treats filtering predicates that are empty no-ops on subfields as `true`" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "bio" => {
               "age" => {"gt" => nil},
               "name" => {"equal_to_any_of" => ["Jane"]},
@@ -1782,7 +1782,7 @@ module ElasticGraph
         end
 
         it "does not filter at all when all predicate are empty/null on root fields" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "age" => {"gt" => nil},
             "name" => {"equal_to_any_of" => nil},
             "height" => {"gte" => nil, "lt" => nil},
@@ -1793,7 +1793,7 @@ module ElasticGraph
         end
 
         it "does not filter at all when all predicate are empty/null on subfields" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "bio" => {
               "age" => {"gt" => nil},
               "name" => {"equal_to_any_of" => nil},
@@ -1806,7 +1806,7 @@ module ElasticGraph
         end
 
         it "does not prune out `equal_to_any_of: []` to be consistent with `equal_to_any_of` being like an `IN` in SQL and `where field IN ()` should match nothing" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "name" => {"equal_to_any_of" => []}
           })
 
@@ -1814,7 +1814,7 @@ module ElasticGraph
         end
 
         it "returns the standard always false filter for `any_of: []`" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "any_of" => []
           })
 
@@ -1822,7 +1822,7 @@ module ElasticGraph
         end
 
         it "returns an always false filter for `any_of: [{any_of: []}]`" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "any_of" => [{"any_of" => []}]
           })
 
@@ -1832,7 +1832,7 @@ module ElasticGraph
         end
 
         it "does not prune out `any_of: []` to be consistent with `equal_to_any_of: []`, instead providing an 'always false' condition to achieve the same behavior" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "age" => {"gt" => 18},
             "name" => {"any_of" => []}
           })
@@ -1844,7 +1844,7 @@ module ElasticGraph
         end
 
         it "applies no filtering to an `any_of` composed entirely of empty predicates" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "age" => {"any_of" => [{"gt" => nil}, {"lt" => nil}]}
           })
 
@@ -1852,7 +1852,7 @@ module ElasticGraph
         end
 
         it "applies no filtering for an `any_of` composed of an empty predicate and non empty predicate" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "any_of" => [{"age" => {}}, {"equal_to_any_of" => [36]}]
           })
 
@@ -1860,7 +1860,7 @@ module ElasticGraph
         end
 
         it "does not filter at all when given only `any_of: nil` on a root field" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "age" => {"any_of" => nil}
           })
 
@@ -1868,7 +1868,7 @@ module ElasticGraph
         end
 
         it "does not filter at all when given only `any_of: nil` on a subfield" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "bio" => {"age" => {"any_of" => nil}}
           })
 
@@ -1876,7 +1876,7 @@ module ElasticGraph
         end
 
         it "filters to a false condition when given `not: {any_of: {age: nil}}` on a root field" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "not" => {"any_of" => [{"age" => nil}]}
           })
 
@@ -1884,7 +1884,7 @@ module ElasticGraph
         end
 
         it "filters to a false condition when given `not: {any_of: nil}` on a sub field" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "age" => {"not" => {"any_of" => nil}}
           })
 
@@ -1892,7 +1892,7 @@ module ElasticGraph
         end
 
         it "filters to a true condition when given `not: {any_of: []}` on a sub field" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "age" => {"not" => {"any_of" => []}}
           })
 
@@ -1900,7 +1900,7 @@ module ElasticGraph
         end
 
         it "filters to a false condition when given `not: {not: {any_of: []}}` on a sub field" do
-          query = new_query(filter: {
+          query = new_query(client_filter: {
             "age" => {"not" => {"not" => {"any_of" => []}}}
           })
 
@@ -1913,7 +1913,7 @@ module ElasticGraph
         # can't otherwise be exercised.
         describe "`any_of: {}` (which the GraphQL schema does not allow)" do
           it "does not filter at all when given on a root field" do
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "age" => {"any_of" => {}}
             })
 
@@ -1921,13 +1921,36 @@ module ElasticGraph
           end
 
           it "does not filter at all when given on a subfield" do
-            query = new_query(filter: {
+            query = new_query(client_filter: {
               "bio" => {"age" => {"any_of" => {}}}
             })
 
             expect(datastore_body_of(query)).to not_filter_datastore_at_all
           end
         end
+      end
+
+      it "uses both `client_filters` and `internal_filters` in the datastore body query when both are provided" do
+        query = new_query(
+          client_filter: {"age" => {"gt" => 10}},
+          internal_filters: [{"some_id" => {"equal_to_any_of" => ["testid"]}}]
+        )
+
+        expect(datastore_body_of(query)).to filter_datastore_with(
+          {range: {"age" => {gt: 10}}},
+          {terms: {"some_id" => ["testid"]}}
+        )
+      end
+
+      it "uses just `internal_filters` for filtering when no `client_filters` have been provided" do
+        query = new_query(
+          client_filter: nil,
+          internal_filters: [{"some_id" => {"equal_to_any_of" => ["testid"]}}]
+        )
+
+        expect(datastore_body_of(query)).to filter_datastore_with(
+          {terms: {"some_id" => ["testid"]}}
+        )
       end
 
       def not_filter_datastore_at_all
@@ -1950,6 +1973,12 @@ module ElasticGraph
       def color_of(value_name)
         enum_value("ColorInput", value_name)
       end
+
+      prepend Module.new {
+        def new_query(client_filter:, **options)
+          super(client_filters: [client_filter].compact, **options)
+        end
+      }
 
       # Custom matcher that provides nicer, more detailed failure output than what built-in RSpec matchers provide.
       matcher :query_datastore_with do |expected_query|

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/misc_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/misc_spec.rb
@@ -22,7 +22,7 @@ module ElasticGraph
       end
 
       it "inspects nicely, but redacts filters since they could contain PII" do
-        expect(new_query(filter: {"ssn" => {"equal_to_any_of" => ["123-45-6789"]}}, individual_docs_needed: true).inspect).to eq(inspect_output_of(<<~EOS.strip))
+        expect(new_query(client_filters: [{"ssn" => {"equal_to_any_of" => ["123-45-6789"]}}], individual_docs_needed: true).inspect).to eq(inspect_output_of(<<~EOS.strip))
           #<ElasticGraph::GraphQL::DatastoreQuery index="widgets_rollover__*" size=#{default_page_size + 1} sort=[{"id" => {"order" => "asc", "missing" => "_first"}}] track_total_hits=false query=<REDACTED> _source=false>
         EOS
       end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/perform_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/perform_spec.rb
@@ -43,9 +43,9 @@ module ElasticGraph
         expect(widgets_def.cluster_to_query).to eq "main"
         expect(components_def.cluster_to_query).to eq "other1"
 
-        query0 = new_query(search_index_definitions: [widgets_def], filter: {"age" => {"equal_to_any_of" => [0]}}, requested_fields: ["name"])
-        query1 = new_query(search_index_definitions: [widgets_def], filter: {"age" => {"equal_to_any_of" => [10]}}, requested_fields: ["name"])
-        query2 = new_query(search_index_definitions: [components_def], filter: {"age" => {"equal_to_any_of" => [20]}}, requested_fields: ["name"])
+        query0 = new_query(search_index_definitions: [widgets_def], client_filters: [{"age" => {"equal_to_any_of" => [0]}}], requested_fields: ["name"])
+        query1 = new_query(search_index_definitions: [widgets_def], client_filters: [{"age" => {"equal_to_any_of" => [10]}}], requested_fields: ["name"])
+        query2 = new_query(search_index_definitions: [components_def], client_filters: [{"age" => {"equal_to_any_of" => [20]}}], requested_fields: ["name"])
 
         yielded_header_body_tuples_by_query = nil
 
@@ -106,9 +106,9 @@ module ElasticGraph
         expect(widgets_def.cluster_to_query).to eq "main"
         expect(components_def.cluster_to_query).to eq "other1"
 
-        query0 = new_query(search_index_definitions: [widgets_def], filter: {"age" => {"equal_to_any_of" => [0]}}, requested_fields: ["name"])
-        query1 = new_query(search_index_definitions: [widgets_def], filter: {"age" => {"equal_to_any_of" => [10]}}, requested_fields: ["name"])
-        query2 = new_query(search_index_definitions: [components_def], filter: {"age" => {"equal_to_any_of" => [20]}}, requested_fields: ["name"])
+        query0 = new_query(search_index_definitions: [widgets_def], client_filters: [{"age" => {"equal_to_any_of" => [0]}}], requested_fields: ["name"])
+        query1 = new_query(search_index_definitions: [widgets_def], client_filters: [{"age" => {"equal_to_any_of" => [10]}}], requested_fields: ["name"])
+        query2 = new_query(search_index_definitions: [components_def], client_filters: [{"age" => {"equal_to_any_of" => [20]}}], requested_fields: ["name"])
 
         expect {
           DatastoreQuery.perform([query0, query1, query2]) do |header_body_tuples_by_query|

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
@@ -213,7 +213,7 @@ module ElasticGraph
             no_shards_searched_response
           ])
 
-          query_excluding_indices = query2.merge_with(filters: [{"created_at" => {"gte" => "2025-01-01T00:00:00Z"}}])
+          query_excluding_indices = query2.merge_with(client_filters: [{"created_at" => {"gte" => "2025-01-01T00:00:00Z"}}])
           expect(query_excluding_indices.search_index_expression).to eq("widgets_rollover__*,-widgets_rollover__2024")
 
           responses_by_query = router.msearch([query1, query_excluding_indices])

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/http_endpoint_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/http_endpoint_spec.rb
@@ -60,7 +60,7 @@ module ElasticGraph
             adapter = Class.new do
               def call(query:, context:, **)
                 user_name = context.fetch(:http_request).normalized_headers["USER-NAME"]
-                query.merge_with(filters: [{"user_name" => {"equal_to_any_of" => [user_name]}}])
+                query.merge_with(internal_filters: [{"user_name" => {"equal_to_any_of" => [user_name]}}])
               end
             end.new
 
@@ -98,7 +98,7 @@ module ElasticGraph
             process_graphql_expecting(200, extra_headers: {"USER-NAME" => "yoda"})
 
             expect(datastore_queries.size).to eq 1
-            expect(datastore_queries.first.filters).to contain_exactly(
+            expect(datastore_queries.first.internal_filters).to contain_exactly(
               {"user_name" => {"equal_to_any_of" => ["yoda"]}}
             )
           end
@@ -187,7 +187,7 @@ module ElasticGraph
             response_body = process_graphql_expecting(200, query: query, variables: {"filter" => filter})
             expect(response_body).to eq("data" => {"widgets" => {"total_edge_count" => 0}})
             expect(datastore_queries.size).to eq(1)
-            expect(datastore_queries.first.filters.to_a).to eq [filter]
+            expect(datastore_queries.first.client_filters.to_a).to eq [filter]
           end
 
           it "returns a 400 response when the variables are not a JSON object" do

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/query_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/query_adapter_spec.rb
@@ -102,7 +102,7 @@ module ElasticGraph
 
           it "supports `filter`" do
             datastore_query = build_query_from({filter: {name: {equal_to_any_of: ["ben"]}}})
-            expect(datastore_query.filters).to contain_exactly({"name" => {"equal_to_any_of" => ["ben"]}})
+            expect(datastore_query.client_filters).to contain_exactly({"name" => {"equal_to_any_of" => ["ben"]}})
           end
 
           describe "document_pagination" do

--- a/elasticgraph-health_check/lib/elastic_graph/health_check/health_checker.rb
+++ b/elasticgraph-health_check/lib/elastic_graph/health_check/health_checker.rb
@@ -85,7 +85,7 @@ module ElasticGraph
 
         @datastore_query_builder.new_query(
           search_index_definitions: type.search_index_definitions,
-          filters: [build_index_optimization_filter_for(recency_config)],
+          internal_filters: [build_index_optimization_filter_for(recency_config)],
           requested_fields: ["id", recency_config.timestamp_field],
           document_pagination: {first: 1},
           sort: [{recency_config.timestamp_field => {"order" => "desc"}}]

--- a/elasticgraph-query_interceptor/spec/unit/elastic_graph/query_interceptor/graphql_extension_spec.rb
+++ b/elasticgraph-query_interceptor/spec/unit/elastic_graph/query_interceptor/graphql_extension_spec.rb
@@ -39,7 +39,7 @@ module ElasticGraph
               end
 
               def intercept(query, field:, args:, http_request:, context:)
-                query.merge_with(filters: [{"public" => {"equal_to_any_of" => [false]}}])
+                query.merge_with(internal_filters: [{"public" => {"equal_to_any_of" => [false]}}])
               end
             end
           end
@@ -57,7 +57,7 @@ module ElasticGraph
 
               def intercept(query, field:, args:, http_request:, context:)
                 user_name = http_request.normalized_headers[@config.fetch("header")]
-                query.merge_with(filters: [{@config.fetch("key") => {"equal_to_any_of" => [user_name]}}])
+                query.merge_with(internal_filters: [{@config.fetch("key") => {"equal_to_any_of" => [user_name]}}])
               end
             end
           end
@@ -85,7 +85,7 @@ module ElasticGraph
         EOS
 
         expect(performed_datastore_queries.size).to eq(1)
-        expect(performed_datastore_queries.first.filters).to contain_exactly(
+        expect(performed_datastore_queries.first.internal_filters).to contain_exactly(
           {"public" => {"equal_to_any_of" => [false]}},
           {"user" => {"equal_to_any_of" => ["yoda"]}}
         )


### PR DESCRIPTION
Previously, we just had `filters`. That's been replaced by three attributes:

* `client_filters` for filters that were directly provided in the GraphQL query by the client.
* `internal_filters` for filters added internally by ElasticGraph or a query interceptor.
* `all_filters` for the combined set of `client_filters` and `internal_filters`.

This split is a necessary change to support search highlighting as planned in #561. For the `all_highlights` field we'll be adding to edge types, we only want to include highlights that actually came from the client-specified filters. Filters added internally by ElasticGraph or a query interceptor should not produce highlights we return to the client as those filters are hidden/private/internal.

To faciliate that, we'll be using `highlight_query`, which allows us to specify a query for the purposes of highlighting. We'll use `all_filters` for the main search query but only `client_filters` for the `highlight_query`.

Note: this is a bit of a breaking change for ElasticGraph projects that use `elasticgraph-query_interceptor` to add internal filters (as the query interceptors will have to migrate from `filters` to updating `internal_filters`) but this is the ideal time to make that change, as our next release will be 1.0.0.