### PR TITLE
Add set_extension_data method for the 'QueryDuration' log message, utilize in Query Registry

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_details_tracker.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_details_tracker.rb
@@ -17,6 +17,7 @@ module ElasticGraph
       :datastore_query_server_duration_ms,
       :datastore_query_client_duration_ms,
       :queried_shard_count,
+      :extension_data,
       :mutex
     )
       def self.empty
@@ -27,6 +28,7 @@ module ElasticGraph
           datastore_query_server_duration_ms: 0,
           datastore_query_client_duration_ms: 0,
           queried_shard_count: 0,
+          extension_data: {},
           mutex: ::Thread::Mutex.new
         )
       end
@@ -51,6 +53,13 @@ module ElasticGraph
       # network time, JSON serialization time, etc.
       def datastore_request_transport_duration_ms
         datastore_query_client_duration_ms - datastore_query_server_duration_ms
+      end
+
+      # Allows extensions to add custom data that will be included in the query duration log
+      def set_extension_data(key, value)
+        mutex.synchronize do
+          extension_data[key] = value
+        end
       end
     end
   end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_executor.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_executor.rb
@@ -86,7 +86,7 @@ module ElasticGraph
         end
 
         unless client == Client::ELASTICGRAPH_INTERNAL
-          @logger.info({
+          log_data = {
             "message_type" => "ElasticGraphQueryExecutorQueryDuration",
             "client" => client.name,
             "query_fingerprint" => fingerprint_for(query),
@@ -117,7 +117,12 @@ module ElasticGraph
             "datastore_query_count" => query_tracker.query_counts_per_datastore_request.sum,
             "over_slow_threshold" => (duration > @slow_query_threshold_ms).to_s,
             "slo_result" => slo_result_for(query, duration)
-          })
+          }
+
+          # Merge in any extension-provided data
+          log_data.merge!(query_tracker.extension_data)
+
+          @logger.info(log_data)
         end
 
         result

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/query_details_tracker.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/query_details_tracker.rbs
@@ -7,6 +7,7 @@ module ElasticGraph
       attr_accessor datastore_query_server_duration_ms: ::Integer
       attr_accessor datastore_query_client_duration_ms: ::Integer
       attr_accessor queried_shard_count: ::Integer
+      attr_accessor extension_data: ::Hash[::String, ::String]
       attr_accessor mutex: ::Thread::Mutex
 
       def initialize: (
@@ -16,6 +17,7 @@ module ElasticGraph
         datastore_query_server_duration_ms: ::Integer,
         datastore_query_client_duration_ms: ::Integer,
         queried_shard_count: ::Integer,
+        extension_data: ::Hash[::String, ::String],
         mutex: ::Thread::Mutex
       ) -> void
     end
@@ -30,6 +32,7 @@ module ElasticGraph
       ) -> void
 
       def datastore_request_transport_duration_ms: () -> ::Integer
+      def set_extension_data: (::String, ::String) -> void
     end
   end
 end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_details_tracker_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_details_tracker_spec.rb
@@ -1,0 +1,63 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/graphql/query_details_tracker"
+
+module ElasticGraph
+  class GraphQL
+    RSpec.describe QueryDetailsTracker do
+      describe "#set_extension_data" do
+        let(:tracker) { QueryDetailsTracker.empty }
+
+        it "allows extensions to set custom data" do
+          tracker.set_extension_data("custom_key", "custom_value")
+          expect(tracker.extension_data).to eq("custom_key" => "custom_value")
+        end
+
+        it "allows multiple extensions to set different data" do
+          tracker.set_extension_data("key1", "value1")
+          tracker.set_extension_data("key2", "value2")
+
+          expect(tracker.extension_data).to eq(
+            "key1" => "value1",
+            "key2" => "value2"
+          )
+        end
+
+        it "allows overwriting existing extension data" do
+          tracker.set_extension_data("key", "original_value")
+          tracker.set_extension_data("key", "new_value")
+
+          expect(tracker.extension_data).to eq("key" => "new_value")
+        end
+
+        it "is thread-safe" do
+          threads = []
+          100.times do |i|
+            threads << Thread.new do
+              tracker.set_extension_data("thread_#{i}", "value_#{i}")
+            end
+          end
+          threads.each(&:join)
+
+          expect(tracker.extension_data.size).to eq(100)
+          100.times do |i|
+            expect(tracker.extension_data["thread_#{i}"]).to eq("value_#{i}")
+          end
+        end
+      end
+
+      describe ".empty" do
+        it "initializes with an empty extension_data hash" do
+          tracker = QueryDetailsTracker.empty
+          expect(tracker.extension_data).to eq({})
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/graphql_extension.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/graphql_extension.rb
@@ -59,13 +59,17 @@ module ElasticGraph
       private
 
       def build_and_execute_query(query_string:, variables:, operation_name:, context:, client:)
