### PR TITLE
feat: migrate `graphql` config to use `ElasticGraph::Config`.

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -26,7 +26,7 @@ module ElasticGraph
     # `from_yaml_file(file_name, &block)` is also available (via `Support::FromYamlFile`).
     def self.from_parsed_yaml(parsed_yaml, &datastore_client_customization_block)
       new(
-        config: GraphQL::Config.from_parsed_yaml(parsed_yaml),
+        config: GraphQL::Config.from_parsed_yaml(parsed_yaml) || GraphQL::Config.new,
         datastore_core: DatastoreCore.from_parsed_yaml(parsed_yaml, &datastore_client_customization_block)
       )
     end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/config.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/config.rbs
@@ -1,6 +1,8 @@
 module ElasticGraph
   class GraphQL
     class ConfigSupertype
+      extend ::ElasticGraph::Config::ClassMethods[Config]
+
       attr_reader default_page_size: ::Integer
       attr_reader max_page_size: ::Integer
       attr_reader slow_query_latency_warning_threshold_in_ms: ::Integer
@@ -9,12 +11,12 @@ module ElasticGraph
       attr_reader extension_settings: parsedYamlSettings
 
       def initialize: (
-        default_page_size: ::Integer,
-        max_page_size: ::Integer,
-        slow_query_latency_warning_threshold_in_ms: ::Integer,
-        client_resolver: Client::_Resolver,
-        extension_modules: ::Array[::Module],
-        extension_settings: parsedYamlSettings
+        ?default_page_size: ::Integer,
+        ?max_page_size: ::Integer,
+        ?slow_query_latency_warning_threshold_in_ms: ::Integer,
+        ?client_resolver: Client::_Resolver,
+        ?extension_modules: ::Array[::Module],
+        ?extension_settings: parsedYamlSettings
       ) -> void
 
       def with: (
@@ -27,16 +29,21 @@ module ElasticGraph
       ) -> Config
 
       def self.members: () -> ::Array[::Symbol]
-
-      private
-
-      def self.load_client_resolver: (::Hash[::String, untyped]) -> Client::_Resolver
     end
 
     class Config < ConfigSupertype
-      extend _BuildableFromParsedYaml[Config]
-      EXPECTED_KEYS: ::Array[::String]
       ELASTICGRAPH_CONFIG_KEYS: ::Array[::String]
+
+      private
+
+      def convert_values: (
+        client_resolver: untyped,
+        extension_modules: untyped,
+        **untyped
+      ) -> ::Hash[::Symbol, untyped]
+
+      def load_client_resolver: (::Hash[::String, untyped]) -> Client::_Resolver
+      def load_extension_modules: (::Array[::Hash[::String, untyped]]) -> ::Array[::Module]
     end
   end
 end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/config_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/config_spec.rb
@@ -12,6 +12,12 @@ require "yaml"
 module ElasticGraph
   class GraphQL
     RSpec.describe Config do
+      it "returns `nil` from `from_parsed_yaml` when there is no `graphql` key" do
+        config = GraphQL::Config.from_parsed_yaml({})
+
+        expect(config).to eq nil
+      end
+
       it "sets config values from the given parsed YAML" do
         config = Config.from_parsed_yaml("graphql" => {
           "default_page_size" => 27,

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/extension.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/extension.rbs
@@ -6,20 +6,20 @@ module ElasticGraph
       class ExtensionSupertype
         attr_reader extension_class: extensionClass
         attr_reader require_path: ::String
-        attr_reader config: ::Hash[::Symbol, untyped]
+        attr_reader config: ::Hash[::Symbol | ::String, untyped]
         attr_reader name: ::String
 
         def initialize: (
           extension_class: extensionClass,
           require_path: ::String,
-          config: ::Hash[::Symbol, untyped],
+          config: ::Hash[::Symbol | ::String, untyped],
           name: ::String
         ) -> void
 
         def with: (
           ?extension_class: extensionClass,
           ?require_path: ::String,
-          ?config: ::Hash[::Symbol, untyped],
+          ?config: ::Hash[::Symbol | ::String, untyped],
           ?name: ::String
         ) -> Extension
       end
@@ -28,13 +28,13 @@ module ElasticGraph
         def initialize: (
           extension_class: extensionClass,
           require_path: ::String,
-          config: ::Hash[::Symbol, untyped],
+          config: ::Hash[::Symbol | ::String, untyped],
           ?name: ::String
         ) -> void
 
         def self.new:
-          (extension_class: extensionClass, require_path: ::String, config: ::Hash[::Symbol, untyped], ?name: ::String) -> Extension
-          | (extensionClass, ::String, ::Hash[::Symbol, untyped], ?::String) -> Extension
+          (extension_class: extensionClass, require_path: ::String, config: ::Hash[::Symbol | ::String, untyped], ?name: ::String) -> Extension
+          | (extensionClass, ::String, ::Hash[::Symbol | ::String, untyped], ?::String) -> Extension
 
         def self.load_from_hash: (::Hash[::String, untyped], via: ExtensionLoader) -> Extension
         def to_dumpable_hash: () -> ::Hash[::String, untyped]

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/extension_loader.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/extension_loader.rbs
@@ -4,7 +4,7 @@ module ElasticGraph
       class ExtensionLoader
         def initialize: (extensionClass) -> void
 
-        def load: (::String, from: ::String, config: ::Hash[::Symbol, untyped]) -> Extension
+        def load: (::String, from: ::String, config: ::Hash[::Symbol | ::String, untyped]) -> Extension
 
         private
 

--- a/spec_support/lib/elastic_graph/spec_support/builds_graphql.rb
+++ b/spec_support/lib/elastic_graph/spec_support/builds_graphql.rb
@@ -31,16 +31,22 @@ module ElasticGraph
       **datastore_core_options,
       &customize_datastore_config
     )
+      config = GraphQL::Config.new(
+        max_page_size: max_page_size,
+        default_page_size: default_page_size,
+        slow_query_latency_warning_threshold_in_ms: slow_query_latency_warning_threshold_in_ms
+      )
+
+      # These config settings must bypass the JSON schema validation so we provide them via `with`.
+      config = config.with(
+        client_resolver: client_resolver || config.client_resolver,
+        extension_settings: config.extension_settings.merge(extension_settings),
+        extension_modules: config.extension_modules + extension_modules
+      )
+
       GraphQL.new(
         datastore_core: datastore_core || build_datastore_core(**datastore_core_options, &customize_datastore_config),
-        config: GraphQL::Config.new(
-          max_page_size: max_page_size,
-          default_page_size: default_page_size,
-          slow_query_latency_warning_threshold_in_ms: slow_query_latency_warning_threshold_in_ms,
-          client_resolver: client_resolver || GraphQL::Client::DefaultResolver.new({}),
-          extension_modules: extension_modules,
-          extension_settings: extension_settings
-        ),
+        config: config,
         graphql_adapter: graphql_adapter,
         datastore_search_router: datastore_search_router,
         filter_interpreter: filter_interpreter,


### PR DESCRIPTION
This provides JSON schema validation of the config and participates in the new config system which will be used as the basis of our documentation.