### PR TITLE
Ignore `localhost:9000` when validating the API docs.

### DIFF
--- a/config/site/Rakefile
+++ b/config/site/Rakefile
@@ -285,9 +285,13 @@ module ElasticGraph
             ignore_missing_alt: true,
             allow_missing_href: true,
             disable_external: true,
-            # An invalid URL that made its way into old versions of the docs. We don't want to update old versions of the
-            # API docs to fix broken links.
-            ignore_urls: ["elasticgraph-rack/lib/elastic_graph/rack/graphiql/index.html"]
+            ignore_urls: [
+              # An invalid URL that made its way into old versions of the docs. We don't want to update old versions of the
+              # API docs to fix broken links.
+              "elasticgraph-rack/lib/elastic_graph/rack/graphiql/index.html",
+              # We have links to locally booted ElasticGraph, which HTMLProofer can't resolve.
+              "http://localhost:9000/"
+            ]
           )
 
           # We use stricter settings for the newly generated YARD docs, since we can actually fix these.


### PR DESCRIPTION
The v1.0.0 API docs include links to `localhost:9000` as part of the instructions when booting ElasticGraph locally. The site validator fails on that link since it can't resolve (and doens't use https) but that's fine--we can just ignore it.