### PR TITLE
define schema elements for matchesQueryWithPrefix filtering

### DIFF
--- a/config/schema/artifacts/schema.graphql
+++ b/config/schema/artifacts/schema.graphql
@@ -4692,6 +4692,30 @@ input MatchesQueryFilterInput {
   require_all_terms: Boolean! = false
 }
 
+"""
+Input type used to specify parameters for the `matches_query_with_prefix` filtering operator.
+
+When `null` is passed, matches all documents.
+"""
+input MatchesQueryWithPrefixFilterInput {
+  """
+  Number of allowed modifications per term to arrive at a match. For example, if set to 'ONE', the input
+  term 'glue' would match 'blue' but not 'clued', since the latter requires two modifications.
+  """
+  allowed_edits_per_term: MatchesQueryAllowedEditsPerTermInput! = DYNAMIC
+
+  """
+  The input query to search for, with the last term treated as a prefix.
+  """
+  query_with_prefix: String!
+
+  """
+  Set to `true` to match only if all terms in `query_with_prefix` are found, or
+  `false` to only require one term to be found.
+  """
+  require_all_terms: Boolean! = false
+}
+
 enum Material {
   ALLOY
   CARBON_FIBER
@@ -12546,6 +12570,14 @@ input TextFilterInput {
   When `null` is passed, matches all documents.
   """
   matches_query: MatchesQueryFilterInput
+
+  """
+  Matches records where the field value matches the provided query with the last term treated as a prefix.
+  Similar to `matches_query`, but allows prefix matching on the last term.
+
+  When `null` is passed, matches all documents.
+  """
+  matches_query_with_prefix: MatchesQueryWithPrefixFilterInput
 
   """
   Matches records where the provided sub-filter evaluates to false.

--- a/config/schema/artifacts_with_apollo/schema.graphql
+++ b/config/schema/artifacts_with_apollo/schema.graphql
@@ -4974,6 +4974,30 @@ input MatchesQueryFilterInput {
   require_all_terms: Boolean! = false
 }
 
+"""
+Input type used to specify parameters for the `matches_query_with_prefix` filtering operator.
+
+When `null` is passed, matches all documents.
+"""
+input MatchesQueryWithPrefixFilterInput {
+  """
+  Number of allowed modifications per term to arrive at a match. For example, if set to 'ONE', the input
+  term 'glue' would match 'blue' but not 'clued', since the latter requires two modifications.
+  """
+  allowed_edits_per_term: MatchesQueryAllowedEditsPerTermInput! = DYNAMIC
+
+  """
+  The input query to search for, with the last term treated as a prefix.
+  """
+  query_with_prefix: String!
+
+  """
+  Set to `true` to match only if all terms in `query_with_prefix` are found, or
+  `false` to only require one term to be found.
+  """
+  require_all_terms: Boolean! = false
+}
+
 enum Material {
   ALLOY
   CARBON_FIBER
@@ -12869,6 +12893,14 @@ input TextFilterInput {
   When `null` is passed, matches all documents.
   """
   matches_query: MatchesQueryFilterInput
+
+  """
+  Matches records where the field value matches the provided query with the last term treated as a prefix.
+  Similar to `matches_query`, but allows prefix matching on the last term.
+
+  When `null` is passed, matches all documents.
+  """
+  matches_query_with_prefix: MatchesQueryWithPrefixFilterInput
 
   """
   Matches records where the provided sub-filter evaluates to false.

--- a/elasticgraph-graphql/spec/acceptance/hidden_types_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/hidden_types_spec.rb
@@ -120,7 +120,7 @@ module ElasticGraph
               DayOfWeek DayOfWeekGroupingOffsetInput DistanceUnitInput GeoLocationFilterInput GeoLocationDistanceFilterInput
               IntListFilterInput IntListElementFilterInput AggregationCountDetail
               LocalTimeGroupingOffsetInput LocalTimeGroupingTruncationUnitInput LocalTimeUnitInput MatchesQueryFilterInput
-              MatchesPhraseFilterInput MatchesQueryAllowedEditsPerTermInput StringContainsFilterInput StringStartsWithFilterInput
+              MatchesPhraseFilterInput MatchesQueryWithPrefixFilterInput MatchesQueryAllowedEditsPerTermInput StringContainsFilterInput StringStartsWithFilterInput
               SearchHighlight
             ]
 

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rb
@@ -137,7 +137,7 @@ module ElasticGraph
       SchemaElementNames = SchemaElementNamesDefinition.new(
         # Filter arg and operation names:
         :filter,
-        :equal_to_any_of, :gt, :gte, :lt, :lte, :matches_phrase, :matches_query, :any_of, :all_of, :not,
+        :equal_to_any_of, :gt, :gte, :lt, :lte, :matches_phrase, :matches_query, :matches_query_with_prefix, :any_of, :all_of, :not,
         :time_of_day, :any_satisfy, :contains, :starts_with, :all_substrings_of, :any_substring_of, :ignore_case, :any_prefix_of,
         # Directives
         :eg_latency_slo, :ms,
@@ -159,8 +159,8 @@ module ElasticGraph
         :page_info, :start_cursor, :end_cursor, :total_edge_count, :has_previous_page, :has_next_page,
         # Subfields of `GeoLocation`/`GeoLocationFilterInput`:
         :latitude, :longitude, :near, :max_distance,
-        # Subfields of `MatchesQueryFilterInput`/`MatchesPhraseFilterInput`
-        :query, :phrase, :allowed_edits_per_term, :require_all_terms,
+        # Subfields of `MatchesQueryFilterInput`/`MatchesPhraseFilterInput`/`MatchesQueryWithPrefixFilterInput`
+        :query, :phrase, :query_with_prefix, :allowed_edits_per_term, :require_all_terms,
         # Aggregated values field names:
         :exact_min, :exact_max, :approximate_min, :approximate_max, :approximate_avg, :approximate_sum, :exact_sum,
         :approximate_distinct_value_count

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rbs
@@ -24,6 +24,7 @@ module ElasticGraph
         attr_reader lte: ::String
         attr_reader matches_query: ::String
         attr_reader matches_phrase: ::String
+        attr_reader matches_query_with_prefix: ::String
         attr_reader all_of: ::String
         attr_reader any_of: ::String
         attr_reader not: ::String
@@ -84,6 +85,7 @@ module ElasticGraph
 
         attr_reader query: ::String
         attr_reader phrase: ::String
+        attr_reader query_with_prefix: ::String
         attr_reader allowed_edits_per_term: ::Integer
         attr_reader require_all_terms: bool
 

--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
@@ -370,7 +370,7 @@ module ElasticGraph
             DayOfWeekGroupingOffsetInput
             LocalTimeGroupingOffsetInput LocalTimeGroupingTruncationUnitInput LocalTimeUnitInput
             NonNumericAggregatedValues TextFilterInput
-            MatchesQueryFilterInput MatchesQueryAllowedEditsPerTermInput MatchesPhraseFilterInput
+            MatchesQueryFilterInput MatchesQueryAllowedEditsPerTermInput MatchesPhraseFilterInput MatchesQueryWithPrefixFilterInput
           ]
 
           expect(filtered_types).to match_array(allowed_list)

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/built_in_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/built_in_types_spec.rb
@@ -752,7 +752,6 @@ module ElasticGraph
               #{schema_elements.matches_phrase}: MatchesPhraseFilterInput
               """
               Matches records where the field value matches the provided query with the last term treated as a prefix.
-              This is useful for search-as-you-type functionality, where users expect to see results as they type.
               Similar to `#{schema_elements.matches_query}`, but allows prefix matching on the last term.
 
               When `null` is passed, matches all documents.
@@ -804,7 +803,6 @@ module ElasticGraph
               #{schema_elements.matches_phrase}: MatchesPhraseFilterInput
               """
               Matches records where the field value matches the provided query with the last term treated as a prefix.
-              This is useful for search-as-you-type functionality, where users expect to see results as they type.
               Similar to `#{schema_elements.matches_query}`, but allows prefix matching on the last term.
 
               When `null` is passed, matches all documents.

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/built_in_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/built_in_types_spec.rb
@@ -750,6 +750,14 @@ module ElasticGraph
               When `null` is passed, matches all documents.
               """
               #{schema_elements.matches_phrase}: MatchesPhraseFilterInput
+              """
+              Matches records where the field value matches the provided query with the last term treated as a prefix.
+              This is useful for search-as-you-type functionality, where users expect to see results as they type.
+              Similar to `#{schema_elements.matches_query}`, but allows prefix matching on the last term.
+
+              When `null` is passed, matches all documents.
+              """
+              #{schema_elements.matches_query_with_prefix}: MatchesQueryWithPrefixFilterInput
             }
           EOS
 
@@ -794,6 +802,14 @@ module ElasticGraph
               When `null` is passed, matches all documents.
               """
               #{schema_elements.matches_phrase}: MatchesPhraseFilterInput
+              """
+              Matches records where the field value matches the provided query with the last term treated as a prefix.
+              This is useful for search-as-you-type functionality, where users expect to see results as they type.
+              Similar to `#{schema_elements.matches_query}`, but allows prefix matching on the last term.
+
+              When `null` is passed, matches all documents.
+              """
+              #{schema_elements.matches_query_with_prefix}: MatchesQueryWithPrefixFilterInput
             }
           EOS
         end
@@ -917,6 +933,32 @@ module ElasticGraph
               The input phrase to search for.
               """
               #{schema_elements.phrase}: String!
+            }
+          EOS
+        end
+
+        it "defines a `MatchesQueryWithPrefixFilterInput` type" do
+          expect(type_named("MatchesQueryWithPrefixFilterInput", include_docs: true)).to eq(<<~EOS.strip)
+            """
+            Input type used to specify parameters for the `#{schema_elements.matches_query_with_prefix}` filtering operator.
+
+            When `null` is passed, matches all documents.
+            """
+            input MatchesQueryWithPrefixFilterInput {
+              """
+              The input query to search for, with the last term treated as a prefix.
+              """
+              #{schema_elements.query_with_prefix}: String!
+              """
+              Number of allowed modifications per term to arrive at a match. For example, if set to 'ONE', the input
+              term 'glue' would match 'blue' but not 'clued', since the latter requires two modifications.
+              """
+              #{schema_elements.allowed_edits_per_term}: MatchesQueryAllowedEditsPerTermInput! = "DYNAMIC"
+              """
+              Set to `true` to match only if all terms in `#{schema_elements.query_with_prefix}` are found, or
+              `false` to only require one term to be found.
+              """
+              #{schema_elements.require_all_terms}: Boolean! = false
             }
           EOS
         end


### PR DESCRIPTION
 Changes
  - Added new schema element names in schema_element_names.rb:
    - Added matches_query_with_prefix to filter operation names
    - Added query_with_prefix to subfields
  - Updated type definitions in schema_element_names.rbs
  - Added schema definition in built_in_types.rb:
    - Created MatchesQueryWithPrefix filter type
    - Added matchesQueryWithPrefix field to TextFilterInput

  - Added test coverage in built_in_types_spec.rb
  - Updated hidden_types_spec.rb to include the new filter type

  This PR only defines the schema elements. The query translation implementation
  will follow in a subsequent PR.