### PR TITLE
Remove vestigial RBS definition of `Config#health_check`.

### DIFF
--- a/elasticgraph-health_check/sig/elastic_graph/health_check/config.rbs
+++ b/elasticgraph-health_check/sig/elastic_graph/health_check/config.rbs
@@ -36,8 +36,4 @@ module ElasticGraph
       end
     end
   end
-
-  class Config
-    attr_reader health_check: HealthCheck::Config
-  end
 end


### PR DESCRIPTION
This is no longer needed, and gets in the way of further changes I am making.