### PR TITLE
Add new ElasticGraph Warehouse gem

### DIFF
--- a/config/site/support/doctest_helper.rb
+++ b/config/site/support/doctest_helper.rb
@@ -154,7 +154,6 @@ module ElasticGraph
     [
       "ElasticGraph::Apollo@Use elasticgraph-apollo in a project",
       "ElasticGraph::Apollo::SchemaDefinition::APIExtension@Define local rake tasks with this extension module",
-      "ElasticGraph::Warehouse@Using the warehouse extension",
       "ElasticGraph::Warehouse::SchemaDefinition::APIExtension@Define local rake tasks with this extension module",
       "ElasticGraph::Local::RakeTasks"
     ].each do |description|

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/factory_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/factory_extension.rb
@@ -8,7 +8,9 @@
 
 require "elastic_graph/warehouse/schema_definition/enum_type_extension"
 require "elastic_graph/warehouse/schema_definition/object_and_interface_extension"
+require "elastic_graph/warehouse/schema_definition/results_extension"
 require "elastic_graph/warehouse/schema_definition/scalar_type_extension"
+require "elastic_graph/warehouse/schema_definition/schema_artifact_manager_extension"
 
 module ElasticGraph
   module Warehouse
@@ -70,6 +72,36 @@ module ElasticGraph
             # :nocov: -- currently all invocations have a block
             yield type if block_given?
             # :nocov:
+          end
+        end
+
+        # Creates a new Results instance with warehouse extensions.
+        #
+        # @return [ElasticGraph::SchemaDefinition::Results] the created results instance
+        def new_results
+          super.tap do |results|
+            results.extend ResultsExtension
+          end
+        end
+
+        # Creates a new SchemaArtifactManager instance with warehouse extensions.
+        #
+        # @param schema_definition_results [ElasticGraph::SchemaDefinition::Results] the schema definition results
+        # @param schema_artifacts_directory [String] directory where schema artifacts are stored
+        # @param enforce_json_schema_version [Boolean] whether to enforce JSON schema version
+        # @param output [IO, nil] output stream for warnings and messages
+        # @param max_diff_lines [Integer] maximum number of diff lines to display
+        # @return [ElasticGraph::SchemaDefinition::SchemaArtifactManager] the created artifact manager
+        def new_schema_artifact_manager(
+          schema_definition_results:,
+          schema_artifacts_directory:,
+          enforce_json_schema_version:,
+          output:,
+          max_diff_lines: 50
+        )
+          super.tap do |manager|
+            manager.extend SchemaArtifactManagerExtension
+            manager.add_warehouse_artifact
           end
         end
       end

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/object_and_interface_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/object_and_interface_extension.rb
@@ -7,13 +7,24 @@
 # frozen_string_literal: true
 
 require "elastic_graph/warehouse/schema_definition/field_type_converter"
+require "elastic_graph/warehouse/schema_definition/warehouse_table"
 
 module ElasticGraph
   module Warehouse
     module SchemaDefinition
       # Extends {ElasticGraph::SchemaDefinition::SchemaElements::ObjectType} and
-      # {ElasticGraph::SchemaDefinition::SchemaElements::InterfaceType} to add warehouse column type conversion.
+      # {ElasticGraph::SchemaDefinition::SchemaElements::InterfaceType} to add warehouse table definition support.
       module ObjectAndInterfaceExtension
