### PR TITLE
Upgrade YARD to 0.9.38.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ group :site do
   # TODO: switch back to a release version once that fix is merged and released.
   gem "rouge", github: "myronmarston/rouge", ref: "12c0da6aa98e0d0a0762c47103b64290c88620a1"
 
-  gem "yard", "~> 0.9", ">= 0.9.37"
+  gem "yard", "~> 0.9", ">= 0.9.38"
   gem "yard-doctest", "~> 0.1", ">= 0.1.17"
   gem "yard-markdown", "~> 0.5"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -583,7 +583,7 @@ GEM
     vcr (6.3.1)
       base64
     webrick (1.9.1)
-    yard (0.9.37)
+    yard (0.9.38)
     yard-doctest (0.1.17)
       minitest
       yard
@@ -663,7 +663,7 @@ DEPENDENCIES
   steep (~> 1.10.0)
   super_diff (~> 0.17)
   vcr (~> 6.3, >= 6.3.1)
-  yard (~> 0.9, >= 0.9.37)
+  yard (~> 0.9, >= 0.9.38)
   yard-doctest (~> 0.1, >= 0.1.17)
   yard-markdown (~> 0.5)
 

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/entities_field_resolver.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/entities_field_resolver.rb
@@ -155,9 +155,17 @@ module ElasticGraph
             )
           end
 
+          # @private
           Adapter = ::Data.define(:type, :schema_element_names) do
             # @implements Adapter
 
+            # Customizes the given query to filter to entities matching the provided representations.
+            # Builds a filter matching all IDs from the representations and configures pagination
+            # and requested fields.
+            #
+            # @param query [ElasticGraph::GraphQL::DatastoreQuery] the query to customize
+            # @param representations [Array<RepresentationWithId>] the representations to query for
+            # @return [ElasticGraph::GraphQL::DatastoreQuery] the customized query
             def customize_query(query, representations)
               # Given a set of representations, builds a filter that will match all of them (and only them).
               all_ids = representations.map(&:id).reject { |id| id.is_a?(::Array) or id.is_a?(::Hash) }

--- a/elasticgraph-support/lib/elastic_graph/support/faraday_middleware/msearch_using_get_instead_of_post.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/faraday_middleware/msearch_using_get_instead_of_post.rb
@@ -20,8 +20,14 @@ module ElasticGraph
       # did for years.
       #
       # For more info, see: https://github.com/elastic/elasticsearch-ruby/issues/1005
+      # @private
       MSearchUsingGetInsteadOfPost = ::Data.define(:app) do
         # @implements MSearchUsingGetInsteadOfPost
+
+        # Processes a Faraday request, converting `_msearch` POST requests to GET requests.
+        #
+        # @param env [Faraday::Env] the Faraday request environment
+        # @return [Faraday::Response] the response from the next middleware in the stack
         def call(env)
           env.method = :get if env.url.path.to_s.end_with?("/_msearch")
           app.call(env)

--- a/elasticgraph-support/lib/elastic_graph/support/faraday_middleware/support_timeouts.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/faraday_middleware/support_timeouts.rb
@@ -20,8 +20,16 @@ module ElasticGraph
       #
       # This middleware helps us work around this deficiency by looking for the TIMEOUT_MS_HEADER. If present, it deletes
       # it from the headers and instead sets it as the request timeout.
+      # @private
       SupportTimeouts = ::Data.define(:app) do
         # @implements SupportTimeouts
+
+        # Processes a Faraday request, extracting timeout from headers and applying it to the request.
+        # Converts {TIMEOUT_MS_HEADER} from request headers into a Faraday request timeout setting.
+        #
+        # @param env [Faraday::Env] the Faraday request environment
+        # @return [Faraday::Response] the response from the next middleware in the stack
+        # @raise [Errors::RequestExceededDeadlineError] if the request times out
         def call(env)
           if (timeout_ms = env.request_headers.delete(TIMEOUT_MS_HEADER))
             env.request.timeout = Integer(timeout_ms) / 1000.0


### PR DESCRIPTION
YARD 0.9.38 parses `MyClass = Data.define(...)` for the first time:

https://github.com/lsegal/yard/pull/1600

There are 3 spots in this codebase that `be rake site:docs_coverage` reported as uncovered on YARD 0.9.38. This addresses all three.