### PR TITLE
Enable `insecure-external-code-execution` for bundler dependabot updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
 
   - package-ecosystem: bundler
     directory: /
+    insecure-external-code-execution: allow # https://github.com/dependabot/dependabot-core/issues/12426#issuecomment-3001420174
     schedule:
       interval: weekly
 


### PR DESCRIPTION
This was recommended by @Nishnha, a GitHub employee, on the dependabot issue I opened:

https://github.com/dependabot/dependabot-core/issues/12426