### PR TITLE
Add elasticgraph-warehouse_lambda

### DIFF
--- a/CODEBASE_OVERVIEW.md
+++ b/CODEBASE_OVERVIEW.md
@@ -260,7 +260,7 @@ graph LR;
     click rake href "https://rubygems.org/gems/rake" "Open on RubyGems.org" _blank;
 ```
 
-### AWS Lambda Integration Libraries (5 gems)
+### AWS Lambda Integration Libraries (6 gems)
 
 These libraries wrap the the core ElasticGraph libraries so that they can be deployed using AWS Lambda.
 
@@ -269,6 +269,7 @@ These libraries wrap the the core ElasticGraph libraries so that they can be dep
 * [elasticgraph-indexer_autoscaler_lambda](elasticgraph-indexer_autoscaler_lambda/README.md): Monitors OpenSearch CPU utilization to autoscale elasticgraph-indexer_lambda concurrency.
 * [elasticgraph-indexer_lambda](elasticgraph-indexer_lambda/README.md): Adapts elasticgraph-indexer to run in an AWS Lambda.
 * [elasticgraph-lambda_support](elasticgraph-lambda_support/README.md): Supports running ElasticGraph using AWS Lambda.
+* [elasticgraph-warehouse_lambda](elasticgraph-warehouse_lambda/README.md): ElasticGraph lambda for ingesting data into a warehouse.
 
 #### Dependency Diagram
 
@@ -294,6 +295,7 @@ graph LR;
     aws-sdk-s3["aws-sdk-s3"];
     elasticgraph-opensearch["eg-opensearch"];
     faraday_middleware-aws-sigv4["faraday_middleware-aws-sigv4"];
+    elasticgraph-warehouse_lambda["eg-warehouse_lambda"];
     elasticgraph-admin_lambda --> rake;
     elasticgraph-admin_lambda --> elasticgraph-admin;
     elasticgraph-admin_lambda --> elasticgraph-lambda_support;
@@ -311,6 +313,10 @@ graph LR;
     elasticgraph-indexer_lambda --> ox;
     elasticgraph-lambda_support --> elasticgraph-opensearch;
     elasticgraph-lambda_support --> faraday_middleware-aws-sigv4;
+    elasticgraph-warehouse_lambda --> elasticgraph-indexer_lambda;
+    elasticgraph-warehouse_lambda --> elasticgraph-lambda_support;
+    elasticgraph-warehouse_lambda --> aws-sdk-s3;
+    elasticgraph-warehouse_lambda --> ox;
     class elasticgraph-admin_lambda targetGemStyle;
     class rake externalGemCatStyle;
     class elasticgraph-admin otherEgGemStyle;
@@ -328,6 +334,7 @@ graph LR;
     class aws-sdk-s3 externalGemCatStyle;
     class elasticgraph-opensearch otherEgGemStyle;
     class faraday_middleware-aws-sigv4 externalGemCatStyle;
+    class elasticgraph-warehouse_lambda targetGemStyle;
     click rake href "https://rubygems.org/gems/rake" "Open on RubyGems.org" _blank;
     click aws-sdk-lambda href "https://rubygems.org/gems/aws-sdk-lambda" "Open on RubyGems.org" _blank;
     click aws-sdk-sqs href "https://rubygems.org/gems/aws-sdk-sqs" "Open on RubyGems.org" _blank;

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,15 @@ PATH
       logger (~> 1.7)
 
 PATH
+  remote: elasticgraph-warehouse_lambda
+  specs:
+    elasticgraph-warehouse_lambda (1.0.3.pre)
+      aws-sdk-s3 (~> 1.182)
+      elasticgraph-indexer_lambda (= 1.0.3.pre)
+      elasticgraph-lambda_support (= 1.0.3.pre)
+      ox (~> 2.14, >= 2.14.22)
+
+PATH
   remote: elasticgraph
   specs:
     elasticgraph (1.0.3.pre)
@@ -629,6 +638,7 @@ DEPENDENCIES
   elasticgraph-schema_artifacts (= 1.0.3.pre)!
   elasticgraph-schema_definition (= 1.0.3.pre)!
   elasticgraph-support (= 1.0.3.pre)!
+  elasticgraph-warehouse_lambda (= 1.0.3.pre)!
   factory_bot (~> 6.5, >= 6.5.5)
   faker (~> 3.5, >= 3.5.2)
   filewatcher (~> 2.1)

--- a/elasticgraph-indexer_lambda/README.md
+++ b/elasticgraph-indexer_lambda/README.md
@@ -23,6 +23,9 @@ graph LR;
     ox["ox"];
     elasticgraph-indexer_lambda --> ox;
     class ox externalGemStyle;
+    elasticgraph-warehouse_lambda["elasticgraph-warehouse_lambda"];
+    elasticgraph-warehouse_lambda --> elasticgraph-indexer_lambda;
+    class elasticgraph-warehouse_lambda otherEgGemStyle;
     click aws-sdk-s3 href "https://rubygems.org/gems/aws-sdk-s3" "Open on RubyGems.org" _blank;
     click ox href "https://rubygems.org/gems/ox" "Open on RubyGems.org" _blank;
 ```

