### PR TITLE
Add support for `IGNORE_SQS_LATENCY_TIMESTAMPS_FROM_ARNS`.

### DIFF
--- a/elasticgraph-indexer_lambda/sig/elastic_graph/indexer_lambda/lambda_function.rbs
+++ b/elasticgraph-indexer_lambda/sig/elastic_graph/indexer_lambda/lambda_function.rbs
@@ -3,7 +3,7 @@ module ElasticGraph
     class LambdaFunction
       include LambdaSupport::LambdaFunction[void]
       include LambdaSupport::_LambdaFunctionClass[void]
-      @sqs_processor: SqsProcessor
+      attr_reader sqs_processor: SqsProcessor
     end
   end
 end

--- a/elasticgraph-indexer_lambda/sig/elastic_graph/indexer_lambda/sqs_processor.rbs
+++ b/elasticgraph-indexer_lambda/sig/elastic_graph/indexer_lambda/sqs_processor.rbs
@@ -4,7 +4,8 @@ module ElasticGraph
       def initialize: (
         Indexer::Processor,
         logger: ::Logger,
-        ?s3_client: Aws::S3::Client?
+        ignore_sqs_latency_timestamps_from_arns: ::Set[::String],
+        ?s3_client: Aws::S3::Client?,
       ) -> void
 
       def process: (::Hash[::String, untyped], ?refresh_indices: bool) -> void
@@ -14,6 +15,8 @@ module ElasticGraph
       @indexer_processor: Indexer::Processor
       @logger: ::Logger
       @s3_client: Aws::S3::Client?
+
+      attr_reader ignore_sqs_latency_timestamps_from_arns: ::Set[::String]
 
       def events_from: (::Hash[::String, untyped]) -> ::Array[::Hash[::String, untyped]]
       S3_OFFLOADING_INDICATOR: String

--- a/elasticgraph-indexer_lambda/spec/unit/elastic_graph/indexer_lambda/lambda_function_spec.rb
+++ b/elasticgraph-indexer_lambda/spec/unit/elastic_graph/indexer_lambda/lambda_function_spec.rb
@@ -18,6 +18,25 @@ RSpec.describe "Indexer lambda function" do
     ) do |lambda_function|
       response = lambda_function.handle_request(event: {"Records" => []}, context: {})
       expect(response).to eq({"batchItemFailures" => []})
+      expect(lambda_function.sqs_processor.ignore_sqs_latency_timestamps_from_arns).to eq([].to_set)
+    end
+  end
+
+  it "configures `ignore_sqs_latency_timestamps_from_arns` based on an ENV var" do
+    env_var_value = ::JSON.generate(["ignored-arn1", "ignored-arn2"])
+
+    with_env "IGNORE_SQS_LATENCY_TIMESTAMPS_FROM_ARNS" => env_var_value do
+      expect_loading_lambda_to_define_constant(
+        lambda: "elastic_graph/indexer_lambda/lambda_function.rb",
+        const: :ProcessEventStreamEvent
+      ) do |lambda_function|
+        response = lambda_function.handle_request(event: {"Records" => []}, context: {})
+        expect(response).to eq({"batchItemFailures" => []})
+        expect(lambda_function.sqs_processor.ignore_sqs_latency_timestamps_from_arns).to eq([
+          "ignored-arn1",
+          "ignored-arn2"
+        ].to_set)
+      end
     end
   end
 end


### PR DESCRIPTION
This can be used from `elasticgraph-indexer_lambda` to ignore SQS latency timestamps for messages coming from a specific SQS queue. This is useful, for example, when dealing with an indexer lambda which ingests messages from multiple queues which are treated as being at different priorities. A low-pri queue that is intentionally throttled could skew overall latency metrics and it's nice to be able to ignore the latency timestamps for messages from such a queue.