### PR TITLE
chore: upgrade bundler to 2.6.9.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gems_in_this_repo = ::Dir.glob("#{repo_root}/*/*.gemspec").map do |gemspec|
   ::File.basename(::File.dirname(gemspec))
 end.to_set
 
-# Here we override the `gem` method to automatically add the ElasticGraph version
+# Here we override the `add_dependency` method to automatically add the ElasticGraph version
 # to all ElasticGraph gems. If we don't do this, we can get confusing bundler warnings
 # like:
 #
@@ -75,12 +75,9 @@ end.to_set
 # This is necessary because our `gemspec` call below registers a `gem` for the gem defined by the gemspec, but it does not include
 # a version requirement, and bundler gets confused when other gems have dependencies on the same gem with a version requirement.
 # This ensures that we always have the same version requirements for all ElasticGraph gems.
-define_singleton_method :gem do |name, *args|
-  if gems_in_this_repo.include?(name)
-    args.unshift ::ElasticGraph::VERSION unless args.first.include?(::ElasticGraph::VERSION)
-  end
-
-  super(name, *args)
+define_singleton_method :add_dependency do |name, version = nil, *args, **options, &block|
+  version = ::ElasticGraph::VERSION if gems_in_this_repo.include?(name)
+  super(name, version, *args, **options, &block)
 end
 
 # This file is symlinked from the repo root into each gem directory. To detect which case we're in,

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -661,4 +661,4 @@ DEPENDENCIES
   yard-markdown (~> 0.5)
 
 BUNDLED WITH
-   2.6.2
+   2.6.9


### PR DESCRIPTION
The new version of bundler includes some internal refactorings that broke our monorepo setup. To stay compatible, I've had to rework our `gem` override to instead override `add_dependency`.

I believe this is the root of the problem I reported to dependabot:

https://github.com/dependabot/dependabot-core/issues/12426

The latest dependabot uses Bundler 2.6.9, and this was causing the issues reported in that ticket since our `gem` override was no longer effective.

The specific bundler change prompting this is this PR:

https://github.com/rubygems/rubygems/pull/8480

In that PR, the `gemspec` method was refactored to no longer call `gem`. Instead, it calls a new `add_dependency` method.