### PR TITLE
chore: rework Gemfiles.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,158 +8,19 @@
 
 source "https://rubygems.org"
 
-# Gems needed by the test suite and other CI checks.
-group :development do
-  gem "aws_lambda_ric", "~> 3.0"
-  gem "benchmark-ips", "~> 2.14"
-  gem "coderay", "~> 1.1", ">= 1.1.3"
-  gem "factory_bot", "~> 6.5", ">= 6.5.1"
-  gem "faker", "~> 3.5", ">= 3.5.1"
-  gem "flatware-rspec", "~> 2.3", ">= 2.3.4"
-  gem "httpx", "~> 1.4", ">= 1.4.1"
-  gem "memory_profiler", "~> 1.1"
-  gem "method_source", "~> 1.1"
-  # We are waiting to upgrade to >= 2.27 until standardrb compatibility with rubocop plugins is fixed:
-  # https://github.com/standardrb/standard/issues/701
-  gem "rubocop-factory_bot", "~> 2.26.1"
-  # We are waiting to upgrade to >= 0.7 until standardrb compatibility with rubocop plugins is fixed:
-  # https://github.com/standardrb/standard/issues/701
-  gem "rubocop-rake", "~> 0.6.0"
-  # We are waiting to upgrade to >= 3.5 until standardrb compatibility with rubocop plugins is fixed:
-  # https://github.com/standardrb/standard/issues/701
-  gem "rubocop-rspec", "~> 3.4.0"
-  gem "rspec", "~> 3.13"
-  gem "rspec-retry", "~> 0.6", ">= 0.6.2"
-  gem "simplecov", "~> 0.22"
-  gem "simplecov-console", "~> 0.9", ">= 0.9.3"
-  gem "standard", "~> 1.49.0"
-  gem "steep", "~> 1.10.0"
-  gem "super_diff", "~> 0.15"
-  gem "vcr", "~> 6.3", ">= 6.3.1"
+require_relative "elasticgraph-support/lib/elastic_graph/version"
+
+# Depend on each ElasticGraph gem in the repo.
+::Dir.glob("#{__dir__}/*/*.gemspec").map do |gemspec|
+  elasticgraph_gem = ::File.basename(::File.dirname(gemspec))
+  gem elasticgraph_gem, ::ElasticGraph::VERSION, path: elasticgraph_gem
 end
 
-# Documentation generation gems
-group :site do
-  gem "filewatcher", "~> 2.1"
-  gem "html-proofer", "~> 5.0", ">= 5.0.10"
-  gem "jekyll", "~> 4.4", ">= 4.4.1"
-  gem "nokogiri", "~> 1.18", ">= 1.18.8"
-  gem "redcarpet", "~> 3.6", ">= 3.6.1"
-  gem "yard", "~> 0.9", ">= 0.9.37"
-  gem "yard-doctest", "~> 0.1", ">= 0.1.17"
-  gem "yard-markdown", "~> 0.5"
-end
-
-# Since this file gets symlinked both at the repo root and into each Gem directory, we have
-# to dynamically detect the repo root, by looking for one of the subdirs at the root.
-repo_root = ::Pathname.new(__dir__).ascend.find { |dir| ::Dir.exist?("#{dir}/elasticgraph-support") }.to_s
+# Defer to `Gemfile-shared` for dependencies on non-ElasticGraph gems.
+eval_gemfile "Gemfile-shared"
 
 # `tmp` and `log` are git-ignored but many of our build tasks and scripts expect them to exist.
 # We create them here since `Gemfile` evaluation happens before anything else.
 require "fileutils"
