### PR TITLE
Normalizes DateTime values to consistent 3-digit millisecond precision

### DIFF
--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -7732,8 +7732,8 @@ scalar_types_by_name:
       name: ElasticGraph::GraphQL::ScalarCoercionAdapters::DateTime
       require_path: elastic_graph/graphql/scalar_coercion_adapters/date_time
     indexing_preparer:
-      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
-      require_path: elastic_graph/indexer/indexing_preparers/no_op
+      name: ElasticGraph::Indexer::IndexingPreparers::DateTime
+      require_path: elastic_graph/indexer/indexing_preparers/date_time
   Float:
     coercion_adapter:
       name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -7869,8 +7869,8 @@ scalar_types_by_name:
       name: ElasticGraph::GraphQL::ScalarCoercionAdapters::DateTime
       require_path: elastic_graph/graphql/scalar_coercion_adapters/date_time
     indexing_preparer:
-      name: ElasticGraph::Indexer::IndexingPreparers::NoOp
-      require_path: elastic_graph/indexer/indexing_preparers/no_op
+      name: ElasticGraph::Indexer::IndexingPreparers::DateTime
+      require_path: elastic_graph/indexer/indexing_preparers/date_time
   FieldSet:
     coercion_adapter:
       name: ElasticGraph::GraphQL::ScalarCoercionAdapters::NoOp

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/date_time.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/scalar_coercion_adapters/date_time.rb
@@ -6,14 +6,13 @@
 #
 # frozen_string_literal: true
 
+require "elastic_graph/constants"
 require "time"
 
 module ElasticGraph
   class GraphQL
     module ScalarCoercionAdapters
       class DateTime
-        PRECISION = 3 # millisecond precision
-
         def self.coerce_input(value, ctx)
           return value if value.nil?
 
@@ -33,7 +32,7 @@ module ElasticGraph
           # format, so here we convert it to that format (which is just ISO8601 format). Ultimately,
           # that means that this method just "roundtrips" the input string back to a string, but it validates
           # the string is formatted correctly and returns a string in the exact format we need for the datastore.
-          time.iso8601(PRECISION)
+          time.iso8601(DATE_TIME_PRECISION)
         rescue ::ArgumentError, ::TypeError
           raise_coercion_error(value)
         end
@@ -41,9 +40,9 @@ module ElasticGraph
         def self.coerce_result(value, ctx)
           case value
           when ::Time
-            value.iso8601(PRECISION)
+            value.iso8601(DATE_TIME_PRECISION)
           when ::String
-            ::Time.iso8601(value).iso8601(PRECISION)
+            ::Time.iso8601(value).iso8601(DATE_TIME_PRECISION)
           end
         rescue ::ArgumentError
           nil

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/scalar_coercion_adapters/date_time_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/scalar_coercion_adapters/date_time_spec.rb
@@ -26,6 +26,14 @@ module ElasticGraph
             expect_input_value_to_be_accepted("2021-11-05T12:30:00.123Z")
           end
 
+          it "preserves trailing zeros in milliseconds to ensure consistent string comparison" do
+            # This is critical for min/max value tracking which uses string comparison.
+            # Without consistent precision, ".530Z" > ".531Z" in string comparison because 'Z' > '1'.
+            expect_input_value_to_be_accepted("2021-11-05T12:30:00.530Z", as: "2021-11-05T12:30:00.530Z")
+            expect_input_value_to_be_accepted("2021-11-05T12:30:00.500Z", as: "2021-11-05T12:30:00.500Z")
+            expect_input_value_to_be_accepted("2021-11-05T12:30:00.100Z", as: "2021-11-05T12:30:00.100Z")
+          end
+
           it "accepts an ISO8601 formatted timestamp string with s precision" do
             string_time = "2021-11-05T12:30:05Z"
 
@@ -81,6 +89,16 @@ module ElasticGraph
             string, time = string_time_pair_from("2021-11-05T12:30:00.123Z")
 
             expect_result_to_be_returned(time, as: string)
