### PR TITLE
Update CODEOWNERS, site config, and discord URL.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 # The format is described: https://github.blog/2017-07-06-introducing-code-owners/
 
 # These owners will be the default owners for everything in the repo.
-*       @myronmarston @BrianSigafoos-SQ
+*       @ayousufi @bsorbo @BrianSigafoos-SQ @jwils @jwondrusch @myronmarston @nicolewoch @thomasmahoney @zachbutler-squareup
 
 # -----------------------------------------------
 # BELOW THIS LINE ARE TEMPLATES, UNUSED

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
     - name: ❓ Questions and Help 🤔
-      url: https://discord.gg/8m9FqJ7a7F
-      about: This issue tracker is not for support questions. Please refer to the community for more help. 
+      url: https://discord.gg/block-opensource
+      about: This issue tracker is not for support questions. For support questions, please join the `#elasticgraph` channel on the Block Open Source Discord server.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 There are many ways to be an open source contributor, and we're here to help you on your way! You may:
 
-* Propose ideas in our [discord](https://discord.gg/8m9FqJ7a7F)
+* Propose ideas in the `#elasticgraph` channel on the [Block Open Source Discord server](https://discord.gg/block-opensource)
 * Raise an issue or feature request in our [issue tracker](https://github.com/block/elasticgraph/issues)
 * Help another contributor with one of their questions, or a code review
 * Suggest improvements to our Getting Started documentation by supplying a Pull Request
@@ -330,8 +330,8 @@ Anyone from the community is welcome (and encouraged!) to raise issues via
 Design discussions and proposals take place on [GitHub discussions](https://github.com/block/elasticgraph/discussions).
 We advocate an asynchronous, written discussion model - so write up your thoughts and invite the community to join in!
 
-In addition, we have a [discord channel](https://discord.gg/8m9FqJ7a7F) for synchronous communication. Discord is best
-for questions and general conversation.
+In addition, we have a discord channel (`#elasticgraph`) on the [Block Open Source Discord server](https://discord.gg/block-opensource)
+for synchronous communication. Discord is best for questions and general conversation.
 
 ### Continuous Integration
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -12,7 +12,8 @@
 
 Anyone may be a contributor to Block open source projects. Contribution may take the form of:
 
-* Asking and answering questions on the [Discord](https://discord.gg/8m9FqJ7a7F) or [GitHub Issues](https://github.com/block/elasticgraph/issues).
+* Asking and answering questions in the `#elasticgraph` channel on the [Block Open Source Discord server](https://discord.gg/block-opensource)
+  or [GitHub Issues](https://github.com/block/elasticgraph/issues)
 * Filing an issue
 * Offering a feature or bug fix via a Pull Request
 * Suggesting documentation improvements

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The [project website](https://block.github.io/elasticgraph/) has extensive user 
 
 We welcome contributions to ElasticGraph!
 
-* Join the community on [Discord](https://discord.gg/8m9FqJ7a7F).
+* Join the community in the `#elasticgraph` channel on the [Block Open Source Discord server](https://discord.gg/block-opensource).
 * Read [CONTRIBUTING.md](https://github.com/block/elasticgraph/blob/main/CONTRIBUTING.md) to learn how you can help, including our development workflow and coding conventions.
 
 ## License

--- a/config/site/src/_config.yaml
+++ b/config/site/src/_config.yaml
@@ -4,10 +4,7 @@ kramdown:
 
 # Site-wide variables available to all pages via the `site` variable, ex: `{{ site.github_url }}`
 github_url: https://github.com/block/elasticgraph
-discord_url: https://discord.gg/8m9FqJ7a7F
-x_url: https://x.com/elasticgraph
-x_username: "@ElasticGraph"
-support_email: elasticgraph@squareup.com
+discord_url: https://discord.gg/block-opensource
 description: Open source framework for indexing, searching, and aggregating data powered by GraphQL and Elasticsearch / OpenSearch
 tagline: Schema-driven, scalable, cloud-native, batteries-included GraphQL, backed by Elasticsearch / OpenSearch
 

--- a/config/site/src/getting-started.md
+++ b/config/site/src/getting-started.md
@@ -173,7 +173,8 @@ can be used in your publishing system to validate the indexing payloads or for c
 ## Feedback
 
 We'd love to hear your feedback. If you encounter any issues or have suggestions, please start a discussion in
-our [discord channel](https://discord.gg/8m9FqJ7a7F) or on [GitHub](https://github.com/block/elasticgraph/discussions).
+the `#elasticgraph` channel on the [Block Open Source Discord server](https://discord.gg/block-opensource) or on
+[GitHub](https://github.com/block/elasticgraph/discussions).
 
 ---
 


### PR DESCRIPTION
* We now have a team of ElasticGraph maintainers--they are all listed in CODEOWNERS.
* We're migrating the discord channel to the Block Open Source Discord server since we are able to get better support there (and since ElasticGraph is a Block open source project!).
* The site config had some unused settings which referenced online accounts/emails that don't exist, so I've removed them.