### PR TITLE
feat: migrate `health_check` config to use `ElasticGraph::Config`.

### DIFF
--- a/elasticgraph-health_check/lib/elastic_graph/health_check/health_checker.rb
+++ b/elasticgraph-health_check/lib/elastic_graph/health_check/health_checker.rb
@@ -21,7 +21,7 @@ module ElasticGraph
       def self.build_from(graphql)
         new(
           schema: graphql.schema,
-          config: HealthCheck::Config.from_parsed_yaml(graphql.config.extension_settings),
+          config: HealthCheck::Config.from_parsed_yaml(graphql.config.extension_settings) || HealthCheck::Config.new,
           datastore_search_router: graphql.datastore_search_router,
           datastore_query_builder: graphql.datastore_query_builder,
           datastore_clients_by_name: graphql.datastore_core.clients_by_name,

--- a/elasticgraph-health_check/sig/elastic_graph/health_check/config.rbs
+++ b/elasticgraph-health_check/sig/elastic_graph/health_check/config.rbs
@@ -1,15 +1,19 @@
 module ElasticGraph
   module HealthCheck
+    type dataRecencyCheckHash = ::Hash[::String, untyped]
+
     class ConfigSupertype
+      extend ::ElasticGraph::Config::ClassMethods[Config]
+
       attr_reader clusters_to_consider: ::Array[::String]
       attr_reader data_recency_checks: ::Hash[::String, Config::DataRecencyCheck]
 
       def self.new: (
         ::Array[::String],
-        ::Hash[::String, Config::DataRecencyCheck]
+        ::Hash[::String, dataRecencyCheckHash]
       ) -> Config | (
-        clusters_to_consider: ::Array[::String],
-        data_recency_checks: ::Hash[::String, Config::DataRecencyCheck]
+        ?clusters_to_consider: ::Array[::String],
+        ?data_recency_checks: ::Hash[::String, dataRecencyCheckHash]
       ) -> Config
 
       def with: (
@@ -18,21 +22,21 @@ module ElasticGraph
     end
 
     class Config < ConfigSupertype
-      EMPTY: Config
-      extend _BuildableFromParsedYaml[Config]
+      private
+
+      def convert_values: (clusters_to_consider: untyped, data_recency_checks: untyped) -> untyped
 
       class DataRecencyCheck
         attr_reader expected_max_recency_seconds: ::Integer
         attr_reader timestamp_field: ::String
 
-        def self.new: (
+        def initialize: (
           expected_max_recency_seconds: ::Integer,
           timestamp_field: ::String) -> DataRecencyCheck
+
         def with: (
           ?expected_max_recency_seconds: ::Integer,
           ?timestamp_field: ::String) -> DataRecencyCheck
-
-        def self.from: (::Hash[::String, untyped]) -> DataRecencyCheck
       end
     end
   end

--- a/elasticgraph-health_check/spec/acceptance/health_checker_spec.rb
+++ b/elasticgraph-health_check/spec/acceptance/health_checker_spec.rb
@@ -22,13 +22,13 @@ module ElasticGraph
           health_check: {
             clusters_to_consider: ["main", "other2"],
             data_recency_checks: {
-              Widget: {
-                expected_max_recency_seconds: 300,
-                timestamp_field: "created_at2" # use a field that has an alternate `name_in_index`.
+              "Widget" => {
+                "expected_max_recency_seconds" => 300,
+                "timestamp_field" => "created_at2" # use a field that has an alternate `name_in_index`.
               },
-              Component: {
-                expected_max_recency_seconds: 30,
-                timestamp_field: "created_at"
+              "Component" => {
+                "expected_max_recency_seconds" => 30,
+                "timestamp_field" => "created_at"
               }
             }
           }

--- a/elasticgraph/spec/unit/elastic_graph/gem_spec.rb
+++ b/elasticgraph/spec/unit/elastic_graph/gem_spec.rb
@@ -197,7 +197,6 @@ module ElasticGraph
         include_examples "an ElasticGraph gem", gem_name, config_pending: %w[
           elasticgraph-datastore_core
           elasticgraph-graphql
-          elasticgraph-health_check
           elasticgraph-query_interceptor
           elasticgraph-query_registry
         ].include?(gem_name)


### PR DESCRIPTION
This provides JSON schema validation of the config, participates in the new config system which will be used as the basis of our documentation, and provides default values so that the `health_check` config is optional.