### PR TITLE
Add WarehouseTable model and warehouse_table type method.

### DIFF
--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rb
@@ -7,21 +7,36 @@
 # frozen_string_literal: true
 
 require "elastic_graph/warehouse/schema_definition/field_type_converter"
+require "elastic_graph/warehouse/schema_definition/warehouse_table"
 
 module ElasticGraph
   module Warehouse
     module SchemaDefinition
       # Extends {ElasticGraph::SchemaDefinition::SchemaElements::ObjectType},
       # {ElasticGraph::SchemaDefinition::SchemaElements::InterfaceType}, and
-      # {ElasticGraph::SchemaDefinition::SchemaElements::UnionType} to add warehouse column type conversion.
+      # {ElasticGraph::SchemaDefinition::SchemaElements::UnionType} to add warehouse table and column type definition support.
       module ObjectInterfaceAndUnionExtension
+        # Returns the warehouse table definition for this type, if one has been defined via {#warehouse_table}.
+        #
+        # @return [WarehouseTable, nil] the warehouse table definition, or `nil` if none has been defined
+        # @dynamic warehouse_table_def
+        attr_reader :warehouse_table_def
+
+        # Defines a warehouse table for this object or interface type.
+        #
+        # @param name [String] name of the warehouse table
+        # @return [void]
+        def warehouse_table(name)
+          @warehouse_table_def = WarehouseTable.new(name: name, indexed_type: self)
+        end
+
         # Returns the warehouse column type representation for this object, interface, or union type.
         #
         # @return [String] a STRUCT SQL type containing all subfields
         # @note For union types, the STRUCT includes all fields from all subtypes, following the same pattern used
         #   in the datastore mapping (see {ElasticGraph::SchemaDefinition::Indexing::FieldType::Union#to_mapping}).
         def to_warehouse_column_type
-          subfields = indexing_fields_by_name_in_index.values.map(&:to_indexing_field).compact
+          subfields = indexing_fields_by_name_in_index.values.filter_map(&:to_indexing_field)
 
           struct_field_expressions = subfields.map do |subfield|
             warehouse_type = FieldTypeConverter.convert(subfield.type)

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/warehouse_table.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/warehouse_table.rb
@@ -1,0 +1,53 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/warehouse/schema_definition/field_type_converter"
+
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      # Represents a warehouse table configuration.
+      class WarehouseTable < ::Data.define(:name, :indexed_type)
+        # Converts the warehouse table to a configuration hash.
+        #
+        # @return [Hash] configuration hash with table_schema
+        def to_config
+          {
+            "table_schema" => table_schema
+          }
+        end
+
+        private
+
+        # Generates the SQL CREATE TABLE statement for this warehouse table.
+        #
+        # @return [String] SQL CREATE TABLE statement with all fields
+        def table_schema
+          fields = indexed_type
+            .indexing_fields_by_name_in_index
+            .values
+            .filter_map(&:to_indexing_field)
+            .map { |field| table_field(field) }
+            .join(",\n  ")
+
+          <<~SQL.strip
+            CREATE TABLE IF NOT EXISTS #{name} (
+              #{fields}
+            )
+          SQL
+        end
+
+        def table_field(field)
+          field_name = field.name_in_index
+          warehouse_type = FieldTypeConverter.convert(field.type)
+          "#{field_name} #{warehouse_type}"
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rbs
+++ b/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rbs
@@ -1,8 +1,17 @@
 module ElasticGraph
   module Warehouse
     module SchemaDefinition
-      module ObjectInterfaceAndUnionExtension: ::ElasticGraph::SchemaDefinition::SchemaElements::TypeWithSubfields
+      module ObjectInterfaceAndUnionExtension : _ObjectInterfaceAndUnionExtensionInterface
+        def warehouse_table_def: () -> WarehouseTable?
+        def warehouse_table: (::String) -> void
         def to_warehouse_column_type: () -> ::String
+
+        @warehouse_table_def: WarehouseTable?
+      end
+
+      interface _ObjectInterfaceAndUnionExtensionInterface
+        def schema_def_state: () -> ::ElasticGraph::SchemaDefinition::State
+        def indexing_fields_by_name_in_index: () -> ::Hash[::String, ::ElasticGraph::SchemaDefinition::SchemaElements::Field]
       end
     end
   end

