### PR TITLE
Wire warehouse schema generation.

### DIFF
--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/factory_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/factory_extension.rb
@@ -8,7 +8,9 @@
 
 require "elastic_graph/warehouse/schema_definition/enum_type_extension"
 require "elastic_graph/warehouse/schema_definition/object_interface_and_union_extension"
+require "elastic_graph/warehouse/schema_definition/results_extension"
 require "elastic_graph/warehouse/schema_definition/scalar_type_extension"
+require "elastic_graph/warehouse/schema_definition/schema_artifact_manager_extension"
 
 module ElasticGraph
   module Warehouse
@@ -84,6 +86,24 @@ module ElasticGraph
             # :nocov: -- currently all invocations have a block
             yield type if block_given?
             # :nocov:
+          end
+        end
+
+        # Creates a new Results instance with warehouse extensions.
+        #
+        # @return [ElasticGraph::SchemaDefinition::Results] the created results instance
+        def new_results
+          super.tap do |results|
+            results.extend ResultsExtension
+          end
+        end
+
+        # Creates a new SchemaArtifactManager instance with warehouse extensions.
+        #
+        # @return [ElasticGraph::SchemaDefinition::SchemaArtifactManager] the created artifact manager
+        def new_schema_artifact_manager(...)
+          super.tap do |manager|
+            manager.extend SchemaArtifactManagerExtension
           end
         end
       end

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/field_type_converter.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/field_type_converter.rb
@@ -17,15 +17,17 @@ module ElasticGraph
         # the resolved type's `to_warehouse_column_type` method. Supports
         # nested arrays like `[[String!]]` which become `ARRAY<ARRAY<STRING>>`.
         #
-        # @param field_type [Object] the field type to convert
+        # @param field_type [ElasticGraph::SchemaDefinition::SchemaElements::TypeReference] the field type to convert
         # @return [String] the warehouse column type (e.g., "STRING", "ARRAY<INT>", "ARRAY<ARRAY<DOUBLE>>")
+        # @raise [ArgumentError] if the type cannot be resolved to a warehouse column type
         def self.convert(field_type)
           unwrapped_type = field_type.unwrap_non_null
 
           if unwrapped_type.list?
             "ARRAY<#{convert(unwrapped_type.unwrap_list)}>"
           else
-            unwrapped_type.resolved.to_warehouse_column_type
+            resolved_type = unwrapped_type.resolved
+            resolved_type.to_warehouse_column_type
           end
         end
       end

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rb
@@ -7,14 +7,26 @@
 # frozen_string_literal: true
 
 require "elastic_graph/warehouse/schema_definition/field_type_converter"
+require "elastic_graph/warehouse/schema_definition/warehouse_table"
 
 module ElasticGraph
   module Warehouse
     module SchemaDefinition
       # Extends {ElasticGraph::SchemaDefinition::SchemaElements::ObjectType},
       # {ElasticGraph::SchemaDefinition::SchemaElements::InterfaceType}, and
-      # {ElasticGraph::SchemaDefinition::SchemaElements::UnionType} to add warehouse column type conversion.
+      # {ElasticGraph::SchemaDefinition::SchemaElements::UnionType} to add warehouse table and column type definition support.
       module ObjectInterfaceAndUnionExtension
+        # @dynamic warehouse_table_def
+        attr_reader :warehouse_table_def
+
+        # Defines a warehouse table for this object or interface type.
+        #
+        # @param name [String] name of the warehouse table
+        # @return [void]
+        def warehouse_table(name)
+          @warehouse_table_def = WarehouseTable.new(name, self)
+        end
+
         # Returns the warehouse column type representation for this object, interface, or union type.
         #
         # @return [String] a STRUCT SQL type containing all subfields
@@ -25,7 +37,7 @@ module ElasticGraph
 
           struct_field_expressions = subfields.map do |subfield|
             warehouse_type = FieldTypeConverter.convert(subfield.type)
