### PR TITLE
feat: migrate `indexer` config to use `ElasticGraph::Config`.

### DIFF
--- a/elasticgraph-indexer/lib/elastic_graph/indexer.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer.rb
@@ -21,7 +21,7 @@ module ElasticGraph
     # `from_yaml_file(file_name, &block)` is also available (via `Support::FromYamlFile`).
     def self.from_parsed_yaml(parsed_yaml, &datastore_client_customization_block)
       new(
-        config: Indexer::Config.from_parsed_yaml(parsed_yaml),
+        config: Indexer::Config.from_parsed_yaml(parsed_yaml) || Indexer::Config.new,
         datastore_core: DatastoreCore.from_parsed_yaml(parsed_yaml, &datastore_client_customization_block)
       )
     end

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/config.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/config.rb
@@ -6,43 +6,51 @@
 #
 # frozen_string_literal: true
 
+require "elastic_graph/config"
 require "elastic_graph/errors"
-require "elastic_graph/indexer/event_id"
 
 module ElasticGraph
   class Indexer
-    class Config < ::Data.define(
-      # Map of indexing latency thresholds (in milliseconds), keyed by the name of
-      # the indexing latency metric. When an event is indexed with an indexing latency
-      # exceeding the threshold, a warning with the event type, id, and version will
-      # be logged, so the issue can be investigated.
-      :latency_slo_thresholds_by_timestamp_in_ms,
-      # Setting that can be used to specify some derived indexing type updates that should be skipped. This
-      # setting should be a map keyed by the name of the derived indexing type, and the values should be sets
-      # of ids. This can be useful when you have a "hot spot" of a single derived document that is
-      # receiving a ton of updates. During a backfill (or whatever) you may want to skip the derived
-      # type updates.
-      :skip_derived_indexing_type_updates
-    )
-      def self.from_parsed_yaml(hash)
-        hash = hash.fetch("indexer")
-        extra_keys = hash.keys - EXPECTED_KEYS
+    class Config < ElasticGraph::Config.define(:latency_slo_thresholds_by_timestamp_in_ms, :skip_derived_indexing_type_updates)
+      json_schema at: "indexer",
+        properties: {
+          latency_slo_thresholds_by_timestamp_in_ms: {
+            description: "Map of indexing latency thresholds (in milliseconds), keyed by the name of " \
+              "the indexing latency metric. When an event is indexed with an indexing latency " \
+              "exceeding the threshold, a warning with the event type, id, and version will " \
+              "be logged, so the issue can be investigated.",
+            type: "object",
+            patternProperties: {/.+/.source => {type: "integer", minimum: 0}},
+            default: {}, # : untyped
+            examples: [
+              {}, # : untyped
+              {"ingested_from_topic_at" => 10000, "entity_updated_at" => 15000}
+            ]
+          },
+          skip_derived_indexing_type_updates: {
+            description: "Setting that can be used to specify some derived indexing type updates that should be skipped. This " \
+              "setting should be a map keyed by the name of the derived indexing type, and the values should be sets " \
+              'of ids. This can be useful when you have a "hot spot" of a single derived document that is ' \
+              "receiving a ton of updates. During a backfill (or whatever) you may want to skip the derived " \
+              "type updates.",
+            type: "object",
+            patternProperties: {/^[A-Z]\w*$/.source => {type: "array", items: {type: "string", minLength: 1}}},
+            default: {}, # : untyped
+            examples: [
+              {}, # : untyped
+              {"WidgetWorkspace" => ["ABC12345678"]}
+            ]
+          }
+        }
 
-        unless extra_keys.empty?
-          raise Errors::ConfigError, "Unknown `indexer` config settings: #{extra_keys.join(", ")}"
-        end
+      private
 
-        new(
-          latency_slo_thresholds_by_timestamp_in_ms: hash.fetch("latency_slo_thresholds_by_timestamp_in_ms"),
-          skip_derived_indexing_type_updates: (hash["skip_derived_indexing_type_updates"] || {}).transform_values(&:to_set)
-        )
+      def convert_values(skip_derived_indexing_type_updates:, latency_slo_thresholds_by_timestamp_in_ms:)
+        {
+          skip_derived_indexing_type_updates: skip_derived_indexing_type_updates.transform_values(&:to_set),
+          latency_slo_thresholds_by_timestamp_in_ms: latency_slo_thresholds_by_timestamp_in_ms
+        }
       end
