### PR TITLE
site: widen articles a bit, so wider content can fit in code boxes.

### DIFF
--- a/config/site/src/_layouts/markdown.html
+++ b/config/site/src/_layouts/markdown.html
@@ -5,7 +5,7 @@ use_anchor_headings: true
 ---
 <main class="grow">
   <div class="container mx-auto px-4 py-8 lg:py-20">
-    <article class="prose dark:prose-invert lg:prose-xl">
+    <article class="prose dark:prose-invert lg:prose-xl max-w-[85ch]">
       <h2>{{ page.title }}</h2>
 
       {{ content }}


### PR DESCRIPTION
This adds ~20 characters of width to the center `article` element which wraps the content of most pages.

The direct impetus for this is a new configuration guide I'm working on. I am pulling in a generated example config and JSON schema config and they are wider than the article width. As a result, the code boxes have to include horizontal scrolling. While horizontal scrolling isn't the worst to include, I think our `article` elements can be a bit wider. This looks a bit better to me overall and will allow wider code snippets to render without horizontal scrolling.

Before:

<img width="927" height="925" alt="image" src="https://github.com/user-attachments/assets/ca148712-5abe-4a2a-a9de-a12e0f1a0e18" />


After:

<img width="1155" height="955" alt="image" src="https://github.com/user-attachments/assets/49168328-5e5e-4f46-9ff8-205e68e02614" />
