### PR TITLE
feat: Improve config JSON schema in a few ways.

### DIFF
--- a/config/site/support/config_doc_generator.rb
+++ b/config/site/support/config_doc_generator.rb
@@ -9,6 +9,7 @@
 require "elastic_graph/support/json_schema/validator_factory"
 require "json"
 require "pathname"
+require "time"
 require "yaml"
 
 module ElasticGraph
@@ -186,6 +187,9 @@ module ElasticGraph
           end
         end
 
+        # Avoid YAML loading errors when dealing with keys that are timestamps: `Tried to load unspecified class: Time`.
+        key = "'#{key}'" if timestamp?(key)
+
         # Add the key-value pair
         if value.is_a?(Hash) && !value.empty?
           lines << "#{" " * indent}#{key}:"
@@ -201,6 +205,13 @@ module ElasticGraph
 
         lines << "" # Add blank line between sections
       end
+    end
+
+    def timestamp?(key)
+      ::Time.iso8601(key)
+      true
+    rescue ::ArgumentError
+      false
     end
 
     def build_commented_array(config, schema, lines, indent)

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/config.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/config.rb
@@ -24,6 +24,8 @@ module ElasticGraph
       all_json_schema_types = ["array", "string", "number", "boolean", "object", "null"]
 
       json_schema at: "graphql",
