### PR TITLE
Avoid requesting non-existent subfields of a scalar field.

### DIFF
--- a/elasticgraph-graphql/sig/elastic_graph/graphql/query_adapter/requested_fields.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/query_adapter/requested_fields.rbs
@@ -19,11 +19,13 @@ module ElasticGraph
 
         def requested_fields_under: (
           ::GraphQL::Execution::Lookahead,
+          ::Set[::String],
           ?path_prefix: ::String
         ) -> ::Array[::String]
 
         def requested_fields_for: (
           ::GraphQL::Execution::Lookahead,
+          ::Set[::String],
           path_prefix: ::String
         ) -> ::Array[::String]
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/requested_fields_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/requested_fields_spec.rb
@@ -96,7 +96,13 @@ module ElasticGraph
               t.field "last_name", "String"
               t.relates_to_one "widget", "Widget", via: "component_ids", dir: :in
               t.relates_to_many "parts", "Part", via: "part_ids", dir: :out, singular: "part"
+              t.field "owner_id", "ID", indexing_only: true
+              t.field "owner", "ComponentOwner", name_in_index: "owner_id", graphql_only: true
               t.index "components"
+            end
+
+            schema.object_type "ComponentOwner" do |t|
+              t.field "id", "ID"
             end
           end
         end
@@ -187,6 +193,25 @@ module ElasticGraph
           QUERY
 
           expect(query.requested_fields).to contain_exactly("id", "name", "options.size")
+          expect(query.individual_docs_needed).to be true
+          expect(query.total_document_count_needed).to be false
+          expect(query.requested_highlights).to be_empty
+          expect(query.request_all_highlights).to be false
+        end
+
+        it "aligns the requested fields with the index structure even when it differs from the GraphQL structure" do
+          query = datastore_query_for(:Query, :components, <<~QUERY)
+            query {
+              components {
+                nodes {
+                  id
+                  owner { id }
+                }
+              }
+            }
+          QUERY
+
+          expect(query.requested_fields).to contain_exactly("id", "owner_id")
           expect(query.individual_docs_needed).to be true
           expect(query.total_document_count_needed).to be false
           expect(query.requested_highlights).to be_empty


### PR DESCRIPTION
For a custom GraphQL resolver it can be useful to define an object field that has a `name_in_index` of a scalar field. When a client requests subfields of the object field, we want to request the scalar field from the datastore. Previously, we requested non-existent subfields.

For example, given these two fields:

```
t.field "owner_id", "ID", indexing_only: true
t.field "owner", "ComponentOwner", name_in_index: "owner_id", graphql_only: true
```

...when a client requests `owner { id }`, we want to request `owner_id` from the datastore rather than `owner_id.id` (which does not exist, and is what ElasticGraph did before this fix).