### PR TITLE
Rework warehouse test suite to use public API

### DIFF
--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/enum_type_extension_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/enum_type_extension_spec.rb
@@ -12,18 +12,22 @@ module ElasticGraph
   module Warehouse
     module SchemaDefinition
       RSpec.describe EnumTypeExtension, :warehouse_schema do
-        it "converts enum type to warehouse column type" do
+        it "maps enum fields to STRING columns" do
           results = define_warehouse_schema do |s|
-            s.json_schema_version 1
-
             s.enum_type "Status" do |t|
               t.value "ACTIVE"
               t.value "INACTIVE"
               t.value "PENDING"
             end
+
+            s.object_type "Account" do |t|
+              t.field "id", "ID"
+              t.field "status", "Status"
+              t.index "accounts"
+            end
           end
 
-          expect(warehouse_column_type_for(results, "Status")).to eq "STRING"
+          expect(warehouse_column_def_from(results, "accounts", "status")).to eq "status STRING"
         end
       end
     end

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/index_extension_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/index_extension_spec.rb
@@ -22,27 +22,7 @@ module ElasticGraph
             end
           end
 
-          product_type = results.state.object_types_by_name.fetch("Product")
-          index = product_type.index_def
-
-          expect(index.warehouse_table_def).to be_nil
-        end
-
-        it "automatically creates a warehouse table with the index name when no warehouse table is explicitly defined" do
-          results = define_warehouse_schema do |s|
-            s.object_type "Product" do |t|
-              t.field "id", "ID"
-              t.index "products"
-            end
-          end
-
-          product_type = results.state.object_types_by_name.fetch("Product")
-          index = product_type.index_def
-          table = index.warehouse_table_def
-
-          expect(table).to be_a(WarehouseTable)
-          expect(table.name).to eq("products")
-          expect(table.index).to eq(index)
+          expect(table_names_from(results)).not_to include("products")
         end
 
         it "allows overriding the warehouse table name on an index" do
@@ -55,13 +35,7 @@ module ElasticGraph
             end
           end
 
-          product_type = results.state.object_types_by_name.fetch("Product")
-          index = product_type.index_def
-          table = index.warehouse_table_def
-
-          expect(table).to be_a(WarehouseTable)
-          expect(table.name).to eq("products_warehouse")
-          expect(table.index).to eq(index)
+          expect(table_names_from(results)).to contain_exactly("products_warehouse")
         end
 
         it "overwrites the warehouse table when called multiple times" do
@@ -75,10 +49,7 @@ module ElasticGraph
             end
           end
 
-          product_type = results.state.object_types_by_name.fetch("Product")
-          table = product_type.index_def.warehouse_table_def
-
-          expect(table.name).to eq("second_table")
+          expect(table_names_from(results)).to contain_exactly("second_table")
         end
 
         it "uses last-write-wins when exclude_from_warehouse is called before warehouse_table" do
@@ -92,11 +63,7 @@ module ElasticGraph
             end
           end
 
-          product_type = results.state.object_types_by_name.fetch("Product")
-          table = product_type.index_def.warehouse_table_def
-
-          expect(table).to be_a(WarehouseTable)
-          expect(table.name).to eq("products_warehouse")
+          expect(table_names_from(results)).to contain_exactly("products_warehouse")
         end
 
         it "uses last-write-wins when warehouse_table is called before exclude_from_warehouse" do
@@ -110,10 +77,7 @@ module ElasticGraph
             end
           end
 
-          product_type = results.state.object_types_by_name.fetch("Product")
-          index = product_type.index_def
-
-          expect(index.warehouse_table_def).to be_nil
+          expect(table_names_from(results)).to be_empty
         end
 
         it "works with interface types" do
@@ -129,11 +93,7 @@ module ElasticGraph
             end
           end
 
-          interface_type = results.state.types_by_name.fetch("Identifiable")
-          table = interface_type.index_def.warehouse_table_def
-
-          expect(table).to be_a(WarehouseTable)
-          expect(table.name).to eq("identifiables")
+          expect(table_names_from(results)).to contain_exactly("identifiables")
         end
 
         it "works with union types" do
@@ -152,11 +112,7 @@ module ElasticGraph
             end
           end
 
-          union_type = results.state.types_by_name.fetch("PaymentMethod")
-          table = union_type.index_def.warehouse_table_def
-
-          expect(table).to be_a(WarehouseTable)
-          expect(table.name).to eq("payment_methods")
+          expect(table_names_from(results)).to contain_exactly("payment_methods")
         end
       end
     end

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/results_extension_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/results_extension_spec.rb
@@ -66,28 +66,6 @@ module ElasticGraph
           expect(config).to eq({"tables" => {}})
         end
 
-        it "excludes indices that are explicitly excluded from the warehouse" do
-          results = define_warehouse_schema do |s|
-            s.object_type "Product" do |t|
-              t.field "id", "ID"
-              t.field "name", "String"
-              t.index "products"
-            end
-
-            s.object_type "Category" do |t|
-              t.field "id", "ID"
-              t.field "name", "String"
-              t.index "categories" do |i|
-                i.exclude_from_warehouse
-              end
-            end
-          end
-
-          config = results.warehouse_config
-
-          expect(config["tables"].keys).to contain_exactly("products")
-        end
-
         it "sorts warehouse tables by name" do
           results = define_warehouse_schema do |s|
             s.object_type "Zebra" do |t|
