### PR TITLE
feat: migrate `query_interceptor` config to use ElasticGraph::Config.

### DIFF
--- a/elasticgraph-query_interceptor/lib/elastic_graph/query_interceptor/graphql_extension.rb
+++ b/elasticgraph-query_interceptor/lib/elastic_graph/query_interceptor/graphql_extension.rb
@@ -19,8 +19,10 @@ module ElasticGraph
             Support::HashUtil.stringify_keys(ext_mod.config) if ext_mod.extension_class == GraphQLExtension
           end
 
-          interceptors = Config
-            .from_parsed_yaml(config.extension_settings, parsed_runtime_metadata_hashes: runtime_metadata_configs)
+          query_interceptor_config = Config.from_parsed_yaml(config.extension_settings) || Config.new
+
+          interceptors = query_interceptor_config
+            .with_runtime_metadata_configs(runtime_metadata_configs)
             .interceptors
             .map { |data| data.klass.new(elasticgraph_graphql: self, config: data.config) }
 

--- a/elasticgraph-query_interceptor/sig/elastic_graph/query_interceptor/config.rbs
+++ b/elasticgraph-query_interceptor/sig/elastic_graph/query_interceptor/config.rbs
@@ -3,34 +3,36 @@ module ElasticGraph
     type interceptorClass = Class & _InterceptorFactory
 
     class ConfigSupertype
-      attr_reader interceptors: ::Array[InterceptorDataSuperType]
+      extend ::ElasticGraph::Config::ClassMethods[Config]
 
-      def self.new: (::Array[InterceptorDataSuperType]) -> Config
-      def with: (?interceptors: ::Array[InterceptorDataSuperType]) -> Config
-      def self.members: () -> ::Array[::Symbol]
+      attr_reader interceptors: ::Array[Config::InterceptorData]
+
+      def initialize: (?interceptors: ::Array[::Hash[::String, untyped]]) -> void
+      def with: (?interceptors: ::Array[Config::InterceptorData]) -> Config
     end
 
     class Config < ConfigSupertype
-      def self.from_parsed_yaml: (parsedYamlSettings, ?parsed_runtime_metadata_hashes: ::Array[::Hash[::String, untyped]]) -> Config
+      def with_runtime_metadata_configs: (::Array[::Hash[::String, untyped]]) -> Config
 
-      DEFAULT: Config
-      EXPECTED_KEYS: ::Array[::String]
+      private
 
-      class InterceptorData < InterceptorDataSuperType
+      def convert_values: (interceptors: untyped) -> untyped
+
+      def load_interceptors: (::Array[::Hash[::String, untyped]]) -> ::Array[InterceptorData]
+
+      class InterceptorData
+        attr_reader klass: interceptorClass
+        attr_reader config: ::Hash[::String, untyped]
+
+        def initialize: (
+          klass: interceptorClass,
+          config: ::Hash[::String, untyped]
+        ) -> void
       end
 
       class InterceptorInterface
         include _Interceptor
       end
-    end
-
-    class InterceptorDataSuperType
-      attr_reader klass: interceptorClass
-      attr_reader config: ::Hash[::String, untyped]
-
-      def initialize: (
-        klass: ::ElasticGraph::SchemaArtifacts::RuntimeMetadata::extensionClass,
-        config: ::Hash[::String, untyped]) -> void
     end
 
     interface _InterceptorFactory

--- a/elasticgraph-query_interceptor/spec/unit/elastic_graph/query_interceptor/config_spec.rb
+++ b/elasticgraph-query_interceptor/spec/unit/elastic_graph/query_interceptor/config_spec.rb
@@ -12,10 +12,10 @@ require "elastic_graph/query_interceptor/config"
 module ElasticGraph
   module QueryInterceptor
     RSpec.describe Config, :in_temp_dir do
-      it "returns a config instance with no interceptors if extension settings has no `query_interceptor` key" do
+      it "returns nil if extension settings has no `query_interceptor` key" do
         config = Config.from_parsed_yaml({})
 
-        expect(config.interceptors).to eq []
+        expect(config).to eq nil
       end
 
       it "raises an error if configured with unknown keys" do
@@ -24,10 +24,10 @@ module ElasticGraph
         }.to raise_error Errors::ConfigError, a_string_including("other_key")
       end
 
-      it "raises an error if configured with no `interceptors` key" do
-        expect {
-          Config.from_parsed_yaml({"query_interceptor" => {}})
-        }.to raise_error KeyError, a_string_including("interceptors")
+      it "returns a config instance with empty interceptors if configured with no `interceptors` key" do
+        config = Config.from_parsed_yaml({"query_interceptor" => {}})
+
+        expect(config.interceptors).to eq []
       end
 
       it "loads interceptors from disk based on config settings" do

--- a/elasticgraph/spec/unit/elastic_graph/gem_spec.rb
+++ b/elasticgraph/spec/unit/elastic_graph/gem_spec.rb
@@ -197,7 +197,6 @@ module ElasticGraph
         include_examples "an ElasticGraph gem", gem_name, config_pending: %w[
           elasticgraph-datastore_core
           elasticgraph-graphql
-          elasticgraph-query_interceptor
         ].include?(gem_name)
       end
     end


### PR DESCRIPTION
This provides JSON schema validation of the config, participates in the new config system which will be used as the basis of our documentation, and provides default values so that the `query_interceptor` config is optional.