### PR TITLE
Instantiate `Indexing::Index` from the schema def factory.

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
@@ -9,6 +9,7 @@
 require "elastic_graph/constants"
 require "elastic_graph/schema_definition/mixins/has_readable_to_s_and_inspect"
 require "elastic_graph/schema_definition/results"
+require "elastic_graph/schema_definition/indexing/index"
 require "elastic_graph/schema_definition/schema_artifact_manager"
 require "elastic_graph/schema_definition/schema_elements/argument"
 require "elastic_graph/schema_definition/schema_elements/built_in_types"
@@ -276,6 +277,11 @@ module ElasticGraph
         )
       end
       @@relationship_new = prevent_non_factory_instantiation_of(SchemaElements::Relationship)
+
+      def new_index(name, settings, type, &block)
+        @@index_new.call(name, settings, @state, type, &block)
+      end
+      @@index_new = prevent_non_factory_instantiation_of(Indexing::Index)
 
       def new_results
         @@results_new.call(@state)

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
@@ -77,7 +77,7 @@ module ElasticGraph
               "Only one index per type is supported. An index named `#{@index_def.name}` has already been defined."
           end
 
-          @index_def = Indexing::Index.new(name, settings, schema_def_state, self, &block)
+          @index_def = schema_def_state.factory.new_index(name, settings, self, &block)
         end
 
         # Configures the default GraphQL resolver that will be used to resolve the fields of this type. Individual fields

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/factory.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/factory.rbs
@@ -113,6 +113,13 @@ module ElasticGraph
       ) -> SchemaElements::Relationship
       @@relationship_new: ::Method
 
+      def new_index: (
+        ::String,
+        ::Hash[::String, untyped],
+        indexableType
+      ) ?{ (Indexing::Index) -> void } -> Indexing::Index
+      @@index_new: ::Method
+
       def new_results: () -> Results
       @@results_new: ::Method
 


### PR DESCRIPTION
This makes it easier to extend the `Indexing::Index` API from an extension.