### PR TITLE
Phase 4: Use grouping_missing_value_placeholder in aggregation logic

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/date_histogram_grouping.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/date_histogram_grouping.rb
@@ -53,6 +53,10 @@ module ElasticGraph
           INNER_META
         end
 
+        def handles_missing_values?
+          false
+        end
+
         INNER_META = {
           # On a date histogram aggregation, the `key` is formatted as a number (milliseconds since epoch). We
           # need it formatted as a string, which `key_as_string` provides.

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/field_term_grouping.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/field_term_grouping.rb
@@ -11,9 +11,29 @@ require "elastic_graph/graphql/aggregation/term_grouping"
 module ElasticGraph
   class GraphQL
     module Aggregation
-      class FieldTermGrouping < Support::MemoizableData.define(:field_path)
+      class FieldTermGrouping < Support::MemoizableData.define(:field_path, :missing_value_placeholder)
         # @dynamic field_path
         include TermGrouping
+
+        # Returns true if this grouping handles missing values using a placeholder value
+        # instead of a separate missing aggregation.
+        #
+        # @return [Boolean] true if missing values are handled via placeholder
+        def handles_missing_values?
+          !missing_value_placeholder.nil?
+        end
+
+        def non_composite_clause_for(query)
+          return super unless handles_missing_values?
+
+          Support::HashUtil.deep_merge(super, {"terms" => {"missing" => missing_value_placeholder}})
+        end
+
+        def inner_meta
+          return super unless handles_missing_values?
+
+          super.merge({"missing_values" => [missing_value_placeholder]})
+        end
 
         private
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_adapter.rb
@@ -211,7 +211,8 @@ module ElasticGraph
               date_time_groupings_from(field_path: field_path, node: node)
             elsif !field.type.object?
               # Non-date/time grouping
-              [FieldTermGrouping.new(field_path: field_path)]
+              missing_value_placeholder = field.type.unwrap_fully.grouping_missing_value_placeholder
+              [FieldTermGrouping.new(field_path: field_path, missing_value_placeholder: missing_value_placeholder)]
             end
           end
         end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/script_term_grouping.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/script_term_grouping.rb
@@ -16,6 +16,10 @@ module ElasticGraph
         # @dynamic field_path
         include TermGrouping
 
+        def handles_missing_values?
+          false
+        end
+
         private
 
         def terms_subclause

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/date_histogram_grouping.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/date_histogram_grouping.rbs
@@ -28,6 +28,7 @@ module ElasticGraph
         attr_reader key: ::String
         attr_reader encoded_index_field_path: ::String
 
+        def handles_missing_values?: () -> bool
         def composite_clause: (?grouping_options: ::Hash[::String, untyped]) -> ::Hash[::String, untyped]
         def non_composite_clause_for: (Query) -> ::Hash[::String, untyped]
         def inner_meta: () -> ::Hash[::String, untyped]

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/field_term_grouping.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/field_term_grouping.rbs
@@ -3,8 +3,9 @@ module ElasticGraph
     module Aggregation
       class FieldTermGroupingSupertype
         attr_reader field_path: fieldPath
-        def initialize: (field_path: fieldPath) -> void
-        def self.new: (field_path: fieldPath) -> instance | (fieldPath) -> instance
+        attr_reader missing_value_placeholder: (::String | ::Numeric)?
+        def initialize: (field_path: fieldPath, missing_value_placeholder: (::String | ::Numeric)?) -> void
+        def self.new: (field_path: fieldPath, missing_value_placeholder: (::String | ::Numeric)?) -> instance | (fieldPath, ::String?) -> instance
       end
 
       class FieldTermGrouping < FieldTermGroupingSupertype

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/term_grouping.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/term_grouping.rbs
@@ -19,6 +19,7 @@ module ElasticGraph
       interface _TermGroupingSubtype
         def field_path: () -> fieldPath
         def terms_subclause: () -> ::Hash[::String, untyped]
+        def handles_missing_values?: () -> bool
       end
     end
   end

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/sub_aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/sub_aggregations_spec.rb
@@ -369,7 +369,7 @@ module ElasticGraph
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.notes"]}),
               "doc_count" => 4,
               "seasons_nested.notes" => {
-                "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
+                "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
                 "doc_count_error_upper_bound" => 0,
                 "sum_other_doc_count" => 0,
                 "buckets" => [
@@ -390,11 +390,7 @@ module ElasticGraph
                   })
                 ]
               }
-            }.with_missing_value_bucket(0, {
-              "seasons_nested:seasons_nested.year:exact_min" => {"value" => nil},
-              "seasons_nested:seasons_nested.the_record.win_count:exact_max" => {"value" => nil},
-              "seasons_nested:seasons_nested.the_record.win_count:approximate_avg" => {"value" => nil}
-            })
+            }
           }]
         end
 
@@ -444,7 +440,7 @@ module ElasticGraph
         it "can group sub-aggregations on a single non-date field" do
           query = aggregation_query_of(name: "teams", sub_aggregations: [
             nested_sub_aggregation_of(path_in_index: ["seasons_nested"], query: sub_aggregation_query_of(name: "seasons_nested", groupings: [
-              field_term_grouping_of("seasons_nested", "year")
+              field_term_grouping_of("seasons_nested", "year", missing_value_placeholder: MISSING_NUMERIC_PLACEHOLDER)
             ]))
           ])
 
@@ -457,23 +453,23 @@ module ElasticGraph
               "doc_count" => 4,
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.year"]}),
               "seasons_nested.year" => {
-                "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.year"], "key_path" => ["key"]}),
+                "meta" => inner_terms_meta("seasons_nested.year", {"missing_values" => [MISSING_NUMERIC_PLACEHOLDER]}),
                 "buckets" => [
-                  term_bucket(2022, 2),
-                  term_bucket(2020, 1),
-                  term_bucket(2021, 1)
+                  term_bucket(2022.0, 2),
+                  term_bucket(2020.0, 1),
+                  term_bucket(2021.0, 1)
                 ],
                 "doc_count_error_upper_bound" => 0,
                 "sum_other_doc_count" => 0
               }
-            }.with_missing_value_bucket(0)
+            }
           }])
         end
 
         it "can group sub-aggregations on multiple non-date fields" do
           query = aggregation_query_of(name: "teams", sub_aggregations: [
             nested_sub_aggregation_of(path_in_index: ["seasons_nested"], query: sub_aggregation_query_of(name: "seasons_nested", groupings: [
-              field_term_grouping_of("seasons_nested", "year"),
+              field_term_grouping_of("seasons_nested", "year", missing_value_placeholder: MISSING_NUMERIC_PLACEHOLDER),
               field_term_grouping_of("seasons_nested", "notes")
             ]))
           ])
@@ -487,42 +483,34 @@ module ElasticGraph
               "doc_count" => 4,
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.year"]}),
               "seasons_nested.year" => {
-                "meta" => inner_terms_meta({
+                "meta" => inner_terms_meta("seasons_nested.year", {
                   "buckets_path" => ["seasons_nested.notes"],
-                  "key_path" => ["key"],
-                  "grouping_fields" => ["seasons_nested.year"]
+                  "missing_values" => [MISSING_NUMERIC_PLACEHOLDER]
                 }),
                 "doc_count_error_upper_bound" => 0,
                 "sum_other_doc_count" => 0,
                 "buckets" => [
-                  term_bucket(2022, 2, {"seasons_nested.notes" => {
-                    "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
+                  term_bucket(2022.0, 2, {"seasons_nested.notes" => {
+                    "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
                     "doc_count_error_upper_bound" => 0,
                     "sum_other_doc_count" => 0,
                     "buckets" => [term_bucket("new rules", 2)]
-                  }}.with_missing_value_bucket(0)),
-                  term_bucket(2020, 1, {"seasons_nested.notes" => {
-                    "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
+                  }}),
+                  term_bucket(2020.0, 1, {"seasons_nested.notes" => {
+                    "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
                     "doc_count_error_upper_bound" => 0,
                     "sum_other_doc_count" => 0,
                     "buckets" => [term_bucket("old rules", 1), term_bucket("pandemic", 1)]
-                  }}.with_missing_value_bucket(0)),
-                  term_bucket(2021, 1, {"seasons_nested.notes" => {
-                    "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
+                  }}),
+                  term_bucket(2021.0, 1, {"seasons_nested.notes" => {
+                    "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
                     "doc_count_error_upper_bound" => 0,
                     "sum_other_doc_count" => 0,
                     "buckets" => [term_bucket("old rules", 1)]
-                  }}.with_missing_value_bucket(0))
+                  }})
                 ]
               }
-            }.with_missing_value_bucket(0, {
-              "seasons_nested.notes" => {
-                "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
-                "doc_count_error_upper_bound" => 0,
-                "sum_other_doc_count" => 0,
-                "buckets" => []
-              }
-            }.with_missing_value_bucket(0))
+            }
           }])
         end
 
@@ -531,7 +519,7 @@ module ElasticGraph
             nested_sub_aggregation_of(path_in_index: ["seasons_nested"], query: sub_aggregation_query_of(
               name: "seasons_nested",
               first: 1,
-              groupings: [field_term_grouping_of("seasons_nested", "year")]
+              groupings: [field_term_grouping_of("seasons_nested", "year", missing_value_placeholder: MISSING_NUMERIC_PLACEHOLDER)]
             ))
           ])
 
