### PR TITLE
Remove RSpec workaround.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,7 +455,7 @@ GEM
       rspec-support (~> 3.13.0)
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
-    rspec-support (3.13.4)
+    rspec-support (3.13.5)
     rubocop (1.75.8)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)

--- a/elasticgraph-schema_definition/spec/support/json_schema_matcher.rb
+++ b/elasticgraph-schema_definition/spec/support/json_schema_matcher.rb
@@ -10,13 +10,7 @@ require "elastic_graph/support/json_schema/meta_schema_validator"
 require "elastic_graph/support/json_schema/validator_factory"
 require "json"
 
-RSpec::Matchers.define :have_json_schema_like do |type, expected_schema, options = {}|
-  # RSpec 3.13 has a regression related to keyword args that we work around here with an `options` hash.
-  # TODO: Switch back to an `include_typename` keyword arg once we upgrade to a version that fixes the regression.
-  # https://github.com/rspec/rspec-expectations/issues/1451
-  include_typename = options.fetch(:include_typename, true)
-  ignore_descriptions = options.fetch(:ignore_descriptions, false)
-
+RSpec::Matchers.define :have_json_schema_like do |type, expected_schema, include_typename: true, ignore_descriptions: false|
   diffable
 
   attr_reader :actual, :expected


### PR DESCRIPTION
rspec-support 3.13.5 has been released with a fix for the issue that was impacting us here:

https://github.com/rspec/rspec-expectations/issues/1451