### PR TITLE
site: Remove extraneous "v" from version links.

### DIFF
--- a/config/site/src/api-docs.md
+++ b/config/site/src/api-docs.md
@@ -7,5 +7,5 @@ permalink: /api-docs/
 ## Available Versions
 
 {% for version in site.data.doc_versions.versions %}
-- {% if version == 'main' %}[Development (main)]{% else %}[Version {{ version }}]{% endif %}({{ '/api-docs/' | append: version | relative_url }}){% if version == site.data.doc_versions.latest_version %} (Latest){% endif %}
+- {% if version == 'main' %}[Development (main)]{% else %}[Version {{ version | remove: 'v' }}]{% endif %}({{ '/api-docs/' | append: version | relative_url }}){% if version == site.data.doc_versions.latest_version %} (Latest){% endif %}
 {% endfor %}


### PR DESCRIPTION
Before, the bullet point links had text like:

```
* Version v1.0.0 (Latest)
* Version v0.19.3.0
* Version v0.19.2.2
* Version v0.19.2.1
* Version v0.19.2.0
* Version v0.19.1.1
* Version v0.19.1.0
* Version v0.19.0.0
* Development (main)
```

Now the bullet point links have text like this:

```
* Version 1.0.0 (Latest)
* Version 0.19.3.0
* Version 0.19.2.2
* Version 0.19.2.1
* Version 0.19.2.0
* Version 0.19.1.1
* Version 0.19.1.0
* Version 0.19.0.0
* Development (main)
```