+        attr_reader :warehouse_table_def
+
+        # Defines a warehouse table for this object or interface type.
+        #
+        # @param name [String] name of the warehouse table
+        # @return [void]
+        def warehouse_table(name)
+          @warehouse_table_def = WarehouseTable.new(name, schema_def_state, self)
+        end
+
         # Returns the warehouse column type representation for this object or interface type.
         #
         # @return [String] a STRUCT SQL type containing all subfields

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/results_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/results_extension.rb
@@ -1,0 +1,44 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/warehouse/schema_definition/warehouse_table"
+
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      # Extension module for {ElasticGraph::SchemaDefinition::Results} that adds warehouse configuration support.
+      #
+      # @private
+      module ResultsExtension
+        # Returns the warehouse configuration generated from the schema definition.
+        #
+        # @return [Hash<String, Hash>] a hash mapping table names to their configuration
+        def warehouse_config
+          @warehouse_config ||= generate_warehouse_config
+        end
+
+        private
+
+        # Generates warehouse configuration from object types that have warehouse table definitions.
+        #
+        # @return [Hash<String, Hash>] a hash mapping table names to their configuration
+        def generate_warehouse_config
+          # Ensure all_types is called first to trigger on_built_in_types callbacks
+          # which configure warehouse column types for built-in scalar types
+          all_types
+
+          tables = state.object_types_by_name.values
+            .select { |t| t.respond_to?(:warehouse_table_def) }
+            .filter_map(&:warehouse_table_def)
+            .sort_by(&:name)
+          tables.to_h { |i| [i.name, i.to_config] }
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/schema_artifact_manager_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/schema_artifact_manager_extension.rb
@@ -1,0 +1,49 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/warehouse"
+
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      # Extension module for {ElasticGraph::SchemaDefinition::SchemaArtifactManager} that adds
+      # warehouse artifact generation support.
+      #
+      # @private
+      module SchemaArtifactManagerExtension
+        # Adds warehouse artifact to the artifact list after initialization.
+        #
+        # This method is called automatically after the SchemaArtifactManager is initialized.
+        # It checks if the schema has warehouse table definitions and adds the data_warehouse.yaml
+        # artifact if any tables are defined.
+        #
+        # @return [void]
+        def add_warehouse_artifact
+          # Only add the artifact if the results support warehouse_config (i.e., have the extension)
+          return unless schema_definition_results.respond_to?(:warehouse_config)
+
+          warehouse_config = schema_definition_results.warehouse_config
+
+          # Only add the artifact if there are warehouse tables defined.
+          return if warehouse_config.empty?
+
+          warehouse_artifact = ElasticGraph::SchemaDefinition::SchemaArtifact.new(
+            ::File.join(@schema_artifacts_directory, ::ElasticGraph::Warehouse::DATA_WAREHOUSE_FILE),
+            warehouse_config,
+            ->(hash) { ::YAML.dump(hash) },
+            # :nocov: -- Lambda for loading YAML; not executed in tests
+            ->(string) { ::YAML.safe_load(string, permitted_classes: [Symbol]) },
+            # :nocov:
+            ["This file contains Data Warehouse configuration generated from the ElasticGraph schema."]
+          )
+          @artifacts = (@artifacts + [warehouse_artifact]).sort_by(&:file_name)
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/warehouse_table.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/warehouse_table.rb
@@ -1,0 +1,62 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/warehouse/schema_definition/field_type_converter"
+
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      # Represents a warehouse table configuration.
+      class WarehouseTable < Struct.new(:name, :schema_def_state, :indexed_type)
+        # Initializes a new warehouse table.
+        #
+        # @param name [String] the name of the warehouse table
+        # @param schema_def_state [Object] the schema definition state
+        # @param indexed_type [Object] the indexed type this table represents
+        # @return [WarehouseTable] the initialized warehouse table
+        def initialize(name, schema_def_state, indexed_type)
+          super
+        end
+
+        # Converts the warehouse table to a configuration hash.
+        #
+        # @return [Hash] configuration hash with table_schema
+        def to_config
+          {
+            "table_schema" => table_schema
+          }
+        end
+
+        # Generates the SQL CREATE TABLE statement for this warehouse table.
+        #
+        # @return [String] SQL CREATE TABLE statement with all fields
+        def table_schema
+          fields = indexed_type
+            .indexing_fields_by_name_in_index
+            .values
+            .map { |field| "  #{table_field(field)}" }
+            .join(",\n")
+
+          <<~SQL.strip
+            CREATE TABLE IF NOT EXISTS #{name} (
+            #{fields}
+            )
+          SQL
+        end
+
+        private
+
+        def table_field(field)
+          field_name = field.name
+          warehouse_type = FieldTypeConverter.convert(field.type)
+          "#{field_name} #{warehouse_type}"
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/api_extension_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/api_extension_spec.rb
@@ -1,0 +1,337 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/schema_definition/test_support"
+require "elastic_graph/warehouse/schema_definition/api_extension"
+
+RSpec.describe ElasticGraph::Warehouse::SchemaDefinition::APIExtension, :unit do
+  include ElasticGraph::SchemaDefinition::TestSupport
+
+  it "extends the API factory with FactoryExtension" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+
+      # Just define a simple type to test the factory extension
+      s.object_type "Test" do |t|
+        t.field "id", "ID"
+      end
+    end
+
+    # The factory should have been extended during schema definition
+    expect(results).not_to be_nil
+  end
+
+  it "extends built-in scalar types with ScalarTypeExtension" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+
+      s.object_type "TestType" do |t|
+        t.field "id", "ID"  # ID is a built-in scalar
+        t.field "name", "String"  # String is a built-in scalar
+        t.warehouse_table "test_types"
+      end
+    end
+
+    table = results.warehouse_config.fetch("test_types")
+    expect(table.fetch("table_schema")).to include("id STRING")
+    expect(table.fetch("table_schema")).to include("name STRING")
+  end
+
+  it "extends built-in enum types with EnumTypeExtension" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+
+      s.enum_type "TestEnum" do |t|
+        t.value "VALUE1"
+        t.value "VALUE2"
+      end
+
+      s.object_type "TestType" do |t|
+        t.field "id", "ID"
+        t.field "status", "TestEnum"
+        t.warehouse_table "test_types"
+      end
+    end
+
+    # Should have generated warehouse config with enum field
+    table = results.warehouse_config.fetch("test_types")
+    expect(table.fetch("table_schema")).to include("status STRING")
+  end
+
+  it "extends built-in object types with ObjectAndInterfaceExtension" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    # Test with a schema that uses built-in object types
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+
+      # PageInfo is a built-in object type
+      s.object_type "CustomPageInfo" do |t|
+        t.field "has_next_page", "Boolean"
+        t.field "has_previous_page", "Boolean"
+        t.warehouse_table "page_info"
+      end
+    end
+
+    expect(results.warehouse_config).to have_key("page_info")
+  end
+
+  it "extends built-in interface types with ObjectAndInterfaceExtension" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+
+      s.interface_type "TestInterface" do |t|
+        t.field "id", "ID"
+        t.warehouse_table "test_interfaces"
+      end
+
+      s.object_type "TestImpl" do |t|
+        t.implements "TestInterface"
+        t.field "id", "ID"
+      end
+    end
+
+    # Should have warehouse extension
+    expect(results.warehouse_config).to have_key("test_interfaces")
+  end
+
+  it "does not double-extend types that already have extensions" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+
+      # Create a scalar type
+      s.scalar_type "TestScalar" do |t|
+        t.mapping type: "keyword"
+        t.json_schema type: "string"
+      end
+
+      s.object_type "TestType" do |t|
+        t.field "id", "TestScalar"
+      end
+    end
+
+    # Verify the scalar type has the extension
+    scalar_type = results.state.scalar_types_by_name["TestScalar"]
+    expect(scalar_type).to respond_to(:to_warehouse_column_type)
+
+    # Count how many times the module appears
+    count = scalar_type.singleton_class.included_modules.count do |m|
+      m == ElasticGraph::Warehouse::SchemaDefinition::ScalarTypeExtension
+    end
+
+    # Should only have one instance of the module
+    expect(count).to eq(1)
+  end
+
+  it "handles union types which are not extended" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+
+      s.union_type "SearchResult" do |t|
+        t.subtypes "Product", "Category"
+      end
+
+      s.object_type "Product" do |t|
+        t.field "id", "ID"
+        t.warehouse_table "products"
+      end
+
+      s.object_type "Category" do |t|
+        t.field "id", "ID"
+        t.field "name", "String"
+      end
+    end
+
+    # Union types should not have warehouse tables
+    expect(results.warehouse_config.keys).to eq(["products"])
+  end
+
+  it "handles types that are not in the case statement" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    # Test that union types (which are not in the case statement) don't cause errors
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+
+      # Union type is not handled by the case statement in APIExtension
+      s.union_type "TestUnion" do |t|
+        t.subtypes "TypeA", "TypeB"
+      end
+
+      s.object_type "TypeA" do |t|
+        t.field "id", "ID"
+      end
+
+      s.object_type "TypeB" do |t|
+        t.field "id", "ID"
+      end
+    end
+
+    # Should not raise error and should complete successfully
+    expect(results).not_to be_nil
+  end
+
+  it "handles types in the else clause without extending them" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    # This test specifically verifies the else clause by checking that union types
+    # (and other non-warehouse types) are not extended with warehouse methods
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+
+      # Create a union type that will hit the else clause
+      s.union_type "PaymentMethod" do |t|
+        t.subtypes "CreditCard", "BankAccount"
+      end
+
+      s.object_type "CreditCard" do |t|
+        t.field "id", "ID"
+        t.field "last_four", "String"
+      end
+
+      s.object_type "BankAccount" do |t|
+        t.field "id", "ID"
+        t.field "routing_number", "String"
+      end
+
+      # Also create an object type to ensure the schema is valid
+      s.object_type "Payment" do |t|
+        t.field "id", "ID"
+        t.field "amount", "Int"
+        t.warehouse_table "payments"
+      end
+    end
+
+    # Union types should not be extended with warehouse methods
+    union_type = results.state.types_by_name["PaymentMethod"]
+    expect(union_type).not_to respond_to(:to_warehouse_column_type)
+
+    # But object types should still be extended
+    object_type = results.state.object_types_by_name["Payment"]
+    expect(object_type).to respond_to(:to_warehouse_column_type)
+
+    # Verify warehouse config only contains the object type with warehouse_table
+    expect(results.warehouse_config.keys).to eq(["payments"])
+  end
+
+  it "extends interface types when passed to on_built_in_types callback" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    # Directly test that the InterfaceType branch of the case statement works
+    # by simulating what happens in on_built_in_types
+
+    results = define_schema(
+      schema_element_name_form: :snake_case,
+      extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]
+    ) do |s|
+      s.json_schema_version 1
+
+      s.interface_type "TestNode" do |t|
+        t.field "id", "ID!"
+        t.field "name", "String"
+        t.warehouse_table "test_nodes"
+      end
+
+      s.object_type "Product" do |t|
+        t.implements "TestNode"
+        t.field "id", "ID!"
+        t.field "name", "String"
+        t.field "price", "Int"
+        t.warehouse_table "products"
+      end
+    end
+
+    # Get the interface type from the results
+    interface_type = results.state.types_by_name["TestNode"]
+
+    # Verify the interface type was extended with ObjectAndInterfaceExtension
+    # (this happens via FactoryExtension, not on_built_in_types, but tests the same code path)
+    expect(interface_type).to be_a(ElasticGraph::SchemaDefinition::SchemaElements::InterfaceType)
+    expect(interface_type).to respond_to(:to_warehouse_column_type)
+
+    # Verify it has the ObjectAndInterfaceExtension
+    expect(interface_type.singleton_class.included_modules).to include(
+      ElasticGraph::Warehouse::SchemaDefinition::ObjectAndInterfaceExtension
+    )
+
+    # Verify warehouse tables were created for both types
+    expect(results.warehouse_config).to have_key("test_nodes")
+    expect(results.warehouse_config).to have_key("products")
+  end
+
+  it "handles object types in on_built_in_types" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+
+      # This will trigger on_built_in_types for built-in object types
+      s.object_type "TestType" do |t|
+        t.field "id", "ID"
+        t.warehouse_table "test_types"
+      end
+    end
+
+    expect(results.warehouse_config).to have_key("test_types")
+  end
+
+  it "handles interface types in on_built_in_types" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+
+      # This will trigger on_built_in_types for interface types
+      s.interface_type "TestInterface" do |t|
+        t.field "id", "ID"
+        t.warehouse_table "test_interfaces"
+      end
+
+      s.object_type "TestImpl" do |t|
+        t.implements "TestInterface"
+        t.field "id", "ID"
+      end
+    end
+
+    expect(results.warehouse_config).to have_key("test_interfaces")
+  end
+
+  it "handles scalar types in on_built_in_types" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+
+      # This will trigger on_built_in_types for scalar types
+      s.scalar_type "TestScalar" do |t|
+        t.mapping type: "keyword"
+        t.json_schema type: "string"
+        t.warehouse_column type: "STRING"
+      end
+
+      s.object_type "TestType" do |t|
+        t.field "id", "TestScalar"
+        t.warehouse_table "test_types"
+      end
+    end
+
+    expect(results.warehouse_config).to have_key("test_types")
+  end
+end

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/factory_extension_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/factory_extension_spec.rb
@@ -1,0 +1,134 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/schema_definition/test_support"
+require "elastic_graph/warehouse/schema_definition/api_extension"
+
+RSpec.describe ElasticGraph::Warehouse::SchemaDefinition::FactoryExtension, :unit do
+  include ElasticGraph::SchemaDefinition::TestSupport
+
+  it "extends new object types with ObjectAndInterfaceExtension" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+
+      s.object_type "Product" do |t|
+        t.field "id", "ID"
+        t.field "name", "String"
+        t.warehouse_table "products"
+      end
+    end
+
+    expect(results.warehouse_config).to have_key("products")
+  end
+
+  it "extends new interface types with ObjectAndInterfaceExtension" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+
+      s.interface_type "Node" do |t|
+        t.field "id", "ID"
+        t.warehouse_table "nodes"
+      end
+    end
+
+    expect(results.warehouse_config).to have_key("nodes")
+  end
+
+  it "extends new scalar types with ScalarTypeExtension" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+
+      s.scalar_type "CustomDate" do |t|
+        t.mapping type: "date"
+        t.json_schema type: "string", format: "date"
+        t.warehouse_column type: "DATE"
+      end
+
+      s.object_type "Event" do |t|
+        t.field "id", "ID"
+        t.field "date", "CustomDate"
+        t.warehouse_table "events"
+      end
+    end
+
+    table = results.warehouse_config.fetch("events")
+    expect(table.fetch("table_schema")).to include("date DATE")
+  end
+
+  it "extends new enum types with EnumTypeExtension" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+
+      s.enum_type "Status" do |t|
+        t.value "ACTIVE"
+        t.value "INACTIVE"
+      end
+
+      s.object_type "Account" do |t|
+        t.field "id", "ID"
+        t.field "status", "Status"
+        t.warehouse_table "accounts"
+      end
+    end
+
+    table = results.warehouse_config.fetch("accounts")
+    expect(table.fetch("table_schema")).to include("status STRING")
+  end
+
+  it "handles object types without warehouse tables" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+
+      s.object_type "NoWarehouse" do |t|
+        t.field "id", "ID"
+        t.field "name", "String"
+        # No warehouse_table call
+      end
+
+      s.object_type "WithWarehouse" do |t|
+        t.field "id", "ID"
+        t.warehouse_table "with_warehouse"
+      end
+    end
+
+    expect(results.warehouse_config).not_to have_key("no_warehouse")
+    expect(results.warehouse_config).to have_key("with_warehouse")
+  end
+
+  it "handles object types defined without a block" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    # Use define_schema to properly set up the API and factory
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+
+      # Get the factory from the schema
+      factory = s.factory
+
+      # Call new_object_type without a block
+      type = factory.new_object_type("NoBlockType")
+
+      # Should still have warehouse extension methods
+      expect(type).to respond_to(:warehouse_table)
+      expect(type).to respond_to(:warehouse_table_def)
+    end
+
+    # Test passed if we get here without errors
+    expect(results).not_to be_nil
+  end
+end

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/schema_artifact_manager_extension_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/schema_artifact_manager_extension_spec.rb
@@ -1,0 +1,91 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/schema_definition/test_support"
+require "elastic_graph/warehouse/schema_definition/api_extension"
+require "tmpdir"
+
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      RSpec.describe SchemaArtifactManagerExtension, :unit do
+        include ElasticGraph::SchemaDefinition::TestSupport
+
+        it "adds warehouse artifact when warehouse tables are defined" do
+          Dir.mktmpdir do |dir|
+            factory = nil
+            results = define_schema(schema_element_name_form: :snake_case, extension_modules: [APIExtension]) do |s|
+              factory = s.factory
+              s.json_schema_version 1
+
+              s.object_type "User" do |t|
+                t.field "id", "ID"
+                t.warehouse_table "users"
+              end
+            end
+
+            manager = factory.new_schema_artifact_manager(
+              schema_definition_results: results,
+              schema_artifacts_directory: dir,
+              enforce_json_schema_version: true,
+              output: StringIO.new
+            )
+
+            warehouse_artifact = manager.instance_variable_get(:@artifacts).find { |a| a.file_name.include?("data_warehouse.yaml") }
+            expect(warehouse_artifact).not_to be_nil
+            expect(warehouse_artifact.desired_contents).to have_key("users")
+          end
+        end
+
+        it "does not add warehouse artifact when no warehouse tables are defined" do
+          Dir.mktmpdir do |dir|
+            factory = nil
+            results = define_schema(schema_element_name_form: :snake_case, extension_modules: [APIExtension]) do |s|
+              factory = s.factory
+              s.json_schema_version 1
+
+              s.object_type "NoWarehouse" do |t|
+                t.field "id", "ID"
+              end
+            end
+
+            manager = factory.new_schema_artifact_manager(
+              schema_definition_results: results,
+              schema_artifacts_directory: dir,
+              enforce_json_schema_version: true,
+              output: StringIO.new
+            )
+
+            warehouse_artifact = manager.instance_variable_get(:@artifacts).find { |a| a.file_name.include?("data_warehouse.yaml") }
+            expect(warehouse_artifact).to be_nil
+          end
+        end
+
+        it "does not add warehouse artifact when schema definition results don't respond to warehouse_config" do
+          Dir.mktmpdir do |dir|
+            # Create a mock results object that doesn't respond to warehouse_config
+            results = double("results", respond_to?: false)
+
+            # Create a manager and manually extend it with the extension to test the guard clause
+            manager = ElasticGraph::SchemaDefinition::SchemaArtifactManager.allocate
+            manager.instance_variable_set(:@schema_definition_results, results)
+            manager.instance_variable_set(:@schema_artifacts_directory, dir)
+            manager.instance_variable_set(:@artifacts, [])
+            manager.extend SchemaArtifactManagerExtension
+
+            # Call add_warehouse_artifact - it should return early without adding an artifact
+            manager.add_warehouse_artifact
+
+            artifacts = manager.instance_variable_get(:@artifacts)
+            expect(artifacts).to be_empty
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/warehouse_table_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/warehouse_table_spec.rb
@@ -1,0 +1,111 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/schema_definition/test_support"
+require "elastic_graph/warehouse/schema_definition/api_extension"
+
+RSpec.describe ElasticGraph::Warehouse::SchemaDefinition::WarehouseTable, :unit do
+  include ElasticGraph::SchemaDefinition::TestSupport
+
+  it "handles non-null scalars" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(
+      schema_element_name_form: :snake_case,
+      extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]
+    ) do |s|
+      s.json_schema_version 1
+      s.object_type "Doc" do |t|
+        t.field "id", "ID!"
+        t.warehouse_table "doc"
+      end
+    end
+
+    table = results.warehouse_config.fetch("doc")
+    expect(table.fetch("table_schema")).to include("id STRING")
+  end
+
+  it "handles arrays of non-null element types" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(
+      schema_element_name_form: :snake_case,
+      extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]
+    ) do |s|
+      s.json_schema_version 1
+      s.object_type "Entry" do |t|
+        t.field "tags", "[String!]"
+        t.warehouse_table "entry"
+      end
+    end
+
+    table = results.warehouse_config.fetch("entry")
+    expect(table.fetch("table_schema")).to match("tags ARRAY<STRING>")
+  end
+
+  it "handles nested arrays" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(
+      schema_element_name_form: :snake_case,
+      extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]
+    ) do |s|
+      s.json_schema_version 1
+      s.object_type "Matrix" do |t|
+        t.field "data", "[[Float!]]"
+        t.warehouse_table "matrix"
+      end
+    end
+
+    table = results.warehouse_config.fetch("matrix")
+    expect(table.fetch("table_schema")).to include("data ARRAY<ARRAY<DOUBLE>>")
+  end
+
+  it "handles deeply nested arrays" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(
+      schema_element_name_form: :snake_case,
+      extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]
+    ) do |s|
+      s.json_schema_version 1
+      s.object_type "Tensor" do |t|
+        t.field "values", "[[[Int!]]]"
+        t.warehouse_table "tensor"
+      end
+    end
+
+    table = results.warehouse_config.fetch("tensor")
+    expect(table.fetch("table_schema")).to include("values ARRAY<ARRAY<ARRAY<INT>>>")
+  end
+
+  it "handles nested arrays of objects" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(
+      schema_element_name_form: :snake_case,
+      extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]
+    ) do |s|
+      s.json_schema_version 1
+      s.object_type "Point" do |t|
+        t.field "x", "Float"
+        t.field "y", "Float"
+      end
+
+      s.object_type "Grid" do |t|
+        t.field "points", "[[Point!]]" do |f|
+          f.mapping type: "nested"
+        end
+        t.warehouse_table "grid"
+      end
+    end
+
+    table = results.warehouse_config.fetch("grid")
+    expect(table.fetch("table_schema")).to include("points ARRAY<ARRAY<STRUCT<x DOUBLE, y DOUBLE>>>")
+  end
+end

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/warehouse_config_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/warehouse_config_spec.rb
@@ -1,0 +1,100 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/schema_definition/test_support"
+
+RSpec.describe "elasticgraph-warehouse integration", :unit do
+  include ElasticGraph::SchemaDefinition::TestSupport
+
+  it "adds data_warehouse.yaml artifact via SchemaArtifactManager and generates config for simple scalar fields" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    factory = nil
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      factory = s.factory
+      s.json_schema_version 1
+      s.object_type "Person" do |t|
+        t.field "id", "ID"
+        t.field "name", "String"
+        t.field "age", "Int"
+        t.field "score", "Float"
+        t.field "active", "Boolean"
+        t.warehouse_table "person"
+      end
+    end
+
+    expect(results.warehouse_config).to be_a(Hash)
+    expect(results.warehouse_config.keys).to include("person")
+    table = results.warehouse_config.fetch("person")
+
+    expect(table.fetch("table_schema")).to include("id STRING", "name STRING", "age INT", "score DOUBLE", "active BOOLEAN")
+
+    # Validate that SchemaArtifactManager will include the data_warehouse.yaml artifact
+    Dir.mktmpdir do |tmp|
+      out = StringIO.new
+      mgr = factory.new_schema_artifact_manager(
+        schema_definition_results: results,
+        schema_artifacts_directory: tmp,
+        enforce_json_schema_version: false,
+        output: out
+      )
+
+      mgr.dump_artifacts
+      expect(File).to exist(File.join(tmp, "data_warehouse.yaml"))
+      yaml = YAML.safe_load_file(File.join(tmp, "data_warehouse.yaml"))
+      expect(yaml).to include("person")
+    end
+  end
+
+  it "supports nested objects and lists with appropriate SQL mapping" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+      s.object_type "Employer" do |t|
+        t.field "name", "String"
+      end
+
+      s.object_type "Person" do |t|
+        t.field "name", "String"
+        t.field "employer", "Employer"
+        t.field "hobbies", "[String]"
+        t.warehouse_table "person"
+      end
+    end
+
+    table = results.warehouse_config.fetch("person")
+    expect(table.fetch("table_schema")).to include(
+      "name STRING",
+      "employer STRUCT<name STRING>",
+      "hobbies ARRAY<STRING>"
+    )
+  end
+
+  it "allows overriding table type via scalar.warehouse_column" do
+    require "elastic_graph/warehouse/schema_definition/api_extension"
+
+    results = define_schema(schema_element_name_form: :snake_case, extension_modules: [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]) do |s|
+      s.json_schema_version 1
+
+      s.scalar_type "URL" do |t|
+        t.mapping type: "keyword"
+        t.json_schema type: "string", format: "uri"
+        t.warehouse_column type: "STRING"
+      end
+
+      s.object_type "Page" do |t|
+        t.field "url", "URL"
+        t.warehouse_table "page"
+      end
+    end
+
+    table = results.warehouse_config.fetch("page")
+    expect(table.fetch("table_schema")).to include("url STRING")
+  end
+end


### PR DESCRIPTION
This gem supports creating a databricks iceberg table by reading an elasticgraph schema as iceberg. The gem to support writing files in this format will come as a separate PR.  