### PR TITLE
chore: Avoid "Too many open files" errors in test suite.

### DIFF
--- a/spec_support/lib/elastic_graph/spec_support/uses_datastore.rb
+++ b/spec_support/lib/elastic_graph/spec_support/uses_datastore.rb
@@ -18,7 +18,7 @@ require_relative "cluster_configuration_manager"
 require_relative "profiling"
 
 datastore_url = YAML.safe_load_file(ElasticGraph::CommonSpecHelpers::TEST_SETTINGS_FILE_TEMPLATE, aliases: true).fetch("datastore").fetch("clusters").fetch("main").fetch("url")
-datastore_logs = "#{ElasticGraph::CommonSpecHelpers::REPO_ROOT}/log/datastore_client.test.log"
+datastore_logs = ::Logger.new("#{ElasticGraph::CommonSpecHelpers::REPO_ROOT}/log/datastore_client.test.log")
 
 module ElasticGraph
   # A `Logger` implementation that internally delegates to multiple underlying loggers so that we can both observe/assert on the logs
@@ -526,7 +526,7 @@ RSpec.configure do |config|
       client_class = (datastore_backend == :opensearch) ? ElasticGraph::OpenSearch::Client : ElasticGraph::Elasticsearch::Client
       # :nocov:
 
-      client_class.new(name, faraday_adapter: :httpx, url: datastore_url, logger: ElasticGraph::SplitLogger.new(logger, Logger.new(datastore_logs))) do |conn|
+      client_class.new(name, faraday_adapter: :httpx, url: datastore_url, logger: ElasticGraph::SplitLogger.new(logger, datastore_logs)) do |conn|
         conn.use DisallowUnsupportedAWSOperations
         conn.use RequestTracker, datastore_requests_by_cluster_name[name]
       end


### PR DESCRIPTION
On a new machine with a different `ulimit` setting, I got test failures:

```
Failure/Error: dev = File.open(filename, MODE_TO_OPEN)

Errno::EMFILE:
  Too many open files @ rb_sysopen - /Users/myron/code/elasticgraph/log/datastore_client.test.log
```

I can tweak my `ulimit` but there's a simple change to make the test suite open fewer files--just create the `datastore_logs` logger once instead of once per test.