### PR TITLE
Provide `apollo_entity_ref_field` to expose an id field as an entity ref.

### DIFF
--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -1543,6 +1543,10 @@ indices:
               type: integer
         part_ids:
           type: keyword
+        owner_ids:
+          type: keyword
+        owner_id:
+          type: keyword
         __counts:
           properties:
             tags:
@@ -1550,6 +1554,8 @@ indices:
             widget_tags:
               type: integer
             part_ids:
+              type: integer
+            owner_ids:
               type: integer
         __sources:
           type: keyword

--- a/config/schema/artifacts/json_schemas.yaml
+++ b/config/schema/artifacts/json_schemas.yaml
@@ -212,6 +212,18 @@ json_schema_version: 1
           allOf:
           - "$ref": "#/$defs/ID"
           - maxLength: 8191
+      owner_ids:
+        type: array
+        items:
+          allOf:
+          - "$ref": "#/$defs/ID"
+          - maxLength: 8191
+      owner_id:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/ID"
+          - maxLength: 8191
+        - type: 'null'
       __typename:
         type: string
         const: Component
@@ -223,6 +235,8 @@ json_schema_version: 1
     - position
     - tags
     - part_ids
+    - owner_ids
+    - owner_id
   Date:
     type: string
     format: date

--- a/config/schema/artifacts/json_schemas_by_version/v1.yaml
+++ b/config/schema/artifacts/json_schemas_by_version/v1.yaml
@@ -263,6 +263,24 @@ json_schema_version: 1
         ElasticGraph:
           type: "[ID!]!"
           nameInIndex: part_ids
+      owner_ids:
+        type: array
+        items:
+          allOf:
+          - "$ref": "#/$defs/ID"
+          - maxLength: 8191
+        ElasticGraph:
+          type: "[ID!]!"
+          nameInIndex: owner_ids
+      owner_id:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/ID"
+          - maxLength: 8191
+        - type: 'null'
+        ElasticGraph:
+          type: ID
+          nameInIndex: owner_id
       __typename:
         type: string
         const: Component
@@ -274,6 +292,8 @@ json_schema_version: 1
     - position
     - tags
     - part_ids
+    - owner_ids
+    - owner_id
   Date:
     type: string
     format: date

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -1461,6 +1461,8 @@ index_definitions_by_name:
     - direction: desc
       field_path: created_at
     fields_by_path:
+      __counts.owner_ids:
+        source: __self
       __counts.part_ids:
         source: __self
       __counts.tags:
@@ -1472,6 +1474,10 @@ index_definitions_by_name:
       id:
         source: __self
       name:
+        source: __self
+      owner_id:
+        source: __self
+      owner_ids:
         source: __self
       part_ids:
         source: __self
@@ -2896,6 +2902,10 @@ object_types_by_name:
         created_at:
           cardinality: one
         name:
+          cardinality: one
+        owner_id:
+          cardinality: one
+        owner_ids:
           cardinality: one
         part_ids:
           cardinality: one

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -1543,6 +1543,10 @@ indices:
               type: integer
         part_ids:
           type: keyword
+        owner_ids:
+          type: keyword
+        owner_id:
+          type: keyword
         __counts:
           properties:
             tags:
@@ -1550,6 +1554,8 @@ indices:
             widget_tags:
               type: integer
             part_ids:
+              type: integer
+            owner_ids:
               type: integer
         __sources:
           type: keyword

--- a/config/schema/artifacts_with_apollo/json_schemas.yaml
+++ b/config/schema/artifacts_with_apollo/json_schemas.yaml
@@ -212,6 +212,18 @@ json_schema_version: 1
           allOf:
           - "$ref": "#/$defs/ID"
           - maxLength: 8191
+      owner_ids:
+        type: array
+        items:
+          allOf:
+          - "$ref": "#/$defs/ID"
+          - maxLength: 8191
+      owner_id:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/ID"
+          - maxLength: 8191
+        - type: 'null'
       __typename:
         type: string
         const: Component
@@ -223,6 +235,8 @@ json_schema_version: 1
     - position
     - tags
     - part_ids
+    - owner_ids
+    - owner_id
   Date:
     type: string
     format: date

--- a/config/schema/artifacts_with_apollo/json_schemas_by_version/v1.yaml
+++ b/config/schema/artifacts_with_apollo/json_schemas_by_version/v1.yaml
@@ -263,6 +263,24 @@ json_schema_version: 1
         ElasticGraph:
           type: "[ID!]!"
           nameInIndex: part_ids
+      owner_ids:
+        type: array
+        items:
+          allOf:
+          - "$ref": "#/$defs/ID"
+          - maxLength: 8191
+        ElasticGraph:
+          type: "[ID!]!"
+          nameInIndex: owner_ids
+      owner_id:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/ID"
+          - maxLength: 8191
+        - type: 'null'
+        ElasticGraph:
+          type: ID
+          nameInIndex: owner_id
       __typename:
         type: string
         const: Component