@@ -544,13 +532,13 @@ module ElasticGraph
               "doc_count" => 4,
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.year"]}, size: 1),
               "seasons_nested.year" => {
-                "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.year"], "key_path" => ["key"]}),
+                "meta" => inner_terms_meta("seasons_nested.year", {"missing_values" => [MISSING_NUMERIC_PLACEHOLDER]}),
                 # To support `page_info.has_next_page` we request one additional bucket, so we get back 2 here.
                 "buckets" => [term_bucket(2022, 2), term_bucket(2020, 1)],
                 "doc_count_error_upper_bound" => 0,
                 "sum_other_doc_count" => 1
               }
-            }.with_missing_value_bucket(0)
+            }
           }])
         end
 
@@ -559,7 +547,7 @@ module ElasticGraph
             nested_sub_aggregation_of(path_in_index: ["seasons_nested"], query: sub_aggregation_query_of(
               name: "seasons_nested",
               first: 1,
-              groupings: [field_term_grouping_of("seasons_nested", "year"), field_term_grouping_of("seasons_nested", "notes")]
+              groupings: [field_term_grouping_of("seasons_nested", "year", missing_value_placeholder: MISSING_NUMERIC_PLACEHOLDER), field_term_grouping_of("seasons_nested", "notes")]
             ))
           ])
 
@@ -572,38 +560,31 @@ module ElasticGraph
               "doc_count" => 4,
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.year"]}, size: 1),
               "seasons_nested.year" => {
-                "meta" => inner_terms_meta({"buckets_path" => ["seasons_nested.notes"], "grouping_fields" => ["seasons_nested.year"], "key_path" => ["key"]}),
+                "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.notes"], "missing_values" => [MISSING_NUMERIC_PLACEHOLDER]}),
                 # To support `page_info.has_next_page` we request one additional bucket, so we get back 2 here.
                 "buckets" => [
-                  term_bucket(2022, 2, {
+                  term_bucket(2022.0, 2, {
                     "seasons_nested.notes" => {
-                      "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.notes"], "key_path" => ["key"]}),
+                      "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
                       "buckets" => [term_bucket("new rules", 2)],
                       "doc_count_error_upper_bound" => 0,
                       "sum_other_doc_count" => 0
                     }
-                  }.with_missing_value_bucket(0)),
-                  term_bucket(2020, 1, {
+                  }),
+                  term_bucket(2020.0, 1, {
                     "seasons_nested.notes" => {
-                      "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.notes"], "key_path" => ["key"]}),
+                      "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
                       # To support `page_info.has_next_page` we request one additional bucket, so we get back 2 here.
                       "buckets" => [term_bucket("old rules", 1), term_bucket("pandemic", 1)],
                       "doc_count_error_upper_bound" => 0,
                       "sum_other_doc_count" => 0
                     }
-                  }.with_missing_value_bucket(0))
+                  })
                 ],
                 "doc_count_error_upper_bound" => 0,
                 "sum_other_doc_count" => 1
               }
-            }.with_missing_value_bucket(0, {
-              "seasons_nested.notes" => {
-                "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.notes"], "key_path" => ["key"]}),
-                "buckets" => [],
-                "doc_count_error_upper_bound" => 0,
-                "sum_other_doc_count" => 0
-              }
-            }.with_missing_value_bucket(0))
+            }
           }])
         end
 
@@ -612,7 +593,7 @@ module ElasticGraph
             nested_sub_aggregation_of(path_in_index: ["seasons_nested"], query: sub_aggregation_query_of(
               name: "seasons_nested",
               first: 0,
-              groupings: [field_term_grouping_of("seasons_nested", "year"), field_term_grouping_of("seasons_nested", "notes")]
+              groupings: [field_term_grouping_of("seasons_nested", "year", missing_value_placeholder: MISSING_NUMERIC_PLACEHOLDER), field_term_grouping_of("seasons_nested", "notes")]
             ))
           ])
 
@@ -637,7 +618,7 @@ module ElasticGraph
               "doc_count" => 4,
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.started_at"]}),
               "seasons_nested.started_at" => {
-                "meta" => inner_date_meta({"grouping_fields" => ["seasons_nested.started_at"], "key_path" => ["key_as_string"]}),
+                "meta" => inner_date_meta("seasons_nested.started_at"),
                 "buckets" => [
                   date_histogram_bucket(2020, 1),
                   date_histogram_bucket(2021, 1),
@@ -665,24 +646,24 @@ module ElasticGraph
               "doc_count" => 4,
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.started_at"]}),
               "seasons_nested.started_at" => {
-                "meta" => inner_date_meta({"grouping_fields" => ["seasons_nested.started_at"], "buckets_path" => ["seasons_nested.won_games_at"], "key_path" => ["key_as_string"]}),
+                "meta" => inner_date_meta("seasons_nested.started_at", {"buckets_path" => ["seasons_nested.won_games_at"]}),
                 "buckets" => [
                   date_histogram_bucket(2020, 1, {"seasons_nested.won_games_at" => {
-                    "meta" => inner_date_meta({"grouping_fields" => ["seasons_nested.won_games_at"], "key_path" => ["key_as_string"]}),
+                    "meta" => inner_date_meta("seasons_nested.won_games_at"),
                     "buckets" => [date_histogram_bucket(2020, 1)]
                   }}.with_missing_value_bucket(0)),
                   date_histogram_bucket(2021, 1, {"seasons_nested.won_games_at" => {
-                    "meta" => inner_date_meta({"grouping_fields" => ["seasons_nested.won_games_at"], "key_path" => ["key_as_string"]}),
+                    "meta" => inner_date_meta("seasons_nested.won_games_at"),
                     "buckets" => [date_histogram_bucket(2021, 1)]
                   }}.with_missing_value_bucket(0)),
                   date_histogram_bucket(2022, 2, {"seasons_nested.won_games_at" => {
-                    "meta" => inner_date_meta({"grouping_fields" => ["seasons_nested.won_games_at"], "key_path" => ["key_as_string"]}),
+                    "meta" => inner_date_meta("seasons_nested.won_games_at"),
                     "buckets" => [date_histogram_bucket(2022, 2)]
                   }}.with_missing_value_bucket(0))
                 ]
               }
             }.with_missing_value_bucket(0, {"seasons_nested.won_games_at" => {
-              "meta" => inner_date_meta({"grouping_fields" => ["seasons_nested.won_games_at"], "key_path" => ["key_as_string"]}),
+              "meta" => inner_date_meta("seasons_nested.won_games_at"),
               "buckets" => []
             }}.with_missing_value_bucket(0))
           }])
@@ -705,41 +686,41 @@ module ElasticGraph
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.started_at"]}),
               "doc_count" => 4,
               "seasons_nested.started_at" => {
-                "meta" => inner_date_meta({"buckets_path" => ["seasons_nested.notes"], "key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.started_at"]}),
+                "meta" => inner_date_meta("seasons_nested.started_at", {"buckets_path" => ["seasons_nested.notes"]}),
                 "buckets" => [
                   date_histogram_bucket(2020, 1, {"seasons_nested.notes" => {
-                    "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
+                    "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
                     "doc_count_error_upper_bound" => 0,
                     "sum_other_doc_count" => 0,
                     "buckets" => [
                       term_bucket("old rules", 1),
                       term_bucket("pandemic", 1)
                     ]
-                  }}.with_missing_value_bucket(0)),
+                  }}),
                   date_histogram_bucket(2021, 1, {"seasons_nested.notes" => {
-                    "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
+                    "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
                     "doc_count_error_upper_bound" => 0,
                     "sum_other_doc_count" => 0,
                     "buckets" => [
                       term_bucket("old rules", 1)
                     ]
-                  }}.with_missing_value_bucket(0)),
+                  }}),
                   date_histogram_bucket(2022, 2, {"seasons_nested.notes" => {
-                    "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
+                    "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
                     "doc_count_error_upper_bound" => 0,
                     "sum_other_doc_count" => 0,
                     "buckets" => [
                       term_bucket("new rules", 2)
                     ]
-                  }}.with_missing_value_bucket(0))
+                  }})
                 ]
               }
             }.with_missing_value_bucket(0, {"seasons_nested.notes" => {
-              "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
+              "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
               "doc_count_error_upper_bound" => 0,
               "sum_other_doc_count" => 0,
               "buckets" => []
-            }}.with_missing_value_bucket(0))
+            }})
           }])
         end
 
@@ -747,7 +728,7 @@ module ElasticGraph
           query = aggregation_query_of(name: "teams", sub_aggregations: [
             nested_sub_aggregation_of(path_in_index: ["seasons_nested"], query: sub_aggregation_query_of(name: "seasons_nested", groupings: [
               date_histogram_grouping_of("seasons_nested", "started_at", "year"),
-              field_term_grouping_of("seasons_nested", "year"),
+              field_term_grouping_of("seasons_nested", "year", missing_value_placeholder: MISSING_NUMERIC_PLACEHOLDER),
               field_term_grouping_of("seasons_nested", "notes")
             ]))
           ])
