### PR TITLE
Lock graphql gem to 2.5.11 to resolve elasticgraph-apollo test failure introduced in 2.5.12

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ PATH
       apollo-federation (~> 3.10, >= 3.10.1)
       elasticgraph-graphql (= 1.0.2.pre)
       elasticgraph-support (= 1.0.2.pre)
-      graphql (~> 2.5.11)
+      graphql (= 2.5.11)
 
 PATH
   remote: elasticgraph-datastore_core
@@ -68,7 +68,7 @@ PATH
       base64 (~> 0.3)
       elasticgraph-datastore_core (= 1.0.2.pre)
       elasticgraph-schema_artifacts (= 1.0.2.pre)
-      graphql (~> 2.5.11)
+      graphql (= 2.5.11)
       graphql-c_parser (~> 1.1, >= 1.1.3)
 
 PATH
@@ -150,7 +150,7 @@ PATH
     elasticgraph-query_registry (1.0.2.pre)
       elasticgraph-graphql (= 1.0.2.pre)
       elasticgraph-support (= 1.0.2.pre)
-      graphql (~> 2.5.11)
+      graphql (= 2.5.11)
       graphql-c_parser (~> 1.1, >= 1.1.3)
       rake (~> 13.3)
 
@@ -175,7 +175,7 @@ PATH
       elasticgraph-indexer (= 1.0.2.pre)
       elasticgraph-schema_artifacts (= 1.0.2.pre)
       elasticgraph-support (= 1.0.2.pre)
-      graphql (~> 2.5.11)
+      graphql (= 2.5.11)
       graphql-c_parser (~> 1.1, >= 1.1.3)
       rake (~> 13.3)
 

--- a/elasticgraph-apollo/elasticgraph-apollo.gemspec
+++ b/elasticgraph-apollo/elasticgraph-apollo.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "graphql", "2.5.11"
+  spec.add_dependency "graphql", "2.5.11" # 2.5.12 introduces a failure in elasticgraph-apollo.
   spec.add_dependency "apollo-federation", "~> 3.10", ">= 3.10.1"
 
   # Note: technically, this is not purely a development dependency, but since `eg-schema_def`

--- a/elasticgraph-apollo/elasticgraph-apollo.gemspec
+++ b/elasticgraph-apollo/elasticgraph-apollo.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "graphql", "~> 2.5.11"
+  spec.add_dependency "graphql", "2.5.11"
   spec.add_dependency "apollo-federation", "~> 3.10", ">= 3.10.1"
 
   # Note: technically, this is not purely a development dependency, but since `eg-schema_def`

--- a/elasticgraph-graphql/elasticgraph-graphql.gemspec
+++ b/elasticgraph-graphql/elasticgraph-graphql.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "base64", "~> 0.3"
   spec.add_dependency "elasticgraph-datastore_core", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-schema_artifacts", ElasticGraph::VERSION
-  spec.add_dependency "graphql", "~> 2.5.11"
+  spec.add_dependency "graphql", "2.5.11" # Build break in 2.5.12, investigating.
   spec.add_dependency "graphql-c_parser", "~> 1.1", ">= 1.1.3"
 
   spec.add_development_dependency "elasticgraph-admin", ElasticGraph::VERSION

--- a/elasticgraph-query_registry/elasticgraph-query_registry.gemspec
+++ b/elasticgraph-query_registry/elasticgraph-query_registry.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "graphql", "~> 2.5.11"
+  spec.add_dependency "graphql", "2.5.11" # Build break in 2.5.12, investigating.
   spec.add_dependency "graphql-c_parser", "~> 1.1", ">= 1.1.3"
   spec.add_dependency "rake", "~> 13.3"
 

--- a/elasticgraph-query_registry/elasticgraph-query_registry.gemspec
+++ b/elasticgraph-query_registry/elasticgraph-query_registry.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "graphql", "2.5.11" # Build break in 2.5.12, investigating.
+  spec.add_dependency "graphql", "2.5.11" # 2.5.12 introduces a failure in elasticgraph-apollo.
   spec.add_dependency "graphql-c_parser", "~> 1.1", ">= 1.1.3"
   spec.add_dependency "rake", "~> 13.3"
 

