### PR TITLE
Provide a configuration settings reference.

### DIFF
--- a/config/site/Rakefile
+++ b/config/site/Rakefile
@@ -24,6 +24,7 @@ module ElasticGraph
     JEKYLL_API_DOCS_DIR = JEKYLL_SITE_DIR / "api-docs"
     JEKYLL_DATA_DIR = SITE_SOURCE_DIR / "_data"
     STAGED_MARKDOWN_DIR = REPO_ROOT / "tmp" / "staged_markdown"
+    RAW_YARD_FILES_DIR = REPO_ROOT / "tmp" / "raw_yard_files"
     EXAMPLE_SCHEMA_FILES_BY_NAME = SITE_CONFIG_DIR.glob("examples/*/schema.rb").to_h do |file|
       [file.parent.basename.to_s, file]
     end
@@ -555,6 +556,12 @@ module ElasticGraph
       require_relative "support/markdown_post_processor"
       ElasticGraph::MarkdownPostProcessor.new(YARD_OUTPUT_DIR, staged_markdown_mappings).process!
 
+      RAW_YARD_FILES_DIR.glob("**/*").each do |raw_file|
+        relative_path = raw_file.relative_path_from(RAW_YARD_FILES_DIR)
+        ::FileUtils.copy(raw_file, YARD_OUTPUT_DIR + relative_path)
+      end
+      puts "Copied raw files to YARD output directory"
+
       ignored_warnings_output = YARD_WARNINGS_TO_IGNORE.filter_map do |warning, regex|
         if (count = doc_output.scan(regex).count) > 0
           "Ignored #{count} #{warning} warning(s)."
@@ -625,14 +632,32 @@ module ElasticGraph
       FileUtils.cp(codebase_overview_path, staged_path)
       puts "Staged CODEBASE_OVERVIEW.md"
 
+      # Generate and stage configuration documentation
+      generate_and_stage_config_documentation(staged_markdown_mappings)
+
       puts "Staged #{STAGED_MARKDOWN_DIR.glob("*.md").size} README files for documentation"
 
       # Get the list of staged markdown files (use relative paths from repo root)
-      staged_files = STAGED_MARKDOWN_DIR.glob("*.md").map do |absolute_path|
+      staged_files = STAGED_MARKDOWN_DIR.children.sort.map do |absolute_path|
         Pathname.new(absolute_path).relative_path_from(REPO_ROOT).to_s
       end
 
       [staged_files, staged_markdown_mappings]
