### PR TITLE
Fix pagination bugs on `paginated_collection_field` fields.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/array_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/array_adapter.rb
@@ -15,9 +15,9 @@ module ElasticGraph
       module RelayConnection
         # Relay connection adapter for an array. Implemented primarily by `GraphQL::Relay::ArrayConnection`;
         # here we just adapt it to the ElasticGraph internal resolver interface.
-        class ArrayAdapter < ResolvableValue.new(:graphql_impl)
+        class ArrayAdapter < ResolvableValue.new(:graphql_impl, :total_edge_count)
           # `ResolvableValue.new` provides the following methods:
-          # @dynamic initialize, graphql_impl, schema
+          # @dynamic initialize, graphql_impl, total_edge_count, schema
 
           # `def_delegators` provides the following methods:
           # @dynamic start_cursor, end_cursor, has_next_page, has_previous_page
@@ -27,21 +27,23 @@ module ElasticGraph
           def self.build(nodes, args, context)
             schema = context.fetch(:elastic_graph_schema)
             schema_element_names = schema.element_names
+            nodes ||= [] # : ::Array[untyped]
 
             # ElasticGraph supports any schema elements (like a `first` argument) being renamed,
             # but `GraphQL::Relay::ArrayConnection` would not understand a renamed argument.
             # Here we map the args back to the canonical relay args so `ArrayConnection` can
             # understand them.
-            relay_args = [:first, :after, :last, :before].to_h do |arg_name|
-              [arg_name, args[schema_element_names.public_send(arg_name)]]
-            end.compact
+            #
+            # `after` and `before` are encoded to convert them to the string form required by `ArrayConnection`.
+            relay_args = {
+              first: args[schema_element_names.first],
+              after: args[schema_element_names.after]&.encode,
+              last: args[schema_element_names.last],
+              before: args[schema_element_names.before]&.encode
+            }.compact
 
-            graphql_impl = ::GraphQL::Pagination::ArrayConnection.new(nodes || [], context: context, **relay_args)
-            new(schema, graphql_impl)
-          end
-
-          def total_edge_count
-            graphql_impl.nodes.size
+            graphql_impl = ::GraphQL::Pagination::ArrayConnection.new(nodes, context: context, **relay_args)
+            new(schema, graphql_impl, nodes.size)
           end
 
           def page_info

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/relay_connection/array_adapter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/relay_connection/array_adapter.rbs
@@ -9,7 +9,7 @@ module ElasticGraph
           attr_reader schema: Schema
           attr_reader graphql_impl: ::GraphQL::Pagination::ArrayConnection[N]
 
-          def initialize: (Schema, ::GraphQL::Pagination::ArrayConnection[N]) -> void
+          def initialize: (Schema, ::GraphQL::Pagination::ArrayConnection[N], ::Integer) -> void
 
           def self.build: [N] (::Array[N], ::Hash[::String, untyped], ::GraphQL::Query::Context) -> ArrayAdapter[N]
 


### PR DESCRIPTION
- Fix `total_edge_count` so it returns the count of the entire collection, rather than just the number of nodes on the current page.
- Fix handling of `before`/`after` args, converting them to the form required by the GraphQL gem. Previously, a `NoMethodError` was thrown because the GraphQL gem expects `String` arguments but we were providing `DecodedCursor` objects.