### PR TITLE
Phase 1: Add grouping_missing_value_placeholder runtime metadata

### DIFF
--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/scalar_type.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/scalar_type.rbs
@@ -4,15 +4,18 @@ module ElasticGraph
       class ScalarTypeSupertype
         attr_reader coercion_adapter_ref: ::Hash[::String, ::String]
         attr_reader indexing_preparer_ref: ::Hash[::String, ::String]
+        attr_reader grouping_missing_value_placeholder: ::String?
 
         def initialize: (
           coercion_adapter_ref: ::Hash[::String, ::String],
-          indexing_preparer_ref: ::Hash[::String, ::String]
+          indexing_preparer_ref: ::Hash[::String, ::String],
+          grouping_missing_value_placeholder: ::String?
         ) -> void
 
         def with: (
           ?coercion_adapter_ref: ::Hash[::String, ::String],
-          ?indexing_preparer_ref: ::Hash[::String, ::String]
+          ?indexing_preparer_ref: ::Hash[::String, ::String],
+          ?grouping_missing_value_placeholder: ::String?
         ) -> ScalarType
       end
 

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/scalar_type_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/scalar_type_spec.rb
@@ -18,7 +18,7 @@ module ElasticGraph
         include RuntimeMetadataSupport
 
         it "allows `with:` to be used to update a single attribute" do