+    end
+
+    def generate_and_stage_config_documentation(staged_markdown_mappings)
+      require_relative "support/config_doc_generator"
+
+      config_schema_path = REPO_ROOT / "elasticgraph-local" / "lib" / "elastic_graph" / "local" / "spec_support" / "config_schema.yaml"
+
+      generator = ElasticGraph::ConfigDocGenerator.new(config_schema_path, STAGED_MARKDOWN_DIR, RAW_YARD_FILES_DIR)
+      generator.generate!
+
+      # Add to staged mappings for link rewriting
+      staged_markdown_mappings["Configuration.md"] = "Configuration.md"
+      # Don't add ConfigurationSchema.yaml to staged mappings since it's in raw/ subdirectory
+
+      puts "Generated and staged configuration documentation files"
     end
 
     COMMON_JEKYLL_ARGS = [

--- a/config/site/support/config_doc_generator.rb
+++ b/config/site/support/config_doc_generator.rb
@@ -1,0 +1,289 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/support/json_schema/validator_factory"
+require "json"
+require "pathname"
+require "yaml"
+
+module ElasticGraph
+  # Generates markdown documentation for ElasticGraph configuration based on the JSON schema
+  class ConfigDocGenerator
+    def initialize(schema_path, markdown_output_dir, raw_output_dir)
+      @schema_path = Pathname.new(schema_path)
+      @markdown_output_dir = Pathname.new(markdown_output_dir)
+      @raw_output_dir = Pathname.new(raw_output_dir)
+      @schema = YAML.load_file(@schema_path)
+    end
+
+    def generate!
+      generate_schema_files!
+      generate_example_config!
+      generate_main_documentation!
+    end
+
+    private
+
+    def generate_schema_files!
+      # Place schema file in a subdirectory that won't be processed by YARD
+      FileUtils.mkdir_p(@raw_output_dir)
+
+      # Generate YAML version
+      yaml_output_path = @raw_output_dir / "elasticgraph-config-schema.yaml"
+      yaml_content = File.read(@schema_path)
+      File.write(yaml_output_path, yaml_content)
+      puts "Generated configuration schema YAML file at #{yaml_output_path}"
+
+      # Generate JSON version
+      json_output_path = @raw_output_dir / "elasticgraph-config-schema.json"
+      json_content = JSON.pretty_generate(@schema)
+      File.write(json_output_path, json_content)
+      puts "Generated configuration schema JSON file at #{json_output_path}"
+    end
+
+    def generate_example_config!
+      FileUtils.mkdir_p(@raw_output_dir)
+
+      example_config = build_example_config_from_schema(@schema)
+      content = "---\n" + build_commented_yaml(example_config, @schema)
+
+      # Validate the generated example config against the schema
+      validate_example_config!(::YAML.load(content))
+
+      # Write only to raw_output_dir for download - no YARD-rendered version needed
+      raw_example_path = @raw_output_dir / "elasticgraph-config-example.yaml"
+      File.write(raw_example_path, content)
+      puts "Generated example configuration file for download at #{raw_example_path}"
+    end
+
+    def generate_main_documentation!
+      config_output_path = @markdown_output_dir / "Configuration.md"
+      content = build_markdown_content
+      File.write(config_output_path, content)
+      puts "Generated configuration documentation at #{config_output_path}"
+    end
+
+    def build_markdown_content
+      schema_yaml_content = File.read(@raw_output_dir / "elasticgraph-config-schema.yaml")
+      example_yaml_content = File.read(@raw_output_dir / "elasticgraph-config-example.yaml")
+
+      <<~MARKDOWN
+        # ElasticGraph Configuration Settings Reference
+
+        ElasticGraph has an extensive configuration system. Configuration settings files conventionally go in `config/settings`:
+
+        ```
+        config
+        └── settings
+            ├── local.yaml
+            ├── production.yaml
+            └── staging.yaml
+        ```
+
+        Different configuration settings files can then be used in different environments.
+
+        This document provides a comprehensive reference for configuring ElasticGraph applications.
+
+        ## Example Configuration Settings
+
+        Here's a complete example configuration settings file with inline comments explaining each section. Alternately, you can
+        <a href="elasticgraph-config-example.yaml" download="elasticgraph-config-example.yaml">download this example</a>.
+
+        ```yaml
+        #{example_yaml_content}
+        ```
+
+        ## Configuration Settings Schema
+
+        ElasticGraph validates configuration settings using the JSON schema shown below. It can also be downloaded as
+        <a href="elasticgraph-config-schema.yaml" download="elasticgraph-config-schema.yaml">YAML</a> or
+        <a href="elasticgraph-config-schema.json" download="elasticgraph-config-schema.json">JSON</a> for local
+        usage (e.g. in an IDE).
+
+        ```yaml
+        #{schema_yaml_content}
+        ```
+      MARKDOWN
+    end
+
+    def build_example_config_from_schema(schema, path = [])
+      examples = schema.fetch("examples") do
+        if schema["type"] == "object" || schema["properties"]
+          [build_object_example(schema, path)]
+        else
+          raise "Missing 'examples' field in schema at path: #{path.join(".")}"
+        end
+      end
+
+      # Pick the most complete example (treating the size of the example asn indication of its completeness).
+      examples.max_by { |e| e.respond_to?(:size) ? e.size : 0 }
+    end
+
+    def build_object_example(schema, path)
+      if schema.key?("patternProperties")
+        raise "Schema at `#{path}` contains `patternProperties`, which we cannot generate an example for. To fix, add `examples` to the parent."
+      end
+
+      schema.fetch("properties").to_h do |prop_name, prop_config|
+        example_value = build_example_config_from_schema(prop_config, path + [prop_name])
+        [prop_name, example_value]
+      end
+    end
+
+    def build_commented_yaml(config, schema, indent = 0)
+      lines = []
+
+      case config
+      when Hash
+        build_commented_hash(config, schema, lines, indent)
+      when Array
+        build_commented_array(config, schema, lines, indent)
+      else
+        lines << "#{" " * indent}#{config.inspect}"
+      end
+
+      lines.join("\n")
+    end
+
+    def build_commented_hash(config, schema, lines, indent)
+      config.each do |key, value|
+        prop_schema = find_property_schema(schema, key)
+
+        # Add comment for this property
+        if prop_schema
+          comment_parts = []
+
+          # Check if this is a required property
+          parent_required = find_parent_required_fields(schema, key)
+          is_required = parent_required&.include?(key)
+
+          # Add description with optional "Required:" prefix
+          if prop_schema["description"]
+            description = prop_schema["description"]
+            description = "Required. #{description}" if is_required
+            comment_parts << description
+          elsif is_required
+            comment_parts << "Required."
+          end
+
+          # Add default value if present
+          if prop_schema.key?("default")
+            default_value = prop_schema["default"].nil? ? "null" : prop_schema["default"].inspect
+            comment_parts << "Default: #{default_value}"
+          end
+
+          # Output all comment parts with text wrapping
+          comment_parts.each do |comment_part|
+            wrapped_lines = wrap_text(comment_part, 100 - indent - 2) # Account for indent and "# "
+            wrapped_lines.each do |comment_line|
+              lines << "#{" " * indent}# #{comment_line}"
+            end
+          end
+        end
+
+        # Add the key-value pair
+        if value.is_a?(Hash) && !value.empty?
+          lines << "#{" " * indent}#{key}:"
+          nested_yaml = build_commented_yaml(value, prop_schema || {}, indent + 2)
+          lines.concat(nested_yaml.split("\n").reject(&:empty?))
+        elsif value.is_a?(Array) && !value.empty?
+          lines << "#{" " * indent}#{key}:"
+          nested_yaml = build_commented_yaml(value, prop_schema || {}, indent + 2)
+          lines.concat(nested_yaml.split("\n").reject(&:empty?))
+        else
+          lines << "#{" " * indent}#{key}: #{value.inspect}"
+        end
+
+        lines << "" # Add blank line between sections
+      end
+    end
+
+    def build_commented_array(config, schema, lines, indent)
+      config.each_with_index do |item, index|
+        item_schema = schema.dig("items") || {}
+
+        if item.is_a?(Hash)
+          lines << "#{" " * indent}- # Array item #{index + 1}"
+          nested_yaml = build_commented_yaml(item, item_schema, indent + 2)
+          lines.concat(nested_yaml.split("\n").reject(&:empty?))
+        else
+          lines << "#{" " * indent}- #{item.inspect}"
+        end
+      end
+    end
+
+    def find_property_schema(schema, key)
+      return nil unless schema.is_a?(Hash)
+
+      # Check regular properties first
+      if schema.dig("properties", key)
+        return schema["properties"][key]
+      end
+
+      # Check pattern properties
+      schema["patternProperties"]&.each do |pattern, pattern_schema|
+        if key.match?(Regexp.new(pattern))
+          return pattern_schema
+        end
+      end
+
+      nil
+    end
+
+    def find_parent_required_fields(schema, key)
+      return nil unless schema.is_a?(Hash)
+
+      # Check if this key is in the required array at this level
+      return schema["required"] if schema["required"]
+
+      # For pattern properties, we need to check if the pattern itself has required fields
+      schema["patternProperties"]&.each do |pattern, pattern_schema|
+        if key.match?(Regexp.new(pattern))
+          return pattern_schema["required"]
+        end
+      end
+
+      nil
+    end
+
+    def wrap_text(text, max_width)
+      return [text] if text.length <= max_width
+
+      words = text.split(/\s+/)
+      lines = []
+      current_line = ""
+
+      words.each do |word|
+        # If adding this word would exceed the max width, start a new line
+        if !current_line.empty? && (current_line.length + 1 + word.length) > max_width
+          lines << current_line
+          current_line = word
+        else
+          current_line = current_line.empty? ? word : "#{current_line} #{word}"
+        end
+      end
+
+      # Add the last line if it's not empty
+      lines << current_line unless current_line.empty?
+      lines
+    end
+
+    def validate_example_config!(example_config)
+      validator = Support::JSONSchema::Validator.new(
+        schema: ::JSONSchemer.schema(@schema, meta_schema: @schema.fetch("$schema")),
+        sanitize_pii: false
+      )
+
+      if (error_message = validator.validate_with_error_message(example_config))
+        raise "Generated example configuration is invalid according to the JSON schema:\n\n#{error_message}"
+      end
+
+      puts "✓ Generated example configuration is valid according to the JSON schema"
+    end
+  end
+end


### PR DESCRIPTION
This adds a new doc to the versioned YARD docs. This new file contains:

- An extensive config settings example.
- The JSON schema for config settings.

In the future, I want to include similar content as a guide on the main part of the website, but config settings may change between ElatsicGraph versions and its nice to provide access to past versions in our YARD docs.

## Screenshots

Here's what it looks like:

<img width="1586" height="1017" alt="image" src="https://github.com/user-attachments/assets/3e1179fb-6817-4f19-a853-5c5b32252c7a" />

<img width="1328" height="948" alt="image" src="https://github.com/user-attachments/assets/a099da3c-2786-44da-b508-2cb28d0720df" />

## Example Config

Here's the complete example config that is currently generated:

```yaml
---
datastore:
  # Configuration of the faraday adapter to use with the datastore client.
  # Default: {"name" => nil, "require" => nil}
  client_faraday_adapter:
    # The faraday adapter to use with the datastore client, such as `httpx` or `typhoeus`.
    # Default: null
    name: "httpx"
    # A Ruby library to require which provides the named adapter (optional).
    # Default: null
    require: "httpx/adapters/faraday"
  # Required. Map of datastore cluster definitions, keyed by cluster name. The names will be
  # referenced within `index_definitions` by `query_cluster` and `index_into_clusters` to identify
  # datastore clusters.
  clusters:
    # Configuration for a specific datastore cluster.
    main:
      # Required. The URL of the datastore cluster.
      url: "http://localhost:9200"
      # Required. Determines whether `elasticgraph-elasticsearch` or `elasticgraph-opensearch` is
      # used for the datastore client.
      backend: "elasticsearch"
      # Datastore settings in flattened (i.e. dot-separated) name form.
      # Default: {}
      settings:
        cluster.max_shards_per_node: 2000
  # Required. Map of index definition names to `IndexDefinition` objects containing customizations
  # for the named index definitions for this environment.
  index_definitions:
    # Configuration for a specific index definition.
    widgets:
      # Required. Named search cluster to be used for queries on this index. The value must match be
      # a key in the `clusters` map.
      query_cluster: "main"
      # Required. Named search clusters to index data into. The values must match keys in the
      # `clusters` map.
      index_into_clusters:
        - "main"
      # Shard routing values for which the data should be spread across all shards instead of
      # concentrating it on a single shard. This is intended to be used when a handful of known
      # routing value contain such a large portion of the dataset that it extremely lopsided shards
      # would result. Spreading the data across all shards may perform better.
      # Default: []
      ignore_routing_values: []
      # Overrides for index (or index template) settings. The settings specified here will override
      # any settings specified on the Ruby schema definition. This is commonly used to configure a
      # different `number_of_shards` in each environment. An `index.` prefix will be added to the
      # names of all settings before submitting them to the datastore.
      # Default: {}
      setting_overrides: {}
      # Overrides for index template settings for specific dates, allowing variation of settings for
      # different rollover indices. This is commonly used to configure a different
      # `number_of_shards` for each year or month when using yearly or monthly rollover.
      # Default: {}
      setting_overrides_by_timestamp: {}
      # Array of custom timestamp ranges that allow different index settings for specific time
      # periods.
      # Default: []
      custom_timestamp_ranges: []
  # Determines if we log requests/responses to/from the datastore.
  # Default: false
  log_traffic: false
  # Passed down to the datastore client. Controls the number of times ElasticGraph attempts a call
  # against the datastore before failing. Retrying a handful of times is generally advantageous,
  # since some sporadic failures are expected during the course of operation, and better to retry
  # than fail the entire call.
  # Default: 3
  max_client_retries: 3

graphql:
  # Determines the `size` of our datastore search requests if the query does not specify via `first`
  # or `last`.
  # Default: 50
  default_page_size: 25
  # Determines the maximum size of a requested page. If the client requests a page larger than this
  # value, the `size` will be capped by this value.
  # Default: 500
  max_page_size: 100
  # Queries that take longer than this configured threshold will have a sanitized version logged so
  # that they can be investigated.
  # Default: 5000
  slow_query_latency_warning_threshold_in_ms: 3000
  # Object used to identify the client of a GraphQL query based on the HTTP request.
  # Default: {}
  client_resolver:
    # Name of the client resolver class.
    # Default: null
    name: "ElasticGraph::GraphQL::ClientResolvers::ViaHTTPHeader"
    # The path to require to load the client resolver class.
    # Default: null
    require_path: "support/client_resolvers"
    header_name: "X-Client-Name"
  # Array of modules that will be extended onto the `GraphQL` instance to support extension
  # libraries.
  # Default: []
  extension_modules:
    - # Array item 1
      # Required. The name of the extension module class to load.
      name: "MyExtensionModule"
      # Required. The path to require to load the extension module.
      require_path: "./my_extension_module"

health_check:
  # The list of clusters to perform datastore status health checks on. A `green` status maps to
  # `healthy`, a `yellow` status maps to `degraded`, and a `red` status maps to `unhealthy`. The
  # returned status is the minimum status from all clusters in the list (a `yellow` cluster and a
  # `green` cluster will result in a `degraded` status).
  # Default: []
  clusters_to_consider:
    - "cluster-one"
    - "cluster-two"
  # A map of types to perform recency checks on. If no new records for that type have been indexed
  # within the specified period, a `degraded` status will be returned.
  # Default: {}
  data_recency_checks:
    # Configuration for data recency checks on a specific type.
    Widget:
      # Required. The name of the timestamp field to use for recency checks.
      timestamp_field: "createdAt"
      # Required. The maximum number of seconds since the last record was indexed for this type
      # before considering it stale.
      expected_max_recency_seconds: 30

indexer:
  # Map of indexing latency thresholds (in milliseconds), keyed by the name of the indexing latency
  # metric. When an event is indexed with an indexing latency exceeding the threshold, a warning
  # with the event type, id, and version will be logged, so the issue can be investigated.
  # Default: {}
  latency_slo_thresholds_by_timestamp_in_ms:
    ingested_from_topic_at: 10000
    entity_updated_at: 15000
  # Setting that can be used to specify some derived indexing type updates that should be skipped.
  # This setting should be a map keyed by the name of the derived indexing type, and the values
  # should be sets of ids. This can be useful when you have a "hot spot" of a single derived
  # document that is receiving a ton of updates. During a backfill (or whatever) you may want to
  # skip the derived type updates.
  # Default: {}
  skip_derived_indexing_type_updates:
    WidgetWorkspace:
      - "ABC12345678"

query_interceptor:
  # List of query interceptors to apply to datastore queries before they are executed.
  # Default: []
  interceptors:
    - # Array item 1
      # Required. The name of the interceptor extension class.
      name: "HideInternalRecordsInterceptor"
      # Required. The path to require to load the interceptor extension. This should be a relative
      # path from a directory on the Ruby `$LOAD_PATH` or a a relative path from the ElasticGraph
      # application root.
      require_path: "./lib/interceptors/hide_internal_records_interceptor"

query_registry:
  # Required. Path to the directory containing the query registry files.
  path_to_registry: "config/queries"
  # Whether to allow clients that are not registered in the registry.
  # Default: true
  allow_unregistered_clients: true
  # List of client names that are allowed to execute any query, even if not registered.
  # Default: []
  allow_any_query_for_clients:
    - "admin"
    - "internal"

schema_artifacts:
  # Path to the directory where schema artifacts are stored.
  # Default: "config/schema/artifacts"
  directory: "config/schema/artifacts"

logger:
  # Determines what severity level we log.
  # Default: "INFO"
  level: "INFO"
  # Determines where we log to. Must be a string. "stdout" or "stderr" are interpreted as being
  # those output streams; any other value is assumed to be a file path.
  # Default: "stdout"
  device: "logs/development.log"
  # Class used to format log messages.
  # Default: "ElasticGraph::Support::Logger::JSONAwareFormatter"
  formatter: "ElasticGraph::Support::Logger::JSONAwareFormatter"
```