### PR TITLE
Revert "Enable `insecure-external-code-execution` for bundler dependabot updates. (#622)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
 
   - package-ecosystem: bundler
     directory: /
-    insecure-external-code-execution: allow # https://github.com/dependabot/dependabot-core/issues/12426#issuecomment-3001420174
     schedule:
       interval: weekly
 


### PR DESCRIPTION
This reverts commit fb7b93c6b693221556da50a6c9533cd8a6d29249.

This didn't work, and it seems best to not enable it.