+        optional: false,
+        description: "Configuration for GraphQL behavior used by `elasticgraph-graphql`.",
         properties: {
           default_page_size: {
             description: "Determines the `size` of our datastore search requests if the query does not specify via `first` or `last`.",

--- a/elasticgraph-health_check/lib/elastic_graph/health_check/config.rb
+++ b/elasticgraph-health_check/lib/elastic_graph/health_check/config.rb
@@ -12,6 +12,8 @@ module ElasticGraph
   module HealthCheck
     class Config < Support::Config.define(:clusters_to_consider, :data_recency_checks)
       json_schema at: "health_check",
+        optional: true,
+        description: "Configuration for health checks used by `elasticgraph-health_check`.",
         properties: {
           clusters_to_consider: {
             description: "The list of clusters to perform datastore status health checks on. A `green` status maps to `healthy`, a " \

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/config.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/config.rb
@@ -13,6 +13,8 @@ module ElasticGraph
   class Indexer
     class Config < Support::Config.define(:latency_slo_thresholds_by_timestamp_in_ms, :skip_derived_indexing_type_updates)
       json_schema at: "indexer",
+        optional: false,
+        description: "Configuration for indexing operations and metrics used by `elasticgraph-indexer`.",
         properties: {
           latency_slo_thresholds_by_timestamp_in_ms: {
             description: "Map of indexing latency thresholds (in milliseconds), keyed by the name of " \

--- a/elasticgraph-local/lib/elastic_graph/local/spec_support/config_schema.yaml
+++ b/elasticgraph-local/lib/elastic_graph/local/spec_support/config_schema.yaml
@@ -3,8 +3,16 @@
 title: ElasticGraph Configuration
 description: Complete configuration schema for ElasticGraph applications
 type: object
+required:
+- datastore
+- graphql
+- indexer
+- schema_artifacts
+- logger
 properties:
   datastore:
+    description: Configuration for datastore connections and index definitions used
+      by all parts of ElasticGraph.
     properties:
       client_faraday_adapter:
         type: object
@@ -111,10 +119,26 @@ properties:
             - query_cluster: main
               index_into_clusters:
               - main
-              ignore_routing_values: []
-              setting_overrides: {}
-              setting_overrides_by_timestamp: {}
-              custom_timestamp_ranges: []
+              ignore_routing_values:
+              - ABC1234567
+              setting_overrides:
+                number_of_shards: 256
+              setting_overrides_by_timestamp:
+                '2022-01-01T00:00:00Z':
+                  number_of_shards: 64
+                '2023-01-01T00:00:00Z':
+                  number_of_shards: 96
+                '2024-01-01T00:00:00Z':
+                  number_of_shards: 128
+              custom_timestamp_ranges:
+              - index_name_suffix: before_2022
+                lt: '2022-01-01T00:00:00Z'
+                setting_overrides:
+                  number_of_shards: 32
+              - index_name_suffix: after_2026
+                gte: '2027-01-01T00:00:00Z'
+                setting_overrides:
+                  number_of_shards: 32
             properties:
               query_cluster:
                 type: string
@@ -267,6 +291,15 @@ properties:
                   required:
                   - index_name_suffix
                   - setting_overrides
+                  anyOf:
+                  - required:
+                    - lt
+                  - required:
+                    - lte
+                  - required:
+                    - gt
+                  - required:
+                    - gte
                   additionalProperties: false
                 default: []
                 examples:
@@ -283,10 +316,26 @@ properties:
             query_cluster: main
             index_into_clusters:
             - main
-            ignore_routing_values: []
-            setting_overrides: {}
-            setting_overrides_by_timestamp: {}
-            custom_timestamp_ranges: []
+            ignore_routing_values:
+            - ABC1234567
+            setting_overrides:
+              number_of_shards: 256
+            setting_overrides_by_timestamp:
+              '2022-01-01T00:00:00Z':
+                number_of_shards: 64
+              '2023-01-01T00:00:00Z':
+                number_of_shards: 96
+              '2024-01-01T00:00:00Z':
+                number_of_shards: 128
+            custom_timestamp_ranges:
+            - index_name_suffix: before_2022
+              lt: '2022-01-01T00:00:00Z'
+              setting_overrides:
+                number_of_shards: 32
+            - index_name_suffix: after_2026
+              gte: '2027-01-01T00:00:00Z'
+              setting_overrides:
+                number_of_shards: 32
       log_traffic:
         type: boolean
         description: Determines if we log requests/responses to/from the datastore.
@@ -312,6 +361,7 @@ properties:
     - index_definitions
     additionalProperties: false
   graphql:
+    description: Configuration for GraphQL behavior used by `elasticgraph-graphql`.
     properties:
       default_page_size:
         description: Determines the `size` of our datastore search requests if the
@@ -416,7 +466,98 @@ properties:
         - - name: MyExtensionModule
             require_path: "./my_extension_module"
     additionalProperties: false
+  indexer:
+    description: Configuration for indexing operations and metrics used by `elasticgraph-indexer`.
+    properties:
+      latency_slo_thresholds_by_timestamp_in_ms:
+        description: Map of indexing latency thresholds (in milliseconds), keyed by
+          the name of the indexing latency metric. When an event is indexed with an
+          indexing latency exceeding the threshold, a warning with the event type,
+          id, and version will be logged, so the issue can be investigated.
+        type: object
+        patternProperties:
+          ".+":
+            type: integer
+            minimum: 0
+        default: {}
+        examples:
+        - {}
+        - ingested_from_topic_at: 10000
+          entity_updated_at: 15000
+      skip_derived_indexing_type_updates:
+        description: Setting that can be used to specify some derived indexing type
+          updates that should be skipped. This setting should be a map keyed by the
+          name of the derived indexing type, and the values should be sets of ids.
+          This can be useful when you have a "hot spot" of a single derived document
+          that is receiving a ton of updates. During a backfill (or whatever) you
+          may want to skip the derived type updates.
+        type: object
+        patternProperties:
+          "^[A-Z]\\w*$":
+            type: array
+            items:
+              type: string
+              minLength: 1
+        default: {}
+        examples:
+        - {}
+        - WidgetWorkspace:
+          - ABC12345678
+    additionalProperties: false
+  logger:
+    description: Configuration for logging used by all parts of ElasticGraph.
+    properties:
+      level:
+        description: Determines what severity level we log.
+        examples:
+        - INFO
+        - WARN
+        enum:
+        - DEBUG
+        - debug
+        - INFO
+        - info
+        - WARN
+        - warn
+        - ERROR
+        - error
+        - FATAL
+        - fatal
+        - UNKNOWN
+        - unknown
+        default: INFO
+      device:
+        description: Determines where we log to. "stdout" or "stderr" are interpreted
+          as being those output streams; any other value is assumed to be a file path.
+        examples:
+        - stdout
+        - logs/development.log
+        default: stdout
+        type: string
+        minLength: 1
+      formatter:
+        description: Class used to format log messages.
+        examples:
+        - ElasticGraph::Support::Logger::JSONAwareFormatter
+        - MyAlternateFormatter
+        type: string
+        pattern: "^[A-Z]\\w+(::[A-Z]\\w+)*$"
+        default: ElasticGraph::Support::Logger::JSONAwareFormatter
+    additionalProperties: false
+  schema_artifacts:
+    description: Configuration for schema artifact management used by all parts of
+      ElasticGraph.
+    properties:
+      directory:
+        description: Path to the directory where schema artifacts are stored.
+        examples:
+        - config/schema/artifacts
+        default: config/schema/artifacts
+        type: string
+        minLength: 1
+    additionalProperties: false
   health_check:
+    description: Configuration for health checks used by `elasticgraph-health_check`.
     properties:
       clusters_to_consider:
         description: The list of clusters to perform datastore status health checks
@@ -473,44 +614,8 @@ properties:
             timestamp_field: createdAt
             expected_max_recency_seconds: 30
     additionalProperties: false
-  indexer:
-    properties:
-      latency_slo_thresholds_by_timestamp_in_ms:
-        description: Map of indexing latency thresholds (in milliseconds), keyed by
-          the name of the indexing latency metric. When an event is indexed with an
-          indexing latency exceeding the threshold, a warning with the event type,
-          id, and version will be logged, so the issue can be investigated.
-        type: object
-        patternProperties:
-          ".+":
-            type: integer
-            minimum: 0
-        default: {}
-        examples:
-        - {}
-        - ingested_from_topic_at: 10000
-          entity_updated_at: 15000
-      skip_derived_indexing_type_updates:
-        description: Setting that can be used to specify some derived indexing type
-          updates that should be skipped. This setting should be a map keyed by the
-          name of the derived indexing type, and the values should be sets of ids.
-          This can be useful when you have a "hot spot" of a single derived document
-          that is receiving a ton of updates. During a backfill (or whatever) you
-          may want to skip the derived type updates.
-        type: object
-        patternProperties:
-          "^[A-Z]\\w*$":
-            type: array
-            items:
-              type: string
-              minLength: 1
-        default: {}
-        examples:
-        - {}
-        - WidgetWorkspace:
-          - ABC12345678
-    additionalProperties: false
   query_interceptor:
+    description: Configuration of datastore query interceptors used by `elasticgraph-query_interceptor`.
     properties:
       interceptors:
         description: List of query interceptors to apply to datastore queries before
@@ -552,6 +657,7 @@ properties:
         default: []
     additionalProperties: false
   query_registry:
+    description: Configuration for client and query registration used by `elasticgraph-query_registry`.
     properties:
       path_to_registry:
         description: Path to the directory containing the query registry files.
@@ -578,55 +684,5 @@ properties:
         default: []
     required:
     - path_to_registry
-    additionalProperties: false
-  schema_artifacts:
-    properties:
-      directory:
-        description: Path to the directory where schema artifacts are stored.
-        examples:
-        - config/schema/artifacts
-        default: config/schema/artifacts
-        type: string
-        minLength: 1
-    additionalProperties: false
-  logger:
-    properties:
-      level:
-        description: Determines what severity level we log.
-        examples:
-        - INFO
-        - WARN
-        enum:
-        - DEBUG
-        - debug
-        - INFO
-        - info
-        - WARN
-        - warn
-        - ERROR
-        - error
-        - FATAL
-        - fatal
-        - UNKNOWN
-        - unknown
-        default: INFO
-      device:
-        description: Determines where we log to. Must be a string. "stdout" or "stderr"
-          are interpreted as being those output streams; any other value is assumed
-          to be a file path.
-        examples:
-        - stdout
-        - logs/development.log
-        default: stdout
-        type: string
-        minLength: 1
-      formatter:
-        description: Class used to format log messages.
-        examples:
-        - ElasticGraph::Support::Logger::JSONAwareFormatter
-        - MyAlternateFormatter
-        type: string
-        pattern: "^[A-Z]\\w+(::[A-Z]\\w+)*$"
-        default: ElasticGraph::Support::Logger::JSONAwareFormatter
     additionalProperties: false
 additionalProperties: true

--- a/elasticgraph-query_interceptor/lib/elastic_graph/query_interceptor/config.rb
+++ b/elasticgraph-query_interceptor/lib/elastic_graph/query_interceptor/config.rb
@@ -14,6 +14,8 @@ module ElasticGraph
     # Defines configuration for elasticgraph-query_interceptor
     class Config < Support::Config.define(:interceptors)
       json_schema at: "query_interceptor",
+        optional: true,
+        description: "Configuration of datastore query interceptors used by `elasticgraph-query_interceptor`.",
         properties: {
           interceptors: {
             description: "List of query interceptors to apply to datastore queries before they are executed.",

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/config.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/config.rb
@@ -12,6 +12,8 @@ module ElasticGraph
   module QueryRegistry
     class Config < Support::Config.define(:path_to_registry, :allow_unregistered_clients, :allow_any_query_for_clients)
       json_schema at: "query_registry",
+        optional: true,
+        description: "Configuration for client and query registration used by `elasticgraph-query_registry`.",
         properties: {
           path_to_registry: {
             description: "Path to the directory containing the query registry files.",

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts.rb
@@ -31,6 +31,8 @@ module ElasticGraph
     Config = Support::Config.define(:directory) do
       # @implements Config
       json_schema at: "schema_artifacts",
+        optional: false,
+        description: "Configuration for schema artifact management used by all parts of ElasticGraph.",
         properties: {
           directory: {
             description: "Path to the directory where schema artifacts are stored.",

--- a/elasticgraph-support/lib/elastic_graph/support/config.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/config.rb
@@ -26,7 +26,7 @@ module ElasticGraph
       #    require "elastic_graph/support/config"
       #
       #    ExampleConfigClass = ElasticGraph::Support::Config.define(:size, :name) do
-      #      json_schema at: "example",
+      #      json_schema at: "example", optional: false,
       #        properties: {
       #          size: {
       #            description: "Determines the size.",
@@ -57,7 +57,7 @@ module ElasticGraph
       module ClassMethods
         include Support::FromYamlFile
 
-        # @dynamic validator, path
+        # @dynamic validator, path, required
 
         # @return [Support::JSONSchema::Validator] validator for this configuration class
         attr_reader :validator
@@ -65,9 +65,13 @@ module ElasticGraph
         # @return [::String] path from the global configuration root to where this configuration resides.
         attr_reader :path
 
+        # @return [::Boolean] whether this configuration property is required
+        attr_reader :required
+
         # Defines the JSON schema and path for this configuration class.
         #
         # @param at [::String] path from the global configuration root to where this configuration resides
+        # @param optional [::Boolean] whether configuration at the provided `path` is optional
         # @param schema [::Hash<::Symbol, ::Object>] JSON schema definition
         # @return [void]
         #
@@ -75,7 +79,7 @@ module ElasticGraph
         #    require "elastic_graph/support/config"
         #
         #    ExampleConfigClass = ElasticGraph::Support::Config.define(:size, :name) do
-        #      json_schema at: "example",
+        #      json_schema at: "example", optional: false,
         #        properties: {
         #          size: {
         #            description: "Determines the size.",
@@ -92,8 +96,9 @@ module ElasticGraph
         #        },
         #        required: ["size", "name"]
         #    end
-        def json_schema(at:, **schema)
+        def json_schema(at:, optional:, **schema)
           @path = at
+          @required = !optional
 
           schema = Support::HashUtil.stringify_keys(schema)
           @validator = Support::JSONSchema::ValidatorFactory

--- a/elasticgraph-support/lib/elastic_graph/support/logger.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/logger.rb
@@ -26,6 +26,8 @@ module ElasticGraph
         # @dynamic self.from_parsed_yaml
 
         json_schema at: "logger",
+          optional: false,
+          description: "Configuration for logging used by all parts of ElasticGraph.",
           properties: {
             level: {
               description: "Determines what severity level we log.",
@@ -34,7 +36,7 @@ module ElasticGraph
               default: "INFO"
             },
             device: {
-              description: 'Determines where we log to. Must be a string. "stdout" or "stderr" are interpreted ' \
+              description: 'Determines where we log to. "stdout" or "stderr" are interpreted ' \
                 "as being those output streams; any other value is assumed to be a file path.",
               examples: %w[stdout logs/development.log],
               default: "stdout",

--- a/elasticgraph-support/sig/elastic_graph/support/config.rbs
+++ b/elasticgraph-support/sig/elastic_graph/support/config.rbs
@@ -6,8 +6,9 @@ module ElasticGraph
       module ClassMethods[T]: ::Class
         attr_reader validator: Support::JSONSchema::Validator
         attr_reader path: ::String
+        attr_reader required: bool
 
-        def json_schema: (at: ::String, **untyped) -> void
+        def json_schema: (at: ::String, optional: bool, **untyped) -> void
         def from_parsed_yaml: (parsedYamlSettings) -> T?
         def from_parsed_yaml!: (parsedYamlSettings) -> T
         def raise_invalid_config: (::String) -> bot

--- a/elasticgraph-support/spec/unit/elastic_graph/support/config_spec.rb
+++ b/elasticgraph-support/spec/unit/elastic_graph/support/config_spec.rb
@@ -15,7 +15,7 @@ module ElasticGraph
       describe ".define" do
         it "defines a data class with the named attributes" do
           config_def = Config.define(:size, :name) do
-            json_schema at: "test"
+            json_schema at: "test", optional: false
           end
 
           valid_config = config_def.new(size: 10, name: "test")
@@ -27,7 +27,7 @@ module ElasticGraph
 
         it "validates upon instantiation" do
           config_def = Config.define(:size, :name) do
-            json_schema at: "test",
+            json_schema at: "test", optional: false,
               properties: {
                 size: {type: "integer", minimum: 1},
                 name: {type: "string", minLength: 1}
@@ -54,7 +54,7 @@ module ElasticGraph
 
         it "can be defined as a subclass of the class returned by `Config.define`" do
           config_def = ::Class.new(Config.define(:size, :name)) do
-            json_schema at: "test",
+            json_schema at: "test", optional: false,
               properties: {
                 size: {type: "integer", minimum: 1},
                 name: {type: "string", minLength: 1}
@@ -76,7 +76,7 @@ module ElasticGraph
 
         it "prevents unknown keys since they are likely typos" do
           config_def = Config.define(:size, :name) do
-            json_schema at: "test",
+            json_schema at: "test", optional: false,
               properties: {
                 size: {type: "integer", minimum: 1},
                 name: {type: "string", minLength: 1}
@@ -90,7 +90,7 @@ module ElasticGraph
 
         it "honors defaults specified in the JSON schema" do
           config_def = Config.define(:size, :name) do
-            json_schema at: "test",
+            json_schema at: "test", optional: false,
               properties: {
                 size: {type: "integer", minimum: 1, default: 7},
                 name: {type: "string", minLength: 1, default: "example"}
@@ -105,7 +105,7 @@ module ElasticGraph
 
         it "does not allow defaults to violate validations" do
           config_def = Config.define(:size, :name) do
-            json_schema at: "test",
+            json_schema at: "test", optional: false,
               properties: {
                 size: {type: "integer", minimum: 1, default: 0},
                 name: {type: "string", minLength: 1, default: "example"}
@@ -120,7 +120,7 @@ module ElasticGraph
         context "when the config class defines `convert_values`" do
           login_class = ::Data.define(:username, :password)
           config_class = Config.define(:login, :timeout) do
-            json_schema at: "test", properties: {
+            json_schema at: "test", optional: false, properties: {
               login: {type: "object"},
               timeout: {type: "number", default: 10}
             }
@@ -159,7 +159,7 @@ module ElasticGraph
         describe ".from_parsed_yaml" do
           it "loads from a from parsed YAML hash" do
             config_def = Config.define(:size, :name) do
-              json_schema at: "test",
+              json_schema at: "test", optional: false,
                 properties: {
                   size: {type: "integer", minimum: 1},
                   name: {type: "string", minLength: 1}
@@ -182,7 +182,7 @@ module ElasticGraph
 
           it "returns `nil` if the parsed YAML hash has no entry at the specified path" do
             config_def = Config.define(:size, :name) do
-              json_schema at: "test",
+              json_schema at: "test", optional: false,
                 properties: {
                   size: {type: "integer", minimum: 1},
                   name: {type: "string", minLength: 1}
@@ -195,7 +195,7 @@ module ElasticGraph
 
           it "raises from `from_parsed_yaml!` if the parsed YAML hash has no entry at the specified path" do
             config_def = Config.define(:size, :name) do
-              json_schema at: "test",
+              json_schema at: "test", optional: false,
                 properties: {
                   size: {type: "integer", minimum: 1},
                   name: {type: "string", minLength: 1}
@@ -211,7 +211,7 @@ module ElasticGraph
 
           it "extracts config data from nested YAML structure" do
             config_def = Config.define(:database_url, :pool_size) do
-              json_schema at: "database.connection",
+              json_schema at: "database.connection", optional: false,
                 properties: {
                   database_url: {type: "string", minLength: 1},
                   pool_size: {type: "integer", minimum: 1}
@@ -235,7 +235,7 @@ module ElasticGraph
 
           it "does not symbolize string keys on map values" do
             config_def = Config.define(:thresholds_by_name) do
-              json_schema at: "test",
+              json_schema at: "test", optional: false,
                 properties: {
                   thresholds_by_name: {type: "object", patternProperties: {
                     /^\w+$/.source => {type: "integer"}
@@ -253,7 +253,7 @@ module ElasticGraph
 
           it "raises a clear error if the value at the specified path is not a hash" do
             config_def = Config.define(:size, :name) do
-              json_schema at: "test",
+              json_schema at: "test", optional: false,
                 properties: {
                   size: {type: "integer", minimum: 1},
                   name: {type: "string", minLength: 1}
@@ -271,7 +271,7 @@ module ElasticGraph
         context "YAML file integration", :in_temp_dir do
           it "loads configuration from YAML file" do
             config_def = Config.define(:host, :port) do
-              json_schema at: "server",
+              json_schema at: "server", optional: false,
                 properties: {
                   host: {type: "string", minLength: 1},
                   port: {type: "integer", minimum: 1, maximum: 65535}
@@ -295,7 +295,7 @@ module ElasticGraph
 
           it "returns `nil` if the YAML file has no entry at the specified path" do
             config_def = Config.define(:host, :port) do
-              json_schema at: "server",
+              json_schema at: "server", optional: false,
                 properties: {
                   host: {type: "string", minLength: 1},
                   port: {type: "integer", minimum: 1, maximum: 65535}
@@ -318,7 +318,7 @@ module ElasticGraph
 
           it "supports YAML file with block for preprocessing" do
             config_def = Config.define(:name, :env) do
-              json_schema at: "app",
+              json_schema at: "app", optional: false,
                 properties: {
                   name: {type: "string"},
                   env: {type: "string", enum: ["development", "test", "production"]}

--- a/elasticgraph/spec/unit/elastic_graph/gem_spec.rb
+++ b/elasticgraph/spec/unit/elastic_graph/gem_spec.rb
@@ -75,6 +75,10 @@ module ElasticGraph
           expect(meta_schema_validator.validate_with_error_message(json_schema)).to eq nil
           expect(json_schema.fetch("properties").keys).to match_array((config_class.members - extra_config_attributes).map(&:to_s))
 
+          # Check that the root schema has a description
+          expect(json_schema.key?("description")).to be(true),
+            "Config class #{config_class.name} schema must have a description at the root level"
+
           # Recursively validate all properties have required attributes
           validate_schema_properties_recursively(json_schema, config_class.name)
         end

--- a/script/update_config_artifacts
+++ b/script/update_config_artifacts
@@ -55,7 +55,7 @@ module ElasticGraph
     end
 
     def generate_json_schema
-      merged_schemas = @config_loader.merged_json_schema
+      merged_schemas, required_properties = @config_loader.merge_config_schemas
 
       # Create a comprehensive JSON schema
       {
@@ -63,6 +63,7 @@ module ElasticGraph
         "title" => "ElasticGraph Configuration",
         "description" => "Complete configuration schema for ElasticGraph applications",
         "type" => "object",
+        "required" => required_properties,
         "properties" => merged_schemas,
         "additionalProperties" => true
       }
@@ -70,11 +71,23 @@ module ElasticGraph
   end
 
   class ConfigLoader
-    def merged_json_schema
-      @merged_json_schema ||= config_definition_lines.to_h do |line|
-        config_class = load_config_class_for(line)
+    def merge_config_schemas
+      config_classes = config_definition_lines.map { |line| load_config_class_for(line) }
+
+      required_properties = config_classes.filter_map do |config_class|
+        config_class.path if config_class.required
+      end
+
+      properties = config_classes.map do |config_class|
         [config_class.path, config_class.validator.schema.value]
       end
+
+      ordered_properties = properties.sort_by do |prop, _|
+        # Sort required properties before optional properties; then sort alphabetical.
+        [required_properties.include?(prop) ? 0 : 1, prop]
+      end.to_h
+
+      [ordered_properties, required_properties]
     end
 
     private


### PR DESCRIPTION
- Add a `description` to the JSON schema of each config class (and enforce its presence via `gem_spec.rb`) so that the downloadable JSON schema include a `description` for each root property.
- Specify which root properties are `required`. In JSON schema, `required` is specified on the parent object's schema but we want to configure it on each config class. To make this work (without conflicting with a `required` key on the JSON schema of a config class), I've added an `optional` keyword argument which is the inverse (`required = !optional`).
- Specify that each of the extension gem configs (`health_check`, `query_interceptor`, `query_registry`) are optional.
- Sort optional properties after required properties so that the most important ones are listed first.
- Flesh out `datastore_core` config with more complete examples.
- On `custom_timestamp_ranges`, make at least one of `lt`/`lte`/`gt`/`gte` required. A custom timestamp range can't be defined without at least one of those.