--- a/elasticgraph-lambda_support/README.md
+++ b/elasticgraph-lambda_support/README.md
@@ -34,5 +34,8 @@ graph LR;
     elasticgraph-indexer_lambda["elasticgraph-indexer_lambda"];
     elasticgraph-indexer_lambda --> elasticgraph-lambda_support;
     class elasticgraph-indexer_lambda otherEgGemStyle;
+    elasticgraph-warehouse_lambda["elasticgraph-warehouse_lambda"];
+    elasticgraph-warehouse_lambda --> elasticgraph-lambda_support;
+    class elasticgraph-warehouse_lambda otherEgGemStyle;
     click faraday_middleware-aws-sigv4 href "https://rubygems.org/gems/faraday_middleware-aws-sigv4" "Open on RubyGems.org" _blank;
 ```

--- a/elasticgraph-warehouse_lambda/LICENSE.txt
+++ b/elasticgraph-warehouse_lambda/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 - 2025 Block, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/elasticgraph-warehouse_lambda/README.md
+++ b/elasticgraph-warehouse_lambda/README.md
@@ -1,0 +1,120 @@
+# ElasticGraph::WarehouseLambda
+<!-- Mermaid dependency diagram -->
+```mermaid
+graph LR;
+    classDef targetGemStyle fill:#FADBD8,stroke:#EC7063,color:#000,stroke-width:2px;
+    classDef otherEgGemStyle fill:#A9DFBF,stroke:#2ECC71,color:#000;
+    classDef externalGemStyle fill:#E0EFFF,stroke:#70A1D7,color:#2980B9;
+
+    elasticgraph-warehouse_lambda["elasticgraph-warehouse_lambda"];
+    class elasticgraph-warehouse_lambda targetGemStyle;
+
+    elasticgraph-indexer["elasticgraph-indexer"];
+    elasticgraph-warehouse_lambda --> elasticgraph-indexer;
+    class elasticgraph-indexer otherEgGemStyle;
+
+    elasticgraph-lambda_support["elasticgraph-lambda_support"];
+    elasticgraph-warehouse_lambda --> elasticgraph-lambda_support;
+    class elasticgraph-lambda_support otherEgGemStyle;
+
+    aws-sdk-s3["aws-sdk-s3"];
+    elasticgraph-warehouse_lambda --> aws-sdk-s3;
+    class aws-sdk-s3 externalGemStyle;
+
+    ox["ox"];
+    elasticgraph-warehouse_lambda --> ox;
+    class ox externalGemStyle;
+
+    click aws-sdk-s3 href "https://rubygems.org/gems/aws-sdk-s3" "Open on RubyGems.org" _blank;
+    click ox href "https://rubygems.org/gems/ox" "Open on RubyGems.org" _blank;
+```
+
+Write ElasticGraph-shaped JSONL files to S3, packaged for AWS Lambda.
+
+This gem adapts ElasticGraph’s indexing pipeline so that, instead of writing to the datastore,
+it writes batched, gzipped JSON Lines (JSONL) files to Amazon S3. Each line in the file
+conforms to your ElasticGraph schema’s latest JSON Schema for the corresponding object type.
+
+## What it does
+
+- Consumes ElasticGraph indexing operations and groups them by GraphQL type
+- Transforms each operation into a flattened JSON document that matches your ElasticGraph schema
+- Writes one gzipped JSONL file per type per batch to S3 with deterministic keys:
+  - s3://<bucket>/dumped-data/<s3_path_prefix>/<TypeName>/v<json_schema_version>/<YYYY-MM-DD>/<uuid>.jsonl.gz
+- Emits structured logs for observability (counts, sizes, S3 key, etc.)
+
+## When to use it
+
+Use this when you need a durable, append-only export of ElasticGraph data suitable for ingestion
+by downstream systems (e.g., data warehouses, lakehouses, or offline analytics pipelines). It’s a
+drop-in replacement for the Indexer’s datastore router: instead of indexing into the datastore,
+you persist JSONL to S3.
+
+## Configuration
+
+Configuration is sourced from your normal ElasticGraph YAML settings and environment variables used in Lambda.
+
+- YAML (ELASTICGRAPH_YAML_CONFIG):
+  - warehouse:
+    - s3_path_prefix: Prefix for S3 keys under dumped-data/ (e.g., "Data001")
+- Environment Variables:
+  - DATAWAREHOUSE_S3_BUCKET_NAME: The S3 bucket name to write JSONL files into (required)
+  - REPORT_BATCH_ITEM_FAILURES: "true" to enable SQS partial batch failure responses (optional)
+
+Example YAML override snippet:
+
+```yaml
+warehouse:
+  s3_path_prefix: Data001
+```
+
+## Key format
+
+Files are written with the following S3 key format:
+
+```
+dumped-data/<s3_path_prefix>/<TypeName>/v<json_schema_version>/<YYYY-MM-DD>/<uuid>.jsonl.gz
+```
+
+- s3_path_prefix: Configurable in YAML (warehouse.s3_path_prefix)
+- TypeName: GraphQL type from the ElasticGraph event
+- json_schema_version: The latest JSON Schema version available to the Indexer
+- YYYY-MM-DD: UTC date when the batch was processed
+- uuid: A random UUID for uniqueness
+
+## Runtime and deps
+
+- Runs in AWS Lambda via elasticgraph-lambda_support
+- Depends on elasticgraph-indexer for event preparation and schema artifacts
+- Uses aws-sdk-s3 to write to S3
+
+## Example: Lambda handler
+
+This gem exposes a handler constant for AWS Lambda:
+
+```ruby
+# elastic_graph/warehouse_lambda/lambda_function.rb
+ElasticGraphWarehouse = ElasticGraph::WarehouseLambda::LambdaFunction.new
+```
+
+Deploy your Lambda with that handler entry. The function consumes SQS events in the
+same format as `elasticgraph-indexer_lambda` and writes JSONL to S3.
+
+## Observability
+
+The Lambda logs structured events:
+- WarehouseLambdaReceivedBatch: counts per type for incoming batch
+- DumpedToWarehouseFile: S3 key, type, record_count, json_size, gzip_size
+
+## Local development
+
+- Ensure all ElasticGraph gems are vendored/linked via the repo Gemfile
+- Run the gem’s unit tests:
+
+```
+bundle exec rspec elasticgraph-warehouse_lambda/spec/unit
+```
+
+## License
+
+MIT © Block, Inc.

--- a/elasticgraph-warehouse_lambda/elasticgraph-warehouse_lambda.gemspec
+++ b/elasticgraph-warehouse_lambda/elasticgraph-warehouse_lambda.gemspec
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+# Copyright 2024 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require_relative "../elasticgraph-support/lib/elastic_graph/version"
+require_relative "../elasticgraph-support/lib/elastic_graph/version" # keep version centralized in elasticgraph-support
+
+Gem::Specification.new do |spec|
+  spec.name = "elasticgraph-warehouse_lambda"
+  spec.version = ElasticGraph::VERSION
+  spec.authors = ["Josh Wilson", "Block Engineering"]
+  spec.email = ["joshuaw@squareup.com"]
+  spec.homepage = "https://block.github.io/elasticgraph/"
+  spec.license = "MIT"
+  spec.summary = "ElasticGraph lambda for ingesting data into a warehouse."
+
+  # See https://guides.rubygems.org/specification-reference/#metadata
+  # for metadata entries understood by rubygems.org.
+  spec.metadata = {
+    "bug_tracker_uri" => "https://github.com/block/elasticgraph/issues",
+    "changelog_uri" => "https://github.com/block/elasticgraph/releases/tag/v#{ElasticGraph::VERSION}",
+    "documentation_uri" => "https://block.github.io/elasticgraph/docs/main/",
+    "homepage_uri" => "https://block.github.io/elasticgraph/",
+    "source_code_uri" => "https://github.com/block/elasticgraph/tree/v#{ElasticGraph::VERSION}/#{spec.name}",
+    "gem_category" => "lambda" # used by script/update_codebase_overview
+  }
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  # We also remove `.rspec` and `Gemfile` because these files are not needed in
+  # the packaged gem (they are for local development of the gems) and cause a problem
+  # for some users of the gem due to the fact that they are symlinks to a parent path.
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
+    `git ls-files -z`.split("\x0").reject do |f|
+      (f == __FILE__) || f.match(%r{\A(?:(?:test|spec|features|sig)/|\.(?:git|travis|circleci)|appveyor)})
+    end - [".rspec", "Gemfile", ".yardopts"]
+  end
+
+  spec.required_ruby_version = [">= 3.2", "< 3.5"]
+
+  spec.add_dependency "elasticgraph-indexer_lambda", ElasticGraph::VERSION
+  spec.add_dependency "elasticgraph-lambda_support", ElasticGraph::VERSION
+  spec.add_dependency "aws-sdk-s3", "~> 1.182"
+  spec.add_dependency "ox", "~> 2.14", ">= 2.14.22"
+
+  spec.add_development_dependency "aws_lambda_ric", "~> 3.0"
+end

--- a/elasticgraph-warehouse_lambda/lib/elastic_graph/warehouse_lambda.rb
+++ b/elasticgraph-warehouse_lambda/lib/elastic_graph/warehouse_lambda.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "elastic_graph/indexer"
+require "elastic_graph/lambda_support"
+require "elastic_graph/support/from_yaml_file"
+require "elastic_graph/warehouse_lambda/indexer_extension"
+require "elastic_graph/warehouse_lambda/config"
+
+module ElasticGraph
+  class WarehouseLambda
+      extend ::ElasticGraph::Support::FromYamlFile
+
+      attr_reader :logger, :indexer, :clock
+
+      # Builds an `ElasticGraph::WarehouseLambda` instance from our lambda ENV vars.
+      def self.from_env
+        ::ElasticGraph::LambdaSupport.build_from_env(self)
+      end
+
+      def self.from_parsed_yaml(parsed_yaml)
+        new(
+          config: Config.from_parsed_yaml(parsed_yaml),
+          indexer: ::ElasticGraph::Indexer.from_parsed_yaml(parsed_yaml)
+        )
+      end
+
+      def initialize(config:, indexer:, s3_client: nil, s3_bucket_name: nil, clock: ::Time)
+        indexer.extend IndexerExtension
+        indexer.warehouse_lambda = self
+        @logger = indexer.logger
+        @indexer = indexer
+        @s3_client = s3_client
+        @s3_bucket_name = s3_bucket_name
+        @config = config
+        @clock = clock
+      end
+
+      def processor
+        indexer.processor
+      end
+
+      def warehouse_dumper
+        @warehouse_dumper ||= begin
+          require "elastic_graph/warehouse_lambda/warehouse_dumper"
+          WarehouseDumper.new(
+            logger: logger,
+            s3_client: s3_client,
+            s3_bucket_name: s3_bucket_name,
+            s3_file_prefix: @config.s3_path_prefix,
+            latest_json_schema_version: indexer.schema_artifacts.latest_json_schema_version,
+            clock: clock
+          )
+        end
+      end
+
+      def s3_client
+        @s3_client ||= begin
+          require "aws-sdk-s3"
+          ::Aws::S3::Client.new
+        end
+      end
+
+      def s3_bucket_name
+        @s3_bucket_name ||= ENV.fetch("DATAWAREHOUSE_S3_BUCKET_NAME")
+      end
+    end
+  end
+

--- a/elasticgraph-warehouse_lambda/lib/elastic_graph/warehouse_lambda/config.rb
+++ b/elasticgraph-warehouse_lambda/lib/elastic_graph/warehouse_lambda/config.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "elastic_graph/errors"
+
+module ElasticGraph
+  class WarehouseLambda
+    class Config < ::Data.define(
+        # The s3 path prefix to store the data.
+        :s3_path_prefix
+      )
+
+      def self.from_parsed_yaml(hash)
+        warehouse = hash["warehouse"] || {}
+        extra_keys = warehouse.keys - EXPECTED_KEYS
+
+        unless extra_keys.empty?
+          raise ::ElasticGraph::Errors::ConfigError, "Unknown `warehouse` config settings: #{extra_keys.join(", ")}"
+        end
+
+        s3_path_prefix = warehouse["s3_path_prefix"] || "Data001"
+        new(s3_path_prefix: s3_path_prefix)
+      end
+
+      EXPECTED_KEYS = members.map(&:to_s)
+    end
+  end
+end

--- a/elasticgraph-warehouse_lambda/lib/elastic_graph/warehouse_lambda/indexer_extension.rb
+++ b/elasticgraph-warehouse_lambda/lib/elastic_graph/warehouse_lambda/indexer_extension.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ElasticGraph
+  class WarehouseLambda
+    module IndexerExtension
+      attr_accessor :warehouse_lambda
+
+      def datastore_router
+        warehouse_lambda.warehouse_dumper
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse_lambda/lib/elastic_graph/warehouse_lambda/lambda_function.rb
+++ b/elasticgraph-warehouse_lambda/lib/elastic_graph/warehouse_lambda/lambda_function.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "elastic_graph/lambda_support/lambda_function"
+
+module ElasticGraph
+  class WarehouseLambda
+    # @private
+    class LambdaFunction
+        prepend ::ElasticGraph::LambdaSupport::LambdaFunction
+
+        def initialize
+          require "elastic_graph/warehouse_lambda"
+          require "elastic_graph/indexer_lambda/sqs_processor"
+
+          warehouse_lambda = WarehouseLambda.from_env
+          @sqs_processor = ::ElasticGraph::IndexerLambda::SqsProcessor.new(
+            warehouse_lambda.processor,
+            logger: warehouse_lambda.logger,
+            ignore_sqs_latency_timestamps_from_arns: JSON.parse(ENV.fetch("IGNORE_SQS_LATENCY_TIMESTAMPS_FROM_ARNS", "[]"))
+          )
+        end
+
+        def handle_request(event:, context:)
+          @sqs_processor.process(event)
+        end
+    end
+  end
+end
+
+# Lambda handler expected by tf-mod-sq-elasticgraph
+ElasticGraphWarehouse = ElasticGraph::WarehouseLambda::LambdaFunction.new

--- a/elasticgraph-warehouse_lambda/lib/elastic_graph/warehouse_lambda/warehouse_dumper.rb
+++ b/elasticgraph-warehouse_lambda/lib/elastic_graph/warehouse_lambda/warehouse_dumper.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "elastic_graph/indexer/datastore_indexing_router"
+require "elastic_graph/indexer/operation/result"
+require "json"
+require "time"
+require "securerandom"
+require "zlib"
+
+module ElasticGraph
+  class WarehouseLambda
+      # Responsible for dumping data into the data warehouse. Implements the same interface as `DatastoreIndexingRouter` from
+      # `elasticgraph-indexer` so that it can be used in place of the standard datastore indexing router:
+      #
+      # https://github.com/squareup/elasticgraph-public/blob/v0.18.0.5/elasticgraph-indexer/lib/elastic_graph/indexer/datastore_indexing_router.rb#L76
+      class WarehouseDumper
+        def initialize(logger:, s3_client:, s3_bucket_name:, s3_file_prefix:, latest_json_schema_version:, clock:)
+          @logger = logger
+          @s3_client = s3_client
+          @s3_bucket_name = s3_bucket_name
+          @s3_file_prefix = s3_file_prefix
+          @latest_json_schema_version = latest_json_schema_version
+          @clock = clock
+        end
+
+        def bulk(operations, refresh: false)
+          operations_by_type = operations.group_by { |op| op.event.fetch("type") }
+
+          @logger.info({
+            "message_type" => "WarehouseLambdaReceivedBatch",
+            "record_counts_by_type" => operations_by_type.transform_values(&:size)
+          })
+
+          operations_by_type.each do |type, operations|
+            jsonl_data = build_jsonl_file_from(operations)
+            gzip_data = compress(jsonl_data)
+            s3_key = generate_s3_key_for(type)
+
+            @s3_client.put_object(
+              bucket: @s3_bucket_name,
+              key: s3_key,
+              body: gzip_data,
+              checksum_algorithm: :sha256,
+              if_none_match: "*"
+            )
+
+            @logger.info({
+              "message_type" => "DumpedToWarehouseFile",
+              "s3_bucket" => @s3_bucket_name,
+              "s3_key" => s3_key,
+              "type" => type,
+              "record_count" => operations.size,
+              "json_size" => jsonl_data.bytesize,
+              "gzip_size" => gzip_data.bytesize
+            })
+          end
+
+          ops_and_results = operations.map do |op|
+            [op, ::ElasticGraph::Indexer::Operation::Result.success_of(op)]
+          end
+
+          ::ElasticGraph::Indexer::DatastoreIndexingRouter::BulkResult.new({"warehouse" => ops_and_results})
+        end
+
+        def source_event_versions_in_index(operations)
+          {}
+        end
+
+        private
+
+        def generate_s3_key_for(type)
+          date, _ = @clock.now.getutc.iso8601(6).split("T")
+          uuid = ::SecureRandom.uuid
+
+          [
+            "dumped-data",
+            @s3_file_prefix,
+            type,
+            "v#{@latest_json_schema_version}",
+            date,
+            "#{uuid}.jsonl.gz"
+          ].join("/")
+        end
+
+        def build_jsonl_file_from(operations)
+          operation_payloads = operations
+            .select { |op| op.update_target.type == op.event.fetch("type") }
+            .reject { |op| op.to_datastore_bulk.empty? }
+            .map do |op|
+              _, payload_body = op.to_datastore_bulk
+              params = payload_body.fetch(:script).fetch(:params)
+              data = params.fetch("data").merge({
+                "id" => params.fetch("id"),
+                "__eg_version" => params.fetch("version")
+              })
+
+              ::JSON.generate(data)
+            end
+
+          operation_payloads.join("\n")
+        end
+
+        def compress(jsonl_data)
+          io = ::StringIO.new
+          gz = ::Zlib::GzipWriter.new(io)
+
+          begin
+            gz << jsonl_data
+          ensure
+            gz.close
+          end
+          io.string
+        end
+      end
+    end
+  end
+

--- a/elasticgraph-warehouse_lambda/spec/spec_helper.rb
+++ b/elasticgraph-warehouse_lambda/spec/spec_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# This file is contains RSpec configuration and common support code for `elasticgraph-warehouse_lambda`.
+# Note that it gets loaded by `spec_support/spec_helper.rb` which contains common spec support
+# code for all ElasticGraph test suites.

--- a/elasticgraph-warehouse_lambda/spec/unit/elastic_graph/warehouse_lambda/config_spec.rb
+++ b/elasticgraph-warehouse_lambda/spec/unit/elastic_graph/warehouse_lambda/config_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Copyright 2024 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+
+require "elastic_graph/warehouse_lambda/config"
+require "yaml"
+
+module ElasticGraph
+  class WarehouseLambda
+    RSpec.describe Config do
+      it "raises an error when given an unrecognized config setting" do
+        expect {
+          Config.from_parsed_yaml("warehouse" => {
+            "s3_path_prefix" => "PREFIX",
+            "fake_setting" => 23
+          })
+        }.to raise_error ::ElasticGraph::Errors::ConfigError, a_string_including("fake_setting")
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse_lambda/spec/unit/elastic_graph/warehouse_lambda/lambda_function_spec.rb
+++ b/elasticgraph-warehouse_lambda/spec/unit/elastic_graph/warehouse_lambda/lambda_function_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+# Copyright 2024 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+require "elastic_graph/spec_support/lambda_function"
+
+RSpec.describe "Warehouse lambda function" do
+  include_context "lambda function", config_overrides_in_yaml: {"warehouse" => {"s3_path_prefix" => "Data001"}}
+
+  # Provide the S3 bucket env var expected by the lambda under test.
+  around do |ex|
+    with_env({"DATAWAREHOUSE_S3_BUCKET_NAME" => "warehouse-bucket"}) { ex.run }
+  end
+
+  it "ingests data" do
+    expect_loading_lambda_to_define_constant(
+      lambda: "elastic_graph/warehouse_lambda/lambda_function.rb",
+      const: :ElasticGraphWarehouse
+    ) do |lambda_function|
+      response = lambda_function.handle_request(event: {"Records" => []}, context: {})
+      expect(response).to eq({"batchItemFailures" => []})
+    end
+  end
+end

--- a/elasticgraph-warehouse_lambda/spec/unit/elastic_graph/warehouse_lambda/warehouse_dumper_spec.rb
+++ b/elasticgraph-warehouse_lambda/spec/unit/elastic_graph/warehouse_lambda/warehouse_dumper_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+# Copyright 2024 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+require "elastic_graph/spec_support/lambda_function"
+
+require "aws-sdk-s3"
+require "elastic_graph/indexer"
+require "elastic_graph/indexer/operation/update"
+require "elastic_graph/warehouse_lambda"
+require "elastic_graph/warehouse_lambda/warehouse_dumper"
+require "elastic_graph/warehouse_lambda/config"
+
+module ElasticGraph
+  class WarehouseLambda
+    RSpec.describe WarehouseDumper do
+      include_context "lambda function", config_overrides_in_yaml: {"warehouse" => {"s3_path_prefix" => "Data001"}}
+
+      let(:indexer) { ::ElasticGraph::Indexer.from_parsed_yaml(CommonSpecHelpers.parsed_test_settings_yaml) }
+      let(:s3_client) { ::Aws::S3::Client.new(stub_responses: true) }
+      let(:s3_bucket_name) { "warehouse-bucket" }
+      let(:clock) { class_double(::Time, now: ::Time.utc(2024, 9, 15, 12, 30, 12.123454)) }
+
+      let(:warehouse_lambda) do
+        WarehouseLambda.new(
+          config: Config.new(s3_path_prefix: "Data001"),
+          indexer: indexer,
+          s3_client: s3_client,
+          s3_bucket_name: s3_bucket_name,
+          clock: clock
+        )
+      end
+
+      let(:warehouse_dumper) { warehouse_lambda.warehouse_dumper }
+      let(:widget_primary_indexing_op) do
+        new_primary_indexing_op({
+          "type" => "Widget",
+          "id" => "1",
+          "version" => 3,
+          "record" => {"id" => "1", "dayOfWeek" => "MON", "created_at" => "2024-09-15T12:30:12Z", "workspace_id" => "ws-1"}
+        })
+      end
+
+      it "writes to S3" do
+        operations = [widget_primary_indexing_op]
+
+        results = warehouse_dumper.bulk(operations)
+
+        expect(results).to be_a ::ElasticGraph::Indexer::DatastoreIndexingRouter::BulkResult
+        expect(s3_client.api_requests.map { |req| req[:operation_name] }).to eq [:put_object]
+
+        params = s3_client.api_requests.first.fetch(:params)
+        expect(params[:bucket]).to eq s3_bucket_name
+        expect(params[:key]).to match %r{dumped-data/Data001/Widget/v1/2024-09-15/[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}\.jsonl\.gz}
+
+        data = params.fetch(:body)
+          .then { |data| ::Zlib::GzipReader.new(StringIO.new(data)).read }
+          .then { |data| ::JSON.parse(data) }
+
+        expect(data).to include("id" => "1", "__eg_version" => 3)
+      end
+
+      def new_primary_indexing_op(event)
+        update_targets = indexer
+          .schema_artifacts
+          .runtime_metadata
+          .object_types_by_name
+          .fetch(event.fetch("type"))
+          .update_targets
+          .select { |ut| ut.type == event.fetch("type") }
+
+        expect(update_targets.size).to eq(1)
+        index_def = indexer.datastore_core.index_definitions_by_graphql_type.fetch(event.fetch("type")).first
+
+        ::ElasticGraph::Indexer::Operation::Update.new(
+          event: event,
+          prepared_record: indexer.record_preparer_factory.for_latest_json_schema_version.prepare_for_index(
+            event.fetch("type"),
+            event.fetch("record")
+          ),
+          destination_index_def: index_def,
+          update_target: update_targets.first,
+          doc_id: event.fetch("id"),
+          destination_index_mapping: indexer.schema_artifacts.index_mappings_by_index_def_name.fetch(index_def.name)
+        )
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse_lambda/spec/unit/elastic_graph/warehouse_lambda_spec.rb
+++ b/elasticgraph-warehouse_lambda/spec/unit/elastic_graph/warehouse_lambda_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "elastic_graph/spec_support/lambda_function"
+require "elastic_graph/warehouse_lambda"
+
+module ElasticGraph
+  RSpec.describe WarehouseLambda do
+    include_context "lambda function"
+
+    it "returns non-nil values from each attribute" do
+      warehouse_lambda = WarehouseLambda.from_env
+
+      expect(warehouse_lambda).to be_a(WarehouseLambda)
+      expect_to_return_non_nil_values_from_all_attributes(warehouse_lambda)
+    end
+  end
+end


### PR DESCRIPTION
This migrates the existing square internal gem to the open source elasticgraph repo.