### PR TITLE
Remove vestigial `#inspect_output_of`.

### DIFF
--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/misc_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/misc_spec.rb
@@ -22,7 +22,7 @@ module ElasticGraph
       end
 
       it "inspects nicely, but redacts filters since they could contain PII" do
-        expect(new_query(client_filters: [{"ssn" => {"equal_to_any_of" => ["123-45-6789"]}}], individual_docs_needed: true).inspect).to eq(inspect_output_of(<<~EOS.strip))
+        expect(new_query(client_filters: [{"ssn" => {"equal_to_any_of" => ["123-45-6789"]}}], individual_docs_needed: true).inspect).to eq(<<~EOS.strip)
           #<ElasticGraph::GraphQL::DatastoreQuery index="widgets_rollover__*" size=#{default_page_size + 1} sort=[{"id" => {"order" => "asc", "missing" => "_first"}}] track_total_hits=false query=<REDACTED> _source=false>
         EOS
       end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
@@ -187,7 +187,7 @@ module ElasticGraph
           expect {
             router.msearch([query1, query2])
           }.to raise_error(Errors::SearchFailedError, a_string_including(
-            "2) ", '{"index":"widgets_rollover__*"}', inspect_output_of('{"bad stuff" => "happened"}')
+            "2) ", '{"index":"widgets_rollover__*"}', '{"bad stuff" => "happened"}'
           ).and(excluding(
             # These are parts of the body of the request, which we don't want included because it could contain PII!.
             "track_total_hits", "size"

--- a/elasticgraph-local/spec/unit/elastic_graph/local/rake_tasks_spec.rb
+++ b/elasticgraph-local/spec/unit/elastic_graph/local/rake_tasks_spec.rb
@@ -143,7 +143,7 @@ module ElasticGraph
             end
           }.to raise_error a_string_including(
             "`env_port_mapping` has invalid ports: ",
-            inspect_output_of('{local: "123"}')
+            '{local: "123"}'
           )
         end
 
@@ -154,7 +154,7 @@ module ElasticGraph
             end
           }.to raise_error a_string_including(
             "`env_port_mapping` has invalid ports: ",
-            inspect_output_of('{local: "45000"}')
+            '{local: "45000"}'
           )
         end
 

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names_spec.rb
@@ -105,7 +105,7 @@ module ElasticGraph
         it "inspects nicely" do
           names = new_with(form: :camelCase, overrides: {foo: :bar})
 
-          expect(names.inspect).to eq inspect_output_of("#<ElasticGraph::SchemaArtifacts::RuntimeMetadata::ExampleElementNames form=camelCase, overrides={foo: :bar}>")
+          expect(names.inspect).to eq "#<ElasticGraph::SchemaArtifacts::RuntimeMetadata::ExampleElementNames form=camelCase, overrides={foo: :bar}>"
           expect(names.to_s).to eq names.inspect
         end
 

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/abstract_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/abstract_types_spec.rb
@@ -170,8 +170,8 @@ module ElasticGraph
               "subtypes of `Thing`",
               "Widget",
               "Component",
-              inspect_output_of('"type" => "keyword"'),
-              inspect_output_of('"type" => "integer"')
+              '"type" => "keyword"',
+              '"type" => "integer"'
             ).and(excluding("Animal")))
           end
 

--- a/spec_support/spec_helper.rb
+++ b/spec_support/spec_helper.rb
@@ -325,26 +325,6 @@ module ElasticGraph
       CommonSpecHelpers.parsed_test_settings_yaml
     end
 
-    # Ruby 3.4 improved the `#inspect` output of a `Hash`:
-    # - `{foo: 1}` inspects as `{foo: 1}` instead of `{:foo=>1}`
-    # - `{"foo" => 1}` inspects as `{"foo" => 1}` instead of `{"foo"=>1}`
-    #
-    # Some of our specs expect `#inspect` output or an error message generated from `#inspect` output.
-    # We've updated those expectations to match the new Ruby 3.4 formatting. To pass against older
-    # Rubies, `#inspect_output_of` downgrades the output to match the old output seen on Ruby 3.3 and before.
-    # :nocov: -- only one side of this branch is covered on a given test suite run (based on the Ruby version)
-    if RUBY_VERSION >= "3.4"
-      def inspect_output_of(output) = output
-    else
-      def inspect_output_of(output)
-        output
-          .gsub(/(\S) =>/, '\1=>')
-          .gsub(/=> (\S)/, '=>\1')
-          .gsub(/(\w+): /, ':\1=>')
-      end
-    end
-    # :nocov:
-
     module_function
 
     def expect_to_return_non_nil_values_from_all_attributes(object)


### PR DESCRIPTION
This was needed to have passing expectations on Ruby 3.4 and Ruby < 3.4, but is no longer needed now that we only support Ruby 3.4+.