### PR TITLE
Support resolver config parameters when configuring it for use.

### DIFF
--- a/config/site/examples/custom_resolver/lib/roll_dice_resolver.rb
+++ b/config/site/examples/custom_resolver/lib/roll_dice_resolver.rb
@@ -11,13 +11,14 @@
 class RollDiceResolver
   def initialize(elasticgraph_graphql:, config:)
     @number_of_dice = config.fetch(:number_of_dice)
+    @multiplier = config.fetch(:multiplier)
   end
 
   def resolve(field:, object:, args:, context:)
     @number_of_dice
       .times
       .map { rand(args.fetch("sides")) + 1 }
-      .sum
+      .sum * @multiplier
   end
 end
 # :snippet-end:

--- a/config/site/examples/custom_resolver/schema.rb
+++ b/config/site/examples/custom_resolver/schema.rb
@@ -25,7 +25,7 @@ ElasticGraph.define_schema do |schema|
       f.argument "sides", "Int" do |a|
         a.default 6
       end
-      f.resolve_with :roll_dice
+      f.resolve_with :roll_dice, multiplier: 3
     end
   end
   # :snippet-end:

--- a/config/site/examples/custom_resolver/validate.rb
+++ b/config/site/examples/custom_resolver/validate.rb
@@ -16,7 +16,7 @@ query = ::File.read(::File.join(__dir__, "query.graphql"))
 response = graphql.graphql_query_executor.execute(query)
 data = response.fetch("data")
 
-unless (1..12).cover?(data.fetch("roll6SidedDice")) && (1..20).cover?(data.fetch("roll10SidedDice"))
+unless (3..36).cover?(data.fetch("roll6SidedDice")) && (3..60).cover?(data.fetch("roll10SidedDice"))
   raise <<~EOS
     Got an unexpected response:
 

--- a/config/site/src/guides/custom-graphql-resolvers.md
+++ b/config/site/src/guides/custom-graphql-resolvers.md
@@ -50,7 +50,7 @@ which allows you to inspect the child field selections. However, providing it im
 more performant if you omit it from your `resolve` definition.
 
 In this case, our `RollDiceResolver` simulates the rolling of the configured `number_of_dice`, each of which has a number of `sides`
-provided as a query argument.
+provided as a query argument. Finally, it multiplies the dice roll by a configured `multiplier`.
 
 ### Step 2: Register the Resolver
 
@@ -66,7 +66,13 @@ In this case, we've registered the resolver to roll two dice.
 {% include copyable_code_snippet.html language="ruby" data="custom_resolver.snippets.schema_rb.on_root_query_type" %}
 
 Here we've defined a field on `Query` using [`on_root_query_type`](/elasticgraph/api-docs/{{ site.data.doc_versions.latest_version }}/ElasticGraph/SchemaDefinition/API.html#on_root_query_type-instance_method),
-and configured it to use the `:roll_dice` resolver.
+and configured it to use the `:roll_dice` resolver. Extra arguments (`multiplier: 3`, in this case) will be passed to the resolver in `config`.
+
+{: .alert-note}
+**Note**{: .alert-title}
+Resolver config values can be provided both when registering the resolver (via `schema.register_graphql_resolver`)
+and when configuring a field to use the resolver (via `field.resolve_with`). These configuration options will be
+merged together to provide `config` when instantiating the resolver.
 
 ### Step 4: Query the Custom Field
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -183,7 +183,13 @@ module ElasticGraph
     def named_graphql_resolvers
       @named_graphql_resolvers ||= runtime_metadata.graphql_resolvers_by_name.transform_values do |resolver|
         ext = resolver.load_resolver
-        (_ = ext.extension_class).new(elasticgraph_graphql: self, config: ext.config)
+
+        ->(field_config) do
+          (_ = ext.extension_class).new(
+            elasticgraph_graphql: self,
+            config: ext.config.merge(field_config)
+          )
+        end
       end
     end
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql.rbs
@@ -1,5 +1,7 @@
 module ElasticGraph
   class GraphQL
+    type namedGraphQLResolversHash = ::Hash[::Symbol, ^(::Hash[::Symbol, untyped]) -> resolver]
+
     attr_reader config: Config
     attr_reader logger: ::Logger
     attr_reader runtime_metadata: SchemaArtifacts::RuntimeMetadata::Schema
@@ -45,8 +47,8 @@ module ElasticGraph
     @resolver_query_adapter: Resolvers::QueryAdapter?
     def resolver_query_adapter: () -> Resolvers::QueryAdapter
 
-    @named_graphql_resolvers: ::Hash[::Symbol, resolver]?
-    def named_graphql_resolvers: () -> ::Hash[::Symbol, resolver]
+    @named_graphql_resolvers: namedGraphQLResolversHash?
+    def named_graphql_resolvers: () -> namedGraphQLResolversHash
 
     @datastore_query_adapters: ::Array[_QueryAdapter]?
     def datastore_query_adapters: () -> ::Array[_QueryAdapter]

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/graphql_adapter_builder.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/graphql_adapter_builder.rbs
@@ -7,12 +7,12 @@ module ElasticGraph
 
       class GraphQLAdapterBuilder
         @runtime_metadata: SchemaArtifacts::RuntimeMetadata::Schema
