### PR TITLE
chore: fix scripts/tests to tolerate `color.grep=always` in git config.

### DIFF
--- a/elasticgraph/spec/acceptance/cli_new_spec.rb
+++ b/elasticgraph/spec/acceptance/cli_new_spec.rb
@@ -204,7 +204,7 @@ module ElasticGraph
 
     def todo_comments_in(dir)
       ::Dir.chdir(dir) do
-        `git grep TODO`.split("\n").map do |match|
+        `git grep --no-color TODO`.split("\n").map do |match|
           match.sub(/^[^:]+:\s*/, "")
         end
       end

--- a/elasticgraph/spec/unit/elastic_graph/gem_spec.rb
+++ b/elasticgraph/spec/unit/elastic_graph/gem_spec.rb
@@ -34,7 +34,7 @@ module ElasticGraph
 
       let(:gemspec) { gemspecs_by_gem_name[gem_name] }
       let(:config_definition_lines) do
-        `git grep "Config =" -- lib`.strip.lines + `git grep "class Config\\b" -- lib`.strip.lines
+        `git grep --no-color "Config =" -- lib`.strip.lines + `git grep --no-color "class Config\\b" -- lib`.strip.lines
       end
 
       it "has the correct name" do

--- a/script/update_config_artifacts
+++ b/script/update_config_artifacts
@@ -93,7 +93,7 @@ module ElasticGraph
     private
 
     def config_definition_lines
-      @config_definition_lines ||= `git grep "Config.define"`.lines.reject do |line|
+      @config_definition_lines ||= `git grep --no-color "Config.define"`.lines.reject do |line|
         line.include?("elasticgraph-support/lib/elastic_graph/support/config") ||
           line.include?("/spec/") ||
           line.include?(::File.basename(__FILE__))


### PR DESCRIPTION
Passing `--no-color` ensures that when we shell out and run `git grep`, there are no ANSI color sequences in the output, regardless of the git config on the local machine.