### PR TITLE
Make it easier for extensions to add schema artifacts.

### DIFF
--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_artifact_manager.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_artifact_manager.rbs
@@ -24,6 +24,7 @@ module ElasticGraph
       @artifacts: ::Array[SchemaArtifact[untyped]]
       @json_schemas_artifact: SchemaArtifact[untyped]
 
+      def artifacts_from_schema_def: () -> ::Array[SchemaArtifact[untyped]]
       def notify_about_unused_type_name_overrides: () -> void
       def notify_about_unused_enum_value_overrides: () -> void
       def build_desired_versioned_json_schemas: (::Hash[::String, untyped]) -> ::Hash[::Integer, ::Hash[::String, untyped]]


### PR DESCRIPTION
This extracts `SchemaArtifactManager#artifacts_from_schema_def`, providing an easy way for `elasticgraph-warehouse` to hook in and override the generated schema artifacts.