### PR TITLE
Revert "Increase the dependabot open-pull-request-limit. (#657)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,16 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    open-pull-requests-limit: 10
     directory: /
     schedule:
       interval: monthly
 
   - package-ecosystem: bundler
-    open-pull-requests-limit: 20
     directory: /
     schedule:
       interval: weekly
 
   - package-ecosystem: bundler
-    open-pull-requests-limit: 10
     directory: /config/release
     schedule:
       interval: weekly


### PR DESCRIPTION
This reverts commit 9c95fcc9ad93219983bc7b23c1b11cfcacacca43.

Since merging that change, Dependabot has begun failing with:

> Dependabot can't update vulnerable dependencies without a lockfile
> The currently installed version can't be determined.
>
> To resolve the issue add a supported lockfile (Gemfile.lock or gems.locked).

Example: https://github.com/block/elasticgraph/actions/runs/16154309990/job/45593081085

I don't understand the failure (we have a `Gemfile.lock`!) but since the failure only started when I edited `.github/dependabot.yml`, I'm reverting it.