### PR TITLE
Add if block_given? to new_interface_type and new_scalar_type factory methods

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
@@ -218,7 +218,7 @@ module ElasticGraph
 
       def new_interface_type(name)
         @@interface_type_new.call(@state, name.to_s) do |interface_type|
-          yield interface_type
+          yield interface_type if block_given?
         end
       end
       @@interface_type_new = prevent_non_factory_instantiation_of(SchemaElements::InterfaceType)
@@ -232,7 +232,7 @@ module ElasticGraph
 
       def new_scalar_type(name)
         @@scalar_type_new.call(@state, name.to_s) do |scalar_type|
-          yield scalar_type
+          yield scalar_type if block_given?
         end
       end
       @@scalar_type_new = prevent_non_factory_instantiation_of(SchemaElements::ScalarType)


### PR DESCRIPTION
Currently, new_object_type includes if block_given? before yielding:

```ruby
  def new_object_type(name)
    @@object_type_new.call(@state, name.to_s) do |object_type|
      yield object_type if block_given?
    end
  end
```

However, new_interface_type and new_scalar_type unconditionally yield:

```ruby
  def new_interface_type(name)
    @@interface_type_new.call(@state, name.to_s) do |interface_type|
      yield interface_type  # ⚠️ Always yields, even if no block given
    end
  end
```

This inconsistency becomes problematic when extension libraries override these factory methods. For example, an extension might do:

```ruby
  def new_scalar_type(name, &block)
    super(name) do |t|
      # Configure some defaults
      t.mapping type: "long"
      # Call the user's block if they provided one
      block.call(t) if block
    end
  end
```

Without if block_given? in the factory, calling `new_scalar_type("MyType")` without a block would fail because the factory would try to yield when no block was provided.