-            "#{subfield.name} #{warehouse_type}"
+            "#{subfield.name_in_index} #{warehouse_type}"
           end.join(", ")
 
           "STRUCT<#{struct_field_expressions}>"

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/results_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/results_extension.rb
@@ -1,0 +1,40 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/warehouse/schema_definition/warehouse_table"
+
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      # Extension module for {ElasticGraph::SchemaDefinition::Results} that adds warehouse configuration support.
+      #
+      # @private
+      module ResultsExtension
+        # Returns the warehouse configuration generated from the schema definition.
+        #
+        # @return [Hash<String, Hash>] a hash mapping table names to their configuration
+        def warehouse_config
+          @warehouse_config ||= generate_warehouse_config
+        end
+
+        private
+
+        # Generates warehouse configuration from object types that have warehouse table definitions.
+        #
+        # @return [Hash<String, Hash>] a hash mapping table names to their configuration
+        def generate_warehouse_config
+          tables = all_types
+            .filter_map { |type| type.warehouse_table_def if type.respond_to?(:warehouse_table_def) }
+            .sort_by(&:name)
+
+          {"tables" => tables.to_h { |table| [table.name, table.to_config] }}
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/schema_artifact_manager_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/schema_artifact_manager_extension.rb
@@ -1,0 +1,46 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/warehouse"
+
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      # Extension module for {ElasticGraph::SchemaDefinition::SchemaArtifactManager} that adds
+      # warehouse artifact generation support.
+      #
+      # @private
+      module SchemaArtifactManagerExtension
+        private
+
+        # Overrides the base `artifacts_from_schema_def` method to add warehouse artifacts.
+        #
+        # This method is called when computing the list of schema artifacts. It calls super
+        # to get the base artifacts, then appends the warehouse artifact if any warehouse
+        # tables are defined.
+        #
+        # @return [Array<ElasticGraph::SchemaDefinition::SchemaArtifact>] the list of schema artifacts
+        def artifacts_from_schema_def
+          base_artifacts = super
+          warehouse_config = schema_definition_results.warehouse_config
+
+          # Only add the artifact if there are warehouse tables defined.
+          return base_artifacts if warehouse_config["tables"].empty?
+
+          warehouse_artifact = new_yaml_artifact(
+            DATA_WAREHOUSE_FILE,
+            warehouse_config,
+            extra_comment_lines: ["This file contains Data Warehouse configuration generated from the ElasticGraph schema."]
+          )
+
+          base_artifacts + [warehouse_artifact]
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/warehouse_table.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/warehouse_table.rb
@@ -1,0 +1,54 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/warehouse/schema_definition/field_type_converter"
+
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      # Represents a warehouse table configuration.
+      class WarehouseTable < Struct.new(:name, :indexed_type)
+        # Converts the warehouse table to a configuration hash.
+        #
+        # @return [Hash] configuration hash with table_schema
+        def to_config
+          {
+            "table_schema" => table_schema
+          }
+        end
+
+        private
+
+        # Generates the SQL CREATE TABLE statement for this warehouse table.
+        #
+        # @return [String] SQL CREATE TABLE statement with all fields
+        def table_schema
+          fields = indexed_type
+            .indexing_fields_by_name_in_index
+            .values
+            .map(&:to_indexing_field)
+            .compact
+            .map { |field| table_field(field) }
+            .join(",\n  ")
+
+          <<~SQL.strip
+            CREATE TABLE IF NOT EXISTS #{name} (
+              #{fields}
+            )
+          SQL
+        end
+
+        def table_field(field)
+          field_name = field.name_in_index
+          warehouse_type = FieldTypeConverter.convert(field.type)
+          "#{field_name} #{warehouse_type}"
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/factory_extension.rbs
+++ b/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/factory_extension.rbs
@@ -2,25 +2,6 @@ module ElasticGraph
   module Warehouse
     module SchemaDefinition
       module FactoryExtension: ::ElasticGraph::SchemaDefinition::Factory
