### PR TITLE
Pin aws-sdk-cloudwatch to 1.125.0 to fix CI test failures.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ PATH
   remote: elasticgraph-indexer_autoscaler_lambda
   specs:
     elasticgraph-indexer_autoscaler_lambda (1.0.3.pre)
-      aws-sdk-cloudwatch (~> 1.125)
+      aws-sdk-cloudwatch (~> 1.125.0)
       aws-sdk-lambda (~> 1.167)
       aws-sdk-sqs (~> 1.107)
       elasticgraph-datastore_core (= 1.0.3.pre)

--- a/elasticgraph-indexer_autoscaler_lambda/elasticgraph-indexer_autoscaler_lambda.gemspec
+++ b/elasticgraph-indexer_autoscaler_lambda/elasticgraph-indexer_autoscaler_lambda.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "elasticgraph-lambda_support", ElasticGraph::VERSION
   spec.add_dependency "aws-sdk-lambda", "~> 1.167"
   spec.add_dependency "aws-sdk-sqs", "~> 1.107"
-  spec.add_dependency "aws-sdk-cloudwatch", "~> 1.125"
+  spec.add_dependency "aws-sdk-cloudwatch", "~> 1.125.0" # Pinned: 1.126.0 breaks stub_responses (AWS SDK issue #3325)
   # aws-sdk-sqs requires an XML library be available. On Ruby < 3 it'll use rexml from the standard library but on Ruby 3.0+
   # we have to add an explicit dependency. It supports ox, oga, libxml, nokogiri or rexml, and of those, ox seems to be the
   # best choice: it leads benchmarks, is well-maintained, has no dependencies, and is MIT-licensed.


### PR DESCRIPTION
Version 1.126.0 introduced CBOR protocol (Smithy RPC v2) which breaks `stub_responses` in tests. JSON parser receives CBOR binary data instead of JSON. Tracked in AWS SDK issue #3325:

https://github.com/aws/aws-sdk-ruby/issues/3325