### PR TITLE
Only define `all_highlights` on edge types for indexed types.

### DIFF
--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -4413,8 +4413,6 @@ object_types_by_name:
   StringEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
-      all_highlights:
-        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:

--- a/config/schema/artifacts/schema.graphql
+++ b/config/schema/artifacts/schema.graphql
@@ -9636,11 +9636,6 @@ Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for mor
 """
 type StringEdge {
   """
-  Search highlights for this `String`, indicating where in the indexed document the query matched.
-  """
-  all_highlights: [SearchHighlight!]!
-
-  """
   The `Cursor` of this `String`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `String`.
   """

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -4449,8 +4449,6 @@ object_types_by_name:
   StringEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
-      all_highlights:
-        resolver: object_without_lookahead
       cursor:
         resolver: object_without_lookahead
       node:

--- a/config/schema/artifacts_with_apollo/schema.graphql
+++ b/config/schema/artifacts_with_apollo/schema.graphql
@@ -9866,11 +9866,6 @@ Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for mor
 """
 type StringEdge @shareable {
   """
-  Search highlights for this `String`, indicating where in the indexed document the query matched.
-  """
-  all_highlights: [SearchHighlight!]!
-
-  """
   The `Cursor` of this `String`. This can be passed in the next query as
   a `before` or `after` argument to continue paginating from this `String`.
   """

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
@@ -207,9 +207,9 @@ module ElasticGraph
         [single_value_filter, list_filter, fields_list_filter]
       end
 
-      def build_relay_pagination_types(type_name, include_total_edge_count: false, derived_indexed_types: [], support_pagination: true, support_highlights: true, &customize_connection)
+      def build_relay_pagination_types(type_name, include_total_edge_count: false, derived_indexed_types: [], support_pagination: true, &customize_connection)
         [
-          (edge_type_for(type_name, support_highlights) if support_pagination),
+          (edge_type_for(type_name) if support_pagination),
           connection_type_for(type_name, include_total_edge_count, derived_indexed_types, support_pagination, &customize_connection)
         ].compact
       end
@@ -431,7 +431,7 @@ module ElasticGraph
         end
       end
 
-      def edge_type_for(type_name, support_highlights)
+      def edge_type_for(type_name)
         type_ref = @state.type_ref(type_name)
         new_object_type type_ref.as_edge.name do |t|
           t.relay_pagination_type = true
@@ -457,7 +457,7 @@ module ElasticGraph
             EOS
           end
 
-          if support_highlights
+          if type_ref.as_object_type&.indexed?
             t.field @state.schema_elements.all_highlights, "[SearchHighlight!]!" do |f|
               f.documentation "Search highlights for this `#{type_name}`, indicating where in the indexed document the query matched."
             end

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_filtering_and_aggregation.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_filtering_and_aggregation.rb
@@ -36,7 +36,7 @@ module ElasticGraph
           indexed_agg_type = to_indexed_aggregation_type
           indexed_aggregation_pagination_types =
             if indexed_agg_type
-              schema_def_state.factory.build_relay_pagination_types(indexed_agg_type.name, support_highlights: false)
+              schema_def_state.factory.build_relay_pagination_types(indexed_agg_type.name)
             else
               [] # : ::Array[SchemaElements::ObjectType]
             end

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/factory.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/factory.rbs
@@ -73,7 +73,6 @@ module ElasticGraph
         ?include_total_edge_count: bool,
         ?derived_indexed_types: ::Array[Indexing::DerivedIndexedType],
         ?support_pagination: bool,
-        ?support_highlights: bool
       ) ?{ (SchemaElements::ObjectType) -> void } -> ::Array[SchemaElements::ObjectType]
 
       def new_interface_type: (::String) { (SchemaElements::InterfaceType) -> void } -> SchemaElements::InterfaceType
@@ -138,7 +137,7 @@ module ElasticGraph
 
       def define_list_counts_filter_field_on: (SchemaElements::InputType) -> void
 
-      def edge_type_for: (::String, bool) -> SchemaElements::ObjectType
+      def edge_type_for: (::String) -> SchemaElements::ObjectType
       def connection_type_for: (
         ::String,
         bool,

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/paginated_collection_field_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/paginated_collection_field_spec.rb
@@ -62,7 +62,6 @@ module ElasticGraph
             type StringEdge {
               #{schema_elements.node}: String
               #{schema_elements.cursor}: Cursor
-              #{schema_elements.all_highlights}: [SearchHighlight!]!
             }
           EOS
         end
@@ -106,7 +105,6 @@ module ElasticGraph
             type WidgetOptionsEdge {
               #{schema_elements.node}: WidgetOptions
               #{schema_elements.cursor}: Cursor
-              #{schema_elements.all_highlights}: [SearchHighlight!]!
             }
           EOS
         end
@@ -158,7 +156,6 @@ module ElasticGraph
             type TimeOfDayEdge {
               #{schema_elements.node}: TimeOfDay
               #{schema_elements.cursor}: Cursor
-              #{schema_elements.all_highlights}: [SearchHighlight!]!
             }
           EOS
 


### PR DESCRIPTION
It should not be defined on edge types like `StringEdge`, for example. Search highlighting can only be provided on the edges of a root indexed type.