### PR TITLE
Fix typo: remove trailing period from section heading.

### DIFF
--- a/config/site/src/guides/how-it-works.md
+++ b/config/site/src/guides/how-it-works.md
@@ -130,7 +130,7 @@ input ElasticGraph generates to support filtering on `Album` objects:
 This artifact is used by [elasticgraph-graphql](https://github.com/block/elasticgraph/tree/main/elasticgraph-graphql)
 to provide the GraphQL endpoint. In addition, it's a public artifact which can be provided to GraphQL clients.
 
-### Artifact 4: `runtime_metadata.yaml`.
+### Artifact 4: `runtime_metadata.yaml`
 
 The [`runtime_metadata.yaml` artifact]({% link guides/how-it-works/schema-artifacts/runtime_metadata.yaml %}) is the
 final schema artifact. It provides metaadata used by the various parts of ElasticGraph at runtime. For example,


### PR DESCRIPTION
The other headings (for artifacts 1-3) don't have the trailing period, and for consistency, this one shouldn't have it either.