-          scalar_type = ScalarType.new(
+          scalar_type = scalar_type_with(
             coercion_adapter_ref: scalar_coercion_adapter1.to_dumpable_hash,
             indexing_preparer_ref: indexing_preparer1.to_dumpable_hash
           )

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
@@ -90,23 +90,24 @@ module ElasticGraph
               )
             },
             scalar_types_by_name: {
-              "ScalarType1" => ScalarType.new(
-                scalar_coercion_adapter1.to_dumpable_hash,
-                indexing_preparer1.to_dumpable_hash
+              "ScalarType1" => scalar_type_with(
+                coercion_adapter_ref: scalar_coercion_adapter1.to_dumpable_hash,
+                indexing_preparer_ref: indexing_preparer1.to_dumpable_hash
               ),
-              "ScalarType2" => ScalarType.new(
-                scalar_coercion_adapter2.to_dumpable_hash,
-                indexing_preparer2.to_dumpable_hash
+              "ScalarType2" => scalar_type_with(
+                coercion_adapter_ref: scalar_coercion_adapter2.to_dumpable_hash,
+                indexing_preparer_ref: indexing_preparer2.to_dumpable_hash,
+                grouping_missing_value_placeholder: "NaN"
               )
             },
             enum_types_by_name: {
-              "WidgetSort" => Enum::Type.new({
-                "id_ASC" => Enum::Value.new(SortField.new("id", :asc), nil, nil, nil),
-                "id_DESC" => Enum::Value.new(SortField.new("id", :desc), nil, nil, nil)
+              "WidgetSort" => enum_type_with(values_by_name: {
+                "id_ASC" => enum_value_with(sort_field: SortField.new("id", :asc)),
+                "id_DESC" => enum_value_with(sort_field: SortField.new("id", :desc))
               }),
-              "DistanceUnit" => Enum::Type.new({
-                "MILE" => Enum::Value.new(nil, nil, :mi, nil),
-                "KILOMETER" => Enum::Value.new(nil, nil, :km, nil)
+              "DistanceUnit" => enum_type_with(values_by_name: {
+                "MILE" => enum_value_with(datastore_abbreviation: :mi),
+                "KILOMETER" => enum_value_with(datastore_abbreviation: :km)
               })
             },
             index_definitions_by_name: {
@@ -218,6 +219,7 @@ module ElasticGraph
                   "name" => "ElasticGraph::SchemaArtifacts::ScalarCoercionAdapter2",
                   "require_path" => "support/example_extensions/scalar_coercion_adapters"
                 },
+                "grouping_missing_value_placeholder" => "NaN",
                 "indexing_preparer" => {
                   "name" => "ElasticGraph::SchemaArtifacts::IndexingPreparer2",
                   "require_path" => "support/example_extensions/indexing_preparers"
@@ -331,8 +333,8 @@ module ElasticGraph
         it "ignores enum types that have no meaningful runtime metadata" do
           schema = schema_with(enum_types_by_name: {
             "HasValues" => enum_type_with(values_by_name: {
-              "id_ASC" => Enum::Value.new(SortField.new("id", :asc), nil, nil, nil),
-              "id_DESC" => Enum::Value.new(SortField.new("id", :desc), nil, nil, nil)
+              "id_ASC" => enum_value_with(sort_field: SortField.new("id", :asc)),
+              "id_DESC" => enum_value_with(sort_field: SortField.new("id", :desc))
             }),
             "NoValues" => enum_type_with(values_by_name: {})
           })

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/scalar_type.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/scalar_type.rb
@@ -71,7 +71,8 @@ module ElasticGraph
           # Default the runtime metadata before yielding, so it can be overridden as needed.
           self.runtime_metadata = SchemaArtifacts::RuntimeMetadata::ScalarType.new(
             coercion_adapter_ref: SchemaArtifacts::RuntimeMetadata::ScalarType::DEFAULT_COERCION_ADAPTER_REF,
-            indexing_preparer_ref: SchemaArtifacts::RuntimeMetadata::ScalarType::DEFAULT_INDEXING_PREPARER_REF
+            indexing_preparer_ref: SchemaArtifacts::RuntimeMetadata::ScalarType::DEFAULT_INDEXING_PREPARER_REF,
+            grouping_missing_value_placeholder: nil
           )
 
           yield self

--- a/spec_support/lib/elastic_graph/spec_support/runtime_metadata_support.rb
+++ b/spec_support/lib/elastic_graph/spec_support/runtime_metadata_support.rb
@@ -130,6 +130,20 @@ module ElasticGraph
           Enum::Type.new(values_by_name: values_by_name)
         end
 
+        def enum_value_with(
+          sort_field: nil,
+          datastore_value: nil,
+          datastore_abbreviation: nil,
+          alternate_original_name: nil
+        )
+          Enum::Value.new(
+            sort_field: sort_field,
+            datastore_value: datastore_value,
+            datastore_abbreviation: datastore_abbreviation,
+            alternate_original_name: alternate_original_name
+          )
+        end
+
         def sort_field_with(field_path: "path.to.some.field", direction: :asc)
           SortField.new(
             field_path: field_path,
@@ -168,11 +182,13 @@ module ElasticGraph
 
         def scalar_type_with(
           coercion_adapter_ref: ScalarType::DEFAULT_COERCION_ADAPTER_REF,
-          indexing_preparer_ref: ScalarType::DEFAULT_INDEXING_PREPARER_REF
+          indexing_preparer_ref: ScalarType::DEFAULT_INDEXING_PREPARER_REF,
+          grouping_missing_value_placeholder: nil
         )
           ScalarType.new(
             coercion_adapter_ref: coercion_adapter_ref,
-            indexing_preparer_ref: indexing_preparer_ref
+            indexing_preparer_ref: indexing_preparer_ref,
+            grouping_missing_value_placeholder: grouping_missing_value_placeholder
           )
         end
 


### PR DESCRIPTION
This is phase 1 in a series of new pull requests that are working toward a new approach to handling missing values in subaggregations as described in #882. This PR is the first step outlined by @myronmarston [here](https://github.com/block/elasticgraph/pull/882#discussion_r2462223814). It only includes adding grouping_missing_value_placeholder as an attribute of ScalarType and Enum::Type. For scalar types, the placeholder value can be specified when the type is defined. For enum types there is no need to make schema authors define a placeholder value. We use a placeholder value of `**missing**` that can't conflict with enum name (since GraphQL enums may only contain letters and underscores). If this value conflicts with a datastore_value then we fallback to not using a placeholder value.

## Context
Due to limitations in OpenSearch and ElasticSearch, composite aggregations cannot be used as subaggregations with in a composite aggregation. When grouping by multiple fields in a subaggregation, ElasticGraph works around this limitation by creating a hierarchy of subaggregations. To handle missing values, each group by field results in a terms subaggregation and a missing subaggregation. When there are many fields to group by this results in an exponential explosion in the number of subaggregations. For some of our queries this is resulting in poor performance, or worse, causing queries to fail because they exceed max clause count on the OpenSearch cluster.

The new approach still relies on a hierarchy of subaggregations, but at each level of the hierarchy it only uses one child subaggregation instead of two, so the number of subaggregations is linear with respect to the number of group by fields, instead of being exponential.

This approach relies on providing a the terms aggregations a missing value to use as a placeholder. This isn't ideal but all workarounds involve a balance of tradeoffs.

## Other PRs

[Phase 2: Infer grouping_missing_value_placeholder based on mapping_type](https://github.com/block/elasticgraph/pull/893)
[Phase 3: Wire up grouping_missing_value_placeholder in GraphQL layer](https://github.com/block/elasticgraph/pull/894)
[Phase 4: Use grouping_missing_value_placeholder in aggregation logic](https://github.com/block/elasticgraph/pull/895)