-        @named_resolvers: ::Hash[::Symbol, resolver]
+        @resolvers_by_name_and_field_config: ::Hash[::Symbol, ::Hash[::Hash[::Symbol, untyped], resolver]]
         @query_adapter: QueryAdapter
 
         def initialize: (
           runtime_metadata: SchemaArtifacts::RuntimeMetadata::Schema,
-          named_resolvers: ::Hash[::Symbol, resolver],
+          named_resolvers: namedGraphQLResolversHash,
           query_adapter: QueryAdapter
         ) -> void
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
@@ -300,22 +300,29 @@ module ElasticGraph
       # @param defined_at [String] the `require` path of the resolver
       # @param resolver_config [Hash<Symbol, Object>] configuration options for the resolver, to support parameterized resolvers
       # @return [void]
+      # @see Mixins::HasIndices#resolve_fields_with
+      # @see SchemaElements::Field#resolve_with
       #
       # @example Register a custom resolver for use by a custom `Query` field
       #   # In `add_resolver.rb`:
       #   class AddResolver
       #     def initialize(elasticgraph_graphql:, config:)
+      #       @multiplier = config.fetch(:multiplier, 1)
       #     end
       #
       #     def resolve(field:, object:, args:, context:)
-      #       args.fetch("x") + args.fetch("y")
+      #       sum = args.fetch("x") + args.fetch("y")
+      #       sum * @multiplier
       #     end
       #   end
       #
       #   # In `config/schema.rb`:
       #   ElasticGraph.define_schema do |schema|
       #     require(resolver_path = "add_resolver")
-      #     schema.register_graphql_resolver :add, AddResolver, defined_at: resolver_path
+      #     schema.register_graphql_resolver :add,
+      #       AddResolver,
+      #       defined_at: resolver_path,
+      #       multiplier: 2 # extra args are passed to the resolver within `config`.
       #
       #     schema.on_root_query_type do |t|
       #       t.field "add", "Int" do |f|

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
@@ -76,10 +76,12 @@ module ElasticGraph
         # can override this using {SchemaElements::Field#resolve_with}.
         #
         # @param default_resolver_name [Symbol] name of the GraphQL resolver to use as the default for fields of this type
+        # @param config [Hash<Symbol, Object>] configuration parameters for the resolver
         # @return [void]
-        def resolve_fields_with(default_resolver_name)
+        # @see API#register_graphql_resolver
+        def resolve_fields_with(default_resolver_name, **config)
           @default_graphql_resolver = default_resolver_name&.then do
-            SchemaArtifacts::RuntimeMetadata::ConfiguredGraphQLResolver.new(it, {})
+            SchemaArtifacts::RuntimeMetadata::ConfiguredGraphQLResolver.new(it, config)
           end
         end
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
@@ -511,16 +511,20 @@ module ElasticGraph
         # via {Mixins::HasIndices#resolve_fields_with} will be used.
         #
         # @param resolver_name [Symbol] name of the GraphQL resolver
+        # @param config [Hash<Symbol, Object>] configuration parameters for the resolver
         # @return [void]
+        # @see API#register_graphql_resolver
         #
         # @example Use a custom resolver for a custom `Query` field
         #   # In `add_resolver.rb`:
         #   class AddResolver
         #     def initialize(elasticgraph_graphql:, config:)
+        #       @multiplier = config.fetch(:multiplier, 1)
         #     end
         #
         #     def resolve(field:, object:, args:, context:)
-        #       args.fetch("x") + args.fetch("y")
+        #       sum = args.fetch("x") + args.fetch("y")
+        #       sum * @multiplier
         #     end
         #   end
         #
@@ -533,12 +537,14 @@ module ElasticGraph
         #       t.field "add", "Int" do |f|
         #         f.argument "x", "Int!"
         #         f.argument "y", "Int!"
-        #         f.resolve_with :add
+        #
+        #         # Extra args (`multiplier: 2`, in this example) are passed to the resolver within `config`.
+        #         f.resolve_with :add, multiplier: 2
         #       end
         #     end
         #   end
-        def resolve_with(resolver_name)
-          self.resolver = resolver_name&.then { SchemaArtifacts::RuntimeMetadata::ConfiguredGraphQLResolver.new(it, {}) }
+        def resolve_with(resolver_name, **config)
+          self.resolver = resolver_name&.then { SchemaArtifacts::RuntimeMetadata::ConfiguredGraphQLResolver.new(it, config) }
         end
 
         # @private

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/field.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/field.rbs
@@ -78,7 +78,7 @@ module ElasticGraph
         def to_filter_field: (parent_type: anyObjectType, ?for_single_value: bool) -> Field
         def to_sdl: (?type_structure_only: bool, ?default_value_sdl: ::String?) ?{ (argument) -> boolish } -> ::String
         def sourced_from: (::String, ::String) -> void
-        def resolve_with: (::Symbol?) -> void
+        def resolve_with: (::Symbol?, **untyped) -> void
         def paths_to_lists_for_count_indexing: (?has_list_ancestor: bool) -> ::Array[::String]
         def index_leaf?: () -> bool
 


### PR DESCRIPTION
Previously, we supported resolver parameters provided when registering the resolver, but it's quite useful to be able to provide them when configuring a type or field to use a resolver. This allows resolver params to be provided in all 3 spots.