@@ -761,82 +742,62 @@ module ElasticGraph
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.started_at"]}),
               "doc_count" => 4,
               "seasons_nested.started_at" => {
-                "meta" => inner_date_meta({"buckets_path" => ["seasons_nested.year"], "key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.started_at"]}),
+                "meta" => inner_date_meta("seasons_nested.started_at", {"buckets_path" => ["seasons_nested.year"]}),
                 "buckets" => [
                   date_histogram_bucket(2020, 1, {"seasons_nested.year" => {
-                    "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.year"], "buckets_path" => ["seasons_nested.notes"]}),
+                    "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.notes"], "missing_values" => [MISSING_NUMERIC_PLACEHOLDER]}),
                     "doc_count_error_upper_bound" => 0,
                     "sum_other_doc_count" => 0,
                     "buckets" => [
-                      term_bucket(2020, 1, {"seasons_nested.notes" => {
-                        "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
+                      term_bucket(2020.0, 1, {"seasons_nested.notes" => {
+                        "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
                         "doc_count_error_upper_bound" => 0,
                         "sum_other_doc_count" => 0,
                         "buckets" => [
                           term_bucket("old rules", 1),
                           term_bucket("pandemic", 1)
                         ]
-                      }}.with_missing_value_bucket(0))
+                      }})
                     ]
-                  }}.with_missing_value_bucket(0, {"seasons_nested.notes" => {
-                    "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
-                    "doc_count_error_upper_bound" => 0,
-                    "sum_other_doc_count" => 0,
-                    "buckets" => []
-                  }}.with_missing_value_bucket(0))),
+                  }}),
                   date_histogram_bucket(2021, 1, {"seasons_nested.year" => {
-                    "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.year"], "buckets_path" => ["seasons_nested.notes"]}),
+                    "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.notes"], "missing_values" => [MISSING_NUMERIC_PLACEHOLDER]}),
                     "doc_count_error_upper_bound" => 0,
                     "sum_other_doc_count" => 0,
                     "buckets" => [
-                      term_bucket(2021, 1, {"seasons_nested.notes" => {
-                        "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
+                      term_bucket(2021.0, 1, {"seasons_nested.notes" => {
+                        "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
                         "doc_count_error_upper_bound" => 0,
                         "sum_other_doc_count" => 0,
                         "buckets" => [
                           term_bucket("old rules", 1)
                         ]
-                      }}.with_missing_value_bucket(0))
+                      }})
                     ]
-                  }}.with_missing_value_bucket(0, {"seasons_nested.notes" => {
-                    "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
-                    "doc_count_error_upper_bound" => 0,
-                    "sum_other_doc_count" => 0,
-                    "buckets" => []
-                  }}.with_missing_value_bucket(0))),
+                  }}),
                   date_histogram_bucket(2022, 2, {"seasons_nested.year" => {
-                    "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.year"], "buckets_path" => ["seasons_nested.notes"]}),
+                    "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.notes"], "missing_values" => [MISSING_NUMERIC_PLACEHOLDER]}),
                     "doc_count_error_upper_bound" => 0,
                     "sum_other_doc_count" => 0,
                     "buckets" => [
-                      term_bucket(2022, 2, {"seasons_nested.notes" => {
-                        "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
+                      term_bucket(2022.0, 2, {"seasons_nested.notes" => {
+                        "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
                         "doc_count_error_upper_bound" => 0,
                         "sum_other_doc_count" => 0,
                         "buckets" => [
                           term_bucket("new rules", 2)
                         ]
-                      }}.with_missing_value_bucket(0))
+                      }})
                     ]
-                  }}.with_missing_value_bucket(0, {"seasons_nested.notes" => {
-                    "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
-                    "doc_count_error_upper_bound" => 0,
-                    "sum_other_doc_count" => 0,
-                    "buckets" => []
-                  }}.with_missing_value_bucket(0)))
+                  }})
                 ]
               }
             }.with_missing_value_bucket(0, {"seasons_nested.year" => {
-              "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.year"], "buckets_path" => ["seasons_nested.notes"]}),
+              "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.notes"], "missing_values" => [MISSING_NUMERIC_PLACEHOLDER]}),
               "doc_count_error_upper_bound" => 0,
               "sum_other_doc_count" => 0,
               "buckets" => []
-            }}.with_missing_value_bucket(0, {"seasons_nested.notes" => {
-              "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
-              "doc_count_error_upper_bound" => 0,
-              "sum_other_doc_count" => 0,
-              "buckets" => []
-            }}.with_missing_value_bucket(0)))
+            }})
           }])
         end
 
@@ -845,7 +806,7 @@ module ElasticGraph
             nested_sub_aggregation_of(path_in_index: ["seasons_nested"], query: sub_aggregation_query_of(name: "seasons_nested", groupings: [
               date_histogram_grouping_of("seasons_nested", "started_at", "year"),
               date_histogram_grouping_of("seasons_nested", "won_games_at", "year"),
-              field_term_grouping_of("seasons_nested", "year"),
+              field_term_grouping_of("seasons_nested", "year", missing_value_placeholder: MISSING_NUMERIC_PLACEHOLDER),
               field_term_grouping_of("seasons_nested", "notes")
             ]))
           ])
@@ -859,130 +820,95 @@ module ElasticGraph
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.started_at"]}),
               "doc_count" => 4,
               "seasons_nested.started_at" => {
-                "meta" => inner_date_meta({"buckets_path" => ["seasons_nested.won_games_at"], "key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.started_at"]}),
+                "meta" => inner_date_meta("seasons_nested.started_at", {"buckets_path" => ["seasons_nested.won_games_at"]}),
                 "buckets" => [
                   date_histogram_bucket(2020, 1, {"seasons_nested.won_games_at" => {
-                    "meta" => inner_date_meta({"buckets_path" => ["seasons_nested.year"], "key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.won_games_at"]}),
+                    "meta" => inner_date_meta("seasons_nested.won_games_at", {"buckets_path" => ["seasons_nested.year"]}),
                     "buckets" => [
                       date_histogram_bucket(2020, 1, {"seasons_nested.year" => {
-                        "meta" => inner_terms_meta({"buckets_path" => ["seasons_nested.notes"], "key_path" => ["key"], "grouping_fields" => ["seasons_nested.year"]}),
+                        "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.notes"], "missing_values" => [MISSING_NUMERIC_PLACEHOLDER]}),
                         "doc_count_error_upper_bound" => 0,
                         "sum_other_doc_count" => 0,
                         "buckets" => [
-                          term_bucket(2020, 1, {"seasons_nested.notes" => {
-                            "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
+                          term_bucket(2020.0, 1, {"seasons_nested.notes" => {
+                            "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
                             "doc_count_error_upper_bound" => 0,
                             "sum_other_doc_count" => 0,
                             "buckets" => [
                               term_bucket("old rules", 1),
                               term_bucket("pandemic", 1)
                             ]
-                          }}.with_missing_value_bucket(0))
+                          }})
                         ]
-                      }}.with_missing_value_bucket(0, {"seasons_nested.notes" => {
-                        "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
-                        "doc_count_error_upper_bound" => 0,
-                        "sum_other_doc_count" => 0,
-                        "buckets" => []
-                      }}.with_missing_value_bucket(0)))
+                      }})
                     ]
                   }}.with_missing_value_bucket(0, {"seasons_nested.year" => {
-                    "meta" => inner_terms_meta({"buckets_path" => ["seasons_nested.notes"], "key_path" => ["key"], "grouping_fields" => ["seasons_nested.year"]}),
+                    "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.notes"], "missing_values" => [MISSING_NUMERIC_PLACEHOLDER]}),
                     "doc_count_error_upper_bound" => 0,
                     "sum_other_doc_count" => 0,
                     "buckets" => []
-                  }}.with_missing_value_bucket(0, {"seasons_nested.notes" => {
-                    "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
-                    "doc_count_error_upper_bound" => 0,
-                    "sum_other_doc_count" => 0,
-                    "buckets" => []
-                  }}.with_missing_value_bucket(0)))),
+                  }})),
                   date_histogram_bucket(2021, 1, {"seasons_nested.won_games_at" => {
-                    "meta" => inner_date_meta({"buckets_path" => ["seasons_nested.year"], "key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.won_games_at"]}),
+                    "meta" => inner_date_meta("seasons_nested.won_games_at", {"buckets_path" => ["seasons_nested.year"]}),
                     "buckets" => [
                       date_histogram_bucket(2021, 1, {"seasons_nested.year" => {
-                        "meta" => inner_terms_meta({"buckets_path" => ["seasons_nested.notes"], "key_path" => ["key"], "grouping_fields" => ["seasons_nested.year"]}),
+                        "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.notes"], "missing_values" => [MISSING_NUMERIC_PLACEHOLDER]}),
                         "doc_count_error_upper_bound" => 0,
                         "sum_other_doc_count" => 0,
                         "buckets" => [
-                          term_bucket(2021, 1, {"seasons_nested.notes" => {
-                            "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
+                          term_bucket(2021.0, 1, {"seasons_nested.notes" => {
+                            "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
                             "doc_count_error_upper_bound" => 0,
                             "sum_other_doc_count" => 0,
                             "buckets" => [
                               term_bucket("old rules", 1)
                             ]
-                          }}.with_missing_value_bucket(0))
+                          }})
                         ]
-                      }}.with_missing_value_bucket(0, {"seasons_nested.notes" => {
-                        "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
-                        "doc_count_error_upper_bound" => 0,
-                        "sum_other_doc_count" => 0,
-                        "buckets" => []
-                      }}.with_missing_value_bucket(0)))
+                      }})
                     ]
                   }}.with_missing_value_bucket(0, {"seasons_nested.year" => {
-                    "meta" => inner_terms_meta({"buckets_path" => ["seasons_nested.notes"], "key_path" => ["key"], "grouping_fields" => ["seasons_nested.year"]}),
+                    "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.notes"], "missing_values" => [MISSING_NUMERIC_PLACEHOLDER]}),
                     "doc_count_error_upper_bound" => 0,
                     "sum_other_doc_count" => 0,
                     "buckets" => []
