### PR TITLE
Improve handling of `name_in_index` on a `graphql_only` field.

### DIFF
--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -4076,6 +4076,9 @@ object_types_by_name:
         resolver: get_record_field_value
       options:
         resolver: get_record_field_value
+      size:
+        name_in_index: options.size
+        resolver: get_record_field_value
       tags:
         resolver: get_record_field_value
       the_options:
@@ -5911,6 +5914,9 @@ object_types_by_name:
         resolver: get_record_field_value
       options:
         resolver: get_record_field_value
+      size:
+        name_in_index: options.size
+        resolver: get_record_field_value
       tags:
         resolver: get_record_field_value
       the_options:
@@ -6310,6 +6316,9 @@ object_types_by_name:
       named_inventor:
         resolver: get_record_field_value
       options:
+        resolver: get_record_field_value
+      size:
+        name_in_index: options.size
         resolver: get_record_field_value
       tags:
         resolver: get_record_field_value

--- a/config/schema/artifacts/schema.graphql
+++ b/config/schema/artifacts/schema.graphql
@@ -6245,6 +6245,11 @@ type NamedEntityHighlights {
   options: WidgetOptionsHighlights
 
   """
+  Search highlights for the `size`, providing snippets of the matching text.
+  """
+  size: [String!]!
+
+  """
   Search highlights for the `tags`, providing snippets of the matching text.
   """
   tags: [String!]!
@@ -14097,6 +14102,11 @@ type WidgetHighlights {
   options: WidgetOptionsHighlights
 
   """
+  Search highlights for the `size`, providing snippets of the matching text.
+  """
+  size: [String!]!
+
+  """
   Search highlights for the `tags`, providing snippets of the matching text.
   """
   tags: [String!]!
@@ -15152,6 +15162,11 @@ type WidgetOrAddressHighlights {
   Search highlights for the `options`, providing snippets of the matching text.
   """
   options: WidgetOptionsHighlights
+
+  """
+  Search highlights for the `size`, providing snippets of the matching text.
+  """
+  size: [String!]!
 
   """
   Search highlights for the `tags`, providing snippets of the matching text.

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -4108,6 +4108,9 @@ object_types_by_name:
         resolver: get_record_field_value
       options:
         resolver: get_record_field_value
+      size:
+        name_in_index: options.size
+        resolver: get_record_field_value
       tags:
         resolver: get_record_field_value
       the_options:
@@ -5947,6 +5950,9 @@ object_types_by_name:
         resolver: get_record_field_value
       options:
         resolver: get_record_field_value
+      size:
+        name_in_index: options.size
+        resolver: get_record_field_value
       tags:
         resolver: get_record_field_value
       the_options:
@@ -6346,6 +6352,9 @@ object_types_by_name:
       named_inventor:
         resolver: get_record_field_value
       options:
+        resolver: get_record_field_value
+      size:
+        name_in_index: options.size
         resolver: get_record_field_value
       tags:
         resolver: get_record_field_value

--- a/config/schema/artifacts_with_apollo/schema.graphql
+++ b/config/schema/artifacts_with_apollo/schema.graphql
@@ -6434,6 +6434,11 @@ type NamedEntityHighlights {
   options: WidgetOptionsHighlights
 
   """
+  Search highlights for the `size`, providing snippets of the matching text.
+  """
+  size: [String!]!
+
+  """
   Search highlights for the `tags`, providing snippets of the matching text.
   """
   tags: [String!]!
@@ -14327,6 +14332,11 @@ type WidgetHighlights {
   options: WidgetOptionsHighlights
 
   """
+  Search highlights for the `size`, providing snippets of the matching text.
+  """
+  size: [String!]!
+
+  """
   Search highlights for the `tags`, providing snippets of the matching text.
   """
   tags: [String!]!
@@ -15382,6 +15392,11 @@ type WidgetOrAddressHighlights {
   Search highlights for the `options`, providing snippets of the matching text.
   """
   options: WidgetOptionsHighlights
+
+  """
+  Search highlights for the `size`, providing snippets of the matching text.
+  """
+  size: [String!]!
 
   """
   Search highlights for the `tags`, providing snippets of the matching text.

--- a/elasticgraph-graphql/spec/acceptance/search_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/search_spec.rb
@@ -1270,6 +1270,22 @@ module ElasticGraph
           }
         })
 
+        # Demonstrate highlighting on a `graphql_only` field with a `name_in_index` of a child field
+        highlights_by_id = query_highlights("widgets", "size", filter: {
+          "size" => {"equal_to_any_of" => [enum_value(:SMALL), enum_value(:MEDIUM)]}
+        })
+        expect(highlights_by_id).to eq({
+          widget1.fetch(:id) => {
+            case_correctly("size") => ["<em>#{enum_value(:SMALL)}</em>"]
+          },
+          widget2.fetch(:id) => {
+            case_correctly("size") => ["<em>#{enum_value(:SMALL)}</em>"]
+          },
+          widget3.fetch(:id) => {
+            case_correctly("size") => ["<em>#{enum_value(:MEDIUM)}</em>"]
+          }
+        })
+
         # Demonstrate we can get *just* the highlights and no other fields off of the `edges`.
         # (Initially this did not work.)
         highlights = query_just_all_highlights("widgets", filter: {

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
@@ -141,8 +141,20 @@ module ElasticGraph
             resolver: resolver
           )
 
-          if name != name_in_index && name_in_index.include?(".") && !graphql_only
-            raise Errors::SchemaError, "#{self} has an invalid `name_in_index`: #{name_in_index.inspect}. Only `graphql_only: true` fields can have a `name_in_index` that references a child field."
+          if name != name_in_index
+            if graphql_only
+              schema_def_state.after_user_definition_complete do
+                unless backing_indexing_field
+                  raise Errors::SchemaError,
+                    "GraphQL-only field `#{parent_type.name}.#{name}` has a `name_in_index` (#{name_in_index}) which does not reference an " \
+                    "existing indexing field. To proceed, remove `graphql_only: true` or update `name_in_index` to match an existing indexing field."
+                end
+              end
+            elsif name_in_index.include?(".")
+              raise Errors::SchemaError,
+                "#{self} has an invalid `name_in_index`: #{name_in_index.inspect}. " \
+                "Only `graphql_only: true` fields can have a `name_in_index` that references a child field."
+            end
           end
 
           schema_def_state.register_user_defined_field(self)
@@ -1009,7 +1021,19 @@ module ElasticGraph
 
         def backing_indexing_field
           return nil unless graphql_only
-          parent_type.indexing_fields_by_name_in_index[name_in_index]
+
+          type = parent_type
+          field = nil
+
+          name_in_index.split(".").each do |path_part|
+            if (field = type&.indexing_fields_by_name_in_index&.fetch(path_part, nil))
+              type = field.type.fully_unwrapped.as_object_type
+            else
+              return nil
+            end
+          end
+
+          field
         end
 
         def args_sdl(joiner:, after_opening_paren: "", &arg_selector)

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/graphql_fields_by_name_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/graphql_fields_by_name_spec.rb
@@ -128,6 +128,64 @@ module ElasticGraph
           expect(metadata.fetch("WidgetFilterInput").graphql_fields_by_name.fetch("names").name_in_index).to eq("names2")
           expect(metadata.fetch("WidgetHighlights").graphql_fields_by_name.fetch("names").name_in_index).to eq("names2")
         end
+
+        it "allows a `graphql_only` field to reference a child field" do
+          metadata = object_type_metadata_for "Widget" do |s|
+            s.object_type "Options" do |t|
+              t.field "size", "String!"
+            end
+
+            s.object_type "Widget" do |t|
+              t.field "id", "ID!"
+              t.field "size", "String!", name_in_index: "options.size", graphql_only: true
+              t.field "options", "Options!"
+              t.index "widgets"
+            end
+          end
+
+          expect(metadata.graphql_fields_by_name.fetch("size").name_in_index).to eq("options.size")
+        end
+
+        it "raises an error when given a `name_in_index` on a `graphql_only` field which does not match an existing sibling indexing field" do
+          define_widget = lambda do |schema, &block|
+            schema.object_type "Widget" do |t|
+              t.field "id", "ID"
+              t.field "description", "String", name_in_index: "description_index", graphql_only: true
+              block&.call(t)
+              t.index "widgets"
+            end
+          end
+
+          expect {
+            object_type_metadata_for("Widget", &define_widget)
+          }.to raise_error Errors::SchemaError, a_string_including(
+            "GraphQL-only field `Widget.description` has a `name_in_index` (description_index) " \
+            "which does not reference an existing indexing field."
+          )
+
+          metadata = object_type_metadata_for("Widget") do |schema|
+            define_widget.call(schema) do |t|
+              t.field "description_index", "String", indexing_only: true
+            end
+          end
+
+          expect(metadata.graphql_fields_by_name.fetch("description").name_in_index).to eq("description_index")
+        end
+
+        it "raises an error when given a nested `name_in_index` on a `graphql_only` field when a parent part does not reference an object field" do
+          expect {
+            object_type_metadata_for "Widget" do |schema|
+              schema.object_type "Widget" do |t|
+                t.field "id", "ID"
+                t.field "color", "String", name_in_index: "id.color", graphql_only: true
+                t.index "widgets"
+              end
+            end
+          }.to raise_error Errors::SchemaError, a_string_including(
+            "GraphQL-only field `Widget.color` has a `name_in_index` (id.color) " \
+            "which does not reference an existing indexing field."
+          )
+        end
       end
 
       context "on an embedded object type" do


### PR DESCRIPTION
- Validate that an existing indexing field exists at the provided `name_in_index` since we don't define an indexing field for a `graphql_only` field and the referenced field must already exist.
- Fix `backing_indexing_field` to correctly handle nested field paths. This allows us to support `graphql_only` fields with a nested `name_in_index` field path under `highlights`.