### PR TITLE
chore: remove extraneous `ElasticGraph::Config` RBS definition.

### DIFF
--- a/elasticgraph-query_registry/sig/elastic_graph/query_registry/graphql_extension.rbs
+++ b/elasticgraph-query_registry/sig/elastic_graph/query_registry/graphql_extension.rbs
@@ -43,8 +43,4 @@ module ElasticGraph
       DEFAULT: Config
     end
   end
-
-  class Config
-    attr_reader query_registry: QueryRegistry::Config
-  end
 end


### PR DESCRIPTION
There is no `ElasticGraph::Config` class.