### PR TITLE
fix: handle `EOFError` from `Net::HTTP` call.

### DIFF
--- a/elasticgraph-local/lib/elastic_graph/local/rake_tasks.rb
+++ b/elasticgraph-local/lib/elastic_graph/local/rake_tasks.rb
@@ -499,7 +499,7 @@ module ElasticGraph
         task :ensure_local_datastore_running do
           datastore_status_code = begin
             ::Net::HTTP.get_response(URI(local_datastore_url)).code
-          rescue ::SystemCallError
+          rescue ::SystemCallError, ::EOFError
             "500"
           end
 


### PR DESCRIPTION
I'm not entirely sure what causes `EOFError` to be raised sometimes while a `SystemCallError` subclass is raised in other situations, but we got a test a CI failure from this:

https://github.com/block/elasticgraph/actions/runs/16662046152/job/47161190402?pr=703