### PR TITLE
Update gem artifacts.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ PATH
   specs:
     elasticgraph-elasticsearch (1.0.2.pre)
       elasticgraph-support (= 1.0.2.pre)
-      elasticsearch (~> 9.1, >= 9.1.1)
+      elasticsearch (~> 9.1, >= 9.1.2)
       faraday (~> 2.13, >= 2.13.4)
       faraday-retry (~> 2.3, >= 2.3.2)
 
@@ -83,9 +83,9 @@ PATH
   remote: elasticgraph-indexer_autoscaler_lambda
   specs:
     elasticgraph-indexer_autoscaler_lambda (1.0.2.pre)
-      aws-sdk-cloudwatch (~> 1.119)
-      aws-sdk-lambda (~> 1.158)
-      aws-sdk-sqs (~> 1.100)
+      aws-sdk-cloudwatch (~> 1.120)
+      aws-sdk-lambda (~> 1.160)
+      aws-sdk-sqs (~> 1.103)
       elasticgraph-datastore_core (= 1.0.2.pre)
       elasticgraph-lambda_support (= 1.0.2.pre)
       ox (~> 2.14, >= 2.14.23)
@@ -94,7 +94,7 @@ PATH
   remote: elasticgraph-indexer_lambda
   specs:
     elasticgraph-indexer_lambda (1.0.2.pre)
-      aws-sdk-s3 (~> 1.197)
+      aws-sdk-s3 (~> 1.199)
       elasticgraph-indexer (= 1.0.2.pre)
       elasticgraph-lambda_support (= 1.0.2.pre)
       ox (~> 2.14, >= 2.14.23)
@@ -106,7 +106,7 @@ PATH
       elasticgraph-datastore_core (= 1.0.2.pre)
       elasticgraph-schema_artifacts (= 1.0.2.pre)
       elasticgraph-support (= 1.0.2.pre)
-      hashdiff (~> 1.2)
+      hashdiff (~> 1.2, >= 1.2.1)
 
 PATH
   remote: elasticgraph-lambda_support
@@ -159,7 +159,7 @@ PATH
   specs:
     elasticgraph-rack (1.0.2.pre)
       elasticgraph-graphql (= 1.0.2.pre)
-      rack (~> 3.2)
+      rack (~> 3.2, >= 3.2.1)
 
 PATH
   remote: elasticgraph-schema_artifacts

--- a/elasticgraph-elasticsearch/elasticgraph-elasticsearch.gemspec
+++ b/elasticgraph-elasticsearch/elasticgraph-elasticsearch.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = [">= 3.4", "< 3.5"]
 
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "elasticsearch", "~> 9.1", ">= 9.1.1"
+  spec.add_dependency "elasticsearch", "~> 9.1", ">= 9.1.2"
   spec.add_dependency "faraday", "~> 2.13", ">= 2.13.4"
   spec.add_dependency "faraday-retry", "~> 2.3", ">= 2.3.2"
 end

--- a/elasticgraph-indexer/elasticgraph-indexer.gemspec
+++ b/elasticgraph-indexer/elasticgraph-indexer.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "elasticgraph-datastore_core", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-schema_artifacts", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "hashdiff", "~> 1.2"
+  spec.add_dependency "hashdiff", "~> 1.2", ">= 1.2.1"
 
   spec.add_development_dependency "elasticgraph-admin", ElasticGraph::VERSION
   spec.add_development_dependency "elasticgraph-elasticsearch", ElasticGraph::VERSION

--- a/elasticgraph-indexer_autoscaler_lambda/elasticgraph-indexer_autoscaler_lambda.gemspec
+++ b/elasticgraph-indexer_autoscaler_lambda/elasticgraph-indexer_autoscaler_lambda.gemspec
@@ -43,9 +43,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "elasticgraph-datastore_core", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-lambda_support", ElasticGraph::VERSION
-  spec.add_dependency "aws-sdk-lambda", "~> 1.158"
-  spec.add_dependency "aws-sdk-sqs", "~> 1.100"
-  spec.add_dependency "aws-sdk-cloudwatch", "~> 1.119"
+  spec.add_dependency "aws-sdk-lambda", "~> 1.160"
+  spec.add_dependency "aws-sdk-sqs", "~> 1.103"
+  spec.add_dependency "aws-sdk-cloudwatch", "~> 1.120"
   # aws-sdk-sqs requires an XML library be available. On Ruby < 3 it'll use rexml from the standard library but on Ruby 3.0+
   # we have to add an explicit dependency. It supports ox, oga, libxml, nokogiri or rexml, and of those, ox seems to be the
   # best choice: it leads benchmarks, is well-maintained, has no dependencies, and is MIT-licensed.

