### PR TITLE
Omit Elasticsearch API calls on graphql and indexer boots

### DIFF
--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/base.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_definition/base.rb
@@ -66,18 +66,19 @@ module ElasticGraph
         def searches_could_hit_incomplete_docs?
           return @searches_could_hit_incomplete_docs if defined?(@searches_could_hit_incomplete_docs)
 
-          if current_sources.size > 1
+          @searches_could_hit_incomplete_docs = if current_sources.size > 1
             # We know that incomplete docs are possible, without needing to check sources recorded in `_meta`.
-            @searches_could_hit_incomplete_docs = true
+            true
           else
             # While our current configuration can't produce incomplete documents, some may already exist in the index
             # if we previously had some `sourced_from` fields (but no longer have them). Here we check for the sources
             # we've recorded in `_meta` to account for that.
-            client = datastore_clients_by_name.fetch(cluster_to_query)
-            recorded_sources = mappings_in_datastore(client).dig("_meta", "ElasticGraph", "sources") || []
-            sources = recorded_sources.union(current_sources.to_a)
+            # Comment out to avoid boot-time Elasticsearch API calls.
+            # client = datastore_clients_by_name.fetch(cluster_to_query)
+            # recorded_sources = mappings_in_datastore(client).dig("_meta", "ElasticGraph", "sources") || []
+            # sources = recorded_sources.union(current_sources.to_a)
 
-            @searches_could_hit_incomplete_docs = sources.size > 1
+            current_sources.size > 1
           end
         end
 

--- a/elasticgraph-datastore_core/spec/integration/elastic_graph/datastore_core/index_definition/implementation_shared_examples.rb
+++ b/elasticgraph-datastore_core/spec/integration/elastic_graph/datastore_core/index_definition/implementation_shared_examples.rb
@@ -19,7 +19,7 @@ module ElasticGraph
 
             expect {
               expect(index.searches_could_hit_incomplete_docs?).to be false
-            }.to change { datastore_requests("main").count }.by(1)
+            }.not_to change { datastore_requests("main").count }
 
             # Demonstrate that we cache the value by showing the datastore request count doesn't change
             # when we call `searches_could_hit_incomplete_docs?` with the same client again.
@@ -46,7 +46,7 @@ module ElasticGraph
             }.not_to change { datastore_requests("main").count }
           end
 
-          it "returns `true` on an index that no longer has `sourced_from` fields but used to" do
+          it "returns `false` on an index that no longer has `sourced_from` fields but used to" do
             define_index do |t|
               t.field "owner_name", "String" do |f|
                 f.sourced_from "owner", "name"
@@ -55,7 +55,7 @@ module ElasticGraph
 
             index = define_index
 
-            expect(index.searches_could_hit_incomplete_docs?).to be true
+            expect(index.searches_could_hit_incomplete_docs?).to be false
           end
 
           context "when there are no sources recorded in `_meta` on the index" do

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/datastore_indexing_router.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/datastore_indexing_router.rb
@@ -75,7 +75,8 @@ module ElasticGraph
       # with the mappings we expect, meaning that no bulk operations will be attempted if that is not up-to-date.
       def bulk(operations, refresh: false)
         # Before writing these operations, verify their destination index mapping are consistent.
-        validate_mapping_completeness_of!(:accessible_cluster_names_to_index_into, *operations.map(&:destination_index_def).uniq)
+        # Comment out to avoid boot-time Elasticsearch API calls
+        # validate_mapping_completeness_of!(:accessible_cluster_names_to_index_into, *operations.map(&:destination_index_def).uniq)
 
         ops_by_client = ::Hash.new { |h, k| h[k] = [] } # : ::Hash[DatastoreCore::_Client, ::Array[_Operation]]
         unsupported_ops = ::Set.new # : ::Set[_Operation]

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/datastore_indexing_router_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/datastore_indexing_router_spec.rb
@@ -386,11 +386,9 @@ module ElasticGraph
           expect(main_datastore_client).not_to have_received(:bulk)
         end
 
-        it "validates the index mapping consistency of the destination index of each operation before performing the bulk request" do
+        it "does not validate the index mapping consistency of the destination index before performing the bulk request" do
           call_sequence = []
-          allow(index_mapping_checker).to receive(:validate_mapping_completeness_of!) do |index_cluster_name_method, *index_defs|
-            call_sequence << [:validate_indices, index_cluster_name_method, index_defs]
-          end
+          allow(index_mapping_checker).to receive(:validate_mapping_completeness_of!)
 
           allow(main_datastore_client).to receive(:bulk) do |request|
             call_sequence << :bulk
@@ -400,7 +398,6 @@ module ElasticGraph
           router.bulk(operations)
 
           expect(call_sequence).to eq [
-            [:validate_indices, :accessible_cluster_names_to_index_into, operations.map(&:destination_index_def).uniq],
             :bulk
           ]
         end


### PR DESCRIPTION
From https://github.com/block/elasticgraph/pull/850