--- a/elasticgraph-schema_definition/elasticgraph-schema_definition.gemspec
+++ b/elasticgraph-schema_definition/elasticgraph-schema_definition.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "elasticgraph-indexer", ElasticGraph::VERSION # needed since we validate that scalar `prepare_for_indexing_with` options are valid (which loads indexing preparer adapters)
   spec.add_dependency "elasticgraph-schema_artifacts", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "graphql", "~> 2.5.11"
+  spec.add_dependency "graphql", "2.5.11" # Build break in 2.5.12, investigating.
   spec.add_dependency "graphql-c_parser", "~> 1.1", ">= 1.1.3"
   spec.add_dependency "rake", "~> 13.3"
 

--- a/elasticgraph-schema_definition/elasticgraph-schema_definition.gemspec
+++ b/elasticgraph-schema_definition/elasticgraph-schema_definition.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "elasticgraph-indexer", ElasticGraph::VERSION # needed since we validate that scalar `prepare_for_indexing_with` options are valid (which loads indexing preparer adapters)
   spec.add_dependency "elasticgraph-schema_artifacts", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "graphql", "2.5.11" # Build break in 2.5.12, investigating.
+  spec.add_dependency "graphql", "2.5.11" # 2.5.12 introduces a failure in elasticgraph-apollo.
   spec.add_dependency "graphql-c_parser", "~> 1.1", ">= 1.1.3"
   spec.add_dependency "rake", "~> 13.3"
 


### PR DESCRIPTION
Still investigating the root cause, but want to stabilize `main`. It appears that the `graphql` gem's 2.5.12 version (released today) introduces a test failure in elasticgraph-apollo (see below).

Can repro by running `bundle udpate && ./script/run_specs` off of `main`.

### How tested?
- Clean CI build.
- `bundle update && ./script/run_specs` fails off `main`, but on this branch succeeds.

### Failure w/o Fix