-::FileUtils.mkdir_p("#{repo_root}/log")
-::FileUtils.mkdir_p("#{repo_root}/tmp")
-
-# Identify the gems that live in the ElasticGraph repository.
-gems_in_this_repo = ::Dir.glob("#{repo_root}/*/*.gemspec").map do |gemspec|
-  ::File.basename(::File.dirname(gemspec))
-end.to_set
-
-# Here we override the `gem` method to automatically add the ElasticGraph version
-# to all ElasticGraph gems. If we don't do this, we can get confusing bundler warnings
-# like:
-#
-# A gemspec development dependency (elasticgraph-schema_definition, = 0.17.1.0) is being overridden by a Gemfile dependency (elasticgraph-schema_definition, >= 0).
-# This behaviour may change in the future. Please remove either of them, or make sure they both have the same requirement
-#
-# This is necessary because our `gemspec` call below registers a `gem` for the gem defined by the gemspec, but it does not include
-# a version requirement, and bundler gets confused when other gems have dependencies on the same gem with a version requirement.
-# This ensures that we always have the same version requirements for all ElasticGraph gems.
-define_singleton_method :gem do |name, *args|
-  if gems_in_this_repo.include?(name)
-    args.unshift ::ElasticGraph::VERSION unless args.first.include?(::ElasticGraph::VERSION)
-  end
-
-  super(name, *args)
-end
-
-# This file is symlinked from the repo root into each gem directory. To detect which case we're in,
-# we can compare the the current directory to the repo root.
-if repo_root == __dir__
-  # When we are at the root, we want to load the gemspecs for each ElasticGraph gem in the repository.
-  # Note: dependabot can't handle `gemspec` calls that use a variable (e.g. `gemspec path: gem_name`)
-  # rather than a literal value, so this is an intentionally unrolled loop.
-  gemspec path: "elasticgraph"
-  gemspec path: "elasticgraph-admin"
-  gemspec path: "elasticgraph-admin_lambda"
-  gemspec path: "elasticgraph-apollo"
-  gemspec path: "elasticgraph-datastore_core"
-  gemspec path: "elasticgraph-elasticsearch"
-  gemspec path: "elasticgraph-graphql"
-  gemspec path: "elasticgraph-graphql_lambda"
-  gemspec path: "elasticgraph-health_check"
-  gemspec path: "elasticgraph-indexer"
-  gemspec path: "elasticgraph-indexer_autoscaler_lambda"
-  gemspec path: "elasticgraph-indexer_lambda"
-  gemspec path: "elasticgraph-json_schema"
-  gemspec path: "elasticgraph-lambda_support"
-  gemspec path: "elasticgraph-local"
-  gemspec path: "elasticgraph-opensearch"
-  gemspec path: "elasticgraph-query_interceptor"
-  gemspec path: "elasticgraph-query_registry"
-  gemspec path: "elasticgraph-rack"
-  gemspec path: "elasticgraph-schema_artifacts"
-  gemspec path: "elasticgraph-schema_definition"
-  gemspec path: "elasticgraph-support"
-
-  unless @gemspecs.empty?
-    missing_gemspecs = gems_in_this_repo - @gemspecs.map(&:name)
-    unless missing_gemspecs.empty?
-      raise "`Gemfile` is missing `gemspec` calls for gems: #{missing_gemspecs.join(", ")}"
-    end
-  end
-else
-  # Otherwise, we just load the local `.gemspec` file in the current directory.
-  gemspec
-
-  # After loading the gemspec, we want to explicitly tell bundler where to find each of the ElasticGraph
-  # gems that live in this repository. Otherwise, it will try to look in system gems or on a remote
-  # gemserver for them.
-  #
-  # Bundler stores all loaded gemspecs in `@gemspecs` so here we get the gemspec that was just loaded
-  if (loaded_gemspec = @gemspecs.last)
-
-    # This set will keep track of which gems have been registered so far, so we never register an
-    # ElasticGraph gem more than once.
-    registered_gems = ::Set.new
-
-    register_gemspec_gems_with_path = lambda do |deps|
-      deps.each do |dep|
-        next unless gems_in_this_repo.include?(dep.name) && !registered_gems.include?(dep.name)
-
-        dep_path = "#{repo_root}/#{dep.name}"
-        gem dep.name, path: dep_path
-
-        # record the fact that this gem has been registered so that we don't try calling `gem` for it again.
-        registered_gems << dep.name
-
-        # Finally, load the gemspec and recursively apply this process to its runtime dependencies.
-        # Notably, we avoid using `.dependencies` because we do not want development dependencies to
-        # be registered as part of this.
-        runtime_dependencies = ::Bundler.load_gemspec("#{dep_path}/#{dep.name}.gemspec").runtime_dependencies
-        register_gemspec_gems_with_path.call(runtime_dependencies)
-      end
-    end
-
-    # Ensure that the recursive lambda above doesn't try to re-register the loaded gemspec's gem.
-    registered_gems << loaded_gemspec.name
-
-    # Here we begin the process of registering the ElasticGraph gems we need to include in the current
-    # bundle. We use `loaded_gemspec.dependencies` to include development and runtime dependencies.
-    # For the "outer" gem identified by our loaded gemspec, we need the bundle to include both its
-    # runtime and development dependencies. In contrast, when we recurse, we only look at runtime
-    # dependencies. We are ok with transitive runtime dependencies being pulled in but we don't want
-    # transitive development dependencies.
-    register_gemspec_gems_with_path.call(loaded_gemspec.dependencies)
-  end
-end
+::FileUtils.mkdir_p("#{__dir__}/log")
+::FileUtils.mkdir_p("#{__dir__}/tmp")

