### PR TITLE
Add union type support to the warehouse table

### DIFF
--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/api_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/api_extension.rb
@@ -9,7 +9,7 @@
 require "elastic_graph/warehouse/schema_definition/factory_extension"
 require "elastic_graph/warehouse/schema_definition/scalar_type_extension"
 require "elastic_graph/warehouse/schema_definition/enum_type_extension"
-require "elastic_graph/warehouse/schema_definition/object_and_interface_extension"
+require "elastic_graph/warehouse/schema_definition/object_interface_and_union_extension"
 
 module ElasticGraph
   module Warehouse

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/factory_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/factory_extension.rb
@@ -7,7 +7,7 @@
 # frozen_string_literal: true
 
 require "elastic_graph/warehouse/schema_definition/enum_type_extension"
-require "elastic_graph/warehouse/schema_definition/object_and_interface_extension"
+require "elastic_graph/warehouse/schema_definition/object_interface_and_union_extension"
 require "elastic_graph/warehouse/schema_definition/scalar_type_extension"
 
 module ElasticGraph
@@ -38,7 +38,7 @@ module ElasticGraph
         # @return [ElasticGraph::SchemaDefinition::SchemaElements::InterfaceType] the created interface type
         def new_interface_type(name)
           super(name) do |type|
-            type.extend ObjectAndInterfaceExtension
+            type.extend ObjectInterfaceAndUnionExtension
             # :nocov: -- currently all invocations have a block
             yield type if block_given?
             # :nocov:
@@ -52,7 +52,7 @@ module ElasticGraph
         # @return [ElasticGraph::SchemaDefinition::SchemaElements::ObjectType] the created object type
         def new_object_type(name)
           super(name) do |type|
-            type.extend ObjectAndInterfaceExtension
+            type.extend ObjectInterfaceAndUnionExtension
             # :nocov: -- currently all invocations have a block
             yield type if block_given?
             # :nocov:
@@ -67,6 +67,20 @@ module ElasticGraph
         def new_scalar_type(name)
           super(name) do |type|
             type.extend ScalarTypeExtension
+            # :nocov: -- currently all invocations have a block
+            yield type if block_given?
+            # :nocov:
+          end
+        end
+
+        # Creates a new union type with warehouse extensions.
+        #
+        # @param name [String] the name of the union type
+        # @yield [ElasticGraph::SchemaDefinition::SchemaElements::UnionType] the newly created union type
+        # @return [ElasticGraph::SchemaDefinition::SchemaElements::UnionType] the created union type
+        def new_union_type(name)
+          super(name) do |type|
+            type.extend ObjectInterfaceAndUnionExtension
             # :nocov: -- currently all invocations have a block
             yield type if block_given?
             # :nocov:

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rb
@@ -11,12 +11,15 @@ require "elastic_graph/warehouse/schema_definition/field_type_converter"
 module ElasticGraph
   module Warehouse
     module SchemaDefinition
-      # Extends {ElasticGraph::SchemaDefinition::SchemaElements::ObjectType} and
-      # {ElasticGraph::SchemaDefinition::SchemaElements::InterfaceType} to add warehouse column type conversion.
-      module ObjectAndInterfaceExtension
-        # Returns the warehouse column type representation for this object or interface type.
+      # Extends {ElasticGraph::SchemaDefinition::SchemaElements::ObjectType},
+      # {ElasticGraph::SchemaDefinition::SchemaElements::InterfaceType}, and
+      # {ElasticGraph::SchemaDefinition::SchemaElements::UnionType} to add warehouse column type conversion.
+      module ObjectInterfaceAndUnionExtension
+        # Returns the warehouse column type representation for this object, interface, or union type.
         #
         # @return [String] a STRUCT SQL type containing all subfields
+        # @note For union types, the STRUCT includes all fields from all subtypes, following the same pattern used
+        #   in the datastore mapping (see {ElasticGraph::SchemaDefinition::Indexing::FieldType::Union#to_mapping}).
         def to_warehouse_column_type
           subfields = indexing_fields_by_name_in_index.values.map(&:to_indexing_field).compact
 

--- a/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/factory_extension.rbs
+++ b/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/factory_extension.rbs
@@ -17,6 +17,10 @@ module ElasticGraph
         def new_scalar_type: (::String) ?{
           (::ElasticGraph::SchemaDefinition::SchemaElements::ScalarType) -> void
         } -> ::ElasticGraph::SchemaDefinition::SchemaElements::ScalarType
+
+        def new_union_type: (::String) ?{
+          (::ElasticGraph::SchemaDefinition::SchemaElements::UnionType) -> void
+        } -> ::ElasticGraph::SchemaDefinition::SchemaElements::UnionType
       end
     end
   end

--- a/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rbs
+++ b/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rbs
@@ -1,7 +1,7 @@
 module ElasticGraph
   module Warehouse
     module SchemaDefinition
-      module ObjectAndInterfaceExtension: ::ElasticGraph::SchemaDefinition::SchemaElements::TypeWithSubfields
+      module ObjectInterfaceAndUnionExtension: ::ElasticGraph::SchemaDefinition::SchemaElements::TypeWithSubfields
         def to_warehouse_column_type: () -> ::String
       end
     end

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension_spec.rb
@@ -11,7 +11,7 @@ require "elastic_graph/warehouse/schema_definition/api_extension"
 module ElasticGraph
   module Warehouse
     module SchemaDefinition
-      RSpec.describe ObjectAndInterfaceExtension, :warehouse_schema do
+      RSpec.describe ObjectInterfaceAndUnionExtension, :warehouse_schema do
         describe "object types" do
           it "converts object type to warehouse column type" do
             results = define_warehouse_schema do |s|
@@ -55,6 +55,28 @@ module ElasticGraph
             end
 
             expect(warehouse_column_type_for(results, "Identifiable")).to eq("STRUCT<id STRING, name STRING, price DOUBLE, __typename STRING>")
+          end
+        end
+
+        describe "union types" do
+          it "converts union type to warehouse column type" do
+            results = define_warehouse_schema do |s|
+              s.object_type "Card" do |t|
+                t.field "id", "ID"
+                t.field "last_four", "String"
+              end
+
+              s.object_type "BankAccount" do |t|
+                t.field "id", "ID"
+                t.field "account_number", "String"
+              end
+
+              s.union_type "PaymentMethod" do |t|
+                t.subtypes "Card", "BankAccount"
+              end
+            end
+
+            expect(warehouse_column_type_for(results, "PaymentMethod")).to eq("STRUCT<id STRING, last_four STRING, account_number STRING, __typename STRING>")
           end
         end
       end


### PR DESCRIPTION
A union type is just a struct with the union of the fields in the union type. Similar to the elasticsearch sechema we also include a meta field that specifies what the type was