### PR TITLE
Refactor warehouse_table from type level to index level.

### DIFF
--- a/config/site/support/doctest_helper.rb
+++ b/config/site/support/doctest_helper.rb
@@ -10,6 +10,7 @@ require "elastic_graph/apollo/schema_definition/api_extension"
 require "elastic_graph/schema_artifacts/runtime_metadata/schema_element_names"
 require "elastic_graph/schema_definition/api"
 require "elastic_graph/schema_definition/schema_artifact_manager"
+require "elastic_graph/warehouse/schema_definition/api_extension"
 require "rspec/mocks"
 require "stringio"
 require "tmpdir"
@@ -50,7 +51,8 @@ module ElasticGraph
     descriptions_needing_schema_def_api_and_extension_modules = {
       "ElasticGraph.define_schema" => [],
       "ElasticGraph::Apollo::SchemaDefinition" => [ElasticGraph::Apollo::SchemaDefinition::APIExtension],
-      "ElasticGraph::SchemaDefinition" => []
+      "ElasticGraph::SchemaDefinition" => [],
+      "ElasticGraph::Warehouse::SchemaDefinition" => [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]
     }
 
     descriptions_needing_schema_def_api_and_extension_modules.each do |description, extension_modules|

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/index.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/index.rbs
@@ -7,6 +7,8 @@ module ElasticGraph
         attr_reader routing_field_path: SchemaElements::FieldPath?
         attr_reader rollover_config: RolloverConfig?
         attr_reader has_had_multiple_sources_flag: bool
+        attr_reader indexed_type: indexableType
+
         def uses_custom_routing?: () -> bool
         def to_index_config: () -> ::Hash[::String, untyped]
         def to_index_template_config: () -> ::Hash[::String, untyped]

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/factory_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/factory_extension.rb
@@ -7,6 +7,7 @@
 # frozen_string_literal: true
 
 require "elastic_graph/warehouse/schema_definition/enum_type_extension"
+require "elastic_graph/warehouse/schema_definition/index_extension"
 require "elastic_graph/warehouse/schema_definition/object_interface_and_union_extension"
 require "elastic_graph/warehouse/schema_definition/scalar_type_extension"
 
@@ -28,6 +29,20 @@ module ElasticGraph
             # :nocov: -- currently all invocations have a block
             yield type if block_given?
             # :nocov:
+          end
+        end
+
+        # Creates a new index with warehouse extensions.
+        #
+        # @param name [String] the name of the index
+        # @param settings [Hash] additional settings for the index
+        # @param type [Object] the type this index is for
+        # @yield [ElasticGraph::SchemaDefinition::Indexing::Index] the newly created index (optional)
+        # @return [ElasticGraph::SchemaDefinition::Indexing::Index] the created index
+        def new_index(name, settings, type, &block)
+          super(name, settings, type) do |index|
+            index.extend IndexExtension
+            block&.call(index)
           end
         end
 

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/index_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/index_extension.rb
@@ -1,0 +1,44 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/warehouse/schema_definition/warehouse_table"
+
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      # Extends {ElasticGraph::SchemaDefinition::Indexing::Index} to add warehouse table definition support.
+      module IndexExtension
+        # Returns the warehouse table definition for this index, if one has been defined via {#warehouse_table}.
+        #
+        # @return [WarehouseTable, nil] the warehouse table definition, or `nil` if none has been defined
+        # @dynamic warehouse_table_def
+        attr_reader :warehouse_table_def
+
+        # Defines a warehouse table for this index.
+        #
+        # @param name [String] name of the warehouse table
+        # @return [void]
+        #
+        # @example Define a warehouse table for the products index
+        #   ElasticGraph.define_schema do |schema|
+        #     schema.object_type "Product" do |t|
+        #       t.field "id", "ID"
+        #       t.field "name", "String"
+        #
+        #       t.index "products" do |i|
+        #         i.warehouse_table "store_products"
+        #       end
+        #     end
+        #   end
+        def warehouse_table(name)
+          @warehouse_table_def = WarehouseTable.new(name: name, index: self)
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rb
@@ -7,29 +7,14 @@
 # frozen_string_literal: true
 
 require "elastic_graph/warehouse/schema_definition/field_type_converter"
-require "elastic_graph/warehouse/schema_definition/warehouse_table"
 
 module ElasticGraph
   module Warehouse
     module SchemaDefinition
       # Extends {ElasticGraph::SchemaDefinition::SchemaElements::ObjectType},
       # {ElasticGraph::SchemaDefinition::SchemaElements::InterfaceType}, and
