### PR TITLE
Allow `Input` to be removed from specific `SortOrder` enums.

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_reference.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_reference.rb
@@ -343,7 +343,8 @@ module ElasticGraph
           return :object if OBJECT_FORMATS.any? { |f| type_namer.matches_format?(name, f) }
 
           if (as_output_enum_name = type_namer.extract_base_from(name, format: :InputEnum))
-            :enum if schema_def_state.type_ref(as_output_enum_name).enum? { false }
+            return :enum if ENUM_FORMATS.any? { |f| type_namer.matches_format?(as_output_enum_name, f) }
+            :enum if as_output_enum_name != self.name && schema_def_state.type_ref(as_output_enum_name).enum? { false }
           end
         end
 

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/schema_elements/type_reference_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/schema_elements/type_reference_spec.rb
@@ -457,6 +457,16 @@ module ElasticGraph
               expect(ref.to_final_form(as_input: true).name).to eq "NewName"
             end
 
+            it "allows a sort order enum to be overridden to omit the `Input` suffix" do
+              ref = type_ref(
+                "[WidgetSortOrder!]",
+                type_name_overrides: {WidgetSortOrderInput: "WidgetSortOrder"}
+              )
+
+              expect(ref.to_final_form(as_input: true).name).to eq "[WidgetSortOrder!]"
+              expect(ref.to_final_form(as_input: false).name).to eq "[WidgetSortOrder!]"
+            end
+
             def api(type_name_overrides: {}, derived_type_name_formats: {})
               API.new(
                 SchemaArtifacts::RuntimeMetadata::SchemaElementNames.new(form: "snake_case"),


### PR DESCRIPTION
This worked before #595, but it wasn't covered by a test and my changes broke it. This restores it with test coverage.