### PR TITLE
De-duplicate query payloads within a single `msearch` request.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_search_router.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_search_router.rb
@@ -72,12 +72,20 @@ module ElasticGraph
           datastore_query_started_at = @monotonic_clock.now_in_ms
 
           server_took_and_results = Support::Threading.parallel_map(queries_and_header_body_tuples_by_datastore_client) do |datastore_client, query_and_header_body_tuples_for_cluster|
-            queries_for_cluster, header_body_tuples = query_and_header_body_tuples_for_cluster.transpose
-            msearch_body = header_body_tuples.flatten(1)
+            queries_by_header_body_tuples = query_and_header_body_tuples_for_cluster
+              .group_by { |(query, header_body_tuple)| header_body_tuple }
+              .transform_values { |values| values.map(&:first) }
+
+            msearch_body = queries_by_header_body_tuples.keys.flatten(1)
             response = datastore_client.msearch(body: msearch_body, headers: headers)
             debug_query(query: msearch_body, response: response)
-            ordered_responses = response.fetch("responses")
-            [response["took"], queries_for_cluster.zip(ordered_responses)]
+
+            responses_by_header_body_tuple = queries_by_header_body_tuples.keys.zip(response.fetch("responses")).to_h
+            ordered_queries_and_responses = query_and_header_body_tuples_for_cluster.map do |(query, header_body_tuple)|
+              [query, responses_by_header_body_tuple.fetch(header_body_tuple)]
+            end
+
+            [response["took"], ordered_queries_and_responses]
           end
 
           queried_shard_count = server_took_and_results.reduce(0) do |outer_accum, (query, queries_and_responses)|

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
@@ -119,6 +119,28 @@ module ElasticGraph
           }))
         end
 
+        it "avoids sending an identical query multiple times in the same HTTP request" do
+          allow(main_datastore_client).to receive(:msearch) do |queries|
+            # We use `each_slice(2)` because each query has two parts (a `header` and a `body`).
+            expect(queries.fetch(:body).each_slice(2).size).to eq 2
+            {
+              "took" => 10,
+              "responses" => [
+                empty_response.merge("r" => 1),
+                empty_response.merge("r" => 2)
+              ]
+            }
+          end
+
+          # Here we are creating a different `DatastoreQuery` object (by assigning a different deadline) but the query payload is identical.
+          query3 = query1.merge_with(monotonic_clock_deadline: now_when_msearch_is_called + 10000)
+          responses = router.msearch([query1, query2, query3])
+
+          expect(responses.size).to eq(3)
+          expect(responses.fetch(query3)).to eq(responses.fetch(query1))
+          expect(responses.fetch(query2)).not_to eq(responses.fetch(query1))
+        end
+
         it "raises `Errors::RequestExceededDeadlineError` if a query has a deadline in the past" do
           queries = [
             query1.merge_with(monotonic_clock_deadline: now_when_msearch_is_called + -3),


### PR DESCRIPTION
We don't want to make the datastore perform the same query multiple times.