@@ -274,6 +292,8 @@ json_schema_version: 1
     - position
     - tags
     - part_ids
+    - owner_ids
+    - owner_id
   Date:
     type: string
     format: date

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -1406,6 +1406,21 @@ graphql_resolvers_by_name:
     resolver_ref:
       name: ElasticGraph::Apollo::GraphQL::EntitiesFieldResolver
       require_path: elastic_graph/apollo/graphql/entities_field_resolver
+  apollo_entity_ref:
+    needs_lookahead: false
+    resolver_ref:
+      name: ElasticGraph::Apollo::GraphQL::ApolloEntityRefResolver::ForSingleId
+      require_path: elastic_graph/apollo/graphql/apollo_entity_ref_resolver
+  apollo_entity_ref_list:
+    needs_lookahead: false
+    resolver_ref:
+      name: ElasticGraph::Apollo::GraphQL::ApolloEntityRefResolver::ForIdList
+      require_path: elastic_graph/apollo/graphql/apollo_entity_ref_resolver
+  apollo_entity_ref_paginated:
+    needs_lookahead: false
+    resolver_ref:
+      name: ElasticGraph::Apollo::GraphQL::ApolloEntityRefResolver::ForPaginatedList
+      require_path: elastic_graph/apollo/graphql/apollo_entity_ref_resolver
   apollo_service:
     needs_lookahead: false
     resolver_ref:
@@ -1475,6 +1490,8 @@ index_definitions_by_name:
     - direction: desc
       field_path: created_at
     fields_by_path:
+      __counts.owner_ids:
+        source: __self
       __counts.part_ids:
         source: __self
       __counts.tags:
@@ -1486,6 +1503,10 @@ index_definitions_by_name:
       id:
         source: __self
       name:
+        source: __self
+      owner_id:
+        source: __self
+      owner_ids:
         source: __self
       part_ids:
         source: __self
@@ -2851,6 +2872,27 @@ object_types_by_name:
       name:
         resolver:
           name: get_record_field_value
+      owner:
+        name_in_index: owner_id
+        resolver:
+          config:
+            source_id_field: owner_id
+            exposed_id_field: token
+          name: apollo_entity_ref
+      owners:
+        name_in_index: owner_ids
+        resolver:
+          config:
+            source_ids_field: owner_ids
+            exposed_id_field: token
+          name: apollo_entity_ref_list
+      owners_paginated:
+        name_in_index: owner_ids
+        resolver:
+          config:
+            source_ids_field: owner_ids
+            exposed_id_field: token
+          name: apollo_entity_ref_paginated
       part_aggregations:
         relation:
           direction: out
@@ -2910,6 +2952,10 @@ object_types_by_name:
         created_at:
           cardinality: one
         name:
+          cardinality: one
+        owner_id:
+          cardinality: one
+        owner_ids:
           cardinality: one
         part_ids:
           cardinality: one
@@ -3085,6 +3131,35 @@ object_types_by_name:
         name_in_index: widget_workspace_id3
         resolver:
           name: get_record_field_value
+  ComponentOwner:
+    graphql_fields_by_name:
+      token:
+        resolver:
+          name: get_record_field_value
+  ComponentOwnerConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+      total_edge_count:
+        resolver:
+          name: object_without_lookahead
+  ComponentOwnerEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
   Country:
     graphql_fields_by_name:
       currency:
@@ -4090,6 +4165,27 @@ object_types_by_name:
       options:
         resolver:
           name: get_record_field_value
+      owner:
+        name_in_index: owner_id
+        resolver:
+          config:
+            source_id_field: owner_id
+            exposed_id_field: token
+          name: apollo_entity_ref
+      owners:
+        name_in_index: owner_ids
+        resolver:
+          config:
+            source_ids_field: owner_ids
+            exposed_id_field: token
+          name: apollo_entity_ref_list
+      owners_paginated:
+        name_in_index: owner_ids
+        resolver:
+          config:
+            source_ids_field: owner_ids
+            exposed_id_field: token
+          name: apollo_entity_ref_paginated
       part_aggregations:
         relation:
           direction: out

