### PR TITLE
Bugfix: correctly handle graphql-only fields defined with `name_in_index`.

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
@@ -80,8 +80,6 @@ module ElasticGraph
       #   @private
       # @!attribute [rw] non_nullable_in_json_schema
       #   @private
-      # @!attribute [rw] backing_indexing_field
-      #   @private
       # @!attribute [rw] as_input
       #   @private
       class Field < Struct.new(
@@ -89,7 +87,7 @@ module ElasticGraph
         :filter_customizations, :grouped_by_customizations, :sub_aggregations_customizations,
         :aggregated_values_customizations, :sort_order_enum_value_customizations,
         :args, :sortable, :filterable, :aggregatable, :groupable, :graphql_only, :source, :runtime_field_script, :relationship, :singular_name,
-        :computation_detail, :non_nullable_in_json_schema, :backing_indexing_field, :as_input,
+        :computation_detail, :non_nullable_in_json_schema, :as_input,
         :name_in_index, :resolver
       )
         include Mixins::HasDocumentation
@@ -103,7 +101,7 @@ module ElasticGraph
           accuracy_confidence: :high, name_in_index: name,
           type_for_derived_types: nil, graphql_only: nil, singular: nil,
           sortable: nil, filterable: nil, aggregatable: nil, groupable: nil,
-          backing_indexing_field: nil, as_input: false, resolver: nil
+          as_input: false, resolver: nil
         )
           type_ref = schema_def_state.type_ref(type)
           super(
@@ -132,7 +130,6 @@ module ElasticGraph
             singular_name: singular,
             name_in_index: name_in_index,
             non_nullable_in_json_schema: false,
-            backing_indexing_field: backing_indexing_field,
             as_input: as_input,
             resolver: resolver
           )
@@ -930,6 +927,11 @@ module ElasticGraph
         end
 
         private
+
+        def backing_indexing_field
+          return nil unless graphql_only
+          parent_type.indexing_fields_by_name_in_index[name_in_index]
+        end
 
         def args_sdl(joiner:, after_opening_paren: "", &arg_selector)
           selected_args = args.values.select(&arg_selector)

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_with_subfields.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_with_subfields.rb
@@ -301,7 +301,7 @@ module ElasticGraph
 
           schema_def_state.paginated_collection_element_types << element_type
 
-          backing_indexing_field = field(name, "[#{element_type}!]!", indexing_only: true, name_in_index: name_in_index, &block)
+          field(name, "[#{element_type}!]!", indexing_only: true, name_in_index: name_in_index, &block)
 
           field(
             name,
@@ -311,8 +311,7 @@ module ElasticGraph
             groupable: !!singular,
             sortable: false,
             graphql_only: true,
-            singular: singular,
-            backing_indexing_field: backing_indexing_field
+            singular: singular
           ) do |f|
             f.define_relay_pagination_arguments!
             block&.call(f)

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/aggregated_values_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/aggregated_values_type_spec.rb
@@ -207,6 +207,7 @@ module ElasticGraph
               t.field "description", "String" do |f|
                 f.mapping type: "text"
               end
+              t.field "description_alt", "String", name_in_index: "description", graphql_only: true
               t.index "widgets"
             end
           end

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/aggregation_grouped_by_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/aggregation_grouped_by_type_spec.rb
@@ -252,6 +252,7 @@ module ElasticGraph
               t.field "options", "[WidgetOptions!]!" do |f|
                 f.mapping type: "nested"
               end
+              t.field "options_alt", "[WidgetOptions!]!", name_in_index: "options", graphql_only: true
               t.index "widgets"
             end
           end
@@ -366,6 +367,7 @@ module ElasticGraph
               t.field "description", "String" do |f|
                 f.mapping type: "text"
               end
+              t.field "description_alt", "String", name_in_index: "description", graphql_only: true
 
               t.index "widgets"
             end

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/filters_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/filters_spec.rb
@@ -611,6 +611,8 @@ module ElasticGraph
               t.field "description", "String" do |f|
                 f.mapping type: "text"
               end
+
+              t.field "description_alt", "String", name_in_index: "description", graphql_only: true
             end
           end
 
@@ -621,6 +623,7 @@ module ElasticGraph
               #{schema_elements.not}: WidgetFilterInput
               name: StringFilterInput
               description: TextFilterInput
+              description_alt: TextFilterInput
             }
           EOS
         end
@@ -802,6 +805,8 @@ module ElasticGraph
               t.field "tags", "[String!]!" do |f|
                 f.mapping type: "text"
               end
+
+              t.field "tags_alt", "[String!]!", name_in_index: "tags", graphql_only: true
             end
           end
 
@@ -811,6 +816,7 @@ module ElasticGraph
               #{schema_elements.all_of}: [WidgetFilterInput!]
               #{schema_elements.not}: WidgetFilterInput
               tags: TextListFilterInput
+              tags_alt: TextListFilterInput
             }
           EOS
         end

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/sort_order_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/sort_order_spec.rb
@@ -40,6 +40,7 @@ module ElasticGraph
               t.field "some_text", "String" do |f|
                 f.mapping type: "text"
               end
+              t.field "some_text_alt", "String", name_in_index: "some_text", graphql_only: true
               t.relates_to_one "parent", "Widget", via: "parent_id", dir: :out
               t.relates_to_many "children", "Widget", via: "children_ids", dir: :in, singular: "child"
               t.index "widgets"


### PR DESCRIPTION
This can be used, for example, when migrating a field in an index to a new GraphQL field name. Previously, we were not able to correctly determine the mapping of the field in this case (since it's graphql-only). With this fix, we now use the mapping of the indexing field with the same name. This ensures we treat `text` and `nested` fields correctly, for example.