### PR TITLE
Refactor: stop exposing `indices` when we only support one.

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/json_schema_with_metadata.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/json_schema_with_metadata.rb
@@ -160,11 +160,11 @@ module ElasticGraph
               type.indexed? && !@derived_indexing_type_names.include?(type.name)
             end
 
-            types_to_check.flat_map do |object_type|
-              object_type.indices.flat_map do |index_def|
+            types_to_check.filter_map do |object_type|
+              if (index_def = object_type.index_def)
                 identify_missing_necessary_fields_for_index_def(object_type, index_def, json_schema_resolver, version)
               end
-            end
+            end.flatten
           end
 
           def identify_missing_necessary_fields_for_index_def(object_type, index_def, json_schema_resolver, json_schema_version)

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/update_target_resolver.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/update_target_resolver.rb
@@ -137,10 +137,9 @@ module ElasticGraph
         #
         # Returns a tuple of the resolved source (if successful) and an error (if invalid).
         def resolve_field_source(adapter)
-          # For now we only support one index (so we can use the first index) but someday we may need to support multiple.
-          index = object_type.indices.first # : Index
+          index_def = object_type.index_def # : Index
 
-          field_source_graphql_path_string = adapter.get_field_source(resolved_relationship.relationship, index) do |local_need|
+          field_source_graphql_path_string = adapter.get_field_source(resolved_relationship.relationship, index_def) do |local_need|
             relationship_name = resolved_relationship.relationship_name
 
             error = "Cannot update `#{object_type.name}` documents with data from related `#{relationship_name}` events, " \

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/mixins/has_indices.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/mixins/has_indices.rbs
@@ -2,10 +2,10 @@ module ElasticGraph
   module SchemaDefinition
     module Mixins
       module HasIndices
-        attr_reader indices: ::Array[Indexing::Index]
+        def index_def: () -> Indexing::Index?
         attr_reader runtime_metadata_overrides: ::Hash[::Symbol, untyped]
         attr_reader default_graphql_resolver: SchemaArtifacts::RuntimeMetadata::ConfiguredGraphQLResolver?
-        def index: (::String, ::Hash[::Symbol, ::String | ::Integer]) ?{ (Indexing::Index) -> void } -> ::Array[Indexing::Index]
+        def index: (::String, ::Hash[::Symbol, ::String | ::Integer]) ?{ (Indexing::Index) -> void } -> Indexing::Index
         def resolve_fields_with: (::Symbol?) -> void
         def indexed?: () -> bool
         def override_runtime_metadata: (**untyped) -> void

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/index_definition_names_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/index_definition_names_spec.rb
@@ -40,6 +40,21 @@ module ElasticGraph
             end
           }.to raise_error(ElasticGraph::Errors::SchemaError, a_string_including("Cannot define an index on `Widget` after initialization is complete"))
         end
+
+        it "does not allow two indices to be defined on the same type" do
+          expect {
+            object_type_metadata_for "Widget" do |schema|
+              schema.object_type "Widget" do |t|
+                t.field "id", "ID!"
+                t.field "name", "String"
+
+                t.index "widgets1"
+
+                t.index "widgets2"
+              end
+            end
+          }.to raise_error(ElasticGraph::Errors::SchemaError, /Cannot define multiple indices on `Widget`/)
+        end
       end
 
       context "on an embedded object type" do

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/update_targets_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/update_targets_spec.rb
@@ -147,7 +147,7 @@ module ElasticGraph
           )
         end
 
-        it "does not dump any update targets for interface types with no defined indices, even if they are implemented by other types with defined indices" do
+        it "does not dump any update targets for interface types with no defined index, even if they are implemented by other types with defined indices" do
           metadata = object_type_metadata_for "WidgetWorkspace" do |s|
             s.interface_type "NamedEntity" do |t|
               t.field "name", "String"


### PR DESCRIPTION
Originally, we thought we might support multiple but there's never been a need and it's annoying to always have to deal with `indices` as a list when we only have one (or none).

As part of this, we've changed the behavior slightly for when `index` is called more than once: previously, we replaced the existing definition. Now we raise an error as we should.