### PR TITLE
Fix filters on deeply nested subaggregations

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/nested_sub_aggregation.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/nested_sub_aggregation.rb
@@ -26,7 +26,7 @@ module ElasticGraph
         end
 
         def build_agg_hash(filter_interpreter, parent_queries:)
-          detail = query.build_agg_detail(filter_interpreter, field_path: nested_path, parent_queries: parent_queries)
+          detail = query.build_agg_detail(filter_interpreter, field_path: nested_path, parent_queries: parent_queries, nested_context: true)
           return {} if detail.nil?
 
           parent_query_names = parent_queries.map(&:name)

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query.rb
@@ -72,14 +72,14 @@ module ElasticGraph
 
         def filter_detail(filter_interpreter, field_path, nested_context: false)
           filtering_field_path = Filtering::FieldPath.of(field_path.filter_map(&:name_in_index))
-          
+
           # When we're dealing with a nested sub-aggregation, we need to apply the nested transformation
           # to the filtering field path to ensure count filters and other nested field operations work correctly.
           # This is necessary because nested fields create separate document contexts in Elasticsearch/OpenSearch.
           if nested_context && field_path.any?
             filtering_field_path = filtering_field_path.nested
           end
-          
+
           filter_clause = filter_interpreter.build_query([filter].compact, from_field_path: filtering_field_path)
 
           inner_detail = yield

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/query.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/query.rbs
@@ -47,7 +47,7 @@ module ElasticGraph
           Filtering::FilterInterpreter,
           field_path: ::Array[PathSegment],
           parent_queries: ::Array[Query],
-          nested_context: bool
+          ?nested_context: bool
         ) -> AggregationDetail?
 
         private
@@ -55,7 +55,7 @@ module ElasticGraph
         def filter_detail: (
           Filtering::FilterInterpreter,
           ::Array[PathSegment],
-          nested_context: bool
+          ?nested_context: bool
         ) { () -> AggregationDetail } -> AggregationDetail
 
         def computations_detail: () -> ::Hash[::String, untyped]

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/query.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/query.rbs
@@ -46,14 +46,16 @@ module ElasticGraph
         def build_agg_detail: (
           Filtering::FilterInterpreter,
           field_path: ::Array[PathSegment],
-          parent_queries: ::Array[Query]
+          parent_queries: ::Array[Query],
+          nested_context: bool
         ) -> AggregationDetail?
 
         private
 
         def filter_detail: (
           Filtering::FilterInterpreter,
-          ::Array[PathSegment]
+          ::Array[PathSegment],
+          nested_context: bool
         ) { () -> AggregationDetail } -> AggregationDetail
 
         def computations_detail: () -> ::Hash[::String, untyped]

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_adapter_spec.rb
@@ -471,7 +471,7 @@ module ElasticGraph
               # Create a mock filter interpreter that captures the field path used
               captured_field_paths = []
 
-              filter_interpreter = instance_double("GraphQL::Filtering::FilterInterpreter")
+              filter_interpreter = instance_double(ElasticGraph::GraphQL::Filtering::FilterInterpreter)
               allow(filter_interpreter).to receive(:build_query) do |filters, from_field_path:|
                 captured_field_paths << from_field_path
                 {"seasons_nested" => {"__counts" => {"gt" => 0}}}

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_adapter_spec.rb
@@ -467,10 +467,6 @@ module ElasticGraph
             it "builds a `count` filter on a nested sub-aggregation correctly for deeply nested fields" do
               # This test verifies the fix for nested count filters in aggregations by checking
               # that the field path gets the proper nested transformation when processing filters.
-              #
-              # To verify this test fails without the fix, comment out the nested context logic in
-              # Query#filter_detail (lines with `if nested_context && field_path.any?`) and change
-              # the expectation below to `expect(field_path.from_parent).to eq(["current_players_nested"])`
               
               # Create a mock filter interpreter that captures the field path used
               captured_field_paths = []


### PR DESCRIPTION
## Description

This PR fixes a bug where nested sub-aggregation count filters were not working correctly. Queries like `lineItems(filter: {modifiers: {count: {gt: 0}}})` were returning 0 results despite matching documents existing in the datastore.

## Root Cause

The issue was in the `Query#filter_detail` method. When processing filters for nested sub-aggregations, the filtering field path wasn't getting the `.nested` transformation required for proper Elasticsearch/OpenSearch nested document context.

## Solution

- Added `nested_context` parameter to `build_agg_detail` and `filter_detail` methods
- Modified `NestedSubAggregation` to pass `nested_context: true` when calling `build_agg_detail`
- Updated filtering logic to apply `.nested` transformation when in nested context
- Fixed RBS type signatures to mark `nested_context` as optional parameter
- Added comprehensive test coverage for nested count filters in aggregations

## Files Modified

- `elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query.rb`
- `elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/nested_sub_aggregation.rb`
- `elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/query.rbs`
- `elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_adapter_spec.rb`

## Testing

Added comprehensive test cases to verify that nested count filters work correctly in aggregations. The test specifically verifies that when filtering on nested document counts, the proper nested context is applied and the field path transformation works as expected.

## Technical Details

The key insight is that nested fields in Elasticsearch/OpenSearch create separate document contexts. When processing filters for nested sub-aggregations, the filtering field path must be transformed using the `.nested` method to ensure proper context handling. Without this transformation, count filters on nested fields would fail to match documents correctly.

Closes #635