--- a/Gemfile-shared
+++ b/Gemfile-shared
@@ -1,0 +1,46 @@
+# This file declares dependencies on non-ElasticGraph gems for both the root bundle and also
+# the "local" bundle for each individual ElasticGraph gem that is used when you `cd` into
+# a gem's directory.
+
+# Gems needed by the test suite and other CI checks.
+group :development do
+  gem "aws_lambda_ric", "~> 3.0"
+  gem "benchmark-ips", "~> 2.14"
+  gem "coderay", "~> 1.1", ">= 1.1.3"
+  gem "factory_bot", "~> 6.5", ">= 6.5.1"
+  gem "faker", "~> 3.5", ">= 3.5.1"
+  gem "flatware-rspec", "~> 2.3", ">= 2.3.4"
+  gem "httpx", "~> 1.4", ">= 1.4.1"
+  gem "memory_profiler", "~> 1.1"
+  gem "method_source", "~> 1.1"
+  gem "rack-test", "~> 2.2"
+  gem "rspec", "~> 3.13"
+  gem "rspec-retry", "~> 0.6", ">= 0.6.2"
+  # We are waiting to upgrade to >= 2.27 until standardrb compatibility with rubocop plugins is fixed:
+  # https://github.com/standardrb/standard/issues/701
+  gem "rubocop-factory_bot", "~> 2.26.1"
+  # We are waiting to upgrade to >= 0.7 until standardrb compatibility with rubocop plugins is fixed:
+  # https://github.com/standardrb/standard/issues/701
+  gem "rubocop-rake", "~> 0.6.0"
+  # We are waiting to upgrade to >= 3.5 until standardrb compatibility with rubocop plugins is fixed:
+  # https://github.com/standardrb/standard/issues/701
+  gem "rubocop-rspec", "~> 3.4.0"
+  gem "simplecov", "~> 0.22"
+  gem "simplecov-console", "~> 0.9", ">= 0.9.3"
+  gem "standard", "~> 1.49.0"
+  gem "steep", "~> 1.10.0"
+  gem "super_diff", "~> 0.15"
+  gem "vcr", "~> 6.3", ">= 6.3.1"
+end
+
+# Documentation/website gems
+group :site do
+  gem "filewatcher", "~> 2.1"
+  gem "html-proofer", "~> 5.0", ">= 5.0.10"
+  gem "jekyll", "~> 4.4", ">= 4.4.1"
+  gem "nokogiri", "~> 1.18", ">= 1.18.8"
+  gem "redcarpet", "~> 3.6", ">= 3.6.1"
+  gem "yard", "~> 0.9", ">= 0.9.37"
+  gem "yard-doctest", "~> 0.1", ">= 0.1.17"
+  gem "yard-markdown", "~> 0.5"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -633,7 +633,6 @@ DEPENDENCIES
   elasticgraph-support (= 1.0.0.pre)!
   factory_bot (~> 6.5, >= 6.5.1)
   faker (~> 3.5, >= 3.5.1)