```
  1) ElasticGraph::Apollo::GraphQL::HTTPEndpointExtension adds Apollo tracing if the `Apollo-Federation-Include-Trace` header is set to `ftv1`, regardless of its casing
     Failure/Error: Google::Protobuf::Timestamp.new(seconds: time.to_i, nanos: time.nsec)
     
     NoMethodError:
       undefined method 'nsec' for nil
     # /Users/bsorbo/.rvm/gems/ruby-3.4.3/gems/apollo-federation-3.10.1/lib/apollo-federation/tracing/tracer.rb:271:in 'ApolloFederation::Tracing::Tracer.to_proto_timestamp'
     # /Users/bsorbo/.rvm/gems/ruby-3.4.3/gems/apollo-federation-3.10.1/lib/apollo-federation/tracing/tracer.rb:254:in 'ApolloFederation::Tracing::Tracer.attach_trace_to_result'
     # /Users/bsorbo/.rvm/gems/ruby-3.4.3/gems/apollo-federation-3.10.1/lib/apollo-federation/tracing/tracer.rb:101:in 'block in ApolloFederation::Tracing::Tracer.execute_multiplex'
     # /Users/bsorbo/.rvm/gems/ruby-3.4.3/gems/apollo-federation-3.10.1/lib/apollo-federation/tracing/tracer.rb:101:in 'Array#map'
     # /Users/bsorbo/.rvm/gems/ruby-3.4.3/gems/apollo-federation-3.10.1/lib/apollo-federation/tracing/tracer.rb:101:in 'ApolloFederation::Tracing::Tracer.execute_multiplex'
     # /Users/bsorbo/.rvm/gems/ruby-3.4.3/gems/apollo-federation-3.10.1/lib/apollo-federation/tracing/tracer.rb:80:in 'ApolloFederation::Tracing::Tracer.trace'
     # /Users/bsorbo/.rvm/gems/ruby-3.4.3/gems/graphql-2.5.12/lib/graphql/tracing.rb:63:in 'GraphQL::Tracing::Traceable#call_tracers'
     # /Users/bsorbo/.rvm/gems/ruby-3.4.3/gems/graphql-2.5.12/lib/graphql/tracing.rb:47:in 'GraphQL::Tracing::Traceable#trace'
     # /Users/bsorbo/.rvm/gems/ruby-3.4.3/gems/graphql-2.5.12/lib/graphql/tracing/call_legacy_tracers.rb:30:in 'GraphQL::Tracing::CallLegacyTracers#execute_multiplex'
     # /Users/bsorbo/.rvm/gems/ruby-3.4.3/gems/graphql-2.5.12/lib/graphql/execution/interpreter.rb:42:in 'GraphQL::Execution::Interpreter.run_all'
     # /Users/bsorbo/.rvm/gems/ruby-3.4.3/gems/graphql-2.5.12/lib/graphql/query.rb:281:in 'GraphQL::Query#result'
     # ./elasticgraph-graphql/lib/elastic_graph/graphql/query_executor.rb:147:in 'ElasticGraph::GraphQL::QueryExecutor#execute_query'
     # ./elasticgraph-graphql/lib/elastic_graph/graphql/query_executor.rb:138:in 'ElasticGraph::GraphQL::QueryExecutor#build_and_execute_query'
     # ./elasticgraph-graphql/lib/elastic_graph/graphql/query_executor.rb:55:in 'ElasticGraph::GraphQL::QueryExecutor#execute'
     # ./elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb:53:in 'block in ElasticGraph::GraphQL::HTTPEndpoint#process'
     # ./elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb:78:in 'block (3 levels) in ElasticGraph::GraphQL::HTTPEndpoint#with_parsed_request'
     # ./elasticgraph-apollo/lib/elastic_graph/apollo/graphql/http_endpoint_extension.rb:41:in 'block in ElasticGraph::Apollo::GraphQL::HTTPEndpointExtension#with_context'
     # ./elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb:168:in 'ElasticGraph::GraphQL::HTTPEndpoint#with_context'
     # ./elasticgraph-apollo/lib/elastic_graph/apollo/graphql/http_endpoint_extension.rb:32:in 'ElasticGraph::Apollo::GraphQL::HTTPEndpointExtension#with_context'
     # ./elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb:77:in 'block (2 levels) in ElasticGraph::GraphQL::HTTPEndpoint#with_parsed_request'
     # ./elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb:155:in 'ElasticGraph::GraphQL::HTTPEndpoint#with_timeout'
     # ./elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb:76:in 'block in ElasticGraph::GraphQL::HTTPEndpoint#with_parsed_request'
     # ./elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb:137:in 'ElasticGraph::GraphQL::HTTPEndpoint#with_request_params'
     # ./elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb:75:in 'ElasticGraph::GraphQL::HTTPEndpoint#with_parsed_request'
     # ./elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb:52:in 'ElasticGraph::GraphQL::HTTPEndpoint#process'
     # ./elasticgraph-apollo/spec/unit/elastic_graph/apollo/graphql/http_endpoint_extension_spec.rb:61:in 'RSpec::ExampleGroups::ElasticGraphApolloGraphQLHTTPEndpointExtension#execute_expecting_no_errors'
     # ./elasticgraph-apollo/spec/unit/elastic_graph/apollo/graphql/http_endpoint_extension_spec.rb:34:in 'block (2 levels) in <module:GraphQL>'
     # /Users/bsorbo/.rvm/gems/ruby-3.4.3/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in 'block in RSpec::Retry#run'
     # /Users/bsorbo/.rvm/gems/ruby-3.4.3/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in 'RSpec::Retry#run'
     # /Users/bsorbo/.rvm/gems/ruby-3.4.3/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in 'RSpec::Core::Example::Procsy#run_with_retry'
     # /Users/bsorbo/.rvm/gems/ruby-3.4.3/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in 'block (2 levels) in RSpec::Retry.setup'
     # ./spec_support/spec_helper.rb:71:in 'block (2 levels) in <top (required)>'
     # /Users/bsorbo/.rvm/gems/ruby-3.4.3/gems/thor-1.4.0/lib/thor/command.rb:28:in 'Thor::Command#run'
     # /Users/bsorbo/.rvm/gems/ruby-3.4.3/gems/thor-1.4.0/lib/thor/invocation.rb:127:in 'Thor::Invocation#invoke_command'
     # /Users/bsorbo/.rvm/gems/ruby-3.4.3/gems/thor-1.4.0/lib/thor.rb:538:in 'Thor.dispatch'
     # /Users/bsorbo/.rvm/gems/ruby-3.4.3/gems/thor-1.4.0/lib/thor/base.rb:584:in 'Thor::Base::ClassMethods#start'
```