### PR TITLE
Bump rack from 3.2.1 to 3.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :site do
   gem "filewatcher", "~> 2.1"
   gem "html-proofer", "~> 5.0", ">= 5.0.10"
   gem "jekyll", "~> 4.4", ">= 4.4.1"
-  gem "nokogiri", "~> 1.18"
+  gem "nokogiri", "~> 1.18", ">= 1.18.10"
   gem "redcarpet", "~> 3.6", ">= 3.6.1"
 
   # Pull in a YAML syntax highlighting fix so that our JSON schemas render correctly at the website:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,9 +83,9 @@ PATH
   remote: elasticgraph-indexer_autoscaler_lambda
   specs:
     elasticgraph-indexer_autoscaler_lambda (1.0.3.pre)
-      aws-sdk-cloudwatch (~> 1.120)
+      aws-sdk-cloudwatch (~> 1.121)
       aws-sdk-lambda (~> 1.160)
-      aws-sdk-sqs (~> 1.103)
+      aws-sdk-sqs (~> 1.104)
       elasticgraph-datastore_core (= 1.0.3.pre)
       elasticgraph-lambda_support (= 1.0.3.pre)
       ox (~> 2.14, >= 2.14.23)
@@ -159,7 +159,7 @@ PATH
   specs:
     elasticgraph-rack (1.0.3.pre)
       elasticgraph-graphql (= 1.0.3.pre)
-      rack (~> 3.2, >= 3.2.1)
+      rack (~> 3.2, >= 3.2.2)
 
 PATH
   remote: elasticgraph-schema_artifacts
@@ -432,7 +432,7 @@ GEM
     prism (1.5.1)
     public_suffix (6.0.2)
     racc (1.8.1)
-    rack (3.2.1)
+    rack (3.2.2)
     rack-test (2.2.0)
       rack (>= 1.3)
     rackup (2.2.1)
@@ -638,7 +638,7 @@ DEPENDENCIES
   jekyll (~> 4.4, >= 4.4.1)
   memory_profiler (~> 1.1)
   method_source (~> 1.1)
-  nokogiri (~> 1.18)
+  nokogiri (~> 1.18, >= 1.18.10)
   rack-test (~> 2.2)
   redcarpet (~> 3.6, >= 3.6.1)
   rouge!

--- a/elasticgraph-indexer_autoscaler_lambda/elasticgraph-indexer_autoscaler_lambda.gemspec
+++ b/elasticgraph-indexer_autoscaler_lambda/elasticgraph-indexer_autoscaler_lambda.gemspec
@@ -44,8 +44,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "elasticgraph-datastore_core", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-lambda_support", ElasticGraph::VERSION
   spec.add_dependency "aws-sdk-lambda", "~> 1.160"
-  spec.add_dependency "aws-sdk-sqs", "~> 1.103"
-  spec.add_dependency "aws-sdk-cloudwatch", "~> 1.120"
+  spec.add_dependency "aws-sdk-sqs", "~> 1.104"
+  spec.add_dependency "aws-sdk-cloudwatch", "~> 1.121"
   # aws-sdk-sqs requires an XML library be available. On Ruby < 3 it'll use rexml from the standard library but on Ruby 3.0+
   # we have to add an explicit dependency. It supports ox, oga, libxml, nokogiri or rexml, and of those, ox seems to be the
   # best choice: it leads benchmarks, is well-maintained, has no dependencies, and is MIT-licensed.

--- a/elasticgraph-rack/elasticgraph-rack.gemspec
+++ b/elasticgraph-rack/elasticgraph-rack.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = [">= 3.4", "< 3.5"]
 
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION
-  spec.add_dependency "rack", "~> 3.2", ">= 3.2.1"
+  spec.add_dependency "rack", "~> 3.2", ">= 3.2.2"
 
   spec.add_development_dependency "elasticgraph-admin", ElasticGraph::VERSION
   spec.add_development_dependency "elasticgraph-elasticsearch", ElasticGraph::VERSION

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -6,7 +6,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: addressable
@@ -14,7 +14,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ast
@@ -22,7 +22,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: async
@@ -30,11 +30,11 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: aws-sdk-cloudwatch
-  version: 1.120.0
+  version: 1.121.0
   source:
     type: rubygems
 - name: aws-sdk-core