-
-      EXPECTED_KEYS = members.map(&:to_s)
     end
-
-    # Steep weirdly expects them here...
-    # @dynamic initialize, config, datastore_core, schema_artifacts, datastore_router
-    # @dynamic record_preparer, processor, operation_factory
   end
 end

--- a/elasticgraph-indexer/sig/elastic_graph/indexer/config.rbs
+++ b/elasticgraph-indexer/sig/elastic_graph/indexer/config.rbs
@@ -1,12 +1,14 @@
 module ElasticGraph
   class Indexer
     class ConfigSupertype
+      extend ::ElasticGraph::Config::ClassMethods[Config]
+
       attr_reader latency_slo_thresholds_by_timestamp_in_ms: ::Hash[::String, ::Integer]
       attr_reader skip_derived_indexing_type_updates: ::Hash[::String, ::Set[::String]]
 
       def initialize: (
-        latency_slo_thresholds_by_timestamp_in_ms: ::Hash[::String, ::Integer],
-        skip_derived_indexing_type_updates: ::Hash[::String, ::Set[::String]]) -> void
+        ?latency_slo_thresholds_by_timestamp_in_ms: ::Hash[::String, ::Integer],
+        ?skip_derived_indexing_type_updates: ::Hash[::String, ::Set[::String]]) -> void
 
       def with: (
         ?latency_slo_thresholds_by_timestamp_in_ms: ::Hash[::String, ::Integer],
@@ -16,8 +18,12 @@ module ElasticGraph
     end
 
     class Config < ConfigSupertype
-      extend _BuildableFromParsedYaml[Config]
-      EXPECTED_KEYS: ::Array[::String]
+      private
+
+      def convert_values: (
+        latency_slo_thresholds_by_timestamp_in_ms: untyped,
+        skip_derived_indexing_type_updates: untyped
+      ) -> ::Hash[::Symbol, untyped]
     end
   end
 end

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer_spec.rb
@@ -22,6 +22,12 @@ module ElasticGraph
         expect(indexer).to be_a(Indexer)
         expect(indexer.datastore_core.client_customization_block).to be(customization_block)
       end
+
+      it "can build an instance with no `indexer` config" do
+        indexer = Indexer.from_parsed_yaml(parsed_test_settings_yaml.except("indexer"))
+
+        expect(indexer).to be_a(Indexer)
+      end
     end
   end
 end

--- a/elasticgraph/spec/unit/elastic_graph/gem_spec.rb
+++ b/elasticgraph/spec/unit/elastic_graph/gem_spec.rb
@@ -198,7 +198,6 @@ module ElasticGraph
           elasticgraph-datastore_core
           elasticgraph-graphql
           elasticgraph-health_check
-          elasticgraph-indexer
           elasticgraph-query_interceptor
           elasticgraph-query_registry
         ].include?(gem_name)

--- a/spec_support/lib/elastic_graph/spec_support/builds_indexer.rb
+++ b/spec_support/lib/elastic_graph/spec_support/builds_indexer.rb
@@ -28,7 +28,7 @@ module ElasticGraph
         datastore_core: datastore_core || build_datastore_core(**datastore_core_options, &customize_datastore_config),
         config: Indexer::Config.new(
           latency_slo_thresholds_by_timestamp_in_ms: latency_slo_thresholds_by_timestamp_in_ms,
-          skip_derived_indexing_type_updates: skip_derived_indexing_type_updates.transform_values(&:to_set)
+          skip_derived_indexing_type_updates: skip_derived_indexing_type_updates
         ),
         datastore_router: datastore_router,
         clock: clock,


### PR DESCRIPTION
This provides JSON schema validation of the config, participates in the new config system which will be used as the basis of our documentation, and provides default values so that the `indexer` config is optional.