### PR TITLE
Add `requested_highlights` to `DatastoreQuery`.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
@@ -29,7 +29,8 @@ module ElasticGraph
     class DatastoreQuery < Support::MemoizableData.define(
       :total_document_count_needed, :aggregations, :logger, :filter_interpreter, :routing_picker,
       :index_expression_builder, :default_page_size, :search_index_definitions, :max_page_size,
-      :client_filters, :internal_filters, :sort, :document_pagination, :requested_fields, :request_all_fields, :request_all_highlights,
+      :client_filters, :internal_filters, :sort, :document_pagination,
+      :requested_fields, :request_all_fields, :requested_highlights, :request_all_highlights,
       :individual_docs_needed, :size_multiplier, :monotonic_clock_deadline, :schema_element_names
     )
       # Load these files after the `Query` class has been defined, to avoid
@@ -101,20 +102,28 @@ module ElasticGraph
         sort: [],
         requested_fields: [],
         request_all_fields: false,
+        requested_highlights: [],
         request_all_highlights: false,
         document_pagination: {},
         size_multiplier: 1,
         monotonic_clock_deadline: nil,
         aggregations: {}
       )
+        individual_docs_needed ||= self.individual_docs_needed ||
+          !requested_fields.empty? || request_all_fields ||
+          !requested_highlights.empty? || request_all_highlights
+
+        total_document_count_needed ||= self.total_document_count_needed || aggregations.values.any?(&:needs_total_doc_count?)
+
         with(
-          individual_docs_needed: self.individual_docs_needed || individual_docs_needed || !requested_fields.empty? || request_all_fields || request_all_highlights,
-          total_document_count_needed: self.total_document_count_needed || total_document_count_needed || aggregations.values.any?(&:needs_total_doc_count?),
+          individual_docs_needed: individual_docs_needed,
+          total_document_count_needed: total_document_count_needed,
           client_filters: self.client_filters + client_filters,
           internal_filters: self.internal_filters + internal_filters,
           sort: merge_attribute(:sort, sort),
           requested_fields: self.requested_fields + requested_fields,
           request_all_fields: self.request_all_fields || request_all_fields,
+          requested_highlights: self.requested_highlights + requested_highlights,
           request_all_highlights: self.request_all_highlights || request_all_highlights,
           document_pagination: merge_attribute(:document_pagination, document_pagination),
           size_multiplier: self.size_multiplier * size_multiplier,
@@ -322,12 +331,16 @@ module ElasticGraph
       end
 
       def highlight
-        return nil unless request_all_highlights && !client_filters.empty?
+        return nil if !request_all_highlights && requested_highlights.empty?
 
-        {
-          fields: {"*" => {}},
-          highlight_query: (filter_interpreter.build_query(client_filters) unless internal_filters.empty?)
-        }.compact
+        # If there are no filters, there's nothing to highlight.
+        return nil if client_filters.empty?
+
+        field_paths = request_all_highlights ? ["*"] : requested_highlights
+        fields = field_paths.to_h { |field| [field, {}] }
+        highlight_query = filter_interpreter.build_query(client_filters) unless internal_filters.empty?
+
+        {fields:, highlight_query:}.compact
       end
 
       # Encapsulates dependencies of `Query`, giving us something we can expose off of `application`
@@ -357,6 +370,7 @@ module ElasticGraph
           aggregations: {},
           requested_fields: [],
           request_all_fields: false,
+          requested_highlights: [],
           request_all_highlights: false,
           individual_docs_needed: false,
           total_document_count_needed: false,
@@ -365,6 +379,11 @@ module ElasticGraph
           if search_index_definitions.empty?
             raise Errors::SearchFailedError, "Query is invalid, since it contains no `search_index_definitions`."
           end
+
+          individual_docs_needed ||= !requested_fields.empty? || request_all_fields ||
+            !requested_highlights.empty? || request_all_highlights
+
+          total_document_count_needed ||= aggregations.values.any?(&:needs_total_doc_count?)
 
           DatastoreQuery.new(
             routing_picker: routing_picker,
@@ -379,10 +398,11 @@ module ElasticGraph
             size_multiplier: size_multiplier,
             aggregations: aggregations,
             requested_fields: requested_fields.to_set,
+            requested_highlights: requested_highlights.to_set,
             request_all_fields: request_all_fields,
             request_all_highlights: request_all_highlights,
-            individual_docs_needed: individual_docs_needed || !requested_fields.empty? || request_all_fields || request_all_highlights,
-            total_document_count_needed: total_document_count_needed || aggregations.values.any?(&:needs_total_doc_count?),
+            individual_docs_needed: individual_docs_needed,
+            total_document_count_needed: total_document_count_needed,
             monotonic_clock_deadline: monotonic_clock_deadline,
             filter_interpreter: filter_interpreter,
             default_page_size: default_page_size,

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/requested_fields.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/requested_fields.rb
@@ -43,10 +43,15 @@ module ElasticGraph
         def query_attributes_for(field:, lookahead:)
           attributes =
             if field.type.relay_connection?
+              highlights = lookahead
+                .selection(@schema.element_names.edges)
+                .selection(@schema.element_names.highlights)
+
               {
                 individual_docs_needed: pagination_fields_need_individual_docs?(lookahead),
                 requested_fields: requested_fields_under(relay_connection_node_from(lookahead)),
-                request_all_highlights: requesting_all_highlights?(lookahead)
+                request_all_highlights: requesting_all_highlights?(lookahead),
+                requested_highlights: requested_fields_under(highlights)
               }
             else
               {

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/highlighting_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/highlighting_spec.rb
@@ -13,11 +13,10 @@ module ElasticGraph
     RSpec.describe DatastoreQuery, "highlighting" do
       include_context "DatastoreQueryUnitSupport"
 
-      context "with `request_all_highlights: true`" do
+      shared_examples_for "common highlighting examples" do |expected_highlight_fields|
         context "when there are no `client_filters`" do
           it "omits highlights because there are no client filters that could have matches (when there are no `internal_filters`)" do
             query = new_query(
-              request_all_highlights: true,
               client_filters: [],
               internal_filters: []
             )
@@ -27,7 +26,6 @@ module ElasticGraph
 
           it "omits highlights because there are no client filters that could have matches (when there are `internal_filters`)" do
             query = new_query(
-              request_all_highlights: true,
               client_filters: [],
               internal_filters: [{
                 "id" => {"equal_to_any_of" => ["123"]}
@@ -39,31 +37,28 @@ module ElasticGraph
         end
 
         context "when there are `client_filters`" do
-          it "requests all highlights" do
+          it "requests highlights" do
             query = new_query(
-              request_all_highlights: true,
               client_filters: [{"name" => {"equal_to_any_of" => ["Bob"]}}]
             )
 
-            expect(datastore_body_of(query)[:highlight]).to include(fields: {"*" => {}})
+            expect(datastore_body_of(query)[:highlight]).to include(fields: expected_highlight_fields)
           end
 
           context "when there are no `internal_filters`" do
             it "omits `highlight_query` because the main search query can safely be used for highlights" do
               query = new_query(
-                request_all_highlights: true,
                 client_filters: [{"name" => {"equal_to_any_of" => ["Bob"]}}],
                 internal_filters: []
               )
 
-              expect(datastore_body_of(query)[:highlight]).to eq(fields: {"*" => {}})
+              expect(datastore_body_of(query)[:highlight]).to eq(fields: expected_highlight_fields)
             end
           end
 
           context "when there are also `internal_filters`" do
             it "provides a `highlight_query` based on the `client_filters` so that only client filter matches are highlighted" do
               query = new_query(
-                request_all_highlights: true,
                 client_filters: [{
                   "name" => {"starts_with" => {"any_prefix_of" => ["Widget"]}},
                   "tags" => {"any_satisfy" => {"contains" => {"any_substring_of" => ["red"]}}}
@@ -74,7 +69,7 @@ module ElasticGraph
               )
 
               expect(datastore_body_of(query)[:highlight]).to eq({
-                fields: {"*" => {}},
+                fields: expected_highlight_fields,
                 highlight_query: {
                   bool: {filter: [
                     {
@@ -97,9 +92,33 @@ module ElasticGraph
         end
       end
 
-      context "with `request_all_highlights: false`" do
+      context "with `request_all_highlights: false` and some `requested_highlights`" do
+        def new_query(**options)
+          super(request_all_highlights: false, requested_highlights: ["name", "options.color"], **options)
+        end
+
+        include_examples "common highlighting examples", {"name" => {}, "options.color" => {}}
+      end
+
+      context "with `request_all_highlights: true` and `requested_highlights: []`" do
+        def new_query(**options)
+          super(request_all_highlights: true, requested_highlights: [], **options)
+        end
+
+        include_examples "common highlighting examples", {"*" => {}}
+      end
+
+      context "with `request_all_highlights: true` and some `requested_highlights`" do
+        def new_query(**options)
+          super(request_all_highlights: true, requested_highlights: ["name", "options.color"], **options)
+        end
+
+        include_examples "common highlighting examples", {"*" => {}}
+      end
+
+      context "with `request_all_highlights: false` and `requested_highlights: []`" do
         it "requests no highlights when there are no `client_filters`" do
-          query = new_query(request_all_highlights: false, client_filters: [])
+          query = new_query(request_all_highlights: false, requested_highlights: [], client_filters: [])
 
           expect(datastore_body_of(query).keys).to exclude(:highlight)
         end
@@ -107,6 +126,7 @@ module ElasticGraph
         it "requests no highlights when there are `client_filters`" do
           query = new_query(
             request_all_highlights: false,
+            requested_highlights: [],
             client_filters: ["id" => {"equal_to_any_of" => ["123"]}]
           )
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/individual_docs_needed_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/individual_docs_needed_spec.rb
@@ -39,6 +39,14 @@ module ElasticGraph
         query = new_query(request_all_highlights: true, individual_docs_needed: false)
         expect(query.individual_docs_needed).to be true
       end
+
+      it "forces `individual_docs_needed` to `true` if specific highlights are requested, because we will not get back the highlights if we do not fetch documents" do
+        query = new_query(requested_highlights: ["name"])
+        expect(query.individual_docs_needed).to be true
+
+        query = new_query(requested_highlights: ["name"], individual_docs_needed: false)
+        expect(query.individual_docs_needed).to be true
+      end
     end
   end
 end


### PR DESCRIPTION
This is used when a client requests `highlights`. See #561 for background.