-                  }}.with_missing_value_bucket(0, {"seasons_nested.notes" => {
-                    "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
-                    "doc_count_error_upper_bound" => 0,
-                    "sum_other_doc_count" => 0,
-                    "buckets" => []
-                  }}.with_missing_value_bucket(0)))),
+                  }})),
                   date_histogram_bucket(2022, 2, {"seasons_nested.won_games_at" => {
-                    "meta" => inner_date_meta({"buckets_path" => ["seasons_nested.year"], "key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.won_games_at"]}),
+                    "meta" => inner_date_meta("seasons_nested.won_games_at", {"buckets_path" => ["seasons_nested.year"]}),
                     "buckets" => [
                       date_histogram_bucket(2022, 2, {"seasons_nested.year" => {
-                        "meta" => inner_terms_meta({"buckets_path" => ["seasons_nested.notes"], "key_path" => ["key"], "grouping_fields" => ["seasons_nested.year"]}),
+                        "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.notes"], "missing_values" => [MISSING_NUMERIC_PLACEHOLDER]}),
                         "doc_count_error_upper_bound" => 0,
                         "sum_other_doc_count" => 0,
                         "buckets" => [
-                          term_bucket(2022, 2, {"seasons_nested.notes" => {
-                            "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
+                          term_bucket(2022.0, 2, {"seasons_nested.notes" => {
+                            "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
                             "doc_count_error_upper_bound" => 0,
                             "sum_other_doc_count" => 0,
                             "buckets" => [
                               term_bucket("new rules", 2)
                             ]
-                          }}.with_missing_value_bucket(0))
+                          }})
                         ]
-                      }}.with_missing_value_bucket(0, {"seasons_nested.notes" => {
-                        "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
-                        "doc_count_error_upper_bound" => 0,
-                        "sum_other_doc_count" => 0,
-                        "buckets" => []
-                      }}.with_missing_value_bucket(0)))
+                      }})
                     ]
                   }}.with_missing_value_bucket(0, {"seasons_nested.year" => {
-                    "meta" => inner_terms_meta({"buckets_path" => ["seasons_nested.notes"], "key_path" => ["key"], "grouping_fields" => ["seasons_nested.year"]}),
+                    "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.notes"], "missing_values" => [MISSING_NUMERIC_PLACEHOLDER]}),
                     "doc_count_error_upper_bound" => 0,
                     "sum_other_doc_count" => 0,
                     "buckets" => []
-                  }}.with_missing_value_bucket(0, {"seasons_nested.notes" => {
-                    "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
-                    "doc_count_error_upper_bound" => 0,
-                    "sum_other_doc_count" => 0,
-                    "buckets" => []
-                  }}.with_missing_value_bucket(0))))
+                  }}))
                 ]
               }
             }.with_missing_value_bucket(0, {"seasons_nested.won_games_at" => {
-              "meta" => inner_date_meta({"buckets_path" => ["seasons_nested.year"], "key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.won_games_at"]}),
+              "meta" => inner_date_meta("seasons_nested.won_games_at", {"buckets_path" => ["seasons_nested.year"]}),
               "buckets" => []
             }}.with_missing_value_bucket(0, {"seasons_nested.year" => {
-              "meta" => inner_terms_meta({"buckets_path" => ["seasons_nested.notes"], "key_path" => ["key"], "grouping_fields" => ["seasons_nested.year"]}),
+              "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.notes"], "missing_values" => [MISSING_NUMERIC_PLACEHOLDER]}),
               "doc_count_error_upper_bound" => 0,
               "sum_other_doc_count" => 0,
               "buckets" => []
-            }}.with_missing_value_bucket(0, {"seasons_nested.notes" => {
-              "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.notes"]}),
-              "doc_count_error_upper_bound" => 0,
-              "sum_other_doc_count" => 0,
-              "buckets" => []
-            }}.with_missing_value_bucket(0))))
+            }}))
           }])
         end
 
@@ -990,7 +916,7 @@ module ElasticGraph
           query = aggregation_query_of(name: "teams", sub_aggregations: [
             nested_sub_aggregation_of(path_in_index: ["seasons_nested"], query: sub_aggregation_query_of(
               name: "seasons_nested",
-              groupings: [field_term_grouping_of("seasons_nested", "year")],
+              groupings: [field_term_grouping_of("seasons_nested", "year", missing_value_placeholder: MISSING_NUMERIC_PLACEHOLDER)],
               filter: {"year" => {"gt" => 2020}}
             ))
           ])
@@ -1006,7 +932,7 @@ module ElasticGraph
               "seasons_nested:filtered" => {
                 "doc_count" => 3,
                 "seasons_nested.year" => {
-                  "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.year"], "key_path" => ["key"]}),
+                  "meta" => inner_terms_meta("seasons_nested.year", {"missing_values" => [MISSING_NUMERIC_PLACEHOLDER]}),
                   "buckets" => [
                     term_bucket(2022, 2),
                     term_bucket(2021, 1)
@@ -1014,7 +940,7 @@ module ElasticGraph
                   "doc_count_error_upper_bound" => 0,
                   "sum_other_doc_count" => 0
                 }
-              }.with_missing_value_bucket(0)
+              }
             }
           }])
         end
@@ -1053,7 +979,7 @@ module ElasticGraph
               nested_sub_aggregation_of(path_in_index: ["seasons_nested"], query: sub_aggregation_query_of(
                 name: "seasons_nested",
                 needs_doc_count_error: needs_doc_count_error,
-                groupings: [field_term_grouping_of("seasons_nested", "year")]
+                groupings: [field_term_grouping_of("seasons_nested", "year", missing_value_placeholder: MISSING_NUMERIC_PLACEHOLDER)]
               ))
             ])
 
@@ -1090,7 +1016,7 @@ module ElasticGraph
               ],
               groupings: [
                 date_histogram_grouping_of("seasons_nested", "started_at", "year"),
-                field_term_grouping_of("seasons_nested", "year"),
+                field_term_grouping_of("seasons_nested", "year", missing_value_placeholder: MISSING_NUMERIC_PLACEHOLDER),
                 field_term_grouping_of("seasons_nested", "notes")
               ]
             ))

--- a/elasticgraph-graphql/spec/support/aggregations_helpers.rb
+++ b/elasticgraph-graphql/spec/support/aggregations_helpers.rb
@@ -85,9 +85,9 @@ module ElasticGraph
       GraphQL::Aggregation::ScriptTermGrouping.new(field_path: field_path, script_id: script_id, params: params)
     end
 
-    def field_term_grouping_of(*field_names_in_index, field_names_in_graphql_query: field_names_in_index)
+    def field_term_grouping_of(*field_names_in_index, field_names_in_graphql_query: field_names_in_index, missing_value_placeholder: MISSING_STRING_PLACEHOLDER_VALUE)
       field_path = build_field_path(names_in_index: field_names_in_index, names_in_graphql_query: field_names_in_graphql_query)
-      GraphQL::Aggregation::FieldTermGrouping.new(field_path: field_path)
+      GraphQL::Aggregation::FieldTermGrouping.new(field_path: field_path, missing_value_placeholder: missing_value_placeholder)
     end
 
     def nested_sub_aggregation_of(path_in_index: nil, query: nil, path_in_graphql_query: path_in_index)

--- a/elasticgraph-graphql/spec/support/sub_aggregation_support.rb
+++ b/elasticgraph-graphql/spec/support/sub_aggregation_support.rb
@@ -16,12 +16,20 @@ module ElasticGraph
           {"size" => size, "adapter" => grouping_adapter.meta_name}.merge(hash)
         end
 
-        def inner_terms_meta(hash = {})
-          {"merge_into_bucket" => {}}.merge(hash)
+        def inner_terms_meta(grouping_fields, hash = {})
+          {
+            "grouping_fields" => Array(grouping_fields),
+            "key_path" => ["key"],
+            "merge_into_bucket" => {}
+          }.merge(hash)
         end
 
