### PR TITLE
feat: migrate `query_registry` config to use `ElasticGraph::Config`.

### DIFF
--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/config.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/config.rb
@@ -1,0 +1,41 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/config"
+
+module ElasticGraph
+  module QueryRegistry
+    class Config < ElasticGraph::Config.define(:path_to_registry, :allow_unregistered_clients, :allow_any_query_for_clients)
+      json_schema at: "query_registry",
+        properties: {
+          path_to_registry: {
+            description: "Path to the directory containing the query registry files.",
+            type: "string",
+            examples: ["config/queries"]
+          },
+          allow_unregistered_clients: {
+            description: "Whether to allow clients that are not registered in the registry.",
+            type: "boolean",
+            examples: [true, false],
+            default: true
+          },
+          allow_any_query_for_clients: {
+            description: "List of client names that are allowed to execute any query, even if not registered.",
+            type: "array",
+            items: {type: "string"},
+            examples: [
+              [], # : untyped
+              ["admin", "internal"]
+            ],
+            default: [] # : untyped
+          }
+        },
+        required: ["path_to_registry"]
+    end
+  end
+end

--- a/elasticgraph-query_registry/sig/elastic_graph/query_registry/config.rbs
+++ b/elasticgraph-query_registry/sig/elastic_graph/query_registry/config.rbs
@@ -1,0 +1,26 @@
+module ElasticGraph
+  module QueryRegistry
+    class ConfigSupertype
+      extend ::ElasticGraph::Config::ClassMethods[Config]
+
+      attr_reader path_to_registry: ::String
+      attr_reader allow_unregistered_clients: bool
+      attr_reader allow_any_query_for_clients: ::Array[::String]
+
+      def initialize: (
+        ?path_to_registry: ::String,
+        ?allow_unregistered_clients: bool,
+        ?allow_any_query_for_clients: ::Array[::String]
+      ) -> void
+
+      def with: (
+        ?path_to_registry: ::String,
+        ?allow_unregistered_clients: bool,
+        ?allow_any_query_for_clients: ::Array[::String]
+      ) -> Config
+    end
+
+    class Config < ConfigSupertype
+    end
+  end
+end

--- a/elasticgraph-query_registry/sig/elastic_graph/query_registry/graphql_extension.rbs
+++ b/elasticgraph-query_registry/sig/elastic_graph/query_registry/graphql_extension.rbs
@@ -1,7 +1,6 @@
 module ElasticGraph
   module QueryRegistry
     module GraphQLExtension: GraphQL
-      def graphql_query_executor: () -> RegistryAwareQueryExecutor
     end
 
     class RegistryAwareQueryExecutor < GraphQL::QueryExecutor
@@ -18,29 +17,6 @@ module ElasticGraph
       private
 
       @registry: Registry
-    end
-
-    class ConfigSupertype
-      attr_reader path_to_registry: ::String
-      attr_reader allow_unregistered_clients: bool
-      attr_reader allow_any_query_for_clients: ::Array[::String]
-
-      def self.new: (
-        path_to_registry: ::String,
-        allow_unregistered_clients: bool,
-        allow_any_query_for_clients: ::Array[::String]
-      ) -> Config
-
-      def with: (
-        ?path_to_registry: ::String,
-        ?allow_unregistered_clients: bool,
-        ?allow_any_query_for_clients: ::Array[::String]
-      ) -> Config
-    end
-
-    class Config < ConfigSupertype
-      extend _BuildableFromParsedYaml[Config]
-      DEFAULT: Config
     end
   end
 end

--- a/elasticgraph/spec/unit/elastic_graph/gem_spec.rb
+++ b/elasticgraph/spec/unit/elastic_graph/gem_spec.rb
@@ -198,7 +198,6 @@ module ElasticGraph
           elasticgraph-datastore_core
           elasticgraph-graphql
           elasticgraph-query_interceptor
-          elasticgraph-query_registry
         ].include?(gem_name)
       end
     end


### PR DESCRIPTION
This provides JSON schema validation of the config, participates in the new config system which will be used as the basis of our documentation.