-  faraday (~> 2.13, >= 2.13.1)
   filewatcher (~> 2.1)
   flatware-rspec (~> 2.3, >= 2.3.4)
   html-proofer (~> 5.0, >= 5.0.10)
@@ -643,7 +642,6 @@ DEPENDENCIES
   method_source (~> 1.1)
   nokogiri (~> 1.18, >= 1.18.8)
   rack-test (~> 2.2)
-  rake (~> 13.2, >= 13.2.1)
   redcarpet (~> 3.6, >= 3.6.1)
   rspec (~> 3.13)
   rspec-retry (~> 0.6, >= 0.6.2)
@@ -661,4 +659,4 @@ DEPENDENCIES
   yard-markdown (~> 0.5)
 
 BUNDLED WITH
-   2.6.2
+   2.6.9

--- a/config/Gemfile-for-gem
+++ b/config/Gemfile-for-gem
@@ -1,0 +1,72 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+# Note: this file is symlinked as the `Gemfile` for each gem in this repo.
+# It dynamically provides a local bundle for a single ElasticGraph gem. The
+# local bundle includes the overall development dependencies provided by
+# `Gemfile-shared` as well as the ElasticGraph gems that are declared as
+# dependencies from the gemspec.
+#
+# We use this from `script/run_gem_specs` to run a gem's specs in the context of its
+# local bundle. This helps us ensure that our gemspecs have the correct dependencies
+# listed. If a gem's test suite requires another ElasticGraph gem to be available,
+# `script/run_gem_specs` will only pass if we're that gem is in the bundle by being
+# declared as a dependency in the gemspec.
+
+source "https://rubygems.org"
+
+repo_root = ::File.expand_path("..", __dir__)
+eval_gemfile "#{repo_root}/Gemfile-shared"
+
+gemspec
+
+# Identify the gems that live in the ElasticGraph repository.
+gems_in_this_repo = ::Dir.glob("#{repo_root}/*/*.gemspec").map do |gemspec|
+  ::File.basename(::File.dirname(gemspec))
+end.to_set
+
+# After loading the gemspec, we want to explicitly tell bundler where to find each of the ElasticGraph
+# gems that live in this repository. Otherwise, it will try to look in system gems or on a remote
+# gemserver for them.
+#
+# Bundler stores all loaded gemspecs in `@gemspecs` so here we get the gemspec that was just loaded
+if (loaded_gemspec = @gemspecs.last)
+
+  # This set will keep track of which gems have been registered so far, so we never register an
+  # ElasticGraph gem more than once.
+  registered_gems = ::Set.new
+
+  register_gemspec_gems_with_path = lambda do |deps|
+    deps.each do |dep|
+      next unless gems_in_this_repo.include?(dep.name) && !registered_gems.include?(dep.name)
+
+      dep_path = "#{repo_root}/#{dep.name}"
+      gem dep.name, ::ElasticGraph::VERSION, path: dep_path
+
+      # record the fact that this gem has been registered so that we don't try calling `gem` for it again.
+      registered_gems << dep.name
+
+      # Finally, load the gemspec and recursively apply this process to its runtime dependencies.
+      # Notably, we avoid using `.dependencies` because we do not want development dependencies to
+      # be registered as part of this.
+      runtime_dependencies = ::Bundler.load_gemspec("#{dep_path}/#{dep.name}.gemspec").runtime_dependencies
+      register_gemspec_gems_with_path.call(runtime_dependencies)
+    end
+  end
+
+  # Ensure that the recursive lambda above doesn't try to re-register the loaded gemspec's gem.
+  registered_gems << loaded_gemspec.name
+
+  # Here we begin the process of registering the ElasticGraph gems we need to include in the current
+  # bundle. We use `loaded_gemspec.dependencies` to include development and runtime dependencies.
+  # For the "outer" gem identified by our loaded gemspec, we need the bundle to include both its
+  # runtime and development dependencies. In contrast, when we recurse, we only look at runtime
+  # dependencies. We are ok with transitive runtime dependencies being pulled in but we don't want
+  # transitive development dependencies.
+  register_gemspec_gems_with_path.call(loaded_gemspec.dependencies)
+end

