### PR TITLE
fix: handle Content-Type header with parameters

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb
@@ -98,7 +98,7 @@ module ElasticGraph
       def with_request_params(request)
         params =
           # POST with application/json is the most common form requests take, so we have it as the first branch here.
-          if request.http_method == :post && request.content_type == APPLICATION_JSON
+          if request.http_method == :post && request.mime_type == APPLICATION_JSON
             begin
               ::JSON.parse(request.body.to_s)
             rescue ::JSON::ParserError
@@ -107,11 +107,11 @@ module ElasticGraph
               # standard:enable Lint/NoReturnInBeginEndBlocks
             end
 
-          elsif request.http_method == :post && request.content_type == APPLICATION_GRAPHQL
+          elsif request.http_method == :post && request.mime_type == APPLICATION_GRAPHQL
             {"query" => request.body}
 
           elsif request.http_method == :post
-            return HTTPResponse.error(415, "`#{request.content_type}` is not a supported content type. Only `#{APPLICATION_JSON}` and `#{APPLICATION_GRAPHQL}` are supported.")
+            return HTTPResponse.error(415, "`#{request.mime_type}` is not a supported content type. Only `#{APPLICATION_JSON}` and `#{APPLICATION_GRAPHQL}` are supported.")
 
           elsif request.http_method == :get
             ::URI.decode_www_form(::URI.parse(request.url).query.to_s).to_h.tap do |hash|
@@ -196,8 +196,8 @@ module ElasticGraph
         end
       end
 
-      def content_type
-        normalized_headers["CONTENT-TYPE"]
+      def mime_type
+        @mime_type ||= normalized_headers["CONTENT-TYPE"].to_s.split(";").first # strip ; delimiter and any trailing parameters
       end
 
       def self.normalize_header_name(header)

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/http_endpoint.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/http_endpoint.rbs
@@ -84,7 +84,8 @@ module ElasticGraph
       @normalized_headers: ::Hash[::String, ::String]?
       def normalized_headers: () -> ::Hash[::String, ::String]
 
-      def content_type: () -> ::String?
+      @mime_type: ::String?
+      def mime_type: () -> ::String?
 
       def self.normalize_header_name: (::String) -> ::String
     end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/http_endpoint_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/http_endpoint_spec.rb
@@ -231,6 +231,16 @@ module ElasticGraph
           expect([r1, r2, r3, r4, r5]).to all eq("data" => {"widgets" => {"__typename" => "WidgetConnection"}})
         end
 
+        it "tolerates the Content-Type being followed by a semicolon and encoding or other information" do
+          r1 = process_graphql_expecting(200, query: "query { widgets { __typename } }", headers: {"Content-Type" => "application/json;charset=UTF-8"})
+          r2 = process_graphql_expecting(200, query: "query { widgets { __typename } }", headers: {"Content-Type" => "application/json;a=b"})
+          r3 = process_graphql_expecting(200, query: "query { widgets { __typename } }", headers: {"Content-Type" => "application/json;"})
+          r4 = process_graphql_expecting(200, query: "query { widgets { __typename } }", headers: {"Content-Type" => "application/json; "})
+          r5 = process_graphql_expecting(200, query: "query { widgets { __typename } }", headers: {"Content-Type" => "application/json;;;;;"})
+
+          expect([r1, r2, r3, r4, r5]).to all eq("data" => {"widgets" => {"__typename" => "WidgetConnection"}})
+        end
+
         def process_graphql_expecting(status_code, query: default_query, variables: nil, operation_name: nil, **options)
           body = ::JSON.generate({
             "query" => query,


### PR DESCRIPTION
Updates the HTTP request handling in `elasticgraph-graphql` to ignore encoding (or any other parameters) when parsing the Content-Type header.

Previously, a valid Content-Type header such as
`application/json;charset=UTF-8` would yield an HTTP 400 error response.