### PR TITLE
Phase 3: Wire up grouping_missing_value_placeholder in GraphQL layer

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
@@ -53,6 +53,7 @@ module ElasticGraph
             index_definitions_by_graphql_type[key.graphql_name] || [],
             runtime_metadata.object_types_by_name[key.graphql_name],
             runtime_metadata.enum_types_by_name[key.graphql_name],
+            runtime_metadata.scalar_types_by_name[key.graphql_name],
             resolvers_needing_lookahead
           )
         end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/schema/type.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/schema/type.rbs
@@ -7,6 +7,7 @@ module ElasticGraph
         attr_reader fields_by_name: ::Hash[::String, Field]
         attr_reader elasticgraph_category: SchemaArtifacts::RuntimeMetadata::elasticGraphCategory?
         attr_reader graphql_type: ::GraphQL::Schema::_Type
+        attr_reader grouping_missing_value_placeholder: ::String? | ::Numeric?
         def search_index_definitions: () -> ::Array[DatastoreCore::_IndexDefinition]
         def unwrap_fully: () -> Type
         def field_named: (::String) -> Field


### PR DESCRIPTION
This is 3rd in a series of new pull requests that are working toward a new approach to handling missing values in subaggregations as described in #882. For an outline of the steps see the comment from @myronmarston [here](https://github.com/block/elasticgraph/pull/882#discussion_r2462223814). For context see the first PR in the sequence, 
#890. The 2nd PR is #1 (I need to move these PRs to block/elasticgraph).

This replaces the [Phase 3, mattmarston/elasticgraph#2](https://github.com/mmarston/elasticgraph/pull/2) PR that was in my forked repo. This PR addresses the comments there.

This commit makes the grouping_missing_value_placeholder attribute available from ElasticGraph::GraphQL::Schema::Type by wiring it through from runtime metadata for both scalar and enum types.

Changes:
- Add scalar_runtime_metadata as required positional parameter to Type.initialize
- Add grouping_missing_value_placeholder method to Type that checks both scalar and enum runtime metadata
- Update GraphQL::Schema to pass scalar runtime metadata when creating Type instances
- Add tests for the new functionality

## Other PRs

[Phase 1: Add grouping_missing_value_placeholder runtime metadata](https://github.com/block/elasticgraph/pull/890)
[Phase 2: Infer grouping_missing_value_placeholder based on mapping_type](https://github.com/block/elasticgraph/pull/893)
[Phase 3: Wire up grouping_missing_value_placeholder in GraphQL layer](https://github.com/block/elasticgraph/pull/894) (this PR)
[Phase 4: Use grouping_missing_value_placeholder in aggregation logic](https://github.com/block/elasticgraph/pull/895) 