### PR TITLE
Add `script/lint` and document it in `CONTRIBUTING.md`.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,8 +101,11 @@ The codebase includes a variety of build scripts and executables which are usefu
 
 * `script/quick_build`: Performs an abridged version of the CI build. This is generally the most complete CI build we run locally.
   **We recommend running it before opening a PR.**
+* `script/lint`: Runs the linter on the codebase, surfacing style and formatting issues.
+  * Run `script/lint --fix` to autocorrect most linting issues.
 * `script/type_check`: Runs a [steep](https://github.com/soutaro/steep) type check.
 * `script/spellcheck`: Spellchecks the codebase using [codespell](https://github.com/codespell-project/codespell).
+  * Run `script/spellcheck -w` to write autocorrections back to source files.
 * `script/run_specs`: Runs the test suite.
 * `script/run_gem_specs [gem_name]`: Runs the test suite for one ElasticGraph gem.
 

--- a/script/ci_parts/run_misc_checks
+++ b/script/ci_parts/run_misc_checks
@@ -4,6 +4,7 @@
 source "script/ci_parts/setup_env" "local" $1 $2
 
 script/spellcheck
+script/lint
 script/type_check
 script/update_config_artifacts --verify
 script/update_dependency_diagrams --verify
@@ -12,7 +13,6 @@ script/update_licenses --verify
 script/validate_readme_snippets
 script/validate_release_workflow
 
-bundle exec standardrb
 bundle exec rake schema_artifacts:check VERBOSE=true
 
 # verify that we can index fake data locally. Note: this must come _after_ `rake schema_artifacts:check`

--- a/script/lint
+++ b/script/lint
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Abort script at first error, when a command exits with non-zero status.
+# Verbose form of `set -e`.
+set -o errexit
+
+# Attempt to use undefined variable outputs error message, and forces an exit
+# Verbose form of `set -u`.
+set -o nounset
+
+# If set, the return value of a pipeline is the value of the last (rightmost)
+# command to exit with a non-zero status, or zero if all commands in the
+# pipeline exit successfully.
+set -o pipefail
+
+# Print a trace of simple commands.
+# Verbose form of `set -x`.
+set -o xtrace
+
+bundle exec standardrb $@

--- a/script/quick_build
+++ b/script/quick_build
@@ -29,8 +29,7 @@ set -o pipefail
 set -o xtrace
 
 script/spellcheck
-bundle exec standardrb
-
+script/lint
 script/type_check
 
 bundle exec rake schema_artifacts:check


### PR DESCRIPTION
Previously, `CONTRIBUTING.md` didn't document how to run the linter; now it does. This also updates the CI build to use `script/lint` rather than running `bundle exec standardrb` directly, so that the CI build itself validates that `script/lint` works.
