### PR TITLE
Introduce `ElasticGraph::Config`.

### DIFF
--- a/config/site/Rakefile
+++ b/config/site/Rakefile
@@ -527,9 +527,9 @@ module ElasticGraph
       # `Data.define` metaprograms a superclass and there's not a way to avoid the warning:
       # https://github.com/lsegal/yard/issues/1533
       # https://github.com/lsegal/yard/issues/1477#issuecomment-1399339983
-      "`Data.define` superclass" =>
+      "Undocumentable superclass" =>
         # https://rubular.com/r/lecYmbp981T4LY
-        /^\[warn\]: in YARD::Handlers::Ruby::ClassHandler: Undocumentable superclass \(class was added without superclass\)\n\s+in file[^\n]+\n\n\s+\d+:[^\n]*?(Data\.define|Struct.new)[^\n]*\n\n/m,
+        /^\[warn\]: in YARD::Handlers::Ruby::ClassHandler: Undocumentable superclass \(class was added without superclass\)\n\s+in file[^\n]+\n\n\s+\d+:[^\n]*?(Data\.define|Struct\.new|ElasticGraph::Config\.define)[^\n]*\n\n/m,
 
       # We sometimes include/extend/prepend a mixin that is a dynamic module
       # (e.g. `include Mixins::HasReadableToSAndInspect.new`) and YARD isn't able to understand this.

