### PR TITLE
Refactor: instantiate `Results` and `SchemaArtifactManager` from the `Factory`.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -121,7 +121,8 @@ task :update_artifact_derived_constants do
   script_id_pattern = "update_index_data_[0-9a-f]+"
 
   update_index_data_script_id = schema_def_rake_tasks
-    .send(:schema_definition_results)
+    .send(:schema_def_api)
+    .results
     .datastore_scripts.keys
     .grep(/\A#{script_id_pattern}\z/)
     .first

--- a/config/site/support/doctest_helper.rb
+++ b/config/site/support/doctest_helper.rb
@@ -77,7 +77,7 @@ module ElasticGraph
       doctest.after(description) do
         ::Thread.current[:ElasticGraph_SchemaDefinition_API_instance] = nil
 
-        artifacts_manager = SchemaDefinition::SchemaArtifactManager.new(
+        artifacts_manager = @api.factory.new_schema_artifact_manager(
           schema_definition_results: @api.results,
           schema_artifacts_directory: "#{@tmp_dir}/schema_artifacts",
           enforce_json_schema_version: true,

--- a/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/for_index_template_spec.rb
+++ b/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/for_index_template_spec.rb
@@ -154,8 +154,14 @@ module ElasticGraph
 
               updated_schema = schema_def(configure_widget: ->(t) { t.field "amount_cents", "Int" })
 
-              SchemaDefinition::SchemaArtifactManager.new(
-                schema_definition_results: generate_schema_artifacts(&updated_schema),
+              factory = nil
+              schema_def_results = generate_schema_artifacts do |api|
+                updated_schema.call(api)
+                factory = api.factory
+              end
+
+              factory.new_schema_artifact_manager(
+                schema_definition_results: schema_def_results,
                 schema_artifacts_directory: Dir.pwd,
                 enforce_json_schema_version: true,
                 output: output_io

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
@@ -387,7 +387,7 @@ module ElasticGraph
 
       # @return the results of the schema definition
       def results
-        @results ||= Results.new(@state)
+        @results ||= @factory.new_results
       end
 
       # Defines the version number of the current JSON schema. Importantly, every time a change is made that impacts the JSON schema

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
@@ -8,6 +8,8 @@
 
 require "elastic_graph/constants"
 require "elastic_graph/schema_definition/mixins/has_readable_to_s_and_inspect"
+require "elastic_graph/schema_definition/results"
+require "elastic_graph/schema_definition/schema_artifact_manager"
 require "elastic_graph/schema_definition/schema_elements/argument"
 require "elastic_graph/schema_definition/schema_elements/built_in_types"
 require "elastic_graph/schema_definition/schema_elements/deprecated_element"
@@ -274,6 +276,28 @@ module ElasticGraph
         )
       end
       @@relationship_new = prevent_non_factory_instantiation_of(SchemaElements::Relationship)
+
+      def new_results
+        @@results_new.call(@state)
+      end
+      @@results_new = prevent_non_factory_instantiation_of(Results)
+
+      def new_schema_artifact_manager(
+        schema_definition_results:,
+        schema_artifacts_directory:,
+        enforce_json_schema_version:,
+        output:,
+        max_diff_lines: 50
+      )
+        @@schema_artifact_manager_new.call(
+          schema_definition_results:,
+          schema_artifacts_directory:,
+          enforce_json_schema_version:,
+          output:,
+          max_diff_lines:
+        )
+      end
+      @@schema_artifact_manager_new = prevent_non_factory_instantiation_of(SchemaArtifactManager)
 
       # Responsible for creating a new `*AggregatedValues` type for an index leaf type.
       #

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/rake_tasks.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/rake_tasks.rb
@@ -155,14 +155,14 @@ module ElasticGraph
       end
 
       def schema_artifact_manager
-        require "elastic_graph/schema_definition/schema_artifact_manager"
+        require "elastic_graph/schema_definition/api"
 
         # :nocov: -- tests don't cover the `VERBOSE` side
         max_diff_lines = ENV["VERBOSE"] ? 999999999 : 50
         # :nocov:
 
-        SchemaArtifactManager.new(
-          schema_definition_results: schema_definition_results,
+        schema_def_api.factory.new_schema_artifact_manager(
+          schema_definition_results: schema_def_api.results,
           schema_artifacts_directory: @schema_artifacts_directory.to_s,
           enforce_json_schema_version: @enforce_json_schema_version,
           output: @output,
@@ -170,7 +170,7 @@ module ElasticGraph
         )
       end
 
-      def schema_definition_results
+      def schema_def_api
         require "elastic_graph/schema_definition/api"
 
         API.new(
@@ -183,7 +183,7 @@ module ElasticGraph
           output: @output
         ).tap do |api|
           api.as_active_instance { load @path_to_schema.to_s }
-        end.results
+        end
       end
     end
   end

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/test_support.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/test_support.rb
@@ -85,7 +85,7 @@ module ElasticGraph
         # Reloading the schema artifacts takes extra time that we don't usually want to spend (so it's opt-in)
         # but it can be useful in some cases because there is a bit of extra pruning/validation that it applies.
         tmp_dir = ::Dir.mktmpdir
-        artifacts_manager = SchemaDefinition::SchemaArtifactManager.new(
+        artifacts_manager = api.factory.new_schema_artifact_manager(
           schema_definition_results: api.results,
           schema_artifacts_directory: tmp_dir,
           enforce_json_schema_version: false,

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/factory.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/factory.rbs
@@ -113,6 +113,18 @@ module ElasticGraph
       ) -> SchemaElements::Relationship
       @@relationship_new: ::Method
 
+      def new_results: () -> Results
+      @@results_new: ::Method
+
+      def new_schema_artifact_manager: (
+        schema_definition_results: Results,
+        schema_artifacts_directory: ::String,
+        enforce_json_schema_version: bool,
+        output: io,
+        ?max_diff_lines: ::Integer
+      ) -> SchemaArtifactManager
+      @@schema_artifact_manager_new: ::Method
+
       def new_aggregated_values_type_for_index_leaf_type: (
         ::String
       ) { (SchemaElements::ObjectType) -> void } -> SchemaElements::ObjectType

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/rake_tasks.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/rake_tasks.rbs
@@ -30,7 +30,7 @@ module ElasticGraph
 
       def define_tasks: () -> void
       def schema_artifact_manager: () -> SchemaArtifactManager
-      def schema_definition_results: () -> Results
+      def schema_def_api: () -> API
     end
   end
 end


### PR DESCRIPTION
This makes it possible to apply extensions to `Results` and `SchemaArtifactManager` in the same way that extentions can be applied to other `elasticgraph-schema_definition` classes.