-      # {ElasticGraph::SchemaDefinition::SchemaElements::UnionType} to add warehouse table and column type definition support.
+      # {ElasticGraph::SchemaDefinition::SchemaElements::UnionType} to add warehouse column type definition support.
       module ObjectInterfaceAndUnionExtension
-        # Returns the warehouse table definition for this type, if one has been defined via {#warehouse_table}.
-        #
-        # @return [WarehouseTable, nil] the warehouse table definition, or `nil` if none has been defined
-        # @dynamic warehouse_table_def
-        attr_reader :warehouse_table_def
-
-        # Defines a warehouse table for this object or interface type.
-        #
-        # @param name [String] name of the warehouse table
-        # @return [void]
-        def warehouse_table(name)
-          @warehouse_table_def = WarehouseTable.new(name: name, indexed_type: self)
-        end
-
         # Returns the warehouse column type representation for this object, interface, or union type.
         #
         # @return [String] a STRUCT SQL type containing all subfields

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/warehouse_table.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/warehouse_table.rb
@@ -12,7 +12,7 @@ module ElasticGraph
   module Warehouse
     module SchemaDefinition
       # Represents a warehouse table configuration.
-      class WarehouseTable < ::Data.define(:name, :indexed_type)
+      class WarehouseTable < ::Data.define(:name, :index)
         # Converts the warehouse table to a configuration hash.
         #
         # @return [Hash] configuration hash with table_schema
@@ -28,7 +28,7 @@ module ElasticGraph
         #
         # @return [String] SQL CREATE TABLE statement with all fields
         def table_schema
-          fields = indexed_type
+          fields = index.indexed_type
             .indexing_fields_by_name_in_index
             .values
             .filter_map(&:to_indexing_field)

--- a/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/factory_extension.rbs
+++ b/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/factory_extension.rbs
@@ -2,25 +2,6 @@ module ElasticGraph
   module Warehouse
     module SchemaDefinition
       module FactoryExtension: ::ElasticGraph::SchemaDefinition::Factory
-        def new_enum_type: (::String) ?{
-          (::ElasticGraph::SchemaDefinition::SchemaElements::EnumType) -> void
-        } -> ::ElasticGraph::SchemaDefinition::SchemaElements::EnumType
-
-        def new_interface_type: (::String) ?{
-          (::ElasticGraph::SchemaDefinition::SchemaElements::InterfaceType) -> void
-        } -> ::ElasticGraph::SchemaDefinition::SchemaElements::InterfaceType
-
-        def new_object_type: (::String) ?{
-          (::ElasticGraph::SchemaDefinition::SchemaElements::ObjectType) -> void
-        } -> ::ElasticGraph::SchemaDefinition::SchemaElements::ObjectType
-
-        def new_scalar_type: (::String) ?{
-          (::ElasticGraph::SchemaDefinition::SchemaElements::ScalarType) -> void
-        } -> ::ElasticGraph::SchemaDefinition::SchemaElements::ScalarType
-
-        def new_union_type: (::String) ?{
-          (::ElasticGraph::SchemaDefinition::SchemaElements::UnionType) -> void
-        } -> ::ElasticGraph::SchemaDefinition::SchemaElements::UnionType
       end
     end
   end

--- a/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/index_extension.rbs
+++ b/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/index_extension.rbs
@@ -1,0 +1,12 @@
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      module IndexExtension : ::ElasticGraph::SchemaDefinition::Indexing::Index
+        def warehouse_table_def: () -> WarehouseTable?
+        def warehouse_table: (::String) -> void
+
+        @warehouse_table_def: WarehouseTable?
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rbs
+++ b/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rbs
@@ -2,15 +2,10 @@ module ElasticGraph
   module Warehouse
     module SchemaDefinition
       module ObjectInterfaceAndUnionExtension : _ObjectInterfaceAndUnionExtensionInterface
-        def warehouse_table_def: () -> WarehouseTable?
-        def warehouse_table: (::String) -> void
         def to_warehouse_column_type: () -> ::String
-
-        @warehouse_table_def: WarehouseTable?
       end
 
       interface _ObjectInterfaceAndUnionExtensionInterface
-        def schema_def_state: () -> ::ElasticGraph::SchemaDefinition::State
         def indexing_fields_by_name_in_index: () -> ::Hash[::String, ::ElasticGraph::SchemaDefinition::SchemaElements::Field]
       end
     end

