### PR TITLE
chore: fix dependabot--s/exclude-patterns/exclude_patterns/.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       # build on upgrade, we want to keep them in their own PRs. We've listed them in `exclude_patterns` below.
       transitive-and-easy-upgrade-dependencies:
         patterns: ["*"]
-        exclude_patterns:
+        exclude-patterns:
           - "elasticsearch" # listed here as gem releases align with releases of Elasticsearch itself, and a PR notifies us of it
           - "graphql"
           - "json_schemer"


### PR DESCRIPTION
This option was introduced in #733, but had a typo.