@@ -54,7 +54,7 @@ gems:
   source:
     type: rubygems
 - name: aws-sdk-sqs
-  version: 1.103.0
+  version: 1.104.0
   source:
     type: rubygems
 - name: base64
@@ -70,7 +70,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: cgi
@@ -82,7 +82,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: connection_pool
@@ -90,7 +90,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: csv
@@ -98,7 +98,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: date
@@ -110,7 +110,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: digest
@@ -126,7 +126,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: faraday
@@ -134,7 +134,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: fileutils
@@ -150,7 +150,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: hashdiff
@@ -158,7 +158,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: i18n
@@ -166,7 +166,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: json
@@ -178,7 +178,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: logger
@@ -190,7 +190,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: monitor
@@ -210,7 +210,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: openssl
@@ -226,7 +226,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: parser
@@ -234,11 +234,11 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: prism
-  version: 1.4.0
+  version: 1.5.1
   source:
     type: rubygems
 - name: rack
@@ -246,7 +246,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rainbow
@@ -254,7 +254,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rake
@@ -262,7 +262,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: regexp_parser
@@ -270,7 +270,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ripper
@@ -282,7 +282,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rubocop-ast
@@ -290,7 +290,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: securerandom
@@ -302,7 +302,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: singleton
@@ -326,7 +326,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: time
@@ -342,7 +342,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: uri
@@ -358,7 +358,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1c0e3f62ff100436becf905ec3ae30a691019384
+    revision: 0cb6351d218704700cf4df797ff8966b3a418fcd
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: yard-markdown


### PR DESCRIPTION
Updates `rack` from 3.2.1 to 3.2.2
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/rack/rack/blob/main/CHANGELOG.md">rack's changelog</a>.</em></p>
<blockquote>
<h2>[3.2.2] - 2025-10-07</h2>
<h3>Security</h3>
<ul>
<li><a href="https://github.com/advisories/GHSA-wpv5-97wm-hp9c">CVE-2025-61772</a> Multipart parser buffers unbounded per-part headers, enabling DoS (memory exhaustion)</li>
<li><a href="https://github.com/advisories/GHSA-w9pc-fmgc-vxvw">CVE-2025-61771</a> Multipart parser buffers large non‑file fields entirely in memory, enabling DoS (memory exhaustion)</li>
<li><a href="https://github.com/advisories/GHSA-p543-xpfm-54cp">CVE-2025-61770</a> Unbounded multipart preamble buffering enables DoS (memory exhaustion)</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/rack/rack/commit/bce149b11154e851c437b5ece1c026c943f4b571"><code>bce149b</code></a> Bump patch version.</li>
<li><a href="https://github.com/rack/rack/commit/3beacfcd494ec5600c9022d561cfa2f556a524d1"><code>3beacfc</code></a> Limit amount of retained data when parsing multipart requests</li>
<li><a href="https://github.com/rack/rack/commit/589127f4ac8b5cf11cf88fb0cd116ffed4d2181e"><code>589127f</code></a> Fix denial of service vulnerbilties in multipart parsing</li>
<li>See full diff in <a href="https://github.com/rack/rack/compare/v3.2.1...v3.2.2">compare view</a></li>
</ul>
</details>
<br />

This upgrade should address the `rack` security vuln described [here](https://github.com/block/elasticgraph/security/dependabot/13). 

These are the same changes attempted in https://github.com/block/elasticgraph/pull/866, however, we exclude the version constraint update to the `graphql` gem because of a known issue that prevented the merging of the dependabot PR. The `graphql` gem was locked to v2.5.11 in https://github.com/block/elasticgraph/pull/842.