--- a/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/warehouse_table.rbs
+++ b/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/warehouse_table.rbs
@@ -3,9 +3,9 @@ module ElasticGraph
     module SchemaDefinition
       class WarehouseTableSupertype
         attr_reader name: ::String
-        attr_reader indexed_type: _IndexedTypeInterface
+        attr_reader index: ::ElasticGraph::SchemaDefinition::Indexing::Index
 
-        def initialize: (name: ::String, indexed_type: _IndexedTypeInterface) -> void
+        def initialize: (name: ::String, index: ::ElasticGraph::SchemaDefinition::Indexing::Index) -> void
       end
 
       class WarehouseTable < WarehouseTableSupertype
@@ -15,10 +15,6 @@ module ElasticGraph
         private
 
         def table_field: (::ElasticGraph::SchemaDefinition::Indexing::Field) -> ::String
-      end
-
-      interface _IndexedTypeInterface
-        def indexing_fields_by_name_in_index: () -> ::Hash[::String, ::ElasticGraph::SchemaDefinition::SchemaElements::Field]
       end
     end
   end

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/index_extension_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/index_extension_spec.rb
@@ -1,0 +1,114 @@
+# Copyright 2024 - 2025 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/warehouse/schema_definition/api_extension"
+
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      RSpec.describe IndexExtension, :warehouse_schema do
+        it "returns nil for warehouse_table_def when no warehouse table has been defined" do
+          results = define_warehouse_schema do |s|
+            s.object_type "Product" do |t|
+              t.field "id", "ID"
+              t.index "products"
+            end
+          end
+
+          product_type = results.state.object_types_by_name.fetch("Product")
+          index = product_type.index_def
+
+          expect(index.warehouse_table_def).to be_nil
+        end
+
+        it "allows defining a warehouse table on an index" do
+          results = define_warehouse_schema do |s|
+            s.object_type "Product" do |t|
+              t.field "id", "ID"
+              t.index "products" do |i|
+                i.warehouse_table "products_warehouse"
+              end
+            end
+          end
+
+          product_type = results.state.object_types_by_name.fetch("Product")
+          index = product_type.index_def
+          table = index.warehouse_table_def
+
+          expect(table).to be_a(WarehouseTable)
+          expect(table.name).to eq("products_warehouse")
+          expect(table.index).to eq(index)
+        end
+
+        it "overwrites the warehouse table when called multiple times" do
+          results = define_warehouse_schema do |s|
+            s.object_type "Product" do |t|
+              t.field "id", "ID"
+              t.index "products" do |i|
+                i.warehouse_table "first_table"
+                i.warehouse_table "second_table"
+              end
+            end
+          end
+
+          product_type = results.state.object_types_by_name.fetch("Product")
+          table = product_type.index_def.warehouse_table_def
+
+          expect(table.name).to eq("second_table")
+        end
+
+        it "works with interface types" do
+          results = define_warehouse_schema do |s|
+            s.interface_type "Identifiable" do |t|
+              t.field "id", "ID"
+              t.index "identifiables" do |i|
+                i.warehouse_table "identifiables"
+              end
+            end
+
+            s.object_type "Widget" do |t|
+              t.implements "Identifiable"
+              t.field "id", "ID"
+            end
+          end
+
+          interface_type = results.state.types_by_name.fetch("Identifiable")
+          table = interface_type.index_def.warehouse_table_def
+
+          expect(table).to be_a(WarehouseTable)
+          expect(table.name).to eq("identifiables")
+        end
+
+        it "works with union types" do
+          results = define_warehouse_schema do |s|
+            s.object_type "Card" do |t|
+              t.field "id", "ID"
+            end
+
+            s.object_type "BankAccount" do |t|
+              t.field "id", "ID"
+            end
+
+            s.union_type "PaymentMethod" do |t|
+              t.subtypes "Card", "BankAccount"
+              t.index "payment_methods" do |i|
+                i.warehouse_table "payment_methods"
+              end
+            end
+          end
+
+          union_type = results.state.types_by_name.fetch("PaymentMethod")
+          table = union_type.index_def.warehouse_table_def
+
+          expect(table).to be_a(WarehouseTable)
+          expect(table.name).to eq("payment_methods")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Moves warehouse_table definition from ObjectInterfaceAndUnionExtension to a new IndexExtension module. This allows warehouse tables to be defined on indices rather than types, which better reflects the data model since indices contain the actual indexing configuration.

