### PR TITLE
chore: work around a certs issue that some contributors have reported.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 config/release/bin
 config/release/bundle
 config/release/.bundle
+config/site/node_modules
 
 # Allows customization of the bundle for things like pry, debugger, etc.
 Gemfile-custom


### PR DESCRIPTION
This should improve `bundle exec rake site:validate` (called by `script/quick_build`) so that it passes more consistently for all contributors.

In addition, this git-ignores `config/site/node_modules`. I'm not sure why, but the `site:validate` task has started downloading node modules into that directory. We don't want to keep them under source control.