-        def inner_date_meta(hash = {})
-          {"merge_into_bucket" => {"doc_count_error_upper_bound" => 0}}.merge(hash)
+        def inner_date_meta(grouping_fields, hash = {})
+          {
+            "grouping_fields" => Array(grouping_fields),
+            "key_path" => ["key_as_string"],
+            "merge_into_bucket" => {"doc_count_error_upper_bound" => 0}
+          }.merge(hash)
         end
 
         define_method :sub_aggregation_query_of do |**options|

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_adapter_spec.rb
@@ -501,7 +501,7 @@ module ElasticGraph
                 nested_sub_aggregation_of(path_in_index: ["seasons_nested"], query: sub_aggregation_query_of(
                   name: "seasons_nested",
                   groupings: [
-                    field_term_grouping_of("seasons_nested", "year"),
+                    field_term_grouping_of("seasons_nested", "year", missing_value_placeholder: MISSING_NUMERIC_PLACEHOLDER),
                     field_term_grouping_of("seasons_nested", "notes", field_names_in_graphql_query: ["seasons_nested", "note"]),
                     date_histogram_grouping_of("seasons_nested", "started_at", "year", field_names_in_graphql_query: ["seasons_nested", "started_at", "as_date_time"])
                   ],

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/sub_aggregations_with_non_composite_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/sub_aggregations_with_non_composite_adapter_spec.rb
@@ -26,7 +26,7 @@ module ElasticGraph
                 "meta" => outer_meta({"buckets_path" => ["seasons_nested.started_at.as_date_time"]}),
                 "doc_count" => 6,
                 "seasons_nested.started_at.as_date_time" => {
-                  "meta" => inner_date_meta({"grouping_fields" => ["seasons_nested.started_at.as_date_time"], "key_path" => ["key_as_string"]}),
+                  "meta" => inner_date_meta("seasons_nested.started_at.as_date_time"),
                   "doc_count_error_upper_bound" => 0,
                   "sum_other_doc_count" => 0,
                   "buckets" => [
@@ -68,7 +68,7 @@ module ElasticGraph
                 "meta" => outer_meta({"buckets_path" => ["seasons_nested.year"]}),
                 "doc_count" => 4,
                 "seasons_nested.year" => {
-                  "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.year"], "key_path" => ["key"]}),
+                  "meta" => inner_terms_meta("seasons_nested.year"),
                   "doc_count_error_upper_bound" => 0,
                   "sum_other_doc_count" => 0,
                   "buckets" => [
@@ -128,7 +128,7 @@ module ElasticGraph
                   "meta" => outer_meta({"buckets_path" => ["seasons_nested.year"]}, size: first),
                   "doc_count" => 4,
                   "seasons_nested.year" => {
-                    "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.year"], "key_path" => ["key"]}),
+                    "meta" => inner_terms_meta("seasons_nested.year"),
                     "doc_count_error_upper_bound" => 0,
                     "sum_other_doc_count" => 0,
                     "buckets" => [
@@ -216,7 +216,7 @@ module ElasticGraph
                 "meta" => outer_meta({"buckets_path" => ["seasons_nested.year"]}),
                 "doc_count" => 4,
                 "seasons_nested.year" => {
-                  "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.year"], "key_path" => ["key"]}),
+                  "meta" => inner_terms_meta("seasons_nested.year"),
                   "doc_count_error_upper_bound" => 0,
                   "sum_other_doc_count" => 0,
                   "buckets" => [
@@ -271,7 +271,7 @@ module ElasticGraph
                 "meta" => outer_meta({"buckets_path" => ["seasons_nested.was_shortened"]}),
                 "doc_count" => 6,
                 "seasons_nested.was_shortened" => {
-                  "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.was_shortened"], "key_path" => ["key"]}),
+                  "meta" => inner_terms_meta("seasons_nested.was_shortened"),
                   "doc_count_error_upper_bound" => 0,
                   "sum_other_doc_count" => 0,
                   "buckets" => [
@@ -326,7 +326,7 @@ module ElasticGraph
                   "meta" => outer_meta({"buckets_path" => ["seasons_nested.year"]}),
                   "doc_count" => 4,
                   "seasons_nested.year" => {
-                    "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.year"], "key_path" => ["key"]}),
+                    "meta" => inner_terms_meta("seasons_nested.year"),
                     "doc_count_error_upper_bound" => 0,
                     "sum_other_doc_count" => 0,
                     "buckets" => [
@@ -385,7 +385,7 @@ module ElasticGraph
                 "seasons_nested:filtered" => {
                   "doc_count" => 5,
                   "seasons_nested.year" => {
-                    "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.year"], "key_path" => ["key"]}),
+                    "meta" => inner_terms_meta("seasons_nested.year"),
                     "doc_count_error_upper_bound" => 0,
                     "sum_other_doc_count" => 0,
                     "buckets" => [
@@ -432,7 +432,7 @@ module ElasticGraph
                 "meta" => outer_meta({"buckets_path" => ["seasons_nested.year"]}),
                 "doc_count" => 4,
                 "seasons_nested.year" => {
-                  "meta" => inner_terms_meta({"buckets_path" => ["seasons_nested.count"], "grouping_fields" => ["seasons_nested.year"], "key_path" => ["key"]}),
+                  "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.count"]}),
                   "doc_count_error_upper_bound" => 0,
                   "sum_other_doc_count" => 0,
                   "buckets" => [
@@ -442,7 +442,7 @@ module ElasticGraph
                       "doc_count_error_upper_bound" => 0,
                       "sum_other_doc_count" => 0,
                       "seasons_nested.count" => {
-                        "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.count"], "key_path" => ["key"]}),
+                        "meta" => inner_terms_meta("seasons_nested.count"),
                         "buckets" => [{"key" => 3, "doc_count" => 2}]
                       }
                     }.with_missing_value_bucket(0),
@@ -452,7 +452,7 @@ module ElasticGraph
                       "doc_count_error_upper_bound" => 0,
                       "sum_other_doc_count" => 0,
                       "seasons_nested.count" => {
-                        "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.count"], "key_path" => ["key"]}),
+                        "meta" => inner_terms_meta("seasons_nested.count"),
                         "buckets" => [{"key" => 4, "doc_count" => 1}]
                       }
                     }.with_missing_value_bucket(0),
@@ -462,7 +462,7 @@ module ElasticGraph
                       "doc_count_error_upper_bound" => 0,
                       "sum_other_doc_count" => 0,
                       "seasons_nested.count" => {
-                        "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.count"], "key_path" => ["key"]}),
+                        "meta" => inner_terms_meta("seasons_nested.count"),
                         "buckets" => [{"key" => 1, "doc_count" => 1}]
                       }
                     }.with_missing_value_bucket(0)
@@ -509,7 +509,7 @@ module ElasticGraph
                 "meta" => outer_meta({"buckets_path" => ["seasons_nested.year_and_count"]}),
                 "doc_count" => 4,
                 "seasons_nested.year_and_count" => {
-                  "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.year", "seasons_nested.count"], "key_path" => ["key"]}),
+                  "meta" => inner_terms_meta(["seasons_nested.year", "seasons_nested.count"]),
                   "doc_count_error_upper_bound" => 0,
                   "sum_other_doc_count" => 0,
                   "buckets" => [
@@ -564,7 +564,7 @@ module ElasticGraph
                 "meta" => outer_meta({"buckets_path" => ["seasons_nested.year"]}, size: 3),
                 "doc_count" => 10,
                 "seasons_nested.year" => {
-                  "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.year"], "key_path" => ["key"]}),
+                  "meta" => inner_terms_meta("seasons_nested.year"),
                   "doc_count_error_upper_bound" => 0,
                   "sum_other_doc_count" => 0,
                   "buckets" => [
@@ -623,7 +623,7 @@ module ElasticGraph
                 "meta" => outer_meta({"buckets_path" => ["seasons_nested.note"]}, size: 2),
                 "doc_count" => 6,
                 "seasons_nested.note" => {
-                  "meta" => inner_terms_meta({"buckets_path" => ["seasons_nested.record.losses"], "grouping_fields" => ["seasons_nested.note"], "key_path" => ["key"]}),
+                  "meta" => inner_terms_meta("seasons_nested.note", {"buckets_path" => ["seasons_nested.record.losses"]}),
                   "doc_count_error_upper_bound" => 0,
                   "sum_other_doc_count" => 0,
                   "buckets" => [
@@ -632,7 +632,7 @@ module ElasticGraph
                       "doc_count" => 2,
                       "doc_count_error_upper_bound" => 0,
                       "seasons_nested.record.losses" => {
-                        "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.record.losses"]}),
+                        "meta" => inner_terms_meta("seasons_nested.record.losses"),
                         "doc_count_error_upper_bound" => 0,
                         "sum_other_doc_count" => 0,
                         "buckets" => [
@@ -647,7 +647,7 @@ module ElasticGraph
                       "doc_count" => 1,
                       "doc_count_error_upper_bound" => 0,
                       "seasons_nested.record.losses" => {
-                        "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.record.losses"]}),
+                        "meta" => inner_terms_meta("seasons_nested.record.losses"),
                         "doc_count_error_upper_bound" => 0,
                         "sum_other_doc_count" => 0,
                         "buckets" => [
@@ -659,10 +659,10 @@ module ElasticGraph
                   ]
                 },
                 "seasons_nested.note:m" => {
-                  "meta" => inner_terms_meta({"buckets_path" => ["seasons_nested.record.losses"], "grouping_fields" => ["seasons_nested.note"], "key_path" => ["key"]}),
+                  "meta" => inner_terms_meta("seasons_nested.note", {"buckets_path" => ["seasons_nested.record.losses"]}),
                   "doc_count" => 3,
                   "seasons_nested.record.losses" => {
-                    "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.record.losses"]}),
+                    "meta" => inner_terms_meta("seasons_nested.record.losses"),
                     "doc_count_error_upper_bound" => 0,
                     "sum_other_doc_count" => 0,
                     "buckets" => [
@@ -708,7 +708,7 @@ module ElasticGraph
                 "meta" => outer_meta({"buckets_path" => ["seasons_nested.year"]}, size: 3),
                 "doc_count" => 21,
                 "seasons_nested.year" => {
-                  "meta" => inner_terms_meta({"buckets_path" => ["seasons_nested.count"], "grouping_fields" => ["seasons_nested.year"], "key_path" => ["key"]}),
+                  "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.count"]}),
                   "doc_count_error_upper_bound" => 0,
                   "sum_other_doc_count" => 0,
                   "buckets" => [
@@ -718,7 +718,7 @@ module ElasticGraph
                       "doc_count_error_upper_bound" => 0,
                       "sum_other_doc_count" => 0,
                       "seasons_nested.count" => {
-                        "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.count"], "key_path" => ["key"]}),
+                        "meta" => inner_terms_meta("seasons_nested.count"),
                         "buckets" => [
                           {"key" => 1, "doc_count" => 4}
                         ]
