### PR TITLE
Improve `TypeReference.enum?` logic to handle input enums.

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_reference.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_reference.rb
@@ -108,8 +108,12 @@ module ElasticGraph
           when :enum
             true
           else
-            # If we can't determine the type from the name, just raise an error.
-            raise Errors::SchemaError, "Type `#{name}` cannot be resolved. Is it misspelled?"
+            if block_given?
+              yield
+            else
+              # If we can't determine the type from the name, just raise an error.
+              raise Errors::SchemaError, "Type `#{name}` cannot be resolved. Is it misspelled?"
+            end
           end
         end
 
@@ -339,7 +343,7 @@ module ElasticGraph
           return :object if OBJECT_FORMATS.any? { |f| type_namer.matches_format?(name, f) }
 
           if (as_output_enum_name = type_namer.extract_base_from(name, format: :InputEnum))
-            :enum if ENUM_FORMATS.any? { |f| type_namer.matches_format?(as_output_enum_name, f) }
+            :enum if schema_def_state.type_ref(as_output_enum_name).enum? { false }
           end
         end
 

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/type_reference.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/type_reference.rbs
@@ -20,7 +20,7 @@ module ElasticGraph
         def unwrap_list: () -> TypeReference
         def as_object_type: () -> anyObjectType?
         def object?: () -> bool
-        def enum?: () -> bool
+        def enum?: () ?{ () -> bool } -> bool
         def leaf?: () -> bool
         def list?: () -> bool
         def non_null?: () -> bool

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/schema_elements/type_reference_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/schema_elements/type_reference_spec.rb
@@ -161,6 +161,14 @@ module ElasticGraph
             expect(type.enum?).to be false
           end
 
+          it "considers both input and output forms of an enum to be an enum" do
+            type = type_ref("DateTimeUnit")
+            expect(type.enum?).to be true
+
+            type = type_ref("DateTimeUnitInput")
+            expect(type.enum?).to be true
+          end
+
           context "when dealing with a type that has been renamed" do
             it "correctly detects a renamed object type" do
               type = type_ref("RingValuesAggregated")
@@ -564,6 +572,13 @@ module ElasticGraph
                   f.mapping type: "object"
                 end
                 t.index "has_nested"
+              end
+
+              api.on_root_query_type do |t|
+                t.field "time", "DateTime" do |f|
+                  date_time_unit_input_type_name = api.state.type_ref("DateTimeUnit").as_input_enum
+                  f.argument "offsetUnit", "#{date_time_unit_input_type_name}!"
+                end
               end
             end
           end


### PR DESCRIPTION
Since input enums are derived (e.g. by adding `Input` as a suffix), they are not generally explicitly registered. That has workedt  fine because references to them from ElasticGraph's built-in types use the original type name (e.g. `DateTimeUnit` instead of `DateTimeUnitInput`), which is registered.

However, users can get a confusing schema definition error if they directly reference the `Input` enum type from some of their schema elements (such as a custom root `Query` fied with arguments):

```
ElasticGraph::Errors::SchemaError: Type `DateTimeUnitInput` cannot be resolved. Is it misspelled? (ElasticGraph::Errors::SchemaError)
elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_reference.rb:112:in 'ElasticGraph::SchemaDefinition::SchemaElements::TypeReference#enum?'
elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_reference.rb:205:in 'ElasticGraph::SchemaDefinition::SchemaElements::TypeReference#to_final_form'
elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/argument.rb:51:in 'ElasticGraph::SchemaDefinition::SchemaElements::Argument#value_type'
elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/graphql_sdl_enumerator.rb:33:in 'block (2 levels) in ElasticGraph::SchemaDefinition::SchemaElements::GraphQLSDLEnumerator#each'
elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb:1016:in 'Array#select'
elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb:1016:in 'ElasticGraph::SchemaDefinition::SchemaElements::Field#args_sdl'
elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb:532:in 'ElasticGraph::SchemaDefinition::SchemaElements::Field#to_sdl'
elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_with_subfields.rb:511:in 'block in ElasticGraph::SchemaDefinition::SchemaElements::TypeWithSubfields#fields_sdl'
elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_with_subfields.rb:511:in 'Array#map'
elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_with_subfields.rb:511:in 'ElasticGraph::SchemaDefinition::SchemaElements::TypeWithSubfields#fields_sdl'
elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_with_subfields.rb:437:in 'ElasticGraph::SchemaDefinition::SchemaElements::TypeWithSubfields#generate_sdl'
elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/implements_interfaces.rb:118:in 'ElasticGraph::SchemaDefinition::Mixins::ImplementsInterfaces#to_sdl'
elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/graphql_sdl_enumerator.rb:33:in 'block in ElasticGraph::SchemaDefinition::SchemaElements::GraphQLSDLEnumerator#each'
elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/graphql_sdl_enumerator.rb:31:in 'Array#each'
elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/graphql_sdl_enumerator.rb:31:in 'ElasticGraph::SchemaDefinition::SchemaElements::GraphQLSDLEnumerator#each'
elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb:316:in 'Enumerable#map'
elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb:316:in 'ElasticGraph::SchemaDefinition::Results#generate_sdl'
elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb:35:in 'ElasticGraph::SchemaDefinition::Results#graphql_schema_string'
```

To avoid this error, I've made `TypeReference#enum?` more robust.