### PR TITLE
Refactor `ResolvableValue`: accept `schema` instead of `schema_element_names`.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/node.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/node.rb
@@ -29,7 +29,7 @@ module ElasticGraph
 
           def sub_aggregations
             @sub_aggregations ||= SubAggregations.new(
-              schema_element_names,
+              schema,
               query.sub_aggregations,
               parent_queries + [query],
               bucket,
@@ -42,7 +42,7 @@ module ElasticGraph
           end
 
           def count_detail
-            @count_detail ||= CountDetail.new(schema_element_names, bucket)
+            @count_detail ||= CountDetail.new(schema, bucket)
           end
 
           def cursor

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/relay_connection_builder.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/relay_connection_builder.rb
@@ -15,16 +15,16 @@ module ElasticGraph
     module Aggregation
       module Resolvers
         module RelayConnectionBuilder
-          def self.build_from_search_response(query:, search_response:, schema_element_names:)
-            build_from_buckets(query: query, parent_queries: [], schema_element_names: schema_element_names) do
+          def self.build_from_search_response(query:, search_response:, schema:)
+            build_from_buckets(query: query, parent_queries: [], schema: schema) do
               extract_buckets_from(search_response, for_query: query)
             end
           end
 
-          def self.build_from_buckets(query:, parent_queries:, schema_element_names:, field_path: [], &build_buckets)
+          def self.build_from_buckets(query:, parent_queries:, schema:, field_path: [], &build_buckets)
             GraphQL::Resolvers::RelayConnection::GenericAdapter.new(
-              schema_element_names: schema_element_names,
-              raw_nodes: raw_nodes_for(query, parent_queries, schema_element_names, field_path, &build_buckets),
+              schema: schema,
+              raw_nodes: raw_nodes_for(query, parent_queries, schema, field_path, &build_buckets),
               paginator: query.paginator,
               get_total_edge_count: -> {},
               to_sort_value: ->(node, decoded_cursor) do
@@ -39,13 +39,13 @@ module ElasticGraph
             )
           end
 
-          private_class_method def self.raw_nodes_for(query, parent_queries, schema_element_names, field_path)
+          private_class_method def self.raw_nodes_for(query, parent_queries, schema, field_path)
             # The `DecodedCursor::SINGLETON` is a special case, so handle it here.
             return [] if query.paginator.paginated_from_singleton_cursor?
 
             yield.map do |bucket|
               Node.new(
-                schema_element_names: schema_element_names,
+                schema: schema,
                 query: query,
                 parent_queries: parent_queries,
                 bucket: bucket,

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/sub_aggregations.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/sub_aggregations.rb
@@ -19,7 +19,7 @@ module ElasticGraph
   class GraphQL
     module Aggregation
       module Resolvers
-        class SubAggregations < ::Data.define(:schema_element_names, :sub_aggregations, :parent_queries, :sub_aggs_by_agg_key, :field_path)
+        class SubAggregations < ::Data.define(:schema, :sub_aggregations, :parent_queries, :sub_aggs_by_agg_key, :field_path)
           def resolve(field:, object:, args:, context:, lookahead:)
             path_segment = PathSegment.for(field: field, lookahead: lookahead)
             new_field_path = field_path + [path_segment]
@@ -31,7 +31,7 @@ module ElasticGraph
             RelayConnectionBuilder.build_from_buckets(
               query: sub_agg_query,
               parent_queries: parent_queries,
-              schema_element_names: schema_element_names,
+              schema: schema,
               field_path: new_field_path
             ) { extract_buckets(sub_agg_key, args) }
           end
@@ -41,7 +41,7 @@ module ElasticGraph
           def extract_buckets(aggregation_field_path, args)
             # When the client passes `first: 0`, we omit the sub-aggregation from the query body entirely,
             # and it wont' be in `sub_aggs_by_agg_key`. Instead, we can just return an empty list of buckets.
-            return [] if args[schema_element_names.first] == 0
+            return [] if args[schema.element_names.first] == 0
 
             sub_agg_key = Key.encode(parent_queries.map(&:name) + [aggregation_field_path])
             sub_agg = Support::HashUtil.verbose_fetch(sub_aggs_by_agg_key, sub_agg_key)

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/get_record_field_value.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/get_record_field_value.rb
@@ -16,7 +16,6 @@ module ElasticGraph
       # Responsible for fetching a single field value from a document.
       class GetRecordFieldValue
         def initialize(elasticgraph_graphql:, config:)
-          @schema_element_names = elasticgraph_graphql.runtime_metadata.schema_element_names
         end
 
         def resolve(field:, object:, args:, context:)
@@ -32,7 +31,7 @@ module ElasticGraph
           value = [] if value.nil? && field.type.list?
 
           if field.type.relay_connection?
-            RelayConnection::ArrayAdapter.build(value, args, @schema_element_names, context)
+            RelayConnection::ArrayAdapter.build(value, args, context)
           else
             value
           end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection.rb
@@ -20,11 +20,11 @@ module ElasticGraph
         def self.maybe_wrap(search_response, field:, context:, lookahead:, query:)
           return search_response unless field.type.relay_connection?
 
-          schema_element_names = context.fetch(:elastic_graph_schema).element_names
+          schema = context.fetch(:elastic_graph_schema)
 
           unless field.type.unwrap_fully.indexed_aggregation?
             return SearchResponseAdapterBuilder.build_from(
-              schema_element_names: schema_element_names,
+              schema: schema,
               search_response: search_response,
               query: query
             )
@@ -32,7 +32,7 @@ module ElasticGraph
 
           agg_name = lookahead.ast_nodes.first&.alias || lookahead.name
           Aggregation::Resolvers::RelayConnectionBuilder.build_from_search_response(
-            schema_element_names: schema_element_names,
+            schema: schema,
             search_response: search_response,
             query: Support::HashUtil.verbose_fetch(query.aggregations, agg_name)
           )

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/generic_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/generic_adapter.rb
@@ -23,11 +23,11 @@ module ElasticGraph
           # Gets an optional count of total edges.
           :get_total_edge_count
         )
-          # @dynamic initialize, with, schema_element_names, raw_nodes, paginator, to_sort_value, get_total_edge_count
+          # @dynamic initialize, with, schema, raw_nodes, paginator, to_sort_value, get_total_edge_count
 
           def page_info
             @page_info ||= PageInfo.new(
-              schema_element_names: schema_element_names,
+              schema: schema,
               before_truncation_nodes: before_truncation_nodes,
               edges: edges,
               paginator: paginator
@@ -39,7 +39,7 @@ module ElasticGraph
           end
 
           def edges
-            @edges ||= nodes.map { |node| Edge.new(schema_element_names, node) }
+            @edges ||= nodes.map { |node| Edge.new(schema, node) }
           end
 
           def nodes

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/search_response_adapter_builder.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/search_response_adapter_builder.rb
@@ -14,11 +14,11 @@ module ElasticGraph
       module RelayConnection
         # Adapts an `DatastoreResponse::SearchResponse` to what the graphql gem expects for a relay connection.
         class SearchResponseAdapterBuilder
-          def self.build_from(schema_element_names:, search_response:, query:)
+          def self.build_from(schema:, search_response:, query:)
             document_paginator = query.document_paginator
 
             GenericAdapter.new(
-              schema_element_names: schema_element_names,
+              schema: schema,
               raw_nodes: search_response.to_a,
               paginator: document_paginator.paginator,
               get_total_edge_count: -> { search_response.total_document_count },

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/resolvable_value.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/resolvable_value.rb
@@ -17,10 +17,10 @@ module ElasticGraph
       # and also has a corresponding method definition.
       module ResolvableValue
         # `MemoizableData.define` provides the following methods:
-        # @dynamic schema_element_names
+        # @dynamic schema
 
         def self.new(*fields, &block)
-          Support::MemoizableData.define(:schema_element_names, *fields) do
+          Support::MemoizableData.define(:schema, *fields) do
             # @implements ResolvableValueClass
             include ResolvableValue
             class_exec(&block) if block
@@ -41,7 +41,7 @@ module ElasticGraph
         end
 
         def canonical_name_for(name, element_type)
-          schema_element_names.canonical_name_for(name) ||
+          schema.element_names.canonical_name_for(name) ||
             raise(Errors::SchemaError, "#{element_type} `#{name}` is not a defined schema element")
         end
       end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/count_detail.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/count_detail.rbs
@@ -6,20 +6,20 @@ module ElasticGraph
           attr_reader bucket: ::Hash[::String, untyped]
 
           def initialize: (
-            schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
+            schema: Schema,
             bucket: ::Hash[::String, untyped]
           ) -> void
 
           def self.new: (
-            schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
+            schema: Schema,
             bucket: ::Hash[::String, untyped]
           ) -> instance | (
-            SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
+            Schema,
             ::Hash[::String, untyped]
           ) -> instance
 
           def with: (
-            ?schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
+            ?schema: Schema,
             ?bucket: ::Hash[::String, untyped]
           ) -> instance
         end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/node.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/node.rbs
@@ -9,13 +9,13 @@ module ElasticGraph
           attr_reader field_path: ::Array[PathSegment]
 
           def self.new: (
-            SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
+            Schema,
             Query,
             ::Array[Query],
             ::Hash[::String, untyped],
             ::Array[PathSegment]
           ) -> instance | (
-            schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
+            schema: Schema,
             query: Query,
             parent_queries: ::Array[Query],
             bucket: ::Hash[::String, untyped],
@@ -23,7 +23,7 @@ module ElasticGraph
           ) -> instance
 
           def with: (
-            ?schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
+            ?schema: Schema,
             ?query: Query,
             ?parent_queries: ::Array[Query],
             ?bucket: ::Hash[::String, untyped],

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/relay_connection_builder.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/relay_connection_builder.rbs
@@ -6,13 +6,13 @@ module ElasticGraph
           def self.build_from_search_response: (
             query: Query,
             search_response: DatastoreResponse::SearchResponse,
-            schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames
+            schema: Schema
           ) -> GraphQL::Resolvers::RelayConnection::GenericAdapter[Node]
 
           def self.build_from_buckets: (
             query: Query,
             parent_queries: ::Array[Query],
-            schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
+            schema: Schema,
             ?field_path: ::Array[PathSegment]
           ) { () -> ::Array[::Hash[::String, untyped]] } -> GraphQL::Resolvers::RelayConnection::GenericAdapter[Node]
 
@@ -21,7 +21,7 @@ module ElasticGraph
           def self.raw_nodes_for: (
             Query,
             ::Array[Query],
-            SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
+            Schema,
             ::Array[PathSegment]
           ) { () -> ::Array[::Hash[::String, untyped]] } -> ::Array[Node]
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/sub_aggregations.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/sub_aggregations.rbs
@@ -3,20 +3,20 @@ module ElasticGraph
     module Aggregation
       module Resolvers
         class SubAggregationsSupertype
-          attr_reader schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames
+          attr_reader schema: Schema
           attr_reader sub_aggregations: ::Hash[::String, NestedSubAggregation]
           attr_reader parent_queries: ::Array[Query]
           attr_reader sub_aggs_by_agg_key: ::Hash[::String, ::Hash[::String, untyped]]
           attr_reader field_path: ::Array[PathSegment]
 
           def self.new: (
-            schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
+            schema: Schema,
             sub_aggregations: ::Hash[::String, NestedSubAggregation],
             parent_queries: ::Array[Query],
             sub_aggs_by_agg_key: ::Hash[::String, ::Hash[::String, untyped]],
             field_path: ::Array[PathSegment]
           ) -> instance | (
-            SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
+            Schema,
             ::Hash[::String, NestedSubAggregation],
             ::Array[Query],
             ::Hash[::String, ::Hash[::String, untyped]],
@@ -24,7 +24,7 @@ module ElasticGraph
           ) -> instance
 
           def with: (
-            ?schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
+            ?schema: Schema,
             ?sub_aggregations: ::Hash[::String, NestedSubAggregation],
             ?parent_queries: ::Array[Query],
             ?sub_aggs_by_agg_key: ::Hash[::String, ::Hash[::String, untyped]],

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/relay_connection/array_adapter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/relay_connection/array_adapter.rbs
@@ -6,21 +6,21 @@ module ElasticGraph
           extend Forwardable
           include _RelayConnection[N]
           include _RelayPageInfo
-          attr_reader schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames
+          attr_reader schema: Schema
           attr_reader graphql_impl: ::GraphQL::Pagination::ArrayConnection[N]
 
-          def initialize: (SchemaArtifacts::RuntimeMetadata::SchemaElementNames, ::GraphQL::Pagination::ArrayConnection[N]) -> void
+          def initialize: (Schema, ::GraphQL::Pagination::ArrayConnection[N]) -> void
 
-          def self.build: [N] (::Array[N], ::Hash[::String, untyped], SchemaArtifacts::RuntimeMetadata::SchemaElementNames, ::GraphQL::Query::Context) -> ArrayAdapter[N]
+          def self.build: [N] (::Array[N], ::Hash[::String, untyped], ::GraphQL::Query::Context) -> ArrayAdapter[N]
 
           @edges: ::Array[_RelayEdge[N]]?
           @nodes: ::Array[N]?
 
           class Edge[N]
             include _RelayEdge[N]
-            attr_reader schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames
+            attr_reader schema: Schema
             attr_reader graphql_impl: ::GraphQL::Pagination::ArrayConnection[N]
-            def initialize: (SchemaArtifacts::RuntimeMetadata::SchemaElementNames, ::GraphQL::Pagination::ArrayConnection[N], N) -> void
+            def initialize: (Schema, ::GraphQL::Pagination::ArrayConnection[N], N) -> void
           end
         end
       end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/relay_connection/generic_adapter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/relay_connection/generic_adapter.rbs
@@ -11,14 +11,14 @@ module ElasticGraph
         class GenericAdapter[N < _NodeWithCursor] < ResolvableValueClass
           include _RelayConnection[N]
 
-          attr_reader schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames
+          attr_reader schema: Schema
           attr_reader raw_nodes: ::Array[N]
           attr_reader paginator: DatastoreQuery::Paginator[N]
           attr_reader to_sort_value: ^(N, DecodedCursor) -> ::Array[DatastoreQuery::Paginator::SortValue]
           attr_reader get_total_edge_count: ^() -> ::Integer?
 
           def initialize: (
-            schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
+            schema: Schema,
             raw_nodes: ::Array[N],
             paginator: DatastoreQuery::Paginator[N],
             to_sort_value: ^(N, DecodedCursor) -> ::Array[DatastoreQuery::Paginator::SortValue],
@@ -26,7 +26,7 @@ module ElasticGraph
           ) -> void
 
           def with: (
-            ?schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
+            ?schema: Schema,
             ?raw_nodes: ::Array[N],
             ?paginator: DatastoreQuery::Paginator[N],
             ?to_sort_value: ^(N, DecodedCursor) -> ::Array[DatastoreQuery::Paginator::SortValue],
@@ -44,7 +44,7 @@ module ElasticGraph
 
           class Edge[N < _NodeWithCursor] < ResolvableValueClass
             include _RelayEdge[N]
-            def initialize: (SchemaArtifacts::RuntimeMetadata::SchemaElementNames, N) -> void
+            def initialize: (Schema, N) -> void
           end
         end
       end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/relay_connection/page_info.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/relay_connection/page_info.rbs
@@ -10,14 +10,14 @@ module ElasticGraph
           attr_reader paginator: DatastoreQuery::Paginator[N]
 
           def initialize: [N] (
-            schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
+            schema: Schema,
             before_truncation_nodes: ::Array[N],
             edges: ::Array[_RelayEdge[N]],
             paginator: DatastoreQuery::Paginator[N]
           ) -> void
 
           def with: (
-            ?schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
+            ?schema: Schema,
             ?before_truncation_nodes: ::Array[N],
             ?edges: ::Array[_RelayEdge[N]],
             ?paginator: DatastoreQuery::Paginator[N]

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/relay_connection/search_response_adapter_builder.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/relay_connection/search_response_adapter_builder.rbs
@@ -6,7 +6,7 @@ module ElasticGraph
           def self.build_from: (
             query: DatastoreQuery,
             search_response: DatastoreResponse::SearchResponse,
-            schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
+            schema: Schema
           ) -> GraphQL::Resolvers::RelayConnection::GenericAdapter[DatastoreResponse::Document]
         end
       end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/resolvable_value.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/resolvable_value.rbs
@@ -5,7 +5,7 @@ module ElasticGraph
         def self.new: (*Symbol) ?{ () [self: self] -> void } -> ResolvableValueClass
 
         include _GraphQLResolvableWithoutLookahead
-        attr_reader schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames
+        attr_reader schema: Schema
 
         private
 

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/aggregation_pagination_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/aggregation_pagination_spec.rb
@@ -124,7 +124,7 @@ module ElasticGraph
           connection = Aggregation::Resolvers::RelayConnectionBuilder.build_from_search_response(
             query: aggregation_query,
             search_response: response,
-            schema_element_names: graphql.runtime_metadata.schema_element_names
+            schema: graphql.schema
           )
 
           [connection.nodes, connection.page_info]

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/aggregations_spec.rb
@@ -37,7 +37,7 @@ module ElasticGraph
 
         agg_nodes_by_agg_name = all_aggs.to_h do |agg|
           connection = Aggregation::Resolvers::RelayConnectionBuilder.build_from_search_response(
-            schema_element_names: graphql.runtime_metadata.schema_element_names,
+            schema: graphql.schema,
             search_response: results,
             query: agg
           )

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/datastore_aggregation_query_integration_support.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/datastore_aggregation_query_integration_support.rb
@@ -19,7 +19,7 @@ module ElasticGraph
 
       def search_datastore_aggregations(aggregation_query, **options)
         connection = Aggregation::Resolvers::RelayConnectionBuilder.build_from_search_response(
-          schema_element_names: graphql.runtime_metadata.schema_element_names,
+          schema: graphql.schema,
           search_response: search_datastore(aggregations: [aggregation_query], **options),
           query: aggregation_query
         )

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/pagination_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/pagination_spec.rb
@@ -182,7 +182,7 @@ module ElasticGraph
         ) { |q| query = q }
 
         adapter = Resolvers::RelayConnection::SearchResponseAdapterBuilder.build_from(
-          schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames.new(form: :snake_case, overrides: {}),
+          schema: graphql.schema,
           search_response: response,
           query: query
         )

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
@@ -148,15 +148,17 @@ module ElasticGraph
             name: "John", birth_date: "2002-09-01", quote: "To be, or not to be, that is the question."
           |
             element_names = PersonFieldNames.new(form: name_form, overrides: overrides)
+            schema = build_graphql(element_names).schema
+            allow(schema).to receive(:element_names).and_return(element_names)
 
             person = person_class.new(
-              schema_element_names: element_names,
+              schema: schema,
               name: name,
               quote: quote,
               birth_date: birth_date
             )
 
-            [person, build_graphql(element_names).schema.field_named("Person", field)]
+            [person, schema.field_named("Person", field)]
           end
 
           def build_graphql(element_names)


### PR DESCRIPTION
For a `ResolvableValue` subclass I'm working on for search highlighting, I need access to the `schema`. The `schema` also provides access to `schema_element_names` via `schema.element_names`.