--- a/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/warehouse_table.rbs
+++ b/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/warehouse_table.rbs
@@ -1,0 +1,25 @@
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      class WarehouseTableSupertype
+        attr_reader name: ::String
+        attr_reader indexed_type: _IndexedTypeInterface
+
+        def initialize: (name: ::String, indexed_type: _IndexedTypeInterface) -> void
+      end
+
+      class WarehouseTable < WarehouseTableSupertype
+        def to_config: () -> ::Hash[::String, ::String]
+        def table_schema: () -> ::String
+
+        private
+
+        def table_field: (::ElasticGraph::SchemaDefinition::Indexing::Field) -> ::String
+      end
+
+      interface _IndexedTypeInterface
+        def indexing_fields_by_name_in_index: () -> ::Hash[::String, ::ElasticGraph::SchemaDefinition::SchemaElements::Field]
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/warehouse_table_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/warehouse_table_spec.rb
@@ -1,0 +1,106 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/warehouse/schema_definition/api_extension"
+
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      RSpec.describe WarehouseTable, :warehouse_schema do
+        it "generates table schema with warehouse_table definition" do
+          results = define_warehouse_schema do |s|
+            s.object_type "Product" do |t|
+              t.field "id", "ID"
+              t.field "name", "String"
+              t.field "price", "Float"
+              t.warehouse_table "products"
+            end
+          end
+
+          product_type = results.state.object_types_by_name.fetch("Product")
+          table = product_type.warehouse_table_def
+
+          expect(table).to be_a(WarehouseTable)
+          expect(table.name).to eq("products")
+
+          expect(table.indexed_type).to eq(product_type)
+        end
+
+        it "converts table to configuration hash" do
+          results = define_warehouse_schema do |s|
+            s.object_type "Order" do |t|
+              t.field "order_id", "ID"
+              t.field "total", "Float"
+              t.warehouse_table "orders"
+            end
+          end
+
+          order_type = results.state.object_types_by_name.fetch("Order")
+          table = order_type.warehouse_table_def
+
+          config = table.to_config
+          expect(config).to have_key("table_schema")
+          expect(config["table_schema"]).to eq(<<~SQL.strip)
+            CREATE TABLE IF NOT EXISTS orders (
+              order_id STRING,
+              total DOUBLE
+            )
+          SQL
+        end
+
+        it "generates complete CREATE TABLE SQL statement" do
+          results = define_warehouse_schema do |s|
+            s.object_type "User" do |t|
+              t.field "user_id", "ID"
+              t.field "email", "String"
+              t.field "age", "Int"
+              t.field "is_active", "Boolean"
+              t.warehouse_table "users"
+            end
+          end
+
+          user_type = results.state.object_types_by_name.fetch("User")
+          table = user_type.warehouse_table_def
+
+          table_schema = table.to_config["table_schema"]
+          expect(table_schema).to eq(<<~SQL.strip)
+            CREATE TABLE IF NOT EXISTS users (
+              user_id STRING,
+              email STRING,
+              age INT,
+              is_active BOOLEAN
+            )
+          SQL
+        end
+
+        it "uses name_in_index for column names instead of GraphQL field names" do
+          results = define_warehouse_schema do |s|
+            s.object_type "Payment" do |t|
+              t.field "id", "ID"
+              t.field "amount", "Int", name_in_index: "amount_cents"
+              t.field "currencyCode", "String", name_in_index: "currency"
+              t.warehouse_table "payments"
+            end
+          end
+
+          payment_type = results.state.object_types_by_name.fetch("Payment")
+          table = payment_type.warehouse_table_def
+
+          table_schema = table.to_config["table_schema"]
+          expect(table_schema).to eq(<<~SQL.strip)
+            CREATE TABLE IF NOT EXISTS payments (
+              id STRING,
+              amount_cents INT,
+              currency STRING
+            )
+          SQL
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduces the WarehouseTable class that generates CREATE TABLE DDL statements from indexed type definitions. Types can now declare warehouse tables via the `warehouse_table` method, which creates a WarehouseTable instance storing the table name and type reference.