@@ -106,9 +84,7 @@ module ElasticGraph
             end
           end
 
-          config = results.warehouse_config
-
-          expect(config["tables"].keys).to eq(["apples", "mangos", "zebras"])
+          expect(table_names_from(results)).to eq(["apples", "mangos", "zebras"])
         end
 
         it "memoizes the warehouse config" do

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/warehouse_table_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/warehouse_table_spec.rb
@@ -12,90 +12,7 @@ module ElasticGraph
   module Warehouse
     module SchemaDefinition
       RSpec.describe WarehouseTable, :warehouse_schema do
-        it "generates table schema with warehouse_table definition on index" do
-          results = define_warehouse_schema do |s|
-            s.object_type "Product" do |t|
-              t.field "id", "ID"
-              t.field "name", "String"
-              t.field "price", "Float"
-              t.index "products"
-            end
-          end
-
-          product_type = results.state.object_types_by_name.fetch("Product")
-          index = product_type.index_def
-          table = index.warehouse_table_def
-
-          expect(table).to be_a(WarehouseTable)
-          expect(table.name).to eq("products")
-
-          expect(table.index).to eq(index)
-        end
-
-        it "allows overriding warehouse_table name to differ from index name" do
-          results = define_warehouse_schema do |s|
-            s.object_type "Product" do |t|
-              t.field "id", "ID"
-              t.field "name", "String"
-              t.index "products" do |i|
-                i.warehouse_table "custom_products_table"
-              end
-            end
-          end
-
-          product_type = results.state.object_types_by_name.fetch("Product")
-          table = product_type.index_def.warehouse_table_def
-
-          expect(table).to be_a(WarehouseTable)
-          expect(table.name).to eq("custom_products_table")
-        end
-
-        it "does not include excluded indices in warehouse config" do
-          results = define_warehouse_schema do |s|
-            s.object_type "Product" do |t|
-              t.field "id", "ID"
-              t.index "products"
-              # This will automatically get a warehouse table
-            end
-
-            s.object_type "InternalMetrics" do |t|
-              t.field "id", "ID"
-              t.index "internal_metrics" do |i|
-                i.exclude_from_warehouse
-              end
-            end
-          end
-
-          warehouse_config = results.warehouse_config
-          table_names = warehouse_config["tables"].keys
-
-          expect(table_names).to eq(["products"])
-          expect(table_names).not_to include("internal_metrics")
-        end
-
-        it "converts table to configuration hash" do
-          results = define_warehouse_schema do |s|
-            s.object_type "Order" do |t|
-              t.field "id", "ID"
-              t.field "total", "Float"
-              t.index "orders"
-            end
-          end
-
-          order_type = results.state.object_types_by_name.fetch("Order")
-          table = order_type.index_def.warehouse_table_def
-
-          config = table.to_config
-          expect(config).to have_key("table_schema")
-          expect(config["table_schema"]).to eq(<<~SQL.strip)
-            CREATE TABLE IF NOT EXISTS orders (
-              id STRING,
-              total FLOAT
-            )
-          SQL
-        end
-
-        it "generates complete CREATE TABLE SQL statement with all common scalar types" do
+        it "generates complete CREATE TABLE SQL statement" do
           results = define_warehouse_schema do |s|
             s.object_type "User" do |t|
               t.field "id", "ID"
@@ -106,11 +23,7 @@ module ElasticGraph
             end
           end
 
-          user_type = results.state.object_types_by_name.fetch("User")
-          table = user_type.index_def.warehouse_table_def
-
-          table_schema = table.to_config["table_schema"]
-          expect(table_schema).to eq(<<~SQL.strip)
+          expect(table_schema_from(results, "users")).to eq(<<~SQL.strip)
             CREATE TABLE IF NOT EXISTS users (
               id STRING,
               email STRING,
@@ -130,11 +43,7 @@ module ElasticGraph
             end
           end
 
-          payment_type = results.state.object_types_by_name.fetch("Payment")
-          table = payment_type.index_def.warehouse_table_def
-
-          table_schema = table.to_config["table_schema"]
-          expect(table_schema).to eq(<<~SQL.strip)
+          expect(table_schema_from(results, "payments")).to eq(<<~SQL.strip)
             CREATE TABLE IF NOT EXISTS payments (
               id STRING,
               amount_cents INT,


### PR DESCRIPTION
- All tests now go through `results.warehouse_config` instead of internal APIs like `warehouse_table_def`, `to_warehouse_column_type`
- Removed TODO hack in warehouse_schema_support.rb (no longer needed)
- Added helper methods: table_schema_from, warehouse_column_def_from, table_names_from
- Deduplicated tests across files (37→33 tests)
- Renamed `count` field to `quantity` to avoid reserved name warning
- Maintained 100% line and branch coverage