--- a/elasticgraph-support/lib/elastic_graph/config.rb
+++ b/elasticgraph-support/lib/elastic_graph/config.rb
@@ -1,0 +1,178 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/errors"
+require "elastic_graph/support/json_schema/validator_factory"
+require "elastic_graph/support/from_yaml_file"
+require "elastic_graph/support/hash_util"
+require "json_schemer"
+
+module ElasticGraph
+  # Provides a standard way to define an ElasticGraph configuration class.
+  module Config
+    # Defines a configuration class with the given attributes.
+    #
+    # @param attrs [::Symbol] attribute names
+    # @return [::Class] the defined configuration class
+    # @yield [::Data] the body of the class (similar to `::Data.define`)
+    #
+    # @example Define a configuration class
+    #    require "elastic_graph/config"
+    #
+    #    ExampleConfigClass = ElasticGraph::Config.define(:size, :name) do
+    #      json_schema at: "example",
+    #        properties: {
+    #          size: {
+    #            description: "Determines the size.",
+    #            examples: [10, 100],
+    #            type: "integer",
+    #            minimum: 1,
+    #          },
+    #          name: {
+    #            description: "Determines the name.",
+    #            examples: ["widget"],
+    #            type: "string",
+    #            minLength: 1
+    #          }
+    #        },
+    #        required: ["size", "name"]
+    #    end
+    def self.define(*attrs, &block)
+      ::Data.define(*attrs) do
+        # @implements ::Data
+        alias_method :__data_initialize, :initialize
+        extend ClassMethods
+        include InstanceMethods
+        class_exec(&(_ = block)) if block
+      end
+    end
+
+    # Defines class methods for configuration classes.
+    module ClassMethods
+      include Support::FromYamlFile
+
+      # @dynamic validator, path
+
+      # @return [Support::JSONSchema::Validator] validator for this configuration class
+      attr_reader :validator
+
+      # @return [::String] path from the global configuration root to where this configuration resides.
+      attr_reader :path
+
+      # Defines the JSON schema and path for this configuration class.
+      #
+      # @param at [::String] path from the global configuration root to where this configuration resides
+      # @param schema [::Hash<::Symbol, ::Object>] JSON schema definition
+      # @return [void]
+      #
+      # @example Define a configuration class
+      #    require "elastic_graph/config"
+      #
+      #    ExampleConfigClass = ElasticGraph::Config.define(:size, :name) do
+      #      json_schema at: "example",
+      #        properties: {
+      #          size: {
+      #            description: "Determines the size.",
+      #            examples: [10, 100],
+      #            type: "integer",
+      #            minimum: 1,
+      #          },
+      #          name: {
+      #            description: "Determines the name.",
+      #            examples: ["widget"],
+      #            type: "string",
+      #            minLength: 1
+      #          }
+      #        },
+      #        required: ["size", "name"]
+      #    end
+      def json_schema(at:, **schema)
+        @path = at
+
+        schema = Support::HashUtil.stringify_keys(schema)
+        @validator = Support::JSONSchema::ValidatorFactory
+          .new(schema: {"$schema" => "http://json-schema.org/draft-07/schema#", "$defs" => {"config" => schema}}, sanitize_pii: false)
+          .with_unknown_properties_disallowed
+          .validator_for("config")
+      end
+
+      # Instantiates a config instance from the given parsed YAML class, returning `nil` if there is no config.
+      # In addition, this (along with `Support::FromYamlFile`) makes `from_yaml_file(path_to_file)` available.
+      #
+      # @param parsed_yaml [::Hash<::String, ::Object>] config hash parsed from YAML
+      # @return [::Data, nil] the instantiated config object or `nil` if there is nothing at the specified path
+      def from_parsed_yaml(parsed_yaml)
+        value_at_path = Support::HashUtil.fetch_value_at_path(parsed_yaml, path.split(".")) { return nil }
+
+        if value_at_path.is_a?(::Hash)
+          config = (_ = value_at_path).transform_keys(&:to_sym) # : ::Hash[::Symbol, untyped]
+          new(**config)
+        else
+          raise_invalid_config("Expected a hash at `#{path}`, got: `#{value_at_path.inspect}`.")
+        end
+      end
+
+      # Instantiates a config instance from the given parsed YAML class, raising an error if there is no config.
+      #
+      # @param parsed_yaml [::Hash<::String, ::Object>] config hash parsed from YAML
+      # @return [::Data] the instantiated config object
+      # @raise [Errors::ConfigError] if there is no config at the specified path.
+      def from_parsed_yaml!(parsed_yaml)
+        from_parsed_yaml(parsed_yaml) || raise_invalid_config("missing configuration at `#{path}`.")
+      end
+
+      # @private
+      def raise_invalid_config(error)
+        raise Errors::ConfigError, "Invalid configuration for `#{name}` at `#{path}`: #{error}"
+      end
+
+      # Like `new`, but avoids applying JSON schema validation. This is needed so that we can make
+      # `#with` work correctly with the validation and conversion features we offer.
+      #
+      # @private
+      def new_without_validation(**data)
+        instance = allocate
+        instance.send(:__data_initialize, **data)
+        instance
+      end
+    end
+
+    # @private
+    module InstanceMethods
+      # Overrides `initialize` to apply JSON schema validation.
+      def initialize(**config)
+        klass = (_ = self.class) # : ClassMethods[::Data]
+        validator = klass.validator
+        config = validator.merge_defaults(config)
+
+        if (error = validator.validate_with_error_message(config))
+          klass.raise_invalid_config(error)
+        end
+
+        config = config.transform_keys(&:to_sym)
+        __skip__ = super(**convert_values(**config))
+      end
+
+      # Overrides `#with` to bypass the normal JSON schema validation that applies in `#initialize`.
+      # This is required so that `config.with(...)` can be used on config classes that use the
+      # `convert_values` hook to convert JSON data to some custom Ruby type. The custom Ruby type
+      # won't pass JSON schema validation, and if we didn't override `with` then we'd get validation
+      # failures due to the converted values failing validation.
+      def with(**updates)
+        (_ = self.class).new_without_validation(**to_h.merge(updates))
+      end
+
+      private
+
+      # Default implementation of a hook that allows config values to be converted during initialization.
+      def convert_values(**values)
+        values
+      end
+    end
+  end
+end