+          end
+
+          it "preserves trailing zeros in milliseconds for consistent string comparison" do
+            # This is critical for min/max value tracking which uses string comparison.
+            # Without consistent precision, ".530Z" > ".531Z" in string comparison because 'Z' > '1'.
+            _, time = string_time_pair_from("2021-11-05T12:30:00.530Z")
+            expect_result_to_be_returned(time, as: "2021-11-05T12:30:00.530Z")
+
+            _, time = string_time_pair_from("2021-11-05T12:30:00.500Z")
+            expect_result_to_be_returned(time, as: "2021-11-05T12:30:00.500Z")
           end
 
           it "formats a Time result with ms precision even if the time value only really has second precision" do

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/indexing_preparers/date_time.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/indexing_preparers/date_time.rb
@@ -1,0 +1,41 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/constants"
+require "time"
+
+module ElasticGraph
+  class Indexer
+    module IndexingPreparers
+      class DateTime
+        # Here we normalize DateTime strings to consistent 3-digit millisecond precision.
+        # This is critical for min/max value tracking which uses string comparison via
+        # Painless's `.compareTo()` method.
+        #
+        # Without consistent precision, string comparison produces incorrect results:
+        #   "2025-12-19T04:15:47.53Z" vs "2025-12-19T04:15:47.531Z"
+        #                        ^                              ^
+        #                       'Z' (ASCII 90)  >  '1' (ASCII 49)
+        #
+        # This would incorrectly determine that `.53Z > .531Z`.
+        #
+        # By normalizing all DateTime values to 3-digit precision, we ensure:
+        #   "2025-12-19T04:15:47.530Z" < "2025-12-19T04:15:47.531Z"
+        def self.prepare_for_indexing(value)
+          return value if value.nil?
+          time = ::Time.iso8601(value)
+          time.getutc.iso8601(DATE_TIME_PRECISION)
+        rescue ::ArgumentError, ::TypeError
+          # If the value is not a valid ISO8601 string, return it as-is
+          # and let the datastore reject it if necessary.
+          value
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-indexer/sig/elastic_graph/indexer/indexing_preparers/date_time.rbs
+++ b/elasticgraph-indexer/sig/elastic_graph/indexer/indexing_preparers/date_time.rbs
@@ -1,0 +1,9 @@
+module ElasticGraph
+  class Indexer
+    module IndexingPreparers
+      class DateTime
+        extend SchemaArtifacts::_IndexingPreparer[::String?, ::String?]
+      end
+    end
+  end
+end

--- a/elasticgraph-indexer/spec/acceptance/multi_source_indexing_spec.rb
+++ b/elasticgraph-indexer/spec/acceptance/multi_source_indexing_spec.rb
@@ -149,8 +149,9 @@ module ElasticGraph
     end
 
     it "is compatible with custom shard routing and rollover indices, so long as `equivalent_field` is used on the schema definition" do
