### PR TITLE
Increase the dependabot open-pull-request-limit.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,19 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
+    open-pull-requests-limit: 10
     directory: /
     schedule:
       interval: monthly
 
   - package-ecosystem: bundler
+    open-pull-requests-limit: 20
     directory: /
     schedule:
       interval: weekly
 
   - package-ecosystem: bundler
+    open-pull-requests-limit: 10
     directory: /config/release
     schedule:
       interval: weekly


### PR DESCRIPTION
Being limited to 5 at a time is having a productivity impact since we're behind on depndency upgrades. And I don't generally want dependabot PRs to be limited (so long as it's not an absurd number of them...).