-        query, errors = @registry.build_and_validate_query(
+        query, errors, query_registered = @registry.build_and_validate_query_with_registration_status(
           query_string,
           variables: variables,
           operation_name: operation_name,
           context: context,
           client: client
         )
+
+        # Set the query_registered field in the query tracker
+        query_tracker = context[:elastic_graph_query_tracker]
+        query_tracker.set_extension_data("query_registered", query_registered.to_s)
 
         if errors.empty?
           [query, execute_query(query, client: client)]

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/query_validators/for_unregistered_client.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/query_validators/for_unregistered_client.rb
@@ -12,18 +12,18 @@ module ElasticGraph
       # Query validator implementation used for unregistered or anonymous clients.
       ForUnregisteredClient = ::Data.define(:allow_unregistered_clients, :allow_any_query_for_clients) do
         # @implements ForUnregisteredClient
-        def build_and_validate_query(query_string, client:, variables: {}, operation_name: nil, context: {})
+        def build_and_validate_query_with_registration_status(query_string, client:, variables: {}, operation_name: nil, context: {})
           query = yield
 
-          return [query, []] if allow_unregistered_clients
+          return [query, [], false] if allow_unregistered_clients
 
           client_name = client&.name
-          return [query, []] if client_name && allow_any_query_for_clients.include?(client_name)
+          return [query, [], false] if client_name && allow_any_query_for_clients.include?(client_name)
 
           [query, [
             "Client #{client&.description || "(unknown)"} is not a registered client, it is not in " \
             "`allow_any_query_for_clients` and `allow_unregistered_clients` is false."
-          ]]
+          ], false]
         end
       end
     end

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/registry.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/registry.rb
@@ -60,6 +60,18 @@ module ElasticGraph
       # and whitespace). If the query differs in a significant way from a registered query, it
       # will not be recognized as registered.
       def build_and_validate_query(query_string, client:, variables: {}, operation_name: nil, context: {})
+        query, errors, _ = build_and_validate_query_with_registration_status(
+          query_string,
+          client: client,
+          variables: variables,
+          operation_name: operation_name,
+          context: context
+        )
+        [query, errors]
+      end
+
+      # Same as build_and_validate_query but also returns whether the query was registered
+      def build_and_validate_query_with_registration_status(query_string, client:, variables: {}, operation_name: nil, context: {})
         validator =
           if @registered_client_validator.applies_to?(client)
             @registered_client_validator
@@ -67,7 +79,7 @@ module ElasticGraph
             @unregistered_client_validator
           end
 
-        validator.build_and_validate_query(query_string, client: client, variables: variables, operation_name: operation_name, context: context) do
+        validator.build_and_validate_query_with_registration_status(query_string, client: client, variables: variables, operation_name: operation_name, context: context) do
           @schema.new_graphql_query(
             query_string,
             variables: variables,

--- a/elasticgraph-query_registry/sig/elastic_graph/query_registry/query_validators/for_registered_client.rbs
+++ b/elasticgraph-query_registry/sig/elastic_graph/query_registry/query_validators/for_registered_client.rbs
@@ -27,13 +27,13 @@ module ElasticGraph
 
         def applies_to?: (GraphQL::Client) -> bool
 
-        def build_and_validate_query: (
+        def build_and_validate_query_with_registration_status: (
           ::String?,
           client: GraphQL::Client,
           ?variables: ::Hash[::String, untyped],
           ?operation_name: ::String?,
           ?context: ::Hash[::Symbol, untyped]
-        ) { () -> ::GraphQL::Query } -> [::GraphQL::Query, ::Array[::String]]
+        ) { () -> ::GraphQL::Query } -> [::GraphQL::Query, ::Array[::String], bool]
 
         private
 

--- a/elasticgraph-query_registry/sig/elastic_graph/query_registry/query_validators/for_unregistered_client.rbs
+++ b/elasticgraph-query_registry/sig/elastic_graph/query_registry/query_validators/for_unregistered_client.rbs
@@ -10,13 +10,13 @@ module ElasticGraph
           allow_any_query_for_clients: ::Set[::String]
         ) -> void
 
-        def build_and_validate_query: (
+        def build_and_validate_query_with_registration_status: (
           ::String?,
           client: GraphQL::Client,
           ?variables: ::Hash[::String, untyped],
           ?operation_name: ::String?,
           ?context: ::Hash[::Symbol, untyped]
-        ) { () -> ::GraphQL::Query } -> [::GraphQL::Query, ::Array[::String]]
+        ) { () -> ::GraphQL::Query } -> [::GraphQL::Query, ::Array[::String], bool]
       end
     end
   end

--- a/elasticgraph-query_registry/sig/elastic_graph/query_registry/registry.rbs
+++ b/elasticgraph-query_registry/sig/elastic_graph/query_registry/registry.rbs
@@ -24,6 +24,14 @@ module ElasticGraph
         ?context: ::Hash[::Symbol, untyped]
       ) -> [::GraphQL::Query, ::Array[::String]]
 
+      def build_and_validate_query_with_registration_status: (
+        ::String?,
+        client: GraphQL::Client,
+        ?variables: ::Hash[::String, untyped],
+        ?operation_name: ::String?,
+        ?context: ::Hash[::Symbol, untyped]
+      ) -> [::GraphQL::Query, ::Array[::String], bool]
+
       private
 
       @schema: GraphQL::Schema


### PR DESCRIPTION
This is a successor to https://github.com/block/elasticgraph/pull/628 - in this PR, we add a general-purpose mechanism for GraphQL extensions (such as the query registry) to log additional data within the `ElasticGraphQueryExecutorQueryDuration` message, and then utilize that within the query registry gem to log whether a given query was registered or not.

### How tested?
- Added/ran unit and acceptance tests.
- Clean CI build?