### PR TITLE
Remove redundant `require "pathname"` from project template.

### DIFF
--- a/elasticgraph/lib/elastic_graph/project_template/config/schema.rb.tt
+++ b/elasticgraph/lib/elastic_graph/project_template/config/schema.rb.tt
@@ -1,5 +1,3 @@
-require "pathname"
-
 ElasticGraph.define_schema do |schema|
   # ElasticGraph will tell you when you need to bump this.
   schema.json_schema_version 1


### PR DESCRIPTION
Standard Ruby 1.53.0 added Lint/RedundantRequireStatement which flags this as unnecessary since Pathname is autoloaded in Ruby 4.0.