### PR TITLE
Remove unnecessary double memoization.

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/state.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/state.rb
@@ -173,8 +173,7 @@ module ElasticGraph
             raise Errors::SchemaError, "Cannot access `user_defined_field_references_by_type_name` until the schema definition is complete."
           end
 
-          @user_defined_field_references_by_type_name ||= user_defined_fields
-            .group_by { |f| f.type.fully_unwrapped.name }
+          user_defined_fields.group_by { |f| f.type.fully_unwrapped.name }
         end
       end
 


### PR DESCRIPTION
`@user_defined_field_references_by_type_name ||= begin ... end` is wrapping this entire chunk of code. We don't need to mess with `@user_defined_field_references_by_type_name` within it as well.