### PR TITLE
chore: Fix YAML syntax highlighting at the website.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,13 @@ group :site do
   gem "jekyll", "~> 4.4", ">= 4.4.1"
   gem "nokogiri", "~> 1.18", ">= 1.18.9"
   gem "redcarpet", "~> 3.6", ">= 3.6.1"
+
+  # Pull in a YAML syntax highlighting fix so that our JSON schemas render correctly at the website:
+  # https://github.com/rouge-ruby/rouge/pull/2156
+  #
+  # TODO: switch back to a release version once that fix is merged and released.
+  gem "rouge", github: "myronmarston/rouge", ref: "12c0da6aa98e0d0a0762c47103b64290c88620a1"
+
   gem "yard", "~> 0.9", ">= 0.9.37"
   gem "yard-doctest", "~> 0.1", ">= 0.1.17"
   gem "yard-markdown", "~> 0.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/myronmarston/rouge.git
+  revision: 12c0da6aa98e0d0a0762c47103b64290c88620a1
+  ref: 12c0da6aa98e0d0a0762c47103b64290c88620a1
+  specs:
+    rouge (4.6.0)
+
 PATH
   remote: elasticgraph-admin_lambda
   specs:
@@ -440,7 +447,6 @@ GEM
     redcarpet (3.6.1)
     regexp_parser (2.11.1)
     rexml (3.4.1)
-    rouge (4.6.0)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -634,6 +640,7 @@ DEPENDENCIES
   nokogiri (~> 1.18, >= 1.18.9)
   rack-test (~> 2.2)
   redcarpet (~> 3.6, >= 3.6.1)
+  rouge!
   rspec (~> 3.13, >= 3.13.1)
   rspec-retry (~> 0.6, >= 0.6.2)
   rubocop-factory_bot (~> 2.26.1)


### PR DESCRIPTION
The syntax highlighter we use, `rouge`, does not handle quoted keys (such as `"$schema"`) correctly--it's been highlighting them as having a syntax error. I dug into the issue in rouge, created a fix, and have a PR against rouge opened with the fix. This pulls in the fix from my fork so we can benefit from it now. Once my fix is merged and released, we can switch to the released version.

Before, here's how the YAML JSON schema at https://block.github.io/elasticgraph/guides/how-it-works/ looked:

<img width="948" height="956" alt="image" src="https://github.com/user-attachments/assets/7d1cf82c-c592-4c4a-b709-c12652761f9e" />

Here's how it looks with this fix:

<img width="913" height="924" alt="image" src="https://github.com/user-attachments/assets/bd4acc32-f2ab-4118-bb54-281b3522fde1" />