-        def new_enum_type: (::String) ?{
-          (::ElasticGraph::SchemaDefinition::SchemaElements::EnumType) -> void
-        } -> ::ElasticGraph::SchemaDefinition::SchemaElements::EnumType
-
-        def new_interface_type: (::String) ?{
-          (::ElasticGraph::SchemaDefinition::SchemaElements::InterfaceType) -> void
-        } -> ::ElasticGraph::SchemaDefinition::SchemaElements::InterfaceType
-
-        def new_object_type: (::String) ?{
-          (::ElasticGraph::SchemaDefinition::SchemaElements::ObjectType) -> void
-        } -> ::ElasticGraph::SchemaDefinition::SchemaElements::ObjectType
-
-        def new_scalar_type: (::String) ?{
-          (::ElasticGraph::SchemaDefinition::SchemaElements::ScalarType) -> void
-        } -> ::ElasticGraph::SchemaDefinition::SchemaElements::ScalarType
-
-        def new_union_type: (::String) ?{
-          (::ElasticGraph::SchemaDefinition::SchemaElements::UnionType) -> void
-        } -> ::ElasticGraph::SchemaDefinition::SchemaElements::UnionType
       end
     end
   end

--- a/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rbs
+++ b/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rbs
@@ -1,8 +1,17 @@
 module ElasticGraph
   module Warehouse
     module SchemaDefinition
-      module ObjectInterfaceAndUnionExtension: ::ElasticGraph::SchemaDefinition::SchemaElements::TypeWithSubfields
+      module ObjectInterfaceAndUnionExtension : _ObjectInterfaceAndUnionExtensionInterface
+        def warehouse_table_def: () -> WarehouseTable?
+        def warehouse_table: (::String) -> void
         def to_warehouse_column_type: () -> ::String
+
+        @warehouse_table_def: WarehouseTable?
+      end
+
+      interface _ObjectInterfaceAndUnionExtensionInterface
+        def schema_def_state: () -> ::ElasticGraph::SchemaDefinition::State
+        def indexing_fields_by_name_in_index: () -> ::Hash[::String, ::ElasticGraph::SchemaDefinition::SchemaElements::Field]
       end
     end
   end