--- a/elasticgraph-support/sig/elastic_graph/config.rbs
+++ b/elasticgraph-support/sig/elastic_graph/config.rbs
@@ -1,0 +1,24 @@
+module ElasticGraph
+  module Config
+    def self.define: [T] (*::Symbol) ?{ (ClassMethods[T]) -> void } -> T
+
+    module ClassMethods[T]: ::Class
+      attr_reader validator: Support::JSONSchema::Validator
+      attr_reader path: ::String
+
+      def json_schema: (at: ::String, **untyped) -> void
+      def from_parsed_yaml: (parsedYamlSettings) -> T?
+      def from_parsed_yaml!: (parsedYamlSettings) -> T
+      def raise_invalid_config: (::String) -> bot
+      def new_without_validation: (**untyped) -> T
+    end
+
+    module InstanceMethods: Data
+      def initialize: (**untyped) -> void
+
+      private
+
+      def convert_values: (**untyped) -> ::Hash[::Symbol, untyped]
+    end
+  end
+end

--- a/elasticgraph-support/spec/unit/elastic_graph/config_spec.rb
+++ b/elasticgraph-support/spec/unit/elastic_graph/config_spec.rb
@@ -1,0 +1,350 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/config"
+require "yaml"
+
+module ElasticGraph
+  RSpec.describe Config do
+    describe ".define" do
+      it "defines a data class with the named attributes" do
+        config_def = Config.define(:size, :name) do
+          json_schema at: "test"
+        end
+
+        valid_config = config_def.new(size: 10, name: "test")
+
+        expect(valid_config.size).to eq(10)
+        expect(valid_config.name).to eq("test")
+        expect(valid_config).to be_a(::Data)
+      end
+
+      it "validates upon instantiation" do
+        config_def = Config.define(:size, :name) do
+          json_schema at: "test",
+            properties: {
+              size: {type: "integer", minimum: 1},
+              name: {type: "string", minLength: 1}
+            },
+            required: ["size", "name"]
+        end
+        stub_const("MyConfig", config_def)
+
+        expect {
+          config_def.new(size: 0, name: "test")
+        }.to raise_error(Errors::ConfigError, a_string_including("Invalid configuration for `MyConfig` at `test`:", "/size", "minimum"))
+
+        expect {
+          config_def.new(size: 10, name: "")
+        }.to raise_error(Errors::ConfigError, a_string_including("Invalid configuration for `MyConfig` at `test`:", "/name", "minLength"))
+
+        expect {
+          config_def.new(size: 10)
+        }.to raise_error(Errors::ConfigError, a_string_including(
+          "Invalid configuration for `MyConfig` at `test`:",
+          "object at root is missing required properties: name"
+        ))
+      end
+
+      it "can be defined as a subclass of the class returned by `Config.define`" do
+        config_def = ::Class.new(Config.define(:size, :name)) do
+          json_schema at: "test",
+            properties: {
+              size: {type: "integer", minimum: 1},
+              name: {type: "string", minLength: 1}
+            },
+            required: ["size", "name"]
+        end
+        stub_const("MyConfig", config_def)
+
+        valid_config = config_def.new(size: 10, name: "test")
+
+        expect(valid_config.size).to eq(10)
+        expect(valid_config.name).to eq("test")
+        expect(valid_config).to be_a(::Data)
+
+        expect {
+          config_def.new(size: 0, name: "test")
+        }.to raise_error(Errors::ConfigError, a_string_including("Invalid configuration for `MyConfig` at `test`:", "/size", "minimum"))
+      end
+
+      it "prevents unknown keys since they are likely typos" do
+        config_def = Config.define(:size, :name) do
+          json_schema at: "test",
+            properties: {
+              size: {type: "integer", minimum: 1},
+              name: {type: "string", minLength: 1}
+            }
+        end
+
+        expect {
+          config_def.new(foo: 10, size: 10, name: "foo")
+        }.to raise_error(Errors::ConfigError, a_string_including("object property at `/foo` is a disallowed additional property"))
+      end
+
+      it "honors defaults specified in the JSON schema" do
+        config_def = Config.define(:size, :name) do
+          json_schema at: "test",
+            properties: {
+              size: {type: "integer", minimum: 1, default: 7},
+              name: {type: "string", minLength: 1, default: "example"}
+            }
+        end
+
+        config = config_def.new
+
+        expect(config.size).to eq 7
+        expect(config.name).to eq "example"
+      end
+
+      it "does not allow defaults to violate validations" do
+        config_def = Config.define(:size, :name) do
+          json_schema at: "test",
+            properties: {
+              size: {type: "integer", minimum: 1, default: 0},
+              name: {type: "string", minLength: 1, default: "example"}
+            }
+        end
+
+        expect {
+          config_def.new
+        }.to raise_error(Errors::ConfigError, a_string_including("/size", "minimum"))
+      end
+
+      context "when the config class defines `convert_values`" do
+        login_class = ::Data.define(:username, :password)
+        config_class = Config.define(:login, :timeout) do
+          json_schema at: "test", properties: {
+            login: {type: "object"},
+            timeout: {type: "number", default: 10}
+          }
+
+          define_method :convert_values do |login:, **others|
+            {login: login_class.new(**login), **others}
+          end
+        end
+
+        before do
+          stub_const("Login", login_class)
+        end
+
+        it "allows the override to convert some config values" do
+          config = config_class.new(login: {username: "bob", password: "123"}, timeout: 10)
+
+          expect(config.login).to eq login_class.new(username: "bob", password: "123")
+          expect(config.timeout).to eq 10
+        end
+
+        it "still validates initialized values" do
+          expect {
+            config_class.new(login: 5)
+          }.to raise_error(Errors::ConfigError, a_string_including("value at `/login` is not an object"))
+        end
+
+        it "allows `#with` to carry forward converted values" do
+          config = config_class.new(login: {username: "bob", password: "123"}, timeout: 10)
+          config.with(timeout: 50)
+
+          expect(config.login).to eq login_class.new(username: "bob", password: "123")
+          expect(config.timeout).to eq 10
+        end
+      end
+
+      describe ".from_parsed_yaml" do
+        it "loads from a from parsed YAML hash" do
+          config_def = Config.define(:size, :name) do
+            json_schema at: "test",
+              properties: {
+                size: {type: "integer", minimum: 1},
+                name: {type: "string", minLength: 1}
+              },
+              required: ["size", "name"]
+          end
+
+          parsed_yaml = {"test" => {"size" => 5, "name" => "yaml_test"}}
+          yaml_config = config_def.from_parsed_yaml(parsed_yaml)
+
+          expect(yaml_config.size).to eq(5)
+          expect(yaml_config.name).to eq("yaml_test")
+          expect(config_def.from_parsed_yaml!(parsed_yaml)).to eq yaml_config
+
+          parsed_yaml = {"test" => {"size" => 0, "name" => "yaml_test"}}
+          expect {
+            config_def.from_parsed_yaml(parsed_yaml)
+          }.to raise_error(Errors::ConfigError, a_string_including("/size", "minimum"))
+        end
+
+        it "returns `nil` if the parsed YAML hash has no entry at the specified path" do
+          config_def = Config.define(:size, :name) do
+            json_schema at: "test",
+              properties: {
+                size: {type: "integer", minimum: 1},
+                name: {type: "string", minLength: 1}
+              },
+              required: ["size", "name"]
+          end
+
+          expect(config_def.from_parsed_yaml({})).to eq nil
+        end
+
+        it "raises from `from_parsed_yaml!` if the parsed YAML hash has no entry at the specified path" do
+          config_def = Config.define(:size, :name) do
+            json_schema at: "test",
+              properties: {
+                size: {type: "integer", minimum: 1},
+                name: {type: "string", minLength: 1}
+              },
+              required: ["size", "name"]
+          end
+          stub_const("MyConfig", config_def)
+
+          expect {
+            config_def.from_parsed_yaml!({})
+          }.to raise_error(Errors::ConfigError, "Invalid configuration for `MyConfig` at `test`: missing configuration at `test`.")
+        end
+
+        it "extracts config data from nested YAML structure" do
+          config_def = Config.define(:database_url, :pool_size) do
+            json_schema at: "database.connection",
+              properties: {
+                database_url: {type: "string", minLength: 1},
+                pool_size: {type: "integer", minimum: 1}
+              },
+              required: ["database_url", "pool_size"]
+          end
+
+          nested_yaml = {
+            "database" => {
+              "connection" => {
+                "database_url" => "postgres://localhost/test",
+                "pool_size" => 5
+              }
+            }
+          }
+
+          config = config_def.from_parsed_yaml(nested_yaml)
+          expect(config.database_url).to eq("postgres://localhost/test")
+          expect(config.pool_size).to eq(5)
+        end
+
+        it "does not symbolize string keys on map values" do
+          config_def = Config.define(:thresholds_by_name) do
+            json_schema at: "test",
+              properties: {
+                thresholds_by_name: {type: "object", patternProperties: {
+                  /^\w+$/.source => {type: "integer"}
+                }}
+              }
+          end
+
+          config = config_def.from_parsed_yaml({"test" => {"thresholds_by_name" => {"foo" => 10, "bar" => 12}}})
+
+          expect(config.thresholds_by_name).to eq({
+            "foo" => 10,
+            "bar" => 12
+          })
+        end
+
+        it "raises a clear error if the value at the specified path is not a hash" do
+          config_def = Config.define(:size, :name) do
+            json_schema at: "test",
+              properties: {
+                size: {type: "integer", minimum: 1},
+                name: {type: "string", minLength: 1}
+              },
+              required: ["size", "name"]
+          end
+          stub_const("MyConfig", config_def)
+
+          expect {
+            config_def.from_parsed_yaml({"test" => 10})
+          }.to raise_error(Errors::ConfigError, "Invalid configuration for `MyConfig` at `test`: Expected a hash at `test`, got: `10`.")
+        end
+      end
+
+      context "YAML file integration", :in_temp_dir do
+        it "loads configuration from YAML file" do
+          config_def = Config.define(:host, :port) do
+            json_schema at: "server",
+              properties: {
+                host: {type: "string", minLength: 1},
+                port: {type: "integer", minimum: 1, maximum: 65535}
+              },
+              required: ["host", "port"]
+          end
+
+          yaml_content = {
+            "server" => {
+              "host" => "localhost",
+              "port" => 3000
+            }
+          }
+
+          ::File.write("config.yaml", ::YAML.dump(yaml_content))
+          config = config_def.from_yaml_file("config.yaml")
+
+          expect(config.host).to eq("localhost")
+          expect(config.port).to eq(3000)
+        end
+
+        it "returns `nil` if the YAML file has no entry at the specified path" do
+          config_def = Config.define(:host, :port) do
+            json_schema at: "server",
+              properties: {
+                host: {type: "string", minLength: 1},
+                port: {type: "integer", minimum: 1, maximum: 65535}
+              },
+              required: ["host", "port"]
+          end
+
+          yaml_content = {
+            "other" => {
+              "host" => "localhost",
+              "port" => 3000
+            }
+          }
+
+          ::File.write("config.yaml", ::YAML.dump(yaml_content))
+          config = config_def.from_yaml_file("config.yaml")
+
+          expect(config).to be nil
+        end
+
+        it "supports YAML file with block for preprocessing" do
+          config_def = Config.define(:name, :env) do
+            json_schema at: "app",
+              properties: {
+                name: {type: "string"},
+                env: {type: "string", enum: ["development", "test", "production"]}
+              },
+              required: ["name", "env"]
+          end
+
+          yaml_content = {
+            "app" => {
+              "name" => "test_app",
+              "env" => "development"
+            }
+          }
+
+          ::File.write("config.yaml", ::YAML.dump(yaml_content))
+
+          # Test with preprocessing block
+          config = config_def.from_yaml_file("config.yaml") do |parsed_yaml|
+            # Modify the environment in preprocessing
+            parsed_yaml["app"]["env"] = "test"
+            parsed_yaml
+          end
+
+          expect(config.name).to eq("test_app")
+          expect(config.env).to eq("test") # Modified by preprocessing block
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This defines a configuration class which uses JSON schema to validate the provided configuration, removing the need to perform ad-hoc config validation like we were before. In addition, the JSON schema will allow us to improve our documentation as we can merge the JSON schemas from all configuration classes to provide the overall config schema of ElasticGraph in our docs. (That will come in a later PR).