### PR TITLE
chore: improve dependabot configuration and documentation.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,20 @@ updates:
       - dependency-type: "all" # Allow both direct and transitive updates for all packages.
     schedule:
       interval: monthly
+    groups:
+      # 1 PR for every single dependency is overkill (it's tedious to have to wade through 20 dependabot PRs!).
+      # However, for certain key dependencies that are important or have had a history of initially failing the
+      # build on upgrade, we want to keep them in their own PRs. We've listed them in `exclude_patterns` below.
+      transitive-and-easy-upgrade-dependencies:
+        patterns: ["*"]
+        exclude_patterns:
+          - "elasticsearch" # listed here as gem releases align with releases of Elasticsearch itself, and a PR notifies us of it
+          - "graphql"
+          - "json_schemer"
+          - "rack"
+          - "rbs"
+          - "standard"
+          - "steep"
 
   - package-ecosystem: bundler
     open-pull-requests-limit: 20

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,6 +205,10 @@ bundle exec rake site:preview_docs:elasticgraph-schema_definition
 
 Then visit http://localhost:8808/. The preview task will rebuild the parts of the generated docs impacted by your edits, and is quite fast.
 
+## Maintenance Tasks
+
+Common codebase maintenance tasks are documented in the [maintainer's runbook](MAINTAINERS_RUNBOOK.md).
+
 ---
 
 ## Communications

--- a/MAINTAINERS_RUNBOOK.md
+++ b/MAINTAINERS_RUNBOOK.md
@@ -169,10 +169,14 @@ Dependabot PRs can be reviewed and merged without the approval of another mainta
 
 * Review the release notes provided by Dependabot in the PR description. If there are any new features of a dependency that we should
   take advantage of, please [open an issue](https://github.com/block/elasticgraph/issues/new/choose) so we can track that work.
-* Confirm the CI build fully passes.
+* Confirm the CI build fully passes. If the build has a non-transient failure and the PR is upgrading multiple dependencies, consider
+  updating [.github/dependabot.yml](https://github.com/block/elasticgraph/blob/main/.github/dependabot.yml) to exclude the culprit from
+  inclusion in a multiple-dependency PR. (It's nice to isolate such a dependency into its own PR.)
 * Review the diff to make sure it looks reasonable.
 
-When merging, please use the "Squash and merge" option as we don't need to keep the two commits in the PR separate.
+When merging, please use the "Squash and merge" option as we don't need to keep the two commits in the PR separate. If a Dependabot PR
+has merge conflicts, comment on the PR with `@dependabot recreate` rather than `@dependabot rebase` so that the updates from
+`script/update_gem_constraints` get recreated as well.
 
 ### Triggering Dependabot
 


### PR DESCRIPTION
This adopts dependabot groups so that we don't get a separate for every dependency. That's been overkill. However, we still want it for important dependencies and any that have tended to fail the build upon upgrade.