### PR TITLE
Remove 'zachbutler-squareup' from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 # The format is described: https://github.blog/2017-07-06-introducing-code-owners/
 
 # These owners will be the default owners for everything in the repo.
-*       @ayousufi @BrianSigafoos-SQ @bsorbo @jwils @jwondrusch @lancethomps @myronmarston @nicolewoch @thomasmahoney @zachbutler-squareup
+*       @ayousufi @BrianSigafoos-SQ @bsorbo @jwils @jwondrusch @lancethomps @myronmarston @nicolewoch @thomasmahoney
 
 # -----------------------------------------------
 # BELOW THIS LINE ARE TEMPLATES, UNUSED


### PR DESCRIPTION
I'm no longer in the maintainers group, just removing myself to clean up the list