@@ -730,7 +730,7 @@ module ElasticGraph
                       "doc_count_error_upper_bound" => 0,
                       "sum_other_doc_count" => 0,
                       "seasons_nested.count" => {
-                        "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.count"], "key_path" => ["key"]}),
+                        "meta" => inner_terms_meta("seasons_nested.count"),
                         "buckets" => [
                           {"key" => 1, "doc_count" => 4},
                           {"key" => 3, "doc_count" => 4}
@@ -743,7 +743,7 @@ module ElasticGraph
                       "doc_count_error_upper_bound" => 0,
                       "sum_other_doc_count" => 0,
                       "seasons_nested.count" => {
-                        "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.count"], "key_path" => ["key"]}),
+                        "meta" => inner_terms_meta("seasons_nested.count"),
                         "buckets" => [
                           {"key" => 4, "doc_count" => 9}
                         ]
@@ -792,7 +792,7 @@ module ElasticGraph
                 "meta" => outer_meta({"buckets_path" => ["seasons_nested.year_and_count"]}, size: 3),
                 "doc_count" => 21,
                 "seasons_nested.year_and_count" => {
-                  "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.year", "seasons_nested.count"], "key_path" => ["key"]}),
+                  "meta" => inner_terms_meta(["seasons_nested.year", "seasons_nested.count"]),
                   "doc_count_error_upper_bound" => 0,
                   "sum_other_doc_count" => 0,
                   "buckets" => [
@@ -851,7 +851,7 @@ module ElasticGraph
                 "meta" => outer_meta({"buckets_path" => ["seasons_nested.started_at.as_date_time"]}),
                 "doc_count" => 6,
                 "seasons_nested.started_at.as_date_time" => {
-                  "meta" => inner_date_meta({"grouping_fields" => ["seasons_nested.started_at.as_date_time"], "key_path" => ["key_as_string"]}),
+                  "meta" => inner_date_meta("seasons_nested.started_at.as_date_time"),
                   "doc_count_error_upper_bound" => 0,
                   "sum_other_doc_count" => 0,
                   "buckets" => [
@@ -910,7 +910,7 @@ module ElasticGraph
                 "meta" => outer_meta({"buckets_path" => ["seasons_nested.year"]}),
                 "doc_count" => 18,
                 "seasons_nested.year" => {
-                  "meta" => inner_terms_meta({"buckets_path" => ["seasons_nested.started_at.as_date_time"], "key_path" => ["key"], "grouping_fields" => ["seasons_nested.year"]}),
+                  "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.started_at.as_date_time"]}),
                   "doc_count_error_upper_bound" => 0,
                   "sum_other_doc_count" => 0,
                   "buckets" => [
@@ -918,14 +918,14 @@ module ElasticGraph
                       "key" => 2020,
                       "doc_count" => 11,
                       "seasons_nested.started_at.as_date_time" => {
-                        "meta" => inner_date_meta({"buckets_path" => ["seasons_nested.won_games_at"], "key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.started_at.as_date_time"]}),
+                        "meta" => inner_date_meta("seasons_nested.started_at.as_date_time", {"buckets_path" => ["seasons_nested.won_games_at"]}),
                         "buckets" => [
                           {
                             "key_as_string" => "2020-01-01T00:00:00.000Z",
                             "key" => 1577836800000,
                             "doc_count" => 11,
                             "seasons_nested.won_games_at" => {
-                              "meta" => inner_date_meta({"key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.won_game_at.as_date_time"]}),
+                              "meta" => inner_date_meta("seasons_nested.won_game_at.as_date_time"),
                               "buckets" => [
                                 {
                                   "key_as_string" => "2020-01-01T00:00:00.000Z",
@@ -947,14 +947,14 @@ module ElasticGraph
                       "key" => 2019,
                       "doc_count" => 7,
                       "seasons_nested.started_at.as_date_time" => {
-                        "meta" => inner_date_meta({"buckets_path" => ["seasons_nested.won_games_at"], "key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.started_at.as_date_time"]}),
+                        "meta" => inner_date_meta("seasons_nested.started_at.as_date_time", {"buckets_path" => ["seasons_nested.won_games_at"]}),
                         "buckets" => [
                           {
                             "key_as_string" => "2019-01-01T00:00:00.000Z",
                             "key" => 1546300800000,
                             "doc_count" => 4,
                             "seasons_nested.won_games_at" => {
-                              "meta" => inner_date_meta({"key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.won_game_at.as_date_time"]}),
+                              "meta" => inner_date_meta("seasons_nested.won_game_at.as_date_time"),
                               "buckets" => [
                                 {
                                   "key_as_string" => "2019-01-01T00:00:00.000Z",
@@ -969,7 +969,7 @@ module ElasticGraph
                             "key" => 1609459200000,
                             "doc_count" => 3,
                             "seasons_nested.won_games_at" => {
-                              "meta" => inner_date_meta({"key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.won_game_at.as_date_time"]}),
+                              "meta" => inner_date_meta("seasons_nested.won_game_at.as_date_time"),
                               "buckets" => [
                                 {
                                   "key_as_string" => "2021-01-01T00:00:00.000Z",
@@ -993,21 +993,21 @@ module ElasticGraph
                 "meta" => outer_meta({"buckets_path" => ["seasons_nested.started_at.as_date_time"]}),
                 "doc_count" => 18,
                 "seasons_nested.started_at.as_date_time" => {
-                  "meta" => inner_date_meta({"buckets_path" => ["seasons_nested.won_games_at"], "key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.started_at.as_date_time"]}),
+                  "meta" => inner_date_meta("seasons_nested.started_at.as_date_time", {"buckets_path" => ["seasons_nested.won_games_at"]}),
                   "buckets" => [
                     {
                       "key_as_string" => "2019-01-01T00:00:00.000Z",
                       "key" => 1546300800000,
                       "doc_count" => 4,
                       "seasons_nested.won_games_at" => {
-                        "meta" => inner_date_meta({"buckets_path" => ["seasons_nested.year"], "key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.won_game_at.as_date_time"]}),
+                        "meta" => inner_date_meta("seasons_nested.won_game_at.as_date_time", {"buckets_path" => ["seasons_nested.year"]}),
                         "buckets" => [
                           {
                             "key_as_string" => "2019-01-01T00:00:00.000Z",
                             "key" => 1546300800000,
                             "doc_count" => 4,
                             "seasons_nested.year" => {
-                              "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.year"]}),
+                              "meta" => inner_terms_meta("seasons_nested.year"),
                               "doc_count_error_upper_bound" => 0,
                               "sum_other_doc_count" => 0,
                               "buckets" => [
@@ -1026,14 +1026,14 @@ module ElasticGraph
                       "key" => 1577836800000,
                       "doc_count" => 2,
                       "seasons_nested.won_games_at" => {
-                        "meta" => inner_date_meta({"buckets_path" => ["seasons_nested.year"], "key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.won_game_at.as_date_time"]}),
+                        "meta" => inner_date_meta("seasons_nested.won_game_at.as_date_time", {"buckets_path" => ["seasons_nested.year"]}),
                         "buckets" => [
                           {
                             "key_as_string" => "2019-01-01T00:00:00.000Z",
                             "key" => 1546300800000,
                             "doc_count" => 5,
                             "seasons_nested.year" => {
-                              "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.year"]}),
+                              "meta" => inner_terms_meta("seasons_nested.year"),
                               "doc_count_error_upper_bound" => 0,
                               "sum_other_doc_count" => 0,
                               "buckets" => [
@@ -1049,7 +1049,7 @@ module ElasticGraph
                             "key" => 1577836800000,
                             "doc_count" => 6,
                             "seasons_nested.year" => {
-                              "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.year"]}),
+                              "meta" => inner_terms_meta("seasons_nested.year"),
                               "doc_count_error_upper_bound" => 0,
                               "sum_other_doc_count" => 0,
                               "buckets" => [
@@ -1068,14 +1068,14 @@ module ElasticGraph
                       "key" => 1609459200000,
                       "doc_count" => 1,
                       "seasons_nested.won_games_at" => {
-                        "meta" => inner_date_meta({"buckets_path" => ["seasons_nested.year"], "key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.won_game_at.as_date_time"]}),
+                        "meta" => inner_date_meta("seasons_nested.won_game_at.as_date_time", {"buckets_path" => ["seasons_nested.year"]}),
                         "buckets" => [
                           {
                             "key_as_string" => "2021-01-01T00:00:00.000Z",
                             "key" => 1609459200000,
                             "doc_count" => 3,
                             "seasons_nested.year" => {
-                              "meta" => inner_terms_meta({"key_path" => ["key"], "grouping_fields" => ["seasons_nested.year"]}),
+                              "meta" => inner_terms_meta("seasons_nested.year"),
                               "doc_count_error_upper_bound" => 0,
                               "sum_other_doc_count" => 0,
                               "buckets" => [
@@ -1167,7 +1167,7 @@ module ElasticGraph
                 "meta" => outer_meta({"buckets_path" => ["seasons_nested.started_at.as_date_time"]}, size: 3),
                 "doc_count" => 18,
                 "seasons_nested.started_at.as_date_time" => {
-                  "meta" => inner_date_meta({"grouping_fields" => ["seasons_nested.started_at.as_date_time"], "key_path" => ["key_as_string"]}),
+                  "meta" => inner_date_meta("seasons_nested.started_at.as_date_time"),
                   "doc_count_error_upper_bound" => 0,
                   "sum_other_doc_count" => 0,
                   "buckets" => [
@@ -1230,7 +1230,7 @@ module ElasticGraph
                 "meta" => outer_meta({"buckets_path" => ["seasons_nested.year"]}, size: 5),
                 "doc_count" => 18,
                 "seasons_nested.year" => {
-                  "meta" => inner_terms_meta({"buckets_path" => ["seasons_nested.started_at.as_date_time"], "key_path" => ["key"], "grouping_fields" => ["seasons_nested.year"]}),
+                  "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.started_at.as_date_time"]}),
                   "doc_count_error_upper_bound" => 0,
                   "sum_other_doc_count" => 0,
                   "buckets" => [
@@ -1238,14 +1238,14 @@ module ElasticGraph
                       "key" => 2020,
                       "doc_count" => 18,
                       "seasons_nested.started_at.as_date_time" => {
-                        "meta" => inner_date_meta({"buckets_path" => ["seasons_nested.won_games_at"], "key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.started_at.as_date_time"]}),
+                        "meta" => inner_date_meta("seasons_nested.started_at.as_date_time", {"buckets_path" => ["seasons_nested.won_games_at"]}),
                         "buckets" => [
                           {
                             "key_as_string" => "2020-01-01T00:00:00.000Z",
                             "key" => 1577836800000,
                             "doc_count" => 18,
                             "seasons_nested.won_games_at" => {
-                              "meta" => inner_date_meta({"key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.won_game_at.as_date_time"]}),
+                              "meta" => inner_date_meta("seasons_nested.won_game_at.as_date_time"),
                               "buckets" => [
                                 {
                                   "key_as_string" => "2019-01-01T00:00:00.000Z",
@@ -1277,14 +1277,14 @@ module ElasticGraph
                       "key" => 2019,
                       "doc_count" => 11,
                       "seasons_nested.started_at.as_date_time" => {
-                        "meta" => inner_date_meta({"buckets_path" => ["seasons_nested.won_games_at"], "key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.started_at.as_date_time"]}),
+                        "meta" => inner_date_meta("seasons_nested.started_at.as_date_time", {"buckets_path" => ["seasons_nested.won_games_at"]}),
                         "buckets" => [
                           {
                             "key_as_string" => "2019-01-01T00:00:00.000Z",
                             "key" => 1546300800000,
                             "doc_count" => 11,
                             "seasons_nested.won_games_at" => {
-                              "meta" => inner_date_meta({"key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.won_game_at.as_date_time"]}),
+                              "meta" => inner_date_meta("seasons_nested.won_game_at.as_date_time"),
                               "buckets" => [
                                 {
                                   "key_as_string" => "2019-01-01T00:00:00.000Z",
@@ -1299,7 +1299,7 @@ module ElasticGraph
                             "key" => 1609459200000,
                             "doc_count" => 2,
                             "seasons_nested.won_games_at" => {
-                              "meta" => inner_date_meta({"key_path" => ["key_as_string"], "grouping_fields" => ["seasons_nested.won_game_at.as_date_time"]}),
+                              "meta" => inner_date_meta("seasons_nested.won_game_at.as_date_time"),
                               "buckets" => [
                                 {
                                   "key_as_string" => "2021-01-01T00:00:00.000Z",

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/sub_aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/sub_aggregations_spec.rb
@@ -391,8 +391,8 @@ module ElasticGraph
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.notes"]}),
               "aggs" => {
                 "seasons_nested.notes" => {
-                  "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.notes"], "key_path" => ["key"]}),
-                  "terms" => terms({"field" => "seasons_nested.notes", "collect_mode" => "depth_first"}),
+                  "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
+                  "terms" => terms({"field" => "seasons_nested.notes", "collect_mode" => "depth_first", "missing" => MISSING_STRING_PLACEHOLDER_VALUE}),
                   "aggs" => {
                     "seasons_nested:seasons_nested.year:exact_min" => {
                       "min" => {"field" => "seasons_nested.year"}
@@ -405,7 +405,7 @@ module ElasticGraph
                     }
                   }
                 }
-              }.with_missing_value_agg
+              }
             }
           })
         end
@@ -424,7 +424,7 @@ module ElasticGraph
           ])])
 
           expect(datastore_body_of(query).dig(:aggs, "teams:seasons_nested", "aggs", "sea_nest.the_notes", "meta")).to eq(
-            inner_terms_meta({"grouping_fields" => ["sea_nest.the_notes"], "key_path" => ["key"]})
+            inner_terms_meta("sea_nest.the_notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]})
           )
         end
 
@@ -492,10 +492,10 @@ module ElasticGraph
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.year"]}),
               "aggs" => {
                 "seasons_nested.year" => {
-                  "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.year"], "key_path" => ["key"]}),
-                  "terms" => terms({"field" => "seasons_nested.year", "collect_mode" => "depth_first"})
+                  "meta" => inner_terms_meta("seasons_nested.year", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
+                  "terms" => terms({"field" => "seasons_nested.year", "collect_mode" => "depth_first", "missing" => MISSING_STRING_PLACEHOLDER_VALUE})
                 }
-              }.with_missing_value_agg
+              }
             }
           })
         end
@@ -514,16 +514,16 @@ module ElasticGraph
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.year"]}),
               "aggs" => {
                 "seasons_nested.year" => {
-                  "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.year"], "key_path" => ["key"], "buckets_path" => ["seasons_nested.notes"]}),
-                  "terms" => terms({"field" => "seasons_nested.year", "collect_mode" => "depth_first"}),
+                  "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.notes"], "missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
+                  "terms" => terms({"field" => "seasons_nested.year", "collect_mode" => "depth_first", "missing" => MISSING_STRING_PLACEHOLDER_VALUE}),
                   "aggs" => {
                     "seasons_nested.notes" => {
-                      "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.notes"], "key_path" => ["key"]}),
-                      "terms" => terms({"field" => "seasons_nested.notes", "collect_mode" => "depth_first"})
+                      "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
+                      "terms" => terms({"field" => "seasons_nested.notes", "collect_mode" => "depth_first", "missing" => MISSING_STRING_PLACEHOLDER_VALUE})
                     }
-                  }.with_missing_value_agg
+                  }
                 }
-              }.with_missing_value_agg
+              }
             }
           })
         end
@@ -543,10 +543,10 @@ module ElasticGraph
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.year"]}, size: 14),
               "aggs" => {
                 "seasons_nested.year" => {
-                  "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.year"], "key_path" => ["key"]}),
-                  "terms" => terms({"field" => "seasons_nested.year", "collect_mode" => "depth_first"}, size: 14)
+                  "meta" => inner_terms_meta("seasons_nested.year", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
+                  "terms" => terms({"field" => "seasons_nested.year", "collect_mode" => "depth_first", "missing" => MISSING_STRING_PLACEHOLDER_VALUE}, size: 14)
                 }
-              }.with_missing_value_agg
+              }
             }
           })
         end
