### PR TITLE
Use name_in_index for warehouse column type generation.

### DIFF
--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rb
@@ -25,7 +25,7 @@ module ElasticGraph
 
           struct_field_expressions = subfields.map do |subfield|
             warehouse_type = FieldTypeConverter.convert(subfield.type)
-            "#{subfield.name} #{warehouse_type}"
+            "#{subfield.name_in_index} #{warehouse_type}"
           end.join(", ")
 
           "STRUCT<#{struct_field_expressions}>"

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension_spec.rb
@@ -34,7 +34,19 @@ module ElasticGraph
               end
             end
 
-            expect(warehouse_column_type_for(results, "Venue")).to eq("STRUCT<id STRING, name STRING, location STRUCT<latitude DOUBLE, longitude DOUBLE>>")
+            # GeoLocation uses name_in_index: "lat" and "lon" for its fields
+            expect(warehouse_column_type_for(results, "Venue")).to eq("STRUCT<id STRING, name STRING, location STRUCT<lat DOUBLE, lon DOUBLE>>")
+          end
+
+          it "respects name_in_index for nested object fields" do
+            results = define_warehouse_schema do |s|
+              s.object_type "Address" do |t|
+                t.field "street_name", "String", name_in_index: "street"
+                t.field "city_name", "String", name_in_index: "city"
+              end
+            end
+
+            expect(warehouse_column_type_for(results, "Address")).to eq("STRUCT<street STRING, city STRING>")
           end
         end
 


### PR DESCRIPTION
When generating STRUCT types for warehouse columns, use the field's name_in_index instead of name. This ensures warehouse schema matches the actual indexed field names (e.g., GeoLocation uses "lat"/"lon" rather than "latitude"/"longitude").