### PR TITLE
feat: migrate `Support::Logger::Config` to use `ElasticGraph::Config`.

### DIFF
--- a/elasticgraph-support/sig/elastic_graph/support/logger.rbs
+++ b/elasticgraph-support/sig/elastic_graph/support/logger.rbs
@@ -16,14 +16,16 @@ module ElasticGraph
       end
 
       class ConfigSupertype
+        extend ::ElasticGraph::Config::ClassMethods[Config]
+
         attr_reader level: ::String
         attr_reader device: ::String
         attr_reader formatter: ::Logger::_Formatter
 
         def initialize: (
-          level: ::String,
-          device: ::String,
-          formatter: ::Logger::_Formatter
+          ?level: ::String,
+          ?device: ::String,
+          ?formatter: ::String
         ) -> void
 
         def with: (
@@ -36,9 +38,12 @@ module ElasticGraph
       end
 
       class Config < ConfigSupertype
-        extend _BuildableFromParsedYaml[Config]
         def prepared_device: () -> (::String | ::IO)
-        EXPECTED_KEYS: ::Array[::String]
+        def self.from_parsed_yaml: (::Hash[::String, untyped]) -> Config
+
+        private
+
+        def convert_values: (formatter: ::String, level: ::String, device: ::String) -> ::Hash[::Symbol, untyped]
       end
     end
   end

--- a/elasticgraph/spec/unit/elastic_graph/gem_spec.rb
+++ b/elasticgraph/spec/unit/elastic_graph/gem_spec.rb
@@ -201,7 +201,6 @@ module ElasticGraph
           elasticgraph-indexer
           elasticgraph-query_interceptor
           elasticgraph-query_registry
-          elasticgraph-support
         ].include?(gem_name)
       end
     end


### PR DESCRIPTION
This improves the validation of the logger config and participates in
our new config system which will be used to drive our documentation.

In addition, this provides defaults for all `logger` config values so
that ElasticGraph can be booted without any `logger` config. Previously,
`device` had no default and was required. Now it defaults to `stdout`.