--- a/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/results_extension.rbs
+++ b/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/results_extension.rbs
@@ -1,0 +1,20 @@
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      module ResultsExtension : _ResultsExtensionInterface
+        def warehouse_config: () -> ::Hash[::String, ::Hash[::String, untyped]]
+
+        private
+
+        def generate_warehouse_config: () -> ::Hash[::String, ::Hash[::String, untyped]]
+
+        @warehouse_config: ::Hash[::String, ::Hash[::String, untyped]]?
+      end
+
+      interface _ResultsExtensionInterface
+        def all_types: () -> ::Array[untyped]
+        def state: () -> ::ElasticGraph::SchemaDefinition::State
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/schema_artifact_manager_extension.rbs
+++ b/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/schema_artifact_manager_extension.rbs
@@ -1,0 +1,19 @@
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      module SchemaArtifactManagerExtension : _SchemaArtifactManagerExtensionInterface
+        private
+
+        def artifacts_from_schema_def: () -> ::Array[ElasticGraph::SchemaDefinition::SchemaArtifact[untyped]]
+
+        @schema_artifacts_directory: ::String
+      end
+
+      interface _SchemaArtifactManagerExtensionInterface
+        def schema_definition_results: () -> (::ElasticGraph::SchemaDefinition::Results & ResultsExtension)
+        def artifacts_from_schema_def: () -> ::Array[ElasticGraph::SchemaDefinition::SchemaArtifact[untyped]]
+        def new_yaml_artifact: (::String, ::Hash[::String, untyped], ?extra_comment_lines: ::Array[::String]) -> ElasticGraph::SchemaDefinition::SchemaArtifact[::Hash[::String, untyped]]
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/warehouse_table.rbs
+++ b/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/warehouse_table.rbs
@@ -1,0 +1,25 @@
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      class WarehouseTableSupertype
+        attr_accessor name: ::String
+        attr_accessor indexed_type: _IndexedTypeInterface
+
+        def initialize: (::String, _IndexedTypeInterface) -> void
+      end
+
+      class WarehouseTable < WarehouseTableSupertype
+        def to_config: () -> ::Hash[::String, ::String]
+        def table_schema: () -> ::String
+
+        private
+
+        def table_field: (::ElasticGraph::SchemaDefinition::Indexing::Field) -> ::String
+      end
+
+      interface _IndexedTypeInterface
+        def indexing_fields_by_name_in_index: () -> ::Hash[::String, ::ElasticGraph::SchemaDefinition::SchemaElements::Field]
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse/spec/integration/elastic_graph/warehouse/schema_definition/rake_tasks_spec.rb
+++ b/elasticgraph-warehouse/spec/integration/elastic_graph/warehouse/schema_definition/rake_tasks_spec.rb
@@ -1,0 +1,199 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/constants"
+require "elastic_graph/schema_definition/rake_tasks"
+require "elastic_graph/warehouse/schema_definition/api_extension"
+require "yaml"
+
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      RSpec.describe "Warehouse RakeTasks", :rake_task, :in_temp_dir do
+        describe "schema_artifacts:dump" do
+          it "dumps warehouse artifact when warehouse tables are defined" do
+            write_warehouse_schema(table_defs: <<~EOS)
+              s.object_type "Product" do |t|
+                t.field "id", "ID"
+                t.field "name", "String"
+                t.field "price", "Float"
+                t.warehouse_table "products"
+              end
+            EOS
+
+            expect {
+              output = run_rake_with_warehouse("schema_artifacts:dump")
+              expect(output.lines).to include(
+                a_string_including("Dumped", Warehouse::DATA_WAREHOUSE_FILE)
+              )
+            }.to change { read_artifact(Warehouse::DATA_WAREHOUSE_FILE) }
+              .from(a_falsy_value)
+              .to(a_string_including("products:", "table_schema:", "CREATE TABLE IF NOT EXISTS products"))
+
+            warehouse_config = YAML.safe_load(read_artifact(Warehouse::DATA_WAREHOUSE_FILE))
+            expect(warehouse_config.keys).to eq(["tables"])
+            expect(warehouse_config["tables"].keys).to eq(["products"])
+            expect(warehouse_config["tables"]["products"]).to have_key("table_schema")
+            expect(warehouse_config["tables"]["products"]["table_schema"]).to start_with("CREATE TABLE IF NOT EXISTS products")
+          end
+
+          it "does not dump warehouse artifact when no warehouse tables are defined" do
+            write_warehouse_schema(table_defs: <<~EOS)
+              s.object_type "User" do |t|
+                t.field "id", "ID"
+                t.field "name", "String"
+                # No warehouse_table definition
+              end
+            EOS
+
+            output = run_rake_with_warehouse("schema_artifacts:dump")
+
+            expect(output.lines).not_to include(
+              a_string_including("Dumped", Warehouse::DATA_WAREHOUSE_FILE)
+            )
+            expect(read_artifact(Warehouse::DATA_WAREHOUSE_FILE)).to be_falsy
+          end
+
+          it "idempotently dumps warehouse artifacts" do
+            write_warehouse_schema(table_defs: <<~EOS)
+              s.object_type "Product" do |t|
+                t.field "id", "ID"
+                t.warehouse_table "products"
+              end
+            EOS
+
+            run_rake_with_warehouse("schema_artifacts:dump")
+
+            expect {
+              output = run_rake_with_warehouse("schema_artifacts:dump")
+              expect(output.lines).to include(a_string_including("already up to date", Warehouse::DATA_WAREHOUSE_FILE))
+            }.to maintain { read_artifact(Warehouse::DATA_WAREHOUSE_FILE) }
+          end
+
+          it "updates warehouse artifact when schema changes" do
+            write_warehouse_schema(table_defs: <<~EOS)
+              s.object_type "Product" do |t|
+                t.field "id", "ID"
+                t.warehouse_table "products"
+              end
+            EOS
+
+            run_rake_with_warehouse("schema_artifacts:dump")
+            original_content = read_artifact(Warehouse::DATA_WAREHOUSE_FILE)
+
+            write_warehouse_schema(table_defs: <<~EOS)
+              s.object_type "Product" do |t|
+                t.field "id", "ID"
+                t.field "name", "String"
+                t.warehouse_table "products"
+              end
+            EOS
+
+            expect {
+              run_rake_with_warehouse("schema_artifacts:dump", enforce_json_schema_version: false)
+            }.to change { read_artifact(Warehouse::DATA_WAREHOUSE_FILE) }
+              .from(original_content)
+              .to(a_string_including("products:", "name"))
+          end
+
+          it "sorts warehouse tables alphabetically by name" do
+            write_warehouse_schema(table_defs: <<~EOS)
+              s.object_type "Zebra" do |t|
+                t.field "id", "ID"
+                t.warehouse_table "zebras"
+              end
+
+              s.object_type "Apple" do |t|
+                t.field "id", "ID"
+                t.warehouse_table "apples"
+              end
+
+              s.object_type "Middle" do |t|
+                t.field "id", "ID"
+                t.warehouse_table "middles"
+              end
+            EOS
+
+            run_rake_with_warehouse("schema_artifacts:dump")
+
+            warehouse_config = YAML.safe_load(read_artifact(Warehouse::DATA_WAREHOUSE_FILE))
+            expect(warehouse_config["tables"].keys).to eq(%w[apples middles zebras])
+          end
+
+          it "includes all warehouse table configurations" do
+            write_warehouse_schema(table_defs: <<~EOS)
+              s.object_type "Product" do |t|
+                t.field "id", "ID"
+                t.field "name", "String"
+                t.field "price", "Float"
+                t.warehouse_table "products"
+              end
+
+              s.object_type "User" do |t|
+                t.field "user_id", "ID"
+                t.field "email", "String"
+                t.warehouse_table "users"
+              end
+
+              s.object_type "Order" do |t|
+                t.field "order_id", "ID"
+                t.warehouse_table "orders"
+              end
+            EOS
+
+            run_rake_with_warehouse("schema_artifacts:dump")
+
+            warehouse_config = YAML.safe_load(read_artifact(Warehouse::DATA_WAREHOUSE_FILE))
+            expect(warehouse_config["tables"].keys).to contain_exactly("orders", "products", "users")
+
+            warehouse_config["tables"].each do |table_name, table_config|
+              expect(table_config).to have_key("table_schema")
+              expect(table_config["table_schema"]).to start_with("CREATE TABLE IF NOT EXISTS #{table_name}")
+            end
+          end
+        end
+
+        def write_warehouse_schema(table_defs:)
+          ::File.write("schema.rb", <<~EOS)
+            ElasticGraph.define_schema do |s|
+              s.json_schema_version 1
+
+              # Add a dummy indexed type to ensure the Query type has at least one field.
+              # This prevents GraphQL-Ruby warnings about empty Query types in tests.
+              s.object_type "_DummyWarehouseTestType" do |t|
+                t.field "id", "ID"
+                t.index "dummy_warehouse_test_indices"
+              end
+
+              #{table_defs}
+            end
+          EOS
+        end
+
+        def run_rake_with_warehouse(*args, enforce_json_schema_version: true)
+          run_rake(*args) do |output|
+            ElasticGraph::SchemaDefinition::RakeTasks.new(
+              schema_element_name_form: :snake_case,
+              index_document_sizes: false,
+              path_to_schema: "schema.rb",
+              schema_artifacts_directory: "config/schema/artifacts",
+              enforce_json_schema_version: enforce_json_schema_version,
+              extension_modules: [Warehouse::SchemaDefinition::APIExtension],
+              output: output
+            )
+          end
+        end
+
+        def read_artifact(name)
+          path = File.join("config", "schema", "artifacts", name)
+          File.exist?(path) && File.read(path)
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse/spec/support/warehouse_schema_support.rb
+++ b/elasticgraph-warehouse/spec/support/warehouse_schema_support.rb
@@ -14,10 +14,18 @@ module ElasticGraph
     module SchemaSupport
       include ElasticGraph::SchemaDefinition::TestSupport
 
