### PR TITLE
Add warning option for Query Registry clients

### DIFF
--- a/ai-memory/README.md
+++ b/ai-memory/README.md
@@ -221,6 +221,7 @@ The project is a monorepo composed of many gems. Each gem typically resides in i
     -   **Key Files**: `lib/elastic_graph/query_registry/registry.rb` (manages query files), `lib/elastic_graph/query_registry/query_validator.rb` (validates queries), `lib/elastic_graph/query_registry/graphql_extension.rb` (GraphQL integration), `lib/elastic_graph/query_registry/rake_tasks.rb` (for CI validation and managing variable artifacts).
     -   **Dependencies**: `elasticgraph-graphql`, `elasticgraph-support`, `graphql`, `graphql-c_parser`, `rake`.
     -   **Provides**: A robust system for managing and validating GraphQL queries, especially useful for internal clients and ensuring schema evolution safety. Uses a directory structure (e.g., `config/queries/[client_name]/query.graphql`) and `*.variables.yaml` files for variable structure validation.
+    -   **Warning Mode Feature**: Added support for `warn_on_unregistered_query_for_clients` configuration option that allows unregistered queries to execute while logging warnings. This provides a gradual migration path for teams adopting the query registry. Warnings are logged even for clients in `allow_any_query_for_clients` to enable monitoring of query usage patterns.
 
 **Datastore Adapters:**
 -   `elasticgraph-elasticsearch/`: Wraps the official Elasticsearch client (`elasticsearch` gem) for use by ElasticGraph.

--- a/elasticgraph-query_registry/README.md
+++ b/elasticgraph-query_registry/README.md
@@ -121,6 +121,9 @@ query_registry:
   allow_unregistered_clients: false
   allow_any_query_for_clients:
   - adhoc_client
