### PR TITLE
Update RBS to 3.10.0.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -452,7 +452,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (3.9.5)
+    rbs (3.10.0)
       logger
     redcarpet (3.6.1)
     regexp_parser (2.11.3)

--- a/Steepfile
+++ b/Steepfile
@@ -76,7 +76,6 @@ target :elasticgraph_gems do
     "forwardable",
     "json",
     "open3",
-    "pathname",
     "shellwords",
     "tmpdir",
     "tempfile",

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/decoded_cursor.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/decoded_cursor.rb
@@ -55,7 +55,7 @@ module ElasticGraph
       # Encodes the cursor to a string using JSON and Base64 encoding.
       def encode
         @encode ||= begin
-          json = ::JSON.fast_generate(sort_values)
+          json = ::JSON.generate(sort_values)
           ::Base64.urlsafe_encode64(json, padding: false)
         end
       end

--- a/elasticgraph-support/lib/elastic_graph/support/untyped_encoder.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/untyped_encoder.rb
@@ -25,15 +25,7 @@ module ElasticGraph
       # Encodes the given untyped value to a String so it can be indexed in a Elasticsearch/OpenSearch `keyword` field.
       def self.encode(value)
         return nil if value.nil?
-        # Note: we use `fast_generate` here instead of `generate`. They basically act the same, except
-        # `generate` includes an extra check for self-referential data structures. `value` here ultimately
-        # comes out of a parsed JSON document (e.g. either from an ElasticGraph event at indexing time, or
-        # as a GraphQL query variable at search time), and JSON cannot express self-referential data
-        # structures, so we do not have to worry about that happening.
-        #
-        # ...but even if it did, we would get an error either way: `JSON.generate` would raise
-        # `JSON::NestingError` whereas `:JSON.fast_generate` would give us a `SystemStackError`.
-        ::JSON.fast_generate(canonicalize(value))
+        ::JSON.generate(canonicalize(value))
       end
 
       # Decodes a previously encoded Untyped value, returning its original value.

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -6,7 +6,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: addressable
@@ -14,7 +14,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ast
@@ -22,7 +22,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: async
@@ -30,7 +30,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: aws-sdk-cloudwatch
@@ -70,19 +70,23 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: cgi
-  version: '0'
+  version: '0.5'
   source:
-    type: stdlib
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: concurrent-ruby
   version: '1.1'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: connection_pool
@@ -90,7 +94,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: csv
@@ -98,7 +102,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: date
@@ -110,7 +114,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: digest
@@ -126,7 +130,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: faraday
@@ -134,7 +138,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: fileutils
@@ -150,7 +154,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: hashdiff
@@ -158,7 +162,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: i18n
@@ -166,7 +170,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: json
@@ -178,7 +182,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: logger
@@ -190,7 +194,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: monitor
@@ -210,7 +214,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: openssl
@@ -226,7 +230,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: parser
@@ -234,7 +238,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: prism
@@ -246,7 +250,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rainbow
@@ -254,7 +258,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rake
@@ -262,7 +266,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: regexp_parser
@@ -270,7 +274,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ripper
@@ -282,7 +286,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rubocop-ast
@@ -290,7 +294,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: securerandom
@@ -302,7 +306,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: singleton
@@ -326,7 +330,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: time
@@ -342,7 +346,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: uri
@@ -358,7 +362,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8c8db1451cc30c65cfec77dbdabf6e6bbc115d01
+    revision: '092afb7dc665e6ea71b50ce15c130a4ae0a7809f'
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: yard-markdown


### PR DESCRIPTION
After upgrading, I got a couple of warnings/errors, as shown below.

```
W, [2025-12-30T18:29:38.165542 #27133]  WARN -- rbs: `pathname` has been moved to core library, so it is always loaded. Remove explicit loading `pathname`
W, [2025-12-30T18:29:38.165641 #27133]  WARN -- rbs: `pathname` has been moved to core library, so it is always loaded. Remove explicit loading `pathname`
W, [2025-12-30T18:29:38.944855 #27167]  WARN -- rbs: `pathname` has been moved to core library, so it is always loaded. Remove explicit loading `pathname`
W, [2025-12-30T18:29:38.944864 #27169]  WARN -- rbs: `pathname` has been moved to core library, so it is always loaded. Remove explicit loading `pathname`
W, [2025-12-30T18:29:38.944856 #27168]  WARN -- rbs: `pathname` has been moved to core library, so it is always loaded. Remove explicit loading `pathname`
W, [2025-12-30T18:29:38.946018 #27170]  WARN -- rbs: `pathname` has been moved to core library, so it is always loaded. Remove explicit loading `pathname`
W, [2025-12-30T18:29:38.945572 #27166]  WARN -- rbs: `pathname` has been moved to core library, so it is always loaded. Remove explicit loading `pathname`
W, [2025-12-30T18:29:38.946532 #27171]  WARN -- rbs: `pathname` has been moved to core library, so it is always loaded. Remove explicit loading `pathname`
W, [2025-12-30T18:29:38.953864 #27172]  WARN -- rbs: `pathname` has been moved to core library, so it is always loaded. Remove explicit loading `pathname`
W, [2025-12-30T18:29:38.974222 #27173]  WARN -- rbs: `pathname` has been moved to core library, so it is always loaded. Remove explicit loading `pathname`
....................................................................F...............................................................................................................................................................................................................................................................................................................................................................................................................................F........................................................................................................................

elasticgraph-graphql/lib/elastic_graph/graphql/decoded_cursor.rb:58:24: [error] The method is deprecated
│ Diagnostic ID: Ruby::DeprecatedReference
│
└           json = ::JSON.fast_generate(sort_values)
                          ~~~~~~~~~~~~~

elasticgraph-support/lib/elastic_graph/support/untyped_encoder.rb:36:15: [error] The method is deprecated
│ Diagnostic ID: Ruby::DeprecatedReference
│
└         ::JSON.fast_generate(canonicalize(value))
                 ~~~~~~~~~~~~~

Detected 2 problems from 2 files
```