-      timestamp_in_2023 = "2023-08-09T10:12:14Z"
-      timestamp_in_2021 = "2021-08-09T10:12:14Z"
+      # Use timestamps with explicit 3-digit millisecond precision to match what the indexer normalizes to
+      timestamp_in_2023 = "2023-08-09T10:12:14.000Z"
+      timestamp_in_2021 = "2021-08-09T10:12:14.000Z"
 
       widget = build_upsert_event(:widget, id: "w1", workspace_id: "wid_23", created_at: timestamp_in_2023)
       workspace = build_upsert_event(:widget_workspace, id: "wid_23", name: "Garage", created_at: timestamp_in_2021, widget: {

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/indexing_preparers/date_time_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/indexing_preparers/date_time_spec.rb
@@ -1,0 +1,109 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "support/indexing_preparer"
+
+module ElasticGraph
+  class Indexer
+    module IndexingPreparers
+      RSpec.describe "DateTime" do
+        include_context "indexing preparer support", "DateTime"
+
+        it "normalizes a DateTime string with 2-digit milliseconds to 3-digit precision for consistent string comparison" do
+          # This is critical for min/max value tracking which uses string comparison.
+          # Without consistent precision, ".53Z" > ".531Z" in string comparison because 'Z' > '1'.
+          expect(prepare_scalar_value("2021-06-10T12:30:00.53Z")).to eq("2021-06-10T12:30:00.530Z")
+        end
+
+        it "normalizes a DateTime string with 1-digit milliseconds to 3-digit precision" do
+          expect(prepare_scalar_value("2021-06-10T12:30:00.5Z")).to eq("2021-06-10T12:30:00.500Z")
+        end
+
+        it "preserves a DateTime string that already has 3-digit milliseconds" do
+          expect(prepare_scalar_value("2021-06-10T12:30:00.123Z")).to eq("2021-06-10T12:30:00.123Z")
+        end
+
+        it "adds milliseconds to a DateTime string with second precision" do
+          expect(prepare_scalar_value("2021-06-10T12:30:00Z")).to eq("2021-06-10T12:30:00.000Z")
+        end
+
+        it "normalizes a DateTime string with timezone offset to UTC" do
+          expect(prepare_scalar_value("2021-06-10T12:30:00.53-07:00")).to eq("2021-06-10T19:30:00.530Z")
+        end
+
+        it "leaves a `nil` value unchanged" do
+          expect(prepare_scalar_value(nil)).to eq(nil)
+        end
+
+        it "applies the value coercion logic to each element of an array" do
+          expect(prepare_array_values(["2021-06-10T12:30:00.53Z", "2021-06-10T12:30:00.5Z"])).to eq(
+            ["2021-06-10T12:30:00.530Z", "2021-06-10T12:30:00.500Z"]
+          )
+          expect(prepare_array_values([nil, nil])).to eq([nil, nil])
+        end
+
+        it "respects the index-preparation logic recursively at each level of a nested array" do
+          results = prepare_array_of_array_of_values([
+            ["2021-06-10T12:30:00.53Z", "2021-06-10T12:30:00.123Z"],
+            ["2021-06-10T12:30:00.5Z", "2021-06-10T12:30:00Z"],
+            [nil, "2021-06-10T12:30:00.53Z"]
+          ])
+
+          expect(results).to eq([
+            ["2021-06-10T12:30:00.530Z", "2021-06-10T12:30:00.123Z"],
+            ["2021-06-10T12:30:00.500Z", "2021-06-10T12:30:00.000Z"],
+            [nil, "2021-06-10T12:30:00.530Z"]
+          ])
+        end
+
+        it "respects the index-preparation rule recursively at each level of an object within an array" do
+          expect(prepare_array_of_objects_of_values(["2021-06-10T12:30:00.53Z", "2021-06-10T12:30:00.5Z"])).to eq(
+            ["2021-06-10T12:30:00.530Z", "2021-06-10T12:30:00.500Z"]
+          )
+          expect(prepare_array_of_objects_of_values([nil, nil])).to eq([nil, nil])
+        end
+
+        it "returns an invalid DateTime string as-is, letting the datastore reject it" do
+          expect(prepare_scalar_value("not-a-date")).to eq("not-a-date")
+        end
+
+        it "returns a non-string value as-is, letting the datastore reject it" do
+          expect(prepare_scalar_value(12345)).to eq(12345)
+        end
+
+        it "returns nil unchanged when called directly" do
+          # This tests the nil guard in `prepare_for_indexing` directly, since RecordPreparer
+          # short-circuits nil values before calling the preparer.
+          expect(DateTime.prepare_for_indexing(nil)).to be_nil
+        end
+
+        describe "string comparison consistency" do
+          # These tests verify the core reason for DateTime normalization:
+          # ensuring that string comparison via .compareTo() in Painless works correctly.
+
+          it "ensures normalized timestamps compare correctly when the less precise one would have won incorrectly" do
+            less_value = prepare_scalar_value("2021-06-10T12:30:00.53Z")   # Would be .53Z without normalization
+            more_value = prepare_scalar_value("2021-06-10T12:30:00.531Z")  # .531Z
+
+            # Without normalization: ".53Z" > ".531Z" because 'Z' > '1'
+            # With normalization: ".530Z" < ".531Z" (correct!)
+            expect(less_value < more_value).to be true
+          end
+
+          it "ensures normalized timestamps compare correctly for trailing zeros" do
+            value_530 = prepare_scalar_value("2021-06-10T12:30:00.530Z")
+            value_53 = prepare_scalar_value("2021-06-10T12:30:00.53Z")
+
+            # Both should normalize to the same value
+            expect(value_530).to eq(value_53)
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
@@ -794,6 +794,8 @@ module ElasticGraph
             t.json_schema type: "string", format: "date-time"
             t.coerce_with "ElasticGraph::GraphQL::ScalarCoercionAdapters::DateTime",
               defined_at: "elastic_graph/graphql/scalar_coercion_adapters/date_time"
+            t.prepare_for_indexing_with "ElasticGraph::Indexer::IndexingPreparers::DateTime",
+              defined_at: "elastic_graph/indexer/indexing_preparers/date_time"
 
             t.documentation <<~EOS
               A timestamp, represented as an [ISO 8601 time string](https://en.wikipedia.org/wiki/ISO_8601).

--- a/elasticgraph-support/lib/elastic_graph/constants.rb
+++ b/elasticgraph-support/lib/elastic_graph/constants.rb
@@ -22,6 +22,15 @@ module ElasticGraph
   # @private
   DATASTORE_DATE_TIME_FORMAT = "strict_date_time"
 
+  # The precision (number of decimal places) used when formatting DateTime values.
+  # A precision of 3 means millisecond precision (e.g., "2025-12-19T04:15:47.530Z").
+  #
+  # Consistent precision is critical for min/max value tracking which uses string comparison.
+  # Without it, string comparison produces incorrect results (e.g., "47.53Z" > "47.531Z"
+  # because 'Z' (ASCII 90) > '1' (ASCII 49)).
+  # @private
+  DATE_TIME_PRECISION = 3
+
   # HTTP header that ElasticGraph HTTP implementations (e.g. elasticgraph-rack, elasticgraph-lambda)
   # look at to determine a client-specified request timeout.
   # @private

--- a/elasticgraph-support/sig/elastic_graph/constants.rbs
+++ b/elasticgraph-support/sig/elastic_graph/constants.rbs
@@ -1,6 +1,7 @@
 module ElasticGraph
   DATASTORE_DATE_FORMAT: ::String
   DATASTORE_DATE_TIME_FORMAT: ::String
+  DATE_TIME_PRECISION: ::Integer
   TIMEOUT_MS_HEADER: ::String
   INT_MIN: ::Integer
   INT_MAX: ::Integer


### PR DESCRIPTION
## Summary

  Fixes incorrect min/max value tracking for DateTime fields when values have inconsistent millisecond precision.

  ## The Problem

  ElasticGraph's `derive_indexed_type_fields` feature allows tracking the min or max value of a field across
  related documents. For DateTime fields, this uses string comparison via Painless's `.compareTo()` method. This
  works correctly for ISO-8601 strings **only when precision is consistent**.

  ## User-Observable Bug

  Example using ElasticGraph's Widget/WidgetCurrency dataset:

  The schema defines a `WidgetCurrency` derived type that tracks `oldest_widget_created_at` (the minimum
  `created_at` across all widgets for a given currency):

  ```ruby
  # From config/schema/widgets.rb
  t.derive_indexed_type_fields "WidgetCurrency", from_id: "cost.currency" do |derive|
    derive.min_value "oldest_widget_created_at", from: "created_at"
  end
```
  1. Widget A (cost currency: USD) is indexed with created_at = "2025-01-15T10:30:00.531Z" (3 decimal digits)
    - WidgetCurrency(USD).oldest_widget_created_at is set to "2025-01-15T10:30:00.531Z"
  2. Widget B (cost currency: USD) is indexed later with created_at = "2025-01-15T10:30:00.53Z" (2 decimal digits)
    - This is actually an earlier timestamp (530ms vs 531ms), so oldest_widget_created_at should update
    - The Painless script compares: "2025-01-15T10:30:00.53Z".compareTo("2025-01-15T10:30:00.531Z")
    - At position 23, it compares 'Z' (ASCII 90) vs '1' (ASCII 49)
    - Since 90 > 49, the comparison incorrectly concludes .53Z > .531Z
    - The min value is NOT updated, even though 530ms < 531ms
  3. User queries for the oldest widget per currency:
  ```
  query {
    widget_currencies(filter: { id: { equalToAnyOf: ["USD"] } }) {
      nodes {
        id
        oldest_widget_created_at  # Returns "2025-01-15T10:30:00.531Z" (WRONG!)
      }
    }
  }
```

    - The query returns "2025-01-15T10:30:00.531Z" instead of the correct "2025-01-15T10:30:00.53Z"
    - Any downstream logic relying on this value (e.g., query interceptors that derive filter bounds) produces incorrect results

  ## Root Cause

  The precision inconsistency happens because different upstream systems format timestamps differently—some emit
  .53Z, others emit .530Z or .531Z. Without normalization, string comparison fails.

  ## The Solution

  Add a DateTime indexing preparer that normalizes all DateTime values to consistent 3-digit millisecond precision
  before indexing:

  - "2025-01-15T10:30:00.53Z" → "2025-01-15T10:30:00.530Z"
  - "2025-01-15T10:30:00Z" → "2025-01-15T10:30:00.000Z"
  - "2025-01-15T10:30:00.5312Z" → "2025-01-15T10:30:00.531Z" (truncated)

  With consistent precision, string comparison produces correct results:
  "2025-01-15T10:30:00.530Z".compareTo("2025-01-15T10:30:00.531Z")  →  negative (correctly identifies 530 < 531)