@@ -569,16 +569,16 @@ module ElasticGraph
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.year"]}, size: 17),
               "aggs" => {
                 "seasons_nested.year" => {
-                  "meta" => inner_terms_meta({"buckets_path" => ["seasons_nested.notes"], "grouping_fields" => ["seasons_nested.year"], "key_path" => ["key"]}),
-                  "terms" => terms({"field" => "seasons_nested.year", "collect_mode" => "depth_first"}, size: 17),
+                  "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.notes"], "missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
+                  "terms" => terms({"field" => "seasons_nested.year", "collect_mode" => "depth_first", "missing" => MISSING_STRING_PLACEHOLDER_VALUE}, size: 17),
                   "aggs" => {
                     "seasons_nested.notes" => {
-                      "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.notes"], "key_path" => ["key"]}),
-                      "terms" => terms({"field" => "seasons_nested.notes", "collect_mode" => "depth_first"}, size: 17)
+                      "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
+                      "terms" => terms({"field" => "seasons_nested.notes", "collect_mode" => "depth_first", "missing" => MISSING_STRING_PLACEHOLDER_VALUE}, size: 17)
                     }
-                  }.with_missing_value_agg
+                  }
                 }
-              }.with_missing_value_agg
+              }
             }
           })
         end
@@ -596,7 +596,7 @@ module ElasticGraph
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.started_at"]}),
               "aggs" => {
                 "seasons_nested.started_at" => {
-                  "meta" => inner_date_meta({"grouping_fields" => ["seasons_nested.started_at"], "key_path" => ["key_as_string"]}),
+                  "meta" => inner_date_meta("seasons_nested.started_at"),
                   "date_histogram" => {
                     "calendar_interval" => "year",
                     "field" => "seasons_nested.started_at",
@@ -618,7 +618,7 @@ module ElasticGraph
           ])])
 
           expect(datastore_body_of(query).dig(:aggs, "teams:seasons_nested", "aggs", "sea_nest.started", "meta")).to eq(
-            inner_date_meta({"grouping_fields" => ["sea_nest.started"], "key_path" => ["key_as_string"]})
+            inner_date_meta("sea_nest.started")
           )
         end
 
