### PR TITLE
Float should map to warehouse FLOAT type

### DIFF
--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/api_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/api_extension.rb
@@ -40,7 +40,7 @@ module ElasticGraph
           "Cursor" => "STRING",
           "Date" => "DATE",
           "DateTime" => "TIMESTAMP",
-          "Float" => "DOUBLE",
+          "Float" => "FLOAT",
           "ID" => "STRING",
           "Int" => "INT",
           "JsonSafeLong" => "BIGINT",

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/field_type_converter_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/field_type_converter_spec.rb
@@ -40,7 +40,7 @@ module ElasticGraph
             end
           end
 
-          expect(convert_field_type(results, "Matrix", "values")).to eq "ARRAY<ARRAY<DOUBLE>>"
+          expect(convert_field_type(results, "Matrix", "values")).to eq "ARRAY<ARRAY<FLOAT>>"
         end
 
         it "unwraps non-null wrapper before checking if type is a list" do

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension_spec.rb
@@ -35,7 +35,7 @@ module ElasticGraph
             end
 
             # GeoLocation uses name_in_index: "lat" and "lon" for its fields
-            expect(warehouse_column_type_for(results, "Venue")).to eq("STRUCT<id STRING, name STRING, location STRUCT<lat DOUBLE, lon DOUBLE>>")
+            expect(warehouse_column_type_for(results, "Venue")).to eq("STRUCT<id STRING, name STRING, location STRUCT<lat FLOAT, lon FLOAT>>")
           end
 
           it "respects name_in_index for nested object fields" do
@@ -66,7 +66,7 @@ module ElasticGraph
               end
             end
 
-            expect(warehouse_column_type_for(results, "Identifiable")).to eq("STRUCT<id STRING, name STRING, price DOUBLE, __typename STRING>")
+            expect(warehouse_column_type_for(results, "Identifiable")).to eq("STRUCT<id STRING, name STRING, price FLOAT, __typename STRING>")
           end
         end
 

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/results_extension_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/results_extension_spec.rb
@@ -40,7 +40,7 @@ module ElasticGraph
                 "table_schema" => <<~SQL.strip
                   CREATE TABLE IF NOT EXISTS orders (
                     id STRING,
-                    total DOUBLE
+                    total FLOAT
                   )
                 SQL
               },
@@ -49,7 +49,7 @@ module ElasticGraph
                   CREATE TABLE IF NOT EXISTS products (
                     id STRING,
                     name STRING,
-                    price DOUBLE
+                    price FLOAT
                   )
                 SQL
               }

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/scalar_type_extension_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/scalar_type_extension_spec.rb
@@ -30,7 +30,7 @@ module ElasticGraph
 
           # Test the scalar types directly
           expect(warehouse_column_type_for(results, "Int")).to eq("INT")
-          expect(warehouse_column_type_for(results, "Float")).to eq("DOUBLE")
+          expect(warehouse_column_type_for(results, "Float")).to eq("FLOAT")
           expect(warehouse_column_type_for(results, "Boolean")).to eq("BOOLEAN")
           expect(warehouse_column_type_for(results, "String")).to eq("STRING")
           expect(warehouse_column_type_for(results, "ID")).to eq("STRING")

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/warehouse_table_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/warehouse_table_spec.rb
@@ -53,7 +53,7 @@ module ElasticGraph
           expect(config["table_schema"]).to eq(<<~SQL.strip)
             CREATE TABLE IF NOT EXISTS orders (
               id STRING,
-              total DOUBLE
+              total FLOAT
             )
           SQL
         end


### PR DESCRIPTION
Float is a valid spark Datatype. There's no
reason to map floats to the larger double type