+  warn_on_unregistered_query_for_clients:
+  - migration_client
+  - test_client
   path_to_registry: config/queries
 ```
 
@@ -152,6 +155,28 @@ will be allowed to execute _all_ queries! We recommend you set
 `allow_unregistered_clients` to `false` unless you specifically need
 to allow unregistered clients. For specific clients that need to be
 allowed to run any query, you can list them in `allow_any_query_for_clients`.
+
+## Warning Mode
+
+In addition to strict enforcement, this library also supports a warning mode
+that can help with gradual migration to the query registry. When clients are
+listed in `warn_on_unregistered_query_for_clients`, their unregistered queries
+will be allowed to execute but will generate warning logs. This is useful for:
+
+* Discovering what queries clients are using before enforcing registration
+* Gradually migrating clients to use registered queries
+* Monitoring query usage patterns during development
+
+The warning logs include:
+* Client name and description
+* Query fingerprint for identification
+* Operation name (if present)
+* Whether the query differs from a registered version
+
+Note that warnings are logged even if a client is listed in both 
+`allow_any_query_for_clients` and `warn_on_unregistered_query_for_clients`.
+This allows you to monitor query usage patterns even for clients that
+are allowed to run any query.
 
 ## Workflow
 

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/graphql_extension.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/graphql_extension.rb
@@ -25,7 +25,8 @@ module ElasticGraph
             slow_query_threshold_ms: config.slow_query_latency_warning_threshold_in_ms,
             registry_directory: registry_config.path_to_registry,
             allow_unregistered_clients: registry_config.allow_unregistered_clients,
-            allow_any_query_for_clients: registry_config.allow_any_query_for_clients
+            allow_any_query_for_clients: registry_config.allow_any_query_for_clients,
+            warn_on_unregistered_query_for_clients: registry_config.warn_on_unregistered_query_for_clients
           )
         end
       end
@@ -36,6 +37,7 @@ module ElasticGraph
         registry_directory:,
         allow_unregistered_clients:,
         allow_any_query_for_clients:,
+        warn_on_unregistered_query_for_clients:,
         schema:,
         monotonic_clock:,
         logger:,
@@ -52,7 +54,9 @@ module ElasticGraph
           schema,
           registry_directory,
           allow_unregistered_clients: allow_unregistered_clients,
-          allow_any_query_for_clients: allow_any_query_for_clients
+          allow_any_query_for_clients: allow_any_query_for_clients,
+          warn_on_unregistered_query_for_clients: warn_on_unregistered_query_for_clients,
+          logger: logger
         )
       end
 
@@ -80,21 +84,25 @@ module ElasticGraph
       end
     end
 
-    class Config < ::Data.define(:path_to_registry, :allow_unregistered_clients, :allow_any_query_for_clients)
+    class Config < ::Data.define(:path_to_registry, :allow_unregistered_clients, :allow_any_query_for_clients, :warn_on_unregistered_query_for_clients)
       def self.from_parsed_yaml(hash)
         hash = hash.fetch("query_registry") { return DEFAULT }
 
         new(
           path_to_registry: hash.fetch("path_to_registry"),
           allow_unregistered_clients: hash.fetch("allow_unregistered_clients"),
-          allow_any_query_for_clients: hash.fetch("allow_any_query_for_clients")
+          allow_any_query_for_clients: hash.fetch("allow_any_query_for_clients"),
+          warn_on_unregistered_query_for_clients: hash.fetch("warn_on_unregistered_query_for_clients") {
+            [] # : ::Array[::String]
+          }
         )
       end
 
       DEFAULT = new(
         path_to_registry: (_ = __dir__),
         allow_unregistered_clients: true,
-        allow_any_query_for_clients: []
+        allow_any_query_for_clients: [], # : ::Array[::String]
+        warn_on_unregistered_query_for_clients: [] # : ::Array[::String]
       )
     end
   end

--- a/elasticgraph-query_registry/sig/elastic_graph/query_registry/graphql_extension.rbs
+++ b/elasticgraph-query_registry/sig/elastic_graph/query_registry/graphql_extension.rbs
@@ -9,6 +9,7 @@ module ElasticGraph
         registry_directory: ::String,
         allow_unregistered_clients: bool,
         allow_any_query_for_clients: ::Array[::String],
+        warn_on_unregistered_query_for_clients: ::Array[::String],
         schema: GraphQL::Schema,
         monotonic_clock: Support::MonotonicClock,
         logger: ::Logger,
@@ -24,17 +25,20 @@ module ElasticGraph
       attr_reader path_to_registry: ::String
       attr_reader allow_unregistered_clients: bool
       attr_reader allow_any_query_for_clients: ::Array[::String]
+      attr_reader warn_on_unregistered_query_for_clients: ::Array[::String]
 
       def self.new: (
         path_to_registry: ::String,
         allow_unregistered_clients: bool,
-        allow_any_query_for_clients: ::Array[::String]
+        allow_any_query_for_clients: ::Array[::String],
+        warn_on_unregistered_query_for_clients: ::Array[::String]
       ) -> Config
 
       def with: (
         ?path_to_registry: ::String,
         ?allow_unregistered_clients: bool,
-        ?allow_any_query_for_clients: ::Array[::String]
+        ?allow_any_query_for_clients: ::Array[::String],
+        ?warn_on_unregistered_query_for_clients: ::Array[::String]
       ) -> Config
     end
 

--- a/elasticgraph-query_registry/sig/elastic_graph/query_registry/query_validators/for_registered_client.rbs
+++ b/elasticgraph-query_registry/sig/elastic_graph/query_registry/query_validators/for_registered_client.rbs
@@ -4,6 +4,8 @@ module ElasticGraph
       class ForRegisteredClientSupertype
         attr_reader schema: GraphQL::Schema
         attr_reader allow_any_query_for_clients: ::Set[::String]
+        attr_reader warn_on_unregistered_query_for_clients: ::Set[::String]
+        attr_reader logger: ::Logger
         attr_reader client_cache_mutex: ::Thread::Mutex
         attr_reader provide_query_strings_for_client: ^(::String) -> ::Array[::String]
         attr_reader client_data_by_client_name: ::Hash[::String, ClientData?]
@@ -11,6 +13,8 @@ module ElasticGraph
         def initialize: (
           schema: GraphQL::Schema,
           allow_any_query_for_clients: ::Set[::String],
+          warn_on_unregistered_query_for_clients: ::Set[::String],
+          logger: ::Logger?,
           client_cache_mutex: ::Thread::Mutex,
           provide_query_strings_for_client: ^(::String) -> ::Array[::String],
           client_data_by_client_name: ::Hash[::String, ClientData?]
@@ -22,6 +26,8 @@ module ElasticGraph
           schema: GraphQL::Schema,
           client_names: ::Array[::String],
           allow_any_query_for_clients: ::Set[::String],
+          warn_on_unregistered_query_for_clients: ::Set[::String],
+          logger: ::Logger,
           provide_query_strings_for_client: ^(String) -> ::Array[::String]
         ) -> void
 
@@ -37,6 +43,7 @@ module ElasticGraph
 
         private
 
+        def log_unregistered_query_warning: (::GraphQL::Query, GraphQL::Client, ClientData) -> void
         def client_data_for: (::String) -> ClientData
         def atomically_update_cached_client_data_for: (::String) { (ClientData?) -> ClientData } -> ClientData
 

--- a/elasticgraph-query_registry/sig/elastic_graph/query_registry/registry.rbs
+++ b/elasticgraph-query_registry/sig/elastic_graph/query_registry/registry.rbs
@@ -6,14 +6,18 @@ module ElasticGraph
         GraphQL::Schema,
         ::String,
         allow_unregistered_clients: bool,
-        allow_any_query_for_clients: ::Array[::String]
+        allow_any_query_for_clients: ::Array[::String],
+        warn_on_unregistered_query_for_clients: ::Array[::String],
+        logger: ::Logger
       ) -> Registry
 
       def initialize: (
         GraphQL::Schema,
         client_names: ::Array[::String],
         allow_unregistered_clients: bool,
-        allow_any_query_for_clients: ::Array[::String]
+        allow_any_query_for_clients: ::Array[::String],
+        warn_on_unregistered_query_for_clients: ::Array[::String],
+        logger: ::Logger
       ) { (String) -> ::Array[::String] } -> void
 
       def build_and_validate_query: (


### PR DESCRIPTION
This PR adds a new `warn_on_unregistered_query_for_clients` configuration option to the query registry that provides a migration path for clients to move to actually enforcing registration for their queries. With this setting, unregistered queries will continue to execute, but a warning message will be emitted for later inspection.

### How tested?
- Added/ran unit tests
- Clean CI build across the project.