### PR TITLE
Add configurable timeout for health check recency queries

### DIFF
--- a/elasticgraph-health_check/README.md
+++ b/elasticgraph-health_check/README.md
@@ -86,6 +86,7 @@ Finally, configure it:
 
 ```yaml
 health_check:
+  timeout_ms: 5000
   clusters_to_consider: ["main"]
   data_recency_checks:
     Widget:
@@ -93,6 +94,9 @@ health_check:
       expected_max_recency_seconds: 30
 ```
 
+- `timeout_ms` (optional, default: 5000) - The timeout in milliseconds for health check datastore queries. If queries take longer than this,
+  the health check will fail fast with a timeout error. This prevents slow or unresponsive datastores from causing the health check endpoint
+  to hang, which can lead to cascading health check requests from load balancers like Envoy.
 - `clusters_to_consider` configures the first check (datastore cluster health), and specifies which clusters' health status is monitored.
 - `data_recency_checks` configures the second check (data recency), and configures the recency check described above. In this example, if no new "Widgets"
   are indexed for thirty seconds (perhaps because of an infrastructure issue), a `degraded` status will be returned.

--- a/elasticgraph-health_check/sig/elastic_graph/health_check/config.rbs
+++ b/elasticgraph-health_check/sig/elastic_graph/health_check/config.rbs
@@ -7,24 +7,28 @@ module ElasticGraph
 
       attr_reader clusters_to_consider: ::Array[::String]
       attr_reader data_recency_checks: ::Hash[::String, Config::DataRecencyCheck]
+      attr_reader timeout_ms: ::Integer
 
       def self.new: (
         ::Array[::String],
-        ::Hash[::String, dataRecencyCheckHash]
+        ::Hash[::String, dataRecencyCheckHash],
+        ::Integer
       ) -> Config | (
         ?clusters_to_consider: ::Array[::String],
-        ?data_recency_checks: ::Hash[::String, dataRecencyCheckHash]
+        ?data_recency_checks: ::Hash[::String, dataRecencyCheckHash],
+        ?timeout_ms: ::Integer
       ) -> Config
 
       def with: (
         ?clusters_to_consider: ::Array[::String],
-        ?data_recency_checks: ::Hash[::String, Config::DataRecencyCheck]) -> Config
+        ?data_recency_checks: ::Hash[::String, Config::DataRecencyCheck],
+        ?timeout_ms: ::Integer) -> Config
     end
 
     class Config < ConfigSupertype
       private
 
-      def convert_values: (clusters_to_consider: untyped, data_recency_checks: untyped) -> untyped
+      def convert_values: (clusters_to_consider: untyped, data_recency_checks: untyped, timeout_ms: untyped) -> untyped
 
       class DataRecencyCheck
         attr_reader expected_max_recency_seconds: ::Integer

--- a/elasticgraph-health_check/sig/elastic_graph/health_check/health_checker.rbs
+++ b/elasticgraph-health_check/sig/elastic_graph/health_check/health_checker.rbs
@@ -10,6 +10,7 @@ module ElasticGraph
         datastore_query_builder: GraphQL::DatastoreQuery::Builder,
         datastore_clients_by_name: ::Hash[::String, DatastoreCore::_Client],
         clock: singleton(::Time),
+        monotonic_clock: Support::MonotonicClock,
         logger: ::Logger
       ) -> void
 
@@ -22,12 +23,14 @@ module ElasticGraph
       @datastore_query_builder: GraphQL::DatastoreQuery::Builder
       @datastore_clients_by_name: ::Hash[::String, DatastoreCore::_Client]
       @clock: singleton(::Time)
+      @monotonic_clock: Support::MonotonicClock
       @logger: ::Logger
       @indexed_document_types_by_name: ::Hash[::String, GraphQL::Schema::Type]
       @config: Config
 
       def datastore_msearch: (::Array[GraphQL::DatastoreQuery]) -> ::Hash[GraphQL::DatastoreQuery, GraphQL::DatastoreResponse::SearchResponse]
       def build_recency_query_for: (::String, Config::DataRecencyCheck) -> GraphQL::DatastoreQuery
+      def monotonic_clock_deadline: () -> ::Integer
       def build_index_optimization_filter_for: (Config::DataRecencyCheck) -> ::Hash[::String, untyped]?
       def execute_in_parallel: (*::Proc) -> ::Array[untyped]
 

--- a/elasticgraph-health_check/spec/unit/elastic_graph/health_check/config_spec.rb
+++ b/elasticgraph-health_check/spec/unit/elastic_graph/health_check/config_spec.rb
@@ -49,6 +49,24 @@ module ElasticGraph
         config = Config.new
         expect(config.clusters_to_consider).to be_empty
         expect(config.data_recency_checks).to be_empty
+        expect(config.timeout_ms).to eq(5000)
+      end
+
+      it "allows configuring a custom timeout_ms" do
+        config = Config.new(timeout_ms: 3000)
+        expect(config.timeout_ms).to eq(3000)
+      end
+
+      it "parses timeout_ms from YAML" do
+        parsed_yaml = ::YAML.safe_load(<<~EOS)
+          health_check:
+            clusters_to_consider: []
+            data_recency_checks: {}
+            timeout_ms: 10000
+        EOS
+
+        config = Config.from_parsed_yaml(parsed_yaml)
+        expect(config.timeout_ms).to eq(10000)
       end
     end
   end


### PR DESCRIPTION
  When the datastore is slow, health check requests can take a long time
  to complete. Since Envoy doesn't cache in-flight health check results,
  it sends additional concurrent requests while waiting, which compounds
  the load on an already struggling datastore.

  This adds a `timeout_ms` configuration option (default: 5000ms) that
  sets a monotonic clock deadline on recency queries. Requests will fail
  fast when the datastore is unresponsive, preventing the cascade of
  concurrent health check requests.

  Configuration example:
  ```yaml
  health_check:
    timeout_ms: 3000
    data_recency_checks:
      Widget:
        timestamp_field: created_at
        expected_max_recency_seconds: 30