### PR TITLE
Remove unneeded work around for invalid operations from indexer.

### DIFF
--- a/elasticgraph-indexer/lib/elastic_graph/indexer/datastore_indexing_router.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/datastore_indexing_router.rb
@@ -46,7 +46,7 @@ module ElasticGraph
         ops_by_client = ::Hash.new { |h, k| h[k] = [] } # : ::Hash[DatastoreCore::_Client, ::Array[_Operation]]
         unsupported_ops = ::Set.new # : ::Set[_Operation]
 
-        operations.reject { |op| op.to_datastore_bulk.empty? }.each do |op|
+        operations.each do |op|
           # Note: this intentionally does not use `accessible_cluster_names_to_index_into`.
           # We want to fail with clear error if any clusters are inaccessible instead of silently ignoring
           # the named cluster. The `IndexingFailuresError` provides a clear error.


### PR DESCRIPTION
Valid `operation` implementations (and all our current implementations) return a non-empty array from `to_datastore_bulk`. The docs on bulk indicate that every valid operation has a non-empty bulk representation:

https://docs.opensearch.org/latest/api-reference/document-apis/bulk/#request-body

We don't need to keep a work around in place for invalid operations. And if we did, I don't think siltently ignoring them is the best approach.