--- a/config/schema/artifacts_with_apollo/schema.graphql
+++ b/config/schema/artifacts_with_apollo/schema.graphql
@@ -857,6 +857,47 @@ type Component implements NamedEntity @key(fields: "id") {
   dollar_widget: Widget
   id: ID!
   name: String
+  owner: ComponentOwner
+  owners: [ComponentOwner!]!
+  owners_paginated(
+    """
+    Used to forward-paginate through the `owners_paginated`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `owners_paginated`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `owners_paginated`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `owners_paginated`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `owners_paginated`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `owners_paginated`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+  ): ComponentOwnerConnection
 
   """
   Aggregations over the `parts` data.
@@ -1426,6 +1467,58 @@ type ComponentHighlights {
   Search highlights for the `widget_workspace_id`, providing snippets of the matching text.
   """
   widget_workspace_id: [String!]!
+}
+
+type ComponentOwner @key(fields: "token", resolvable: false) {
+  token: ID
+}
+
+"""
+Represents a paginated collection of `ComponentOwner` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type ComponentOwnerConnection {
+  """
+  Wraps a specific `ComponentOwner` to pair it with its pagination cursor.
+  """
+  edges: [ComponentOwnerEdge!]!
+
+  """
+  The list of `ComponentOwner` results.
+  """
+  nodes: [ComponentOwner!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+
+  """
+  The total number of edges available in this connection to paginate over.
+  """
+  total_edge_count: JsonSafeLong!
+}
+
+"""
+Represents a specific `ComponentOwner` in the context of a `ComponentOwnerConnection`,
+providing access to both the `ComponentOwner` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type ComponentOwnerEdge {
+  """
+  The `Cursor` of this `ComponentOwner`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `ComponentOwner`.
+  """
+  cursor: Cursor
+
+  """
+  The `ComponentOwner` of this edge.
+  """
+  node: ComponentOwner
 }
 
 """

--- a/config/schema/widgets.rb
+++ b/config/schema/widgets.rb
@@ -256,6 +256,23 @@ ElasticGraph.define_schema do |schema|
     t.relates_to_many "widgets", "Widget", via: "component_ids", dir: :in, singular: "widget"
     t.relates_to_many "parts", "Part", via: "part_ids", dir: :out, singular: "part"
 
+    t.field "owner_ids", "[ID!]!", indexing_only: true
+    t.field "owner_id", "ID", indexing_only: true
+
+    # Define some Apollo-specific schema elements when we are defining the schema for Apollo.
+    if schema.respond_to?(:target_apollo_federation_version)
+      # :nocov: -- this file is only exercised in a test running without `elasticgraph-apollo`.
+      t.apollo_entity_ref_field "owner", "ComponentOwner", id_field_name_in_index: "owner_id"
+      t.apollo_entity_ref_field "owners", "[ComponentOwner!]!", id_field_name_in_index: "owner_ids"
+      t.apollo_entity_ref_paginated_collection_field "owners_paginated", "ComponentOwner", id_field_name_in_index: "owner_ids"
+
+      schema.object_type "ComponentOwner" do |t|
+        t.field "token", "ID"
+        t.apollo_key fields: "token", resolvable: false
+      end
+      # :nocov:
+    end
+
     t.index "components" do |i|
       i.default_sort "created_at", :desc
     end

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/apollo_entity_ref_resolver.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/apollo_entity_ref_resolver.rb
@@ -1,0 +1,66 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/graphql/resolvers/relay_connection/array_adapter"
+
+module ElasticGraph
+  module Apollo
+    module GraphQL
+      # Namespace for resolvers which provide Apollo entity references from ids.
+      #
+      # @private
+      module ApolloEntityRefResolver
+        # GraphQL resolver for fields defined with `apollo_entity_ref_field` that are backed by a single id.
+        #
+        # @private
+        class ForSingleId
+          def initialize(elasticgraph_graphql:, config:)
+            @source_id_field = config.fetch(:source_id_field)
+            @exposed_id_field = config.fetch(:exposed_id_field)
+          end
+
+          def resolve(field:, object:, args:, context:)
+            if (id = object.fetch(@source_id_field))
+              {@exposed_id_field => id}
+            end
+          end
+        end
+
+        # GraphQL resolver for fields defined with `apollo_entity_ref_field` that are backed by an list of ids.
+        #
+        # @private
+        class ForIdList
+          def initialize(elasticgraph_graphql:, config:)
+            @source_ids_field = config.fetch(:source_ids_field)
+            @exposed_id_field = config.fetch(:exposed_id_field)
+          end
+
+          def resolve(field:, object:, args:, context:)
+            object
+              .fetch(@source_ids_field)
+              .map { |id| {@exposed_id_field => id} }
+          end
+        end
+
+        # GraphQL resolver for paginated fields defined with `apollo_entity_ref_paginated_collection_field`.
+        #
+        # @private
+        class ForPaginatedList
+          def initialize(elasticgraph_graphql:, config:)
+            @for_id_list = ForIdList.new(elasticgraph_graphql:, config:)
+          end
+
+          def resolve(field:, object:, args:, context:)
+            array = @for_id_list.resolve(field:, object:, args:, context:)
+            ::ElasticGraph::GraphQL::Resolvers::RelayConnection::ArrayAdapter.build(array, args, context)
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/api_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/api_extension.rb
@@ -8,7 +8,6 @@
 
 require "elastic_graph/errors"
 require "elastic_graph/version"
-require "elastic_graph/apollo/graphql/engine_extension"
 require "elastic_graph/apollo/schema_definition/entity_type_extension"
 require "elastic_graph/apollo/schema_definition/factory_extension"
 require "elastic_graph/apollo/schema_definition/state_extension"
@@ -125,7 +124,6 @@ module ElasticGraph
             end
           end
 
-          api.register_graphql_extension GraphQL::EngineExtension, defined_at: "elastic_graph/apollo/graphql/engine_extension"
           api.state.after_user_definition_complete do
             api.send(:define_apollo_schema_elements)
           end
@@ -380,11 +378,19 @@ module ElasticGraph
             end
           end
 
+          require(require_path = "elastic_graph/apollo/graphql/engine_extension")
+          register_graphql_extension GraphQL::EngineExtension, defined_at: require_path
+
           require(require_path = "elastic_graph/apollo/graphql/entities_field_resolver")
           register_graphql_resolver :apollo_entities, GraphQL::EntitiesFieldResolver, defined_at: require_path
 
           require(require_path = "elastic_graph/apollo/graphql/service_field_resolver")
           register_graphql_resolver :apollo_service, GraphQL::ServiceFieldResolver, defined_at: require_path
+
+          require(require_path = "elastic_graph/apollo/graphql/apollo_entity_ref_resolver")
+          register_graphql_resolver :apollo_entity_ref, GraphQL::ApolloEntityRefResolver::ForSingleId, defined_at: require_path
+          register_graphql_resolver :apollo_entity_ref_list, GraphQL::ApolloEntityRefResolver::ForIdList, defined_at: require_path
+          register_graphql_resolver :apollo_entity_ref_paginated, GraphQL::ApolloEntityRefResolver::ForPaginatedList, defined_at: require_path
         end
 
         def apollo_object_type(name, &block)

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/interface_type_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/interface_type_extension.rb
@@ -7,6 +7,7 @@
 # frozen_string_literal: true
 
 require "elastic_graph/apollo/schema_definition/apollo_directives"
+require "elastic_graph/apollo/schema_definition/object_and_interface_extension"
 
 module ElasticGraph
   module Apollo
@@ -20,6 +21,7 @@ module ElasticGraph
         include ApolloDirectives::Policy
         include ApolloDirectives::RequiresScopes
         include ApolloDirectives::Tag
+        include ObjectAndInterfaceExtension
       end
     end
   end

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/object_and_interface_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/object_and_interface_extension.rb
@@ -1,0 +1,219 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/apollo/schema_definition/apollo_directives"
+
+module ElasticGraph
+  module Apollo
+    module SchemaDefinition
+      # Extends {ElasticGraph::SchemaDefinition::SchemaElements::ObjectType} and
+      # {ElasticGraph::SchemaDefinition::SchemaElements::InterfaceType} to offer some Apollo-specific APIs.
+      module ObjectAndInterfaceExtension
+        # Exposes an Apollo entity reference as a new field, backed by an `ID` field.
+        #
+        # When integrating an ElasticGraph project as a subgraph into a larger Apollo supergraph, it's useful to be able
+        # to reference entities owned by other subgraphs. The most straightforward way to do this is to define an
+        # _entity reference_ type (e.g. a type containing just the `@key` fields such as `id: ID` and marked as
+        # `resolvable: false` in the `@key` directive), and then define fields using that type. This approach works
+        # particularly well when you plan ahead and know which `ID` fields to model with entity reference types.
+        #
+        # However, on an existing schema where you've got some raw `ID` fields of external entities, it can be quite
+        # difficult to replace the `ID` fields with full-blown entity reference types, as doing so would require migrating
+        # clients and running a full backfill.
+        #
+        # This API provides an alternate solution for this situation: it defines a GraphQL-only field which returns an entity
+        # reference type using a custom GraphQL resolver.
+        #
+        # See the [Apollo docs on referencing an entity without contributing
+        # fields](https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/entities/contribute-fields#referencing-an-entity-without-contributing-fields)
+        # for more information.
+        #
+        # @param name [String] Name of the field
+        # @param type [String] Name of the entity reference type (which must be defined separately)
+        # @param id_field_name_in_index [String] Name of the backing ID field in the datastore index
+        # @return [void]
+        # @note This can be used for either a singleton or list reference, based on if `type` is a list.
+        # @note The resulting field will be only be available for clients to request as a return field. It will not support filtering,
+        #   sorting, grouping, aggregated values, or highlights.
+        # @see #apollo_entity_ref_paginated_collection_field
+        #
+        # @example Expose `Review.product` and `Review.comments` entity reference fields
+        #   ElasticGraph.define_schema do |schema|
+        #     schema.object_type "Product" do |t|
+        #       t.field "id", "ID"
+        #       t.apollo_key fields: "id", resolvable: false
+        #     end
+        #
+        #     schema.object_type "Comment" do |t|
+        #       t.field "id", "ID"
+        #       t.apollo_key fields: "id", resolvable: false
+        #     end
+        #
+        #     schema.object_type "Review" do |t|
+        #       t.field "id", "ID"
+        #       t.field "score", "Int"
+        #
+        #       # Fields originally defined in the first version of the schema
+        #       t.field "productId", "ID"
+        #       t.field "commentIds", "[ID!]!"
+        #
+        #       # New field we're adding to expose the existing `productId` field as a `Product` entity reference.
+        #       t.apollo_entity_ref_field "product", "Product", id_field_name_in_index: "productId"
+        #
+        #       # New field we're adding to expose the existing `commentIds` field as a list of `Comment` entity references.
+        #       t.apollo_entity_ref_field "comments", "[Comment!]!", id_field_name_in_index: "commentIds"
+        #
+        #       t.index "reviews"
+        #     end
+        #   end
+        def apollo_entity_ref_field(name, type, id_field_name_in_index:)
+          field(
+            name,
+            type,
+            name_in_index: id_field_name_in_index,
+            **LIMITED_GRAPHQL_ONLY_FIELD_OPTIONS
+          ) do |f|
+            validate_entity_ref_options(__method__.to_s, f, id_field_name_in_index, type) do |exposed_id_field|
+              if f.type.list?
+                f.resolve_with :apollo_entity_ref_list, source_ids_field: id_field_name_in_index, exposed_id_field: exposed_id_field
+              else
+                f.resolve_with :apollo_entity_ref, source_id_field: id_field_name_in_index, exposed_id_field: exposed_id_field
+              end
+            end
+
+            yield f if block_given?
+          end
+        end
+
+        # Exposes a collection of Apollo entity references as a new paginated field, backed by an `ID` field.
+        #
+        # When integrating an ElasticGraph project as a subgraph into a larger Apollo supergraph, it's useful to be able
+        # to reference entities owned by other subgraphs. The most straightforward way to do this is to define an
+        # _entity reference_ type (e.g. a type containing just the `@key` fields such as `id: ID` and marked as
+        # `resolvable: false` in the `@key` directive), and then define fields using that type. This approach works
+        # particularly well when you plan ahead and know which `ID` fields to model with entity reference types.
+        #
+        # However, on an existing schema where you've got some raw `ID` fields of external entities, it can be quite
+        # difficult to replace the `ID` fields with full-blown entity reference types, as doing so would require migrating
+        # clients and running a full backfill.
+        #
+        # This API provides an alternate solution for this situation: it defines a GraphQL-only field which returns an entity
+        # reference type using a custom GraphQL resolver. In contrast to {#apollo_entity_ref_field}, this defines a field as
+        # a [paginated Relay connection](https://relay.dev/graphql/connections.htm) rather than a simple list.
+        #
+        # See the [Apollo docs on referencing an entity without contributing
+        # fields](https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/entities/contribute-fields#referencing-an-entity-without-contributing-fields)
+        # for more information.
+        #
+        # @param name [String] Name of the field
+        # @param element_type [String] Name of the entity reference type (which must be defined separately)
+        # @param id_field_name_in_index [String] Name of the backing ID field in the datastore index
+        # @return [void]
+        # @note This requires `id_field_name_in_index` to be a list or paginated collection field.
+        # @note The resulting field will be only be available for clients to request as a return field. It will not support filtering,
+        #   sorting, grouping, aggregated values, or highlights.
+        # @see #apollo_entity_ref_field
+        # @see ElasticGraph::SchemaDefinition::SchemaElements::TypeWithSubfields#paginated_collection_field
+        #
+        # @example Expose `Review.product` and `Review.comments` entity reference fields
+        #   ElasticGraph.define_schema do |schema|
+        #     schema.object_type "Comment" do |t|
+        #       t.field "id", "ID"
+        #       t.apollo_key fields: "id", resolvable: false
+        #     end
+        #
+        #     schema.object_type "Review" do |t|
+        #       t.field "id", "ID"
+        #       t.field "score", "Int"
+        #
+        #       # Field originally defined in the first version of the schema
+        #       t.field "commentIds", "[ID!]!"
+        #
+        #       # New field we're adding to expose the existing `commentIds` field as a list of `Comment` entity references.
+        #       t.apollo_entity_ref_paginated_collection_field "comments", "Comment", id_field_name_in_index: "commentIds"
+        #
+        #       t.index "reviews"
+        #     end
+        #   end
+        def apollo_entity_ref_paginated_collection_field(name, element_type, id_field_name_in_index:)
+          paginated_collection_field(
+            name,
+            element_type,
+            name_in_index: id_field_name_in_index,
+            **LIMITED_GRAPHQL_ONLY_PAGINATED_FIELD_OPTIONS
+          ) do |f|
+            validate_entity_ref_options(__method__.to_s, f, id_field_name_in_index, element_type) do |exposed_id_field|
+              backing_indexing_field = f.backing_indexing_field # : ::ElasticGraph::SchemaDefinition::SchemaElements::Field
+              unless backing_indexing_field.type.list?
+                raise Errors::SchemaError, "`#{f.parent_type.name}.#{f.name}` is invalid: `id_field_name_in_index` must reference an " \
+                  "id collection field, but the type of `#{id_field_name_in_index}` is `#{backing_indexing_field.type.name}`."
+              end
+
+              f.resolve_with :apollo_entity_ref_paginated, source_ids_field: id_field_name_in_index, exposed_id_field: exposed_id_field
+
+              yield f if block_given?
+            end
+          end
+        end
+
+        private
+
+        # The set of options for a GraphQL-only field that has all abilities disabled. A field defined with these options
+        # is available to be returned, but cannot be used for anything else (filtering, grouping, sorting, etc.).
+        LIMITED_GRAPHQL_ONLY_FIELD_OPTIONS = {
+          graphql_only: true,
+          filterable: false,
+          groupable: false,
+          aggregatable: false,
+          highlightable: false,
+          sortable: false
+        }
+
+        # Like {LIMITED_GRAPHQL_ONLY_FIELD_OPTIONS} but for
+        # {ElasticGraph::SchemaDefinition::SchemaElements::TypeWithSubfields#paginated_collection_field}.
+        # It does not support the `sortable` option.
+        LIMITED_GRAPHQL_ONLY_PAGINATED_FIELD_OPTIONS = LIMITED_GRAPHQL_ONLY_FIELD_OPTIONS.except(:sortable)
+
+        def validate_entity_ref_options(method_name, field, id_field_name_in_index, entity_ref_type_name)
+          # Defer validation since it depends on the definition of the entity ref type, which may be as yet undefined.
+          schema_def_state.after_user_definition_complete do
+            backing_indexing_field = field.backing_indexing_field # : ::ElasticGraph::SchemaDefinition::SchemaElements::Field
+            backing_indexing_field_type = backing_indexing_field.type.fully_unwrapped.name
+
+            unless backing_indexing_field_type == "ID"
+              raise Errors::SchemaError, "`#{field.parent_type.name}.#{field.name}` is invalid: `id_field_name_in_index` must " \
+                "reference an `ID` field, but the type of `#{id_field_name_in_index}` is `#{backing_indexing_field_type}`."
+            end
+
+            entity_ref_type = schema_def_state.type_ref(entity_ref_type_name).fully_unwrapped.as_object_type
+            unless entity_ref_type
+              raise Errors::SchemaError, "`#{field.parent_type.name}.#{field.name}` is invalid: the referenced type " \
+                "(`#{entity_ref_type_name}`) is not an object type as required by `#{method_name}`."
+            end
+
+            entity_ref_type_fields = entity_ref_type.graphql_fields_by_name.keys
+
+            unless entity_ref_type_fields.size == 1
+              raise Errors::SchemaError, "`#{field.parent_type.name}.#{field.name}` is invalid: `#{method_name}` can only be used " \
+                "for types with a single field, but `#{entity_ref_type.name}` has #{entity_ref_type_fields.size} fields."
+            end
+
+            exposed_id_field = entity_ref_type_fields.first
+            exposed_id_field_type = entity_ref_type.graphql_fields_by_name.fetch(exposed_id_field).type
+            unless exposed_id_field_type.unwrap_non_null.name == "ID"
+              raise Errors::SchemaError, "`#{field.parent_type.name}.#{field.name}` is invalid: `#{method_name}` can only be used for " \
+                "types with a single `ID` field, but the type of `#{entity_ref_type.name}.#{exposed_id_field}` is `#{exposed_id_field_type.name}`."
+            end
+
+            yield exposed_id_field
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/object_type_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/object_type_extension.rb
@@ -7,6 +7,7 @@
 # frozen_string_literal: true
 
 require "elastic_graph/apollo/schema_definition/apollo_directives"
+require "elastic_graph/apollo/schema_definition/object_and_interface_extension"
 
 module ElasticGraph
   module Apollo
@@ -23,6 +24,7 @@ module ElasticGraph
         include ApolloDirectives::RequiresScopes
         include ApolloDirectives::Shareable
         include ApolloDirectives::Tag
+        include ObjectAndInterfaceExtension
       end
     end
   end

--- a/elasticgraph-apollo/sig/elastic_graph/apollo/graphql/apollo_entity_ref_resolver.rbs
+++ b/elasticgraph-apollo/sig/elastic_graph/apollo/graphql/apollo_entity_ref_resolver.rbs
@@ -1,0 +1,24 @@
+module ElasticGraph
+  module Apollo
+    module GraphQL
+      module ApolloEntityRefResolver
+        class ForSingleId
+          include ::ElasticGraph::_GraphQLResolverWithoutLookahead
+          @source_id_field: ::String
+          @exposed_id_field: ::String
+        end
+
+        class ForIdList
+          include ::ElasticGraph::_GraphQLResolverWithoutLookahead
+          @source_ids_field: ::String
+          @exposed_id_field: ::String
+        end
+
+        class ForPaginatedList
+          include ::ElasticGraph::_GraphQLResolverWithoutLookahead
+          @for_id_list: ForIdList
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-apollo/sig/elastic_graph/apollo/schema_definition/object_and_interface_extension.rbs
+++ b/elasticgraph-apollo/sig/elastic_graph/apollo/schema_definition/object_and_interface_extension.rbs
@@ -1,0 +1,31 @@
+module ElasticGraph
+  module Apollo
+    module SchemaDefinition
+      module ObjectAndInterfaceExtension: ElasticGraph::SchemaDefinition::SchemaElements::TypeWithSubfields
+        def apollo_entity_ref_field: (
+          ::String,
+          ::String,
+          id_field_name_in_index: ::String
+        ) ?{ (::ElasticGraph::SchemaDefinition::SchemaElements::Field) -> void } -> void
+
+        def apollo_entity_ref_paginated_collection_field: (
+          ::String,
+          ::String,
+          id_field_name_in_index: ::String
+        ) ?{ (::ElasticGraph::SchemaDefinition::SchemaElements::Field) -> void } -> void
+
+        private
+
+        LIMITED_GRAPHQL_ONLY_FIELD_OPTIONS: ::Hash[::Symbol, untyped]
+        LIMITED_GRAPHQL_ONLY_PAGINATED_FIELD_OPTIONS: ::Hash[::Symbol, untyped]
+
+        def validate_entity_ref_options: (
+          ::String,
+          ::ElasticGraph::SchemaDefinition::SchemaElements::Field,
+          ::String,
+          ::String
+        ) { (::String) -> void } -> void
+      end
+    end
+  end
+end

--- a/elasticgraph-apollo/spec/integration/elastic_graph/apollo/graphql/apollo_entity_ref_resolver_spec.rb
+++ b/elasticgraph-apollo/spec/integration/elastic_graph/apollo/graphql/apollo_entity_ref_resolver_spec.rb
@@ -1,0 +1,136 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/apollo/graphql/apollo_entity_ref_resolver"
+require "elastic_graph/graphql"
+
+module ElasticGraph
+  module Apollo
+    module GraphQL
+      RSpec.describe ApolloEntityRefResolver, :uses_datastore, :factories, :builds_graphql, :builds_indexer do
+        let(:graphql) { build_graphql(schema_artifacts_directory: "config/schema/artifacts_with_apollo") }
+        let(:indexer) { build_indexer(datastore_core: graphql.datastore_core) }
+
+        it "resolves an entity ref field backed by a non-list id field" do
+          index_records(
+            build(:component, id: "c1", owner_id: "oid_1"),
+            build(:component, id: "c2", owner_id: nil)
+          )
+
+          data = execute_expecting_no_errors(<<~QUERY).dig("components", "nodes")
+            query {
+              components {
+                nodes {
+                  id
+                  owner { token }
+                }
+              }
+            }
+          QUERY
+
+          expect(data).to contain_exactly(
+            {"id" => "c1", "owner" => {"token" => "oid_1"}},
+            {"id" => "c2", "owner" => nil}
+          )
+        end
+
+        it "resolves an entity ref field backed by a list of ids field" do
+          index_records(
+            build(:component, id: "c1", owner_ids: ["oid_1", "oid_2"]),
+            build(:component, id: "c2", owner_ids: [])
+          )
+
+          data = execute_expecting_no_errors(<<~QUERY).dig("components", "nodes")
+            query {
+              components {
+                nodes {
+                  id
+                  owners { token }
+                }
+              }
+            }
+          QUERY
+
+          expect(data).to contain_exactly(
+            {"id" => "c1", "owners" => [{"token" => "oid_1"}, {"token" => "oid_2"}]},
+            {"id" => "c2", "owners" => []}
+          )
+        end
+
+        it "resolves an entity ref field backed by a paginated list of ids field" do
+          index_records(
+            build(:component, id: "c1", owner_ids: ["oid_1", "oid_2", "oid_3", "oid_4"]),
+            build(:component, id: "c2", owner_ids: [])
+          )
+
+          expected_end_cursor = "Mg"
+          component_nodes_by_id = query_owners_paginated(first: 2)
+          expect(component_nodes_by_id).to eq({
+            "c1" => {
+              "nodes" => [{"token" => "oid_1"}, {"token" => "oid_2"}],
+              "page_info" => {"end_cursor" => expected_end_cursor, "has_next_page" => true},
+              "total_edge_count" => 4
+            },
+            "c2" => {
+              "nodes" => [],
+              "page_info" => {"end_cursor" => nil, "has_next_page" => false},
+              "total_edge_count" => 0
+            }
+          })
+
+          component_nodes_by_id = query_owners_paginated(first: 2, after: expected_end_cursor)
+          expect(component_nodes_by_id).to eq({
+            "c1" => {
+              "nodes" => [{"token" => "oid_3"}, {"token" => "oid_4"}],
+              "page_info" => {"end_cursor" => "NA", "has_next_page" => false},
+              "total_edge_count" => 4
+            },
+            "c2" => {
+              "nodes" => [],
+              "page_info" => {"end_cursor" => nil, "has_next_page" => false},
+              "total_edge_count" => 0
+            }
+          })
+        end
+
+        def query_owners_paginated(**variables)
+          execute_expecting_no_errors(<<~QUERY, variables: variables).dig("components", "nodes").to_h { |n| [n.fetch("id"), n.fetch("owners_paginated")] }
+            query OwnersPaginated($first: Int, $after: Cursor) {
+              components {
+                nodes {
+                  id
+                  owners_paginated(first: $first, after: $after) {
+                    total_edge_count
+                    page_info {
+                      has_next_page
+                      end_cursor
+                    }
+
+                    nodes {
+                      token
+                    }
+                  }
+                }
+              }
+            }
+          QUERY
+        end
+
+        def execute(query, **options)
+          graphql.graphql_query_executor.execute(query, **options)
+        end
+
+        def execute_expecting_no_errors(query, **options)
+          response = execute(query, **options)
+          expect(response["errors"]).to be nil
+          response.fetch("data")
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-indexer/spec/acceptance/multi_source_indexing_spec.rb
+++ b/elasticgraph-indexer/spec/acceptance/multi_source_indexing_spec.rb
@@ -52,7 +52,8 @@ module ElasticGraph
         LIST_COUNTS_FIELD => {
           "tags" => 2,
           "part_ids" => 1,
-          "widget_tags" => 3
+          "widget_tags" => 3,
+          "owner_ids" => 0
         },
         "id" => "c23",
         "name" => "C",
@@ -95,7 +96,8 @@ module ElasticGraph
         LIST_COUNTS_FIELD => {
           "part_ids" => 1,
           "tags" => 2,
-          "widget_tags" => 3
+          "widget_tags" => 3,
+          "owner_ids" => 0
         },
         "id" => "c56",
         "name" => "D",
@@ -116,7 +118,8 @@ module ElasticGraph
         },
         LIST_COUNTS_FIELD => {
           "part_ids" => 1,
-          "tags" => 2
+          "tags" => 2,
+          "owner_ids" => 0
         },
         "id" => "c78",
         "name" => "E",

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/graphql_resolver.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/graphql_resolver.rbs
@@ -67,7 +67,7 @@ module ElasticGraph
   interface _GraphQLResolverWithLookahead
     def initialize: (
       elasticgraph_graphql: GraphQL,
-      config: ::Hash[::String, untyped]
+      config: ::Hash[::Symbol, untyped]
     ) -> void
 
     include _GraphQLResolvableWithLookahead
@@ -76,7 +76,7 @@ module ElasticGraph
   interface _GraphQLResolverWithoutLookahead
     def initialize: (
       elasticgraph_graphql: GraphQL,
-      config: ::Hash[::String, untyped]
+      config: ::Hash[::Symbol, untyped]
     ) -> void
 
     include _GraphQLResolvableWithoutLookahead

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
@@ -1060,8 +1060,10 @@ module ElasticGraph
           )
         end
 
-        private
-
+        # The alternate field that is backing this field in the datastore index. Will only be non-`nil` for `graphql_only` fields.
+        # @return [Field, nil] the field backing this field in the index
+        #
+        # @private
         def backing_indexing_field
           return nil unless graphql_only
 
@@ -1078,6 +1080,8 @@ module ElasticGraph
 
           field
         end
+
+        private
 
         def args_sdl(joiner:, after_opening_paren: "", &arg_selector)
           selected_args = args.values.select(&arg_selector)

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/field.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/field.rbs
@@ -95,6 +95,8 @@ module ElasticGraph
         def runtime_metadata_computation_detail: (empty_bucket_value: ::Numeric?, function: ::Symbol) -> void
         def runtime_metadata_graphql_field: () -> SchemaArtifacts::RuntimeMetadata::GraphQLField
 
+        def backing_indexing_field: () -> Field?
+
         private
 
         def text?: () -> bool

--- a/spec_support/lib/elastic_graph/spec_support/factories/widgets.rb
+++ b/spec_support/lib/elastic_graph/spec_support/factories/widgets.rb
@@ -184,6 +184,8 @@ FactoryBot.define do
     name { Faker::ElectricalComponents.active }
     created_at { Faker::Time.between(from: recent_date - 30, to: recent_date).utc.iso8601 }
     position { build :position }
+    owner_ids { [] }
+    owner_id { owner_ids.first }
 
     part_ids do
       parts.map { |part| part.fetch(:id) }


### PR DESCRIPTION
When plugging into an Apollo supergraph, it's quite useful to be able to expoes "entity reference" types (e.g. a type with just an id field, that refers to an entity owned by another subgraph) rather than just exposing an id field. This allows Apollo to federate the type.

This adds two new APIs to support this:

* `apollo_entity_ref_field`
* `apollo_entity_ref_paginated_collection_field`

The latter exposes a list of ids as a paginated relay connection.