+      # Override define_schema to include APIExtension by default for all warehouse specs
+      def define_schema(**options, &block)
+        super(
+          extension_modules: [SchemaDefinition::APIExtension],
+          **options,
+          &block
+        )
+      end
+
       def define_warehouse_schema(**options, &block)
         results = define_schema(
           schema_element_name_form: :snake_case,
-          extension_modules: [SchemaDefinition::APIExtension],
           **options,
           &block
         )

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/field_type_converter_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/field_type_converter_spec.rb
@@ -142,17 +142,10 @@ module ElasticGraph
           expect(convert_field_type(results, "Event", "occurred_at")).to eq "TIMESTAMP"
         end
 
-        def convert_field_type(results, type, field)
-          field_type = results
-            .state
-            .types_by_name
-            .fetch(type)
-            .indexing_fields_by_name_in_index
-            .fetch(field)
-            .to_indexing_field
-            .type
-
-          FieldTypeConverter.convert(field_type)
+        def convert_field_type(results, type_name, field_name)
+          type = results.state.types_by_name.fetch(type_name)
+          field = type.indexing_fields_by_name_in_index.fetch(field_name).to_indexing_field
+          FieldTypeConverter.convert(field.type)
         end
       end
     end

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension_spec.rb
@@ -34,7 +34,19 @@ module ElasticGraph
               end
             end
 
-            expect(warehouse_column_type_for(results, "Venue")).to eq("STRUCT<id STRING, name STRING, location STRUCT<latitude DOUBLE, longitude DOUBLE>>")
+            # GeoLocation uses name_in_index: "lat" and "lon" for its fields
+            expect(warehouse_column_type_for(results, "Venue")).to eq("STRUCT<id STRING, name STRING, location STRUCT<lat DOUBLE, lon DOUBLE>>")
+          end
+
+          it "respects name_in_index for nested object fields" do
+            results = define_warehouse_schema do |s|
+              s.object_type "Address" do |t|
+                t.field "street_name", "String", name_in_index: "street"
+                t.field "city_name", "String", name_in_index: "city"
+              end
+            end
+
+            expect(warehouse_column_type_for(results, "Address")).to eq("STRUCT<street STRING, city STRING>")
           end
         end
 

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/results_extension_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/results_extension_spec.rb
@@ -1,0 +1,228 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/warehouse/schema_definition/api_extension"
+
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      RSpec.describe ResultsExtension, :warehouse_schema do
+        it "generates warehouse config for types with warehouse_table definitions" do
+          results = define_warehouse_schema do |s|
+            s.object_type "Product" do |t|
+              t.field "id", "ID"
+              t.field "name", "String"
+              t.field "price", "Float"
+              t.warehouse_table "products"
+            end
+
+            s.object_type "Order" do |t|
+              t.field "order_id", "ID"
+              t.field "total", "Float"
+              t.warehouse_table "orders"
+            end
+          end
+
+          config = results.warehouse_config
+
+          expect(config).to eq({
+            "tables" => {
+              "orders" => {
+                "table_schema" => <<~SQL.strip
+                  CREATE TABLE IF NOT EXISTS orders (
+                    order_id STRING,
+                    total DOUBLE
+                  )
+                SQL
+              },
+              "products" => {
+                "table_schema" => <<~SQL.strip
+                  CREATE TABLE IF NOT EXISTS products (
+                    id STRING,
+                    name STRING,
+                    price DOUBLE
+                  )
+                SQL
+              }
+            }
+          })
+        end
+
+        it "returns empty hash when no warehouse tables are defined" do
+          results = define_warehouse_schema do |s|
+            s.object_type "User" do |t|
+              t.field "id", "ID"
+              t.field "name", "String"
+            end
+          end
+
+          config = results.warehouse_config
+
+          expect(config).to eq({"tables" => {}})
+        end
+
+        it "excludes object types without warehouse_table definitions" do
+          results = define_warehouse_schema do |s|
+            s.object_type "Product" do |t|
+              t.field "id", "ID"
+              t.field "name", "String"
+              t.warehouse_table "products"
+            end
+
+            s.object_type "Category" do |t|
+              t.field "id", "ID"
+              t.field "name", "String"
+              # No warehouse_table definition
+            end
+          end
+
+          config = results.warehouse_config
+
+          expect(config["tables"].keys).to contain_exactly("products")
+          expect(config["tables"]).not_to have_key("Category")
+        end
+
+        it "sorts warehouse tables by name" do
+          results = define_warehouse_schema do |s|
+            s.object_type "Zebra" do |t|
+              t.field "id", "ID"
+              t.warehouse_table "zebras"
+            end
+
+            s.object_type "Apple" do |t|
+              t.field "id", "ID"
+              t.warehouse_table "apples"
+            end
+
+            s.object_type "Middle" do |t|
+              t.field "id", "ID"
+              t.warehouse_table "middles"
+            end
+          end
+
+          config = results.warehouse_config
+
+          expect(config["tables"].keys).to eq(%w[apples middles zebras])
+        end
+
+        it "memoizes warehouse config after first generation" do
+          results = define_warehouse_schema do |s|
+            s.object_type "Product" do |t|
+              t.field "id", "ID"
+              t.warehouse_table "products"
+            end
+          end
+
+          # Call twice and verify it returns the same object instance
+          config1 = results.warehouse_config
+          config2 = results.warehouse_config
+
+          expect(config1).to be(config2)
+        end
+
+        it "includes all object types with warehouse_table in config" do
+          results = define_warehouse_schema do |s|
+            s.object_type "Product" do |t|
+              t.field "id", "ID"
+              t.field "name", "String"
+              t.field "price", "Float"
+              t.warehouse_table "products"
+            end
+
+            s.object_type "User" do |t|
+              t.field "user_id", "ID"
+              t.field "email", "String"
+              t.warehouse_table "users"
+            end
+
+            s.object_type "Order" do |t|
+              t.field "order_id", "ID"
+              t.warehouse_table "orders"
+            end
+          end
+
+          config = results.warehouse_config
+
+          expect(config["tables"].keys.size).to eq(3)
+          expect(config["tables"]).to have_key("products")
+          expect(config["tables"]).to have_key("users")
+          expect(config["tables"]).to have_key("orders")
+
+          # Verify each config has the table_schema key
+          config["tables"].each do |table_name, table_config|
+            expect(table_config).to have_key("table_schema")
+            expect(table_config["table_schema"]).to start_with("CREATE TABLE IF NOT EXISTS #{table_name}")
+          end
+        end
+
+        it "includes indexing_only fields in warehouse table definition" do
+          results = define_warehouse_schema do |s|
+            s.object_type "Product" do |t|
+              t.field "id", "ID"
+              t.field "name", "String"
+              t.field "internal_code", "String", indexing_only: true
+              t.warehouse_table "products"
+            end
+          end
+
+          config = results.warehouse_config
+          table_schema = config["tables"]["products"]["table_schema"]
+
+          expect(table_schema).to eq(<<~SQL.strip)
+            CREATE TABLE IF NOT EXISTS products (
+              id STRING,
+              name STRING,
+              internal_code STRING
+            )
+          SQL
+        end
+
+        it "omits graphql_only fields from warehouse table definition" do
+          results = define_warehouse_schema do |s|
+            s.object_type "Product" do |t|
+              t.field "id", "ID"
+              t.field "name", "String"
+              t.field "computed_field", "String", graphql_only: true
+              t.warehouse_table "products"
+            end
+          end
+
+          config = results.warehouse_config
+          table_schema = config["tables"]["products"]["table_schema"]
+
+          expect(table_schema).to eq(<<~SQL.strip)
+            CREATE TABLE IF NOT EXISTS products (
+              id STRING,
+              name STRING
+            )
+          SQL
+        end
+
+        it "respects name_in_index for warehouse table column names" do
+          results = define_warehouse_schema do |s|
+            s.object_type "Product" do |t|
+              t.field "id", "ID"
+              t.field "product_name", "String", name_in_index: "pname"
+              t.warehouse_table "products"
+            end
+          end
+
+          config = results.warehouse_config
+          table_schema = config["tables"]["products"]["table_schema"]
+
+          expect(table_schema).to eq(<<~SQL.strip)
+            CREATE TABLE IF NOT EXISTS products (
+              id STRING,
+              pname STRING
+            )
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/warehouse_table_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/warehouse_table_spec.rb
@@ -1,0 +1,83 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/warehouse/schema_definition/api_extension"
+
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      RSpec.describe WarehouseTable, :warehouse_schema do
+        it "generates table schema with warehouse_table definition" do
+          results = define_warehouse_schema do |s|
+            s.object_type "Product" do |t|
+              t.field "id", "ID"
+              t.field "name", "String"
+              t.field "price", "Float"
+              t.warehouse_table "products"
+            end
+          end
+
+          product_type = results.state.object_types_by_name.fetch("Product")
+          table = product_type.warehouse_table_def
+
+          expect(table).to be_a(WarehouseTable)
+          expect(table.name).to eq("products")
+
+          expect(table.indexed_type).to eq(product_type)
+        end
+
+        it "converts table to configuration hash" do
+          results = define_warehouse_schema do |s|
+            s.object_type "Order" do |t|
+              t.field "order_id", "ID"
+              t.field "total", "Float"
+              t.warehouse_table "orders"
+            end
+          end
+
+          order_type = results.state.object_types_by_name.fetch("Order")
+          table = order_type.warehouse_table_def
+
+          config = table.to_config
+          expect(config).to have_key("table_schema")
+          expect(config["table_schema"]).to eq(<<~SQL.strip)
+            CREATE TABLE IF NOT EXISTS orders (
+              order_id STRING,
+              total DOUBLE
+            )
+          SQL
+        end
+
+        it "generates complete CREATE TABLE SQL statement" do
+          results = define_warehouse_schema do |s|
+            s.object_type "User" do |t|
+              t.field "user_id", "ID"
+              t.field "email", "String"
+              t.field "age", "Int"
+              t.field "is_active", "Boolean"
+              t.warehouse_table "users"
+            end
+          end
+
+          user_type = results.state.object_types_by_name.fetch("User")
+          table = user_type.warehouse_table_def
+
+          table_schema = table.to_config["table_schema"]
+          expect(table_schema).to eq(<<~SQL.strip)
+            CREATE TABLE IF NOT EXISTS users (
+              user_id STRING,
+              email STRING,
+              age INT,
+              is_active BOOLEAN
+            )
+          SQL
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implements automatic DDL generation for warehouse tables defined in schema definitions. When object types declare warehouse_table definitions, we generates CREATE TABLE statements and exports them as data_warehouse.yaml artifacts via the schema artifact manager.