@@ -635,7 +635,7 @@ module ElasticGraph
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.started_at"]}),
               "aggs" => {
                 "seasons_nested.started_at" => {
-                  "meta" => inner_date_meta({"grouping_fields" => ["seasons_nested.started_at"], "key_path" => ["key_as_string"]}),
+                  "meta" => inner_date_meta("seasons_nested.started_at"),
                   "date_histogram" => {
                     "calendar_interval" => "year",
                     "field" => "seasons_nested.started_at",
@@ -663,7 +663,7 @@ module ElasticGraph
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.started_at"]}),
               "aggs" => {
                 "seasons_nested.started_at" => {
-                  "meta" => inner_date_meta({"grouping_fields" => ["seasons_nested.started_at"], "buckets_path" => ["seasons_nested.won_games_at"], "key_path" => ["key_as_string"]}),
+                  "meta" => inner_date_meta("seasons_nested.started_at", {"buckets_path" => ["seasons_nested.won_games_at"]}),
                   "date_histogram" => {
                     "calendar_interval" => "year",
                     "field" => "seasons_nested.started_at",
@@ -673,7 +673,7 @@ module ElasticGraph
                   },
                   "aggs" => {
                     "seasons_nested.won_games_at" => {
-                      "meta" => inner_date_meta({"grouping_fields" => ["seasons_nested.won_games_at"], "key_path" => ["key_as_string"]}),
+                      "meta" => inner_date_meta("seasons_nested.won_games_at"),
                       "date_histogram" => {
                         "calendar_interval" => "year",
                         "field" => "seasons_nested.won_games_at",
@@ -703,7 +703,7 @@ module ElasticGraph
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.started_at"]}),
               "aggs" => {
                 "seasons_nested.started_at" => {
-                  "meta" => inner_date_meta({"grouping_fields" => ["seasons_nested.started_at"], "buckets_path" => ["seasons_nested.notes"], "key_path" => ["key_as_string"]}),
+                  "meta" => inner_date_meta("seasons_nested.started_at", {"buckets_path" => ["seasons_nested.notes"]}),
                   "date_histogram" => {
                     "calendar_interval" => "year",
                     "field" => "seasons_nested.started_at",
@@ -713,10 +713,10 @@ module ElasticGraph
                   },
                   "aggs" => {
                     "seasons_nested.notes" => {
-                      "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.notes"], "key_path" => ["key"]}),
-                      "terms" => terms({"field" => "seasons_nested.notes", "collect_mode" => "depth_first"})
+                      "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
+                      "terms" => terms({"field" => "seasons_nested.notes", "collect_mode" => "depth_first", "missing" => MISSING_STRING_PLACEHOLDER_VALUE})
                     }
-                  }.with_missing_value_agg
+                  }
                 }
               }.with_missing_value_agg
             }
@@ -738,7 +738,7 @@ module ElasticGraph
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.started_at"]}),
               "aggs" => {
                 "seasons_nested.started_at" => {
-                  "meta" => inner_date_meta({"grouping_fields" => ["seasons_nested.started_at"], "buckets_path" => ["seasons_nested.year"], "key_path" => ["key_as_string"]}),
+                  "meta" => inner_date_meta("seasons_nested.started_at", {"buckets_path" => ["seasons_nested.year"]}),
                   "date_histogram" => {
                     "calendar_interval" => "year",
                     "field" => "seasons_nested.started_at",
@@ -748,16 +748,16 @@ module ElasticGraph
                   },
                   "aggs" => {
                     "seasons_nested.year" => {
-                      "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.year"], "buckets_path" => ["seasons_nested.notes"], "key_path" => ["key"]}),
-                      "terms" => terms({"field" => "seasons_nested.year", "collect_mode" => "depth_first"}),
+                      "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.notes"], "missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
+                      "terms" => terms({"field" => "seasons_nested.year", "collect_mode" => "depth_first", "missing" => MISSING_STRING_PLACEHOLDER_VALUE}),
                       "aggs" => {
                         "seasons_nested.notes" => {
-                          "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.notes"], "key_path" => ["key"]}),
-                          "terms" => terms({"field" => "seasons_nested.notes", "collect_mode" => "depth_first"})
+                          "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
+                          "terms" => terms({"field" => "seasons_nested.notes", "collect_mode" => "depth_first", "missing" => MISSING_STRING_PLACEHOLDER_VALUE})
                         }
-                      }.with_missing_value_agg
+                      }
                     }
-                  }.with_missing_value_agg
+                  }
                 }
               }.with_missing_value_agg
             }
@@ -780,7 +780,7 @@ module ElasticGraph
               "meta" => outer_meta({"buckets_path" => ["seasons_nested.started_at"]}),
               "aggs" => {
                 "seasons_nested.started_at" => {
-                  "meta" => inner_date_meta({"grouping_fields" => ["seasons_nested.started_at"], "buckets_path" => ["seasons_nested.won_games_at"], "key_path" => ["key_as_string"]}),
+                  "meta" => inner_date_meta("seasons_nested.started_at", {"buckets_path" => ["seasons_nested.won_games_at"]}),
                   "date_histogram" => {
                     "calendar_interval" => "year",
                     "field" => "seasons_nested.started_at",
@@ -790,7 +790,7 @@ module ElasticGraph
                   },
                   "aggs" => {
                     "seasons_nested.won_games_at" => {
-                      "meta" => inner_date_meta({"grouping_fields" => ["seasons_nested.won_games_at"], "buckets_path" => ["seasons_nested.year"], "key_path" => ["key_as_string"]}),
+                      "meta" => inner_date_meta("seasons_nested.won_games_at", {"buckets_path" => ["seasons_nested.year"]}),
                       "date_histogram" => {
                         "calendar_interval" => "year",
                         "field" => "seasons_nested.won_games_at",
@@ -800,16 +800,16 @@ module ElasticGraph
                       },
                       "aggs" => {
                         "seasons_nested.year" => {
-                          "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.year"], "buckets_path" => ["seasons_nested.notes"], "key_path" => ["key"]}),
-                          "terms" => terms({"field" => "seasons_nested.year", "collect_mode" => "depth_first"}),
+                          "meta" => inner_terms_meta("seasons_nested.year", {"buckets_path" => ["seasons_nested.notes"], "missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
+                          "terms" => terms({"field" => "seasons_nested.year", "collect_mode" => "depth_first", "missing" => MISSING_STRING_PLACEHOLDER_VALUE}),
                           "aggs" => {
                             "seasons_nested.notes" => {
-                              "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.notes"], "key_path" => ["key"]}),
-                              "terms" => terms({"field" => "seasons_nested.notes", "collect_mode" => "depth_first"})
+                              "meta" => inner_terms_meta("seasons_nested.notes", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
+                              "terms" => terms({"field" => "seasons_nested.notes", "collect_mode" => "depth_first", "missing" => MISSING_STRING_PLACEHOLDER_VALUE})
                             }
-                          }.with_missing_value_agg
+                          }
                         }
-                      }.with_missing_value_agg
+                      }
                     }
                   }.with_missing_value_agg
                 }
@@ -838,10 +838,10 @@ module ElasticGraph
                   },
                   "aggs" => {
                     "seasons_nested.year" => {
-                      "meta" => inner_terms_meta({"grouping_fields" => ["seasons_nested.year"], "key_path" => ["key"]}),
-                      "terms" => terms({"field" => "seasons_nested.year", "collect_mode" => "depth_first"})
+                      "meta" => inner_terms_meta("seasons_nested.year", {"missing_values" => [MISSING_STRING_PLACEHOLDER_VALUE]}),
+                      "terms" => terms({"field" => "seasons_nested.year", "collect_mode" => "depth_first", "missing" => MISSING_STRING_PLACEHOLDER_VALUE})
                     }
-                  }.with_missing_value_agg
+                  }
                 }
               }
             }


### PR DESCRIPTION
This is 4th in a series of new pull requests that are working toward a new approach to handling missing values in subaggregations as described in #882. For an outline of the steps see the comment from @myronmarston [here](https://github.com/block/elasticgraph/pull/882#discussion_r2462223814).

This commit refactors the grouping logic to use the grouping_missing_value_placeholder from types, falling back to separate missing aggregations when no placeholder is defined.

Backward compatibility:
- When no placeholder is defined (returns nil), falls back to the old approach of creating separate missing aggregations
- This ensures existing behavior is preserved for types without placeholders

## Other PRs
Note PRs after the first one are on my fork since I don't currently have permissions to push to the block/elasticgraph repo (so I couldn't create stacked PRs on the block repo that are based on the branch from the prior PR).

[Phase 1: Add grouping_missing_value_placeholder runtime metadata](https://github.com/block/elasticgraph/pull/890)
[Phase 2: Infer grouping_missing_value_placeholder based on mapping_type](https://github.com/block/elasticgraph/pull/893)
[Phase 3: Wire up grouping_missing_value_placeholder in GraphQL layer](https://github.com/block/elasticgraph/pull/894)
[Phase 4: Use grouping_missing_value_placeholder in aggregation logic](https://github.com/block/elasticgraph/pull/895) (this PR)