--- a/elasticgraph-admin/Gemfile
+++ b/elasticgraph-admin/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-admin_lambda/Gemfile
+++ b/elasticgraph-admin_lambda/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-apollo/Gemfile
+++ b/elasticgraph-apollo/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-datastore_core/Gemfile
+++ b/elasticgraph-datastore_core/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-elasticsearch/Gemfile
+++ b/elasticgraph-elasticsearch/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-graphql/Gemfile
+++ b/elasticgraph-graphql/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-graphql_lambda/Gemfile
+++ b/elasticgraph-graphql_lambda/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-health_check/Gemfile
+++ b/elasticgraph-health_check/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-indexer/Gemfile
+++ b/elasticgraph-indexer/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-indexer_autoscaler_lambda/Gemfile
+++ b/elasticgraph-indexer_autoscaler_lambda/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-indexer_lambda/Gemfile
+++ b/elasticgraph-indexer_lambda/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-json_schema/Gemfile
+++ b/elasticgraph-json_schema/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-lambda_support/Gemfile
+++ b/elasticgraph-lambda_support/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-local/Gemfile
+++ b/elasticgraph-local/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-opensearch/Gemfile
+++ b/elasticgraph-opensearch/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-query_interceptor/Gemfile
+++ b/elasticgraph-query_interceptor/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-query_registry/Gemfile
+++ b/elasticgraph-query_registry/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-rack/Gemfile
+++ b/elasticgraph-rack/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-rack/elasticgraph-rack.gemspec
+++ b/elasticgraph-rack/elasticgraph-rack.gemspec
@@ -48,5 +48,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "elasticgraph-elasticsearch", ElasticGraph::VERSION
   spec.add_development_dependency "elasticgraph-opensearch", ElasticGraph::VERSION
   spec.add_development_dependency "elasticgraph-indexer", ElasticGraph::VERSION
-  spec.add_development_dependency "rack-test", "~> 2.2"
 end

--- a/elasticgraph-schema_artifacts/Gemfile
+++ b/elasticgraph-schema_artifacts/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-schema_definition/Gemfile
+++ b/elasticgraph-schema_definition/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-support/Gemfile
+++ b/elasticgraph-support/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem

--- a/elasticgraph-support/elasticgraph-support.gemspec
+++ b/elasticgraph-support/elasticgraph-support.gemspec
@@ -46,5 +46,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "logger", "~> 1.7"
 
   spec.add_development_dependency "faraday", "~> 2.13", ">= 2.13.1"
-  spec.add_development_dependency "rake", "~> 13.2", ">= 13.2.1"
 end

--- a/elasticgraph/Gemfile
+++ b/elasticgraph/Gemfile
@@ -1,1 +1,1 @@
-../Gemfile
+../config/Gemfile-for-gem


### PR DESCRIPTION
Dependabot is currently broken for ElasticGraph:

https://github.com/dependabot/dependabot-core/issues/12426

Troubleshooting points to a root cause of Bundler 2.6.9 (used by the latest dependabot) having some subtle changes to how gemspecs are handled. Specifically, this PR:

https://github.com/rubygems/rubygems/pull/8480

In that PR, the `gemspec` method was refactored to no longer call `gem`.

Previously, our `Gemfile` set up depended on this. However, it was quite complicated in order to support the root `Gemfile` getting symlinkd into each gem subdirectory.

I've simplified things here:

- `Gemfile-shared` now contains all dependencies that are not declared in the gemspecs.
- `Gemfile` is now greatly simplified--it just evals `Gemfile-shared` and declares a dependency on each ElasticGraph gem.
- `config/Gemfile-for-gem` contains a more complex gemfile, which gets symlinked into each ElasticGraph gem.
- I've removed the last few unnecessary gemspec developemnt dependencies for non-ElasticGraph gems--we handle this through the development dependencies in `Gemfile-shared` instead. (`rack-test` was missing from the `Gemfile` before!)

This new simpler setup should fix the issues we're having with dependabot.