### PR TITLE
Fix load errors in release workflow.

### DIFF
--- a/config/release/Gemfile
+++ b/config/release/Gemfile
@@ -9,6 +9,7 @@
 source "https://rubygems.org"
 
 gem "gem-release", "~> 2.2"
+gem "json_schemer", "~> 2.4"
 gem "nokogiri", "~> 1.18", ">= 1.18.9"
 gem "rake", "~> 13.3"
 gem "redcarpet", "~> 3.6", ">= 3.6.1"

--- a/config/release/Gemfile.lock
+++ b/config/release/Gemfile.lock
@@ -1,8 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    bigdecimal (3.2.2)
     csv (3.3.5)
     gem-release (2.2.4)
+    hana (1.3.7)
+    json_schemer (2.4.0)
+      bigdecimal
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
     mini_portile2 (2.8.9)
     nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
@@ -12,6 +19,8 @@ GEM
     racc (1.8.1)
     rake (13.3.0)
     redcarpet (3.6.1)
+    regexp_parser (2.11.2)
+    simpleidn (0.2.3)
     yard (0.9.37)
     yard-markdown (0.5.0)
       csv
@@ -23,6 +32,7 @@ PLATFORMS
 
 DEPENDENCIES
   gem-release (~> 2.2)
+  json_schemer (~> 2.4)
   nokogiri (~> 1.18, >= 1.18.9)
   rake (~> 13.3)
   redcarpet (~> 3.6, >= 3.6.1)

--- a/config/release/Rakefile
+++ b/config/release/Rakefile
@@ -15,7 +15,8 @@ require "gem/release"
 require "#{project_root}/elasticgraph-support/lib/elastic_graph/version"
 require "#{project_root}/script/list_eg_gems"
 
-# Load tasks from config/site/Rakefile
+# Load tasks from config/site/Rakefile. `elasticgraph-support` must be on the `$LOAD_PATH`.
+$LOAD_PATH << ::File.join(project_root, "elasticgraph-support", "lib")
 load "#{project_root}/config/site/Rakefile"
 
 bump_version = lambda do |version:, message:|


### PR DESCRIPTION
The release workflow was broken by #794. It's currently failing with:

```
LoadError: cannot load such file -- elastic_graph/support/json_schema/validator_factory (LoadError)
/home/runner/work/elasticgraph/elasticgraph/config/site/support/config_doc_generator.rb:9:in '<top (required)>'
/home/runner/work/elasticgraph/elasticgraph/config/site/Rakefile:649:in 'Kernel#require_relative'
/home/runner/work/elasticgraph/elasticgraph/config/site/Rakefile:649:in 'ElasticGraph::SiteRakeTasks#generate_and_stage_config_documentation'
/home/runner/work/elasticgraph/elasticgraph/config/site/Rakefile:636:in 'ElasticGraph::SiteRakeTasks#stage_markdown_files'
/home/runner/work/elasticgraph/elasticgraph/config/site/Rakefile:593:in 'ElasticGraph::SiteRakeTasks#yard_cmd'
```

This fixes it.

## How Tested?

Tested locally via by mimicing the steps of the [release workflow](https://github.com/block/elasticgraph/blob/095274ec5158817356efaa70d0a3c5c90206ecf0/.github/workflows/release.yaml#L61-L64):


```
rm Rakefile
cp config/release/Rakefile .
git update-index --skip-worktree Rakefile
export BUNDLE_GEMFILE=config/release/Gemfile
bundle exec rake "site:archive_docs[1.0.1]"
```

Without these changes I got the same error as shown above; with these changes, it worked.