### PR TITLE
Refactor `SchemaArtifactManager` to be friendlier to extension.

### DIFF
--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_artifact_manager.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_artifact_manager.rbs
@@ -21,9 +21,10 @@ module ElasticGraph
       @enforce_json_schema_version: bool
       @output: io
       @max_diff_lines: ::Integer
-      @artifacts: ::Array[SchemaArtifact[untyped]]
+      @artifacts: ::Array[SchemaArtifact[untyped]]?
       @json_schemas_artifact: SchemaArtifact[untyped]
 
+      def artifacts: () -> ::Array[SchemaArtifact[untyped]]
       def artifacts_from_schema_def: () -> ::Array[SchemaArtifact[untyped]]
       def notify_about_unused_type_name_overrides: () -> void
       def notify_about_unused_enum_value_overrides: () -> void


### PR DESCRIPTION
This moves the call to `artifacts_from_schema_def` outside of `initialize` to allow an extension module to override it. An extension module can only be applied after `initialize` returns so if we call it `initialize` there's no opportunity to override it before it's called.