### PR TITLE
Upgrade GraphQL gem from 2.5.11 to 2.5.14.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ PATH
       apollo-federation (~> 3.10, >= 3.10.3)
       elasticgraph-graphql (= 1.0.3.pre)
       elasticgraph-support (= 1.0.3.pre)
-      graphql (= 2.5.11)
+      graphql (~> 2.5.14)
 
 PATH
   remote: elasticgraph-datastore_core
@@ -68,7 +68,7 @@ PATH
       base64 (~> 0.3)
       elasticgraph-datastore_core (= 1.0.3.pre)
       elasticgraph-schema_artifacts (= 1.0.3.pre)
-      graphql (= 2.5.11)
+      graphql (~> 2.5.14)
       graphql-c_parser (~> 1.1, >= 1.1.3)
 
 PATH
@@ -150,7 +150,7 @@ PATH
     elasticgraph-query_registry (1.0.3.pre)
       elasticgraph-graphql (= 1.0.3.pre)
       elasticgraph-support (= 1.0.3.pre)
-      graphql (= 2.5.11)
+      graphql (~> 2.5.14)
       graphql-c_parser (~> 1.1, >= 1.1.3)
       rake (~> 13.3, >= 13.3.1)
 
@@ -175,7 +175,7 @@ PATH
       elasticgraph-indexer (= 1.0.3.pre)
       elasticgraph-schema_artifacts (= 1.0.3.pre)
       elasticgraph-support (= 1.0.3.pre)
-      graphql (= 2.5.11)
+      graphql (~> 2.5.14)
       graphql-c_parser (~> 1.1, >= 1.1.3)
       rake (~> 13.3, >= 13.3.1)
 
@@ -330,7 +330,7 @@ GEM
     google-protobuf (4.33.1-arm64-darwin)
       bigdecimal
       rake (>= 13)
-    graphql (2.5.11)
+    graphql (2.5.14)
       base64
       fiber-storage
       logger

--- a/elasticgraph-apollo/elasticgraph-apollo.gemspec
+++ b/elasticgraph-apollo/elasticgraph-apollo.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "graphql", "2.5.11" # 2.5.12 introduces a failure in elasticgraph-apollo.
+  spec.add_dependency "graphql", "~> 2.5.14"
   spec.add_dependency "apollo-federation", "~> 3.10", ">= 3.10.3"
 
   # Note: technically, this is not purely a development dependency, but since `eg-schema_def`

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/apollo_directives.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/apollo_directives.rb
@@ -157,13 +157,13 @@ module ElasticGraph
           # Adds the [`@policy` directive](https://www.apollographql.com/docs/federation/federated-types/federated-directives/#policy)
           # to the schema element.
           #
-          # @param policies [Array<String>] List of authorization policies.
+          # @param policies [Array<Array<String>>] List of authorization policies to evaluate.
           # @return [void]
           #
           # @example Add `@policy` to a type
           #   ElasticGraph.define_schema do |schema|
           #     schema.object_type "Campaign" do |t|
-          #       t.apollo_policy policies: ["Policy1", "Policy2"]
+          #       t.apollo_policy policies: [["Policy1", "Policy2"]]
           #     end
           #   end
           def apollo_policy(policies:)
@@ -227,14 +227,14 @@ module ElasticGraph
           # Adds the [`@requiresScopes` directive](https://www.apollographql.com/docs/federation/federated-types/federated-directives/#requiresscopes)
           # to the schema element.
           #
-          # @param scopes [Array<String>] List of JWT scopes that must be granted to the user in order to access the underlying element data.
+          # @param scopes [Array<Array<String>>] List of JWT scopes that must be granted to the user in order to access the underlying element data.
           # @return [void]
           #
           # @example Add `@requiresScopes` to a field
           #   ElasticGraph.define_schema do |schema|
           #     schema.object_type "Product" do |t|
           #       t.field "shippingEstimate", "String" do |f|
-          #         f.apollo_requires_scopes scopes: "shipping"
+          #         f.apollo_requires_scopes scopes: [["shipping"]]
           #       end
           #     end
           #   end

--- a/elasticgraph-graphql/elasticgraph-graphql.gemspec
+++ b/elasticgraph-graphql/elasticgraph-graphql.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "base64", "~> 0.3"
   spec.add_dependency "elasticgraph-datastore_core", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-schema_artifacts", ElasticGraph::VERSION
-  spec.add_dependency "graphql", "2.5.11" # Build break in 2.5.12, investigating.
+  spec.add_dependency "graphql", "~> 2.5.14"
   spec.add_dependency "graphql-c_parser", "~> 1.1", ">= 1.1.3"
 
   spec.add_development_dependency "elasticgraph-admin", ElasticGraph::VERSION

--- a/elasticgraph-query_registry/elasticgraph-query_registry.gemspec
+++ b/elasticgraph-query_registry/elasticgraph-query_registry.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "elasticgraph-graphql", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "graphql", "2.5.11" # 2.5.12 introduces a failure in elasticgraph-apollo.
+  spec.add_dependency "graphql", "~> 2.5.14"
   spec.add_dependency "graphql-c_parser", "~> 1.1", ">= 1.1.3"
   spec.add_dependency "rake", "~> 13.3", ">= 13.3.1"
 

--- a/elasticgraph-schema_definition/elasticgraph-schema_definition.gemspec
+++ b/elasticgraph-schema_definition/elasticgraph-schema_definition.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "elasticgraph-indexer", ElasticGraph::VERSION # needed since we validate that scalar `prepare_for_indexing_with` options are valid (which loads indexing preparer adapters)
   spec.add_dependency "elasticgraph-schema_artifacts", ElasticGraph::VERSION
   spec.add_dependency "elasticgraph-support", ElasticGraph::VERSION
-  spec.add_dependency "graphql", "2.5.11" # 2.5.12 introduces a failure in elasticgraph-apollo.
+  spec.add_dependency "graphql", "~> 2.5.14"
   spec.add_dependency "graphql-c_parser", "~> 1.1", ">= 1.1.3"
   spec.add_dependency "rake", "~> 13.3", ">= 13.3.1"
 


### PR DESCRIPTION
We had been pinned to 2.5.11 due to an `elasticgraph-apollo` failure, but since then we've pulled in an `apollo-federation` upgrade which fixes the issue.

In addition, 2.5.13 of the GraphQL gem has a regression which impacts a couple of doc tests:

https://github.com/rmosolgo/graphql-ruby/issues/5466

However, our doc test was not actually correct--it should be passing arguments as a list-of-lists. Once we pass the argument correctly, we can safely upgrade the GraphQL gem to 2.5.14.