### PR TITLE
site: reduce line spacing in code blocks.

### DIFF
--- a/config/site/src/assets/css/tailwind.css
+++ b/config/site/src/assets/css/tailwind.css
@@ -47,6 +47,12 @@
   .alert-tip div.highlight {
     margin-bottom: 0px;
   }
+
+  /* Reduce line spacing in code blocks */
+  div.highlight pre,
+  div.highlight code {
+    line-height: 1.4;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
Code blocks were inheriting the line height of 1.8 which was in use within `.prose` elements (which code blocks reside within). This looked taller than it should be, IMO. I've reduced it to 1.4 which looks better to my eyes.

## Before:

<img width="1104" height="906" alt="image" src="https://github.com/user-attachments/assets/bf5c85d0-60be-4b0b-830a-5dc0a73fc3fb" />

## After:

<img width="1112" height="899" alt="image" src="https://github.com/user-attachments/assets/da7dc8ea-bce9-4ce0-a884-106fc9ca6744" />