--- a/elasticgraph-indexer_lambda/elasticgraph-indexer_lambda.gemspec
+++ b/elasticgraph-indexer_lambda/elasticgraph-indexer_lambda.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "elasticgraph-indexer", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-lambda_support", ElasticGraph::VERSION
-  spec.add_dependency "aws-sdk-s3", "~> 1.197"
+  spec.add_dependency "aws-sdk-s3", "~> 1.199"
 
   # aws-sdk-s3 requires an XML library be available. On Ruby < 3 it'll use rexml from the standard library but on Ruby 3.0+
   # we have to add an explicit dependency. It supports ox, oga, libxml, nokogiri or rexml, and of those, ox seems to be the

--- a/elasticgraph-rack/elasticgraph-rack.gemspec
+++ b/elasticgraph-rack/elasticgraph-rack.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = [">= 3.4", "< 3.5"]
 
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION
-  spec.add_dependency "rack", "~> 3.2"
+  spec.add_dependency "rack", "~> 3.2", ">= 3.2.1"
 
   spec.add_development_dependency "elasticgraph-admin", ElasticGraph::VERSION
   spec.add_development_dependency "elasticgraph-elasticsearch", ElasticGraph::VERSION

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -6,7 +6,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: addressable
@@ -14,7 +14,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ast
@@ -22,7 +22,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: async
@@ -30,31 +30,31 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: aws-sdk-cloudwatch
-  version: 1.119.0
+  version: 1.120.0
   source:
     type: rubygems
 - name: aws-sdk-core
-  version: 3.230.0
+  version: 3.232.0
   source:
     type: rubygems
 - name: aws-sdk-kms
-  version: 1.110.0
+  version: 1.112.0
   source:
     type: rubygems
 - name: aws-sdk-lambda
-  version: 1.158.0
+  version: 1.160.0
   source:
     type: rubygems
 - name: aws-sdk-s3
-  version: 1.197.0
+  version: 1.199.0
   source:
     type: rubygems
 - name: aws-sdk-sqs
-  version: 1.100.0
+  version: 1.103.0
   source:
     type: rubygems
 - name: base64
@@ -70,7 +70,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: cgi
@@ -82,7 +82,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: connection_pool
@@ -90,7 +90,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: csv
@@ -98,7 +98,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: date
@@ -110,7 +110,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: digest
@@ -126,7 +126,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: faraday
@@ -134,7 +134,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: fileutils
@@ -150,7 +150,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: hashdiff
@@ -158,7 +158,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: i18n
@@ -166,7 +166,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: json
@@ -178,7 +178,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: logger
@@ -190,7 +190,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: monitor
@@ -210,7 +210,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: openssl
@@ -226,7 +226,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: parser
@@ -234,7 +234,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: prism
@@ -246,7 +246,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rainbow
@@ -254,7 +254,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rake
@@ -262,7 +262,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: regexp_parser
@@ -270,7 +270,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ripper
@@ -282,7 +282,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rubocop-ast
@@ -290,7 +290,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: securerandom
@@ -302,7 +302,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: singleton
@@ -326,7 +326,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: time
@@ -342,7 +342,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: uri
@@ -358,7 +358,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 815e8f97e0be3127ccdb09c4bfe3908797f937d6
+    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: yard-markdown


### PR DESCRIPTION
The `update-gem-version-artifacts.yaml` workflow is currently not running on dependabot PRs, and these artifacts were not updated as part of recent dependabot PRs.

The changes here were made via these commands:

```
script/update_gem_constraints
bundle exec rbs collection update
```