### PR TITLE
Upgrade datastore versions.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,9 +29,9 @@ jobs:
           - "3.4"
           - "4.0"
         datastore:
-          - "elasticsearch:9.2.0"
+          - "elasticsearch:9.2.4"
           - "elasticsearch:9.0.0"
-          - "opensearch:3.3.0"
+          - "opensearch:3.4.0"
           - "opensearch:2.19.0"
         include:
           # We have 4 build parts. The "primary" one is `run_each_gem_spec`, and we need that to be run on
@@ -40,13 +40,13 @@ jobs:
           # configuration here.
           - build_part: "run_misc_checks"
             ruby: "4.0"
-            datastore: "elasticsearch:9.2.0"
+            datastore: "elasticsearch:9.2.4"
           - build_part: "run_specs_with_vcr"
             ruby: "4.0"
-            datastore: "elasticsearch:9.2.0"
+            datastore: "elasticsearch:9.2.4"
           - build_part: "run_specs_file_by_file"
             ruby: "4.0"
-            datastore: "elasticsearch:9.2.0"
+            datastore: "elasticsearch:9.2.4"
 
     steps:
       - name: Harden Runner
@@ -86,7 +86,7 @@ jobs:
       contents: read
       packages: write
     env:
-      OPENSEARCH_VERSION: "3.3.0"
+      OPENSEARCH_VERSION: "3.4.0"
 
     steps:
       - name: Harden Runner

--- a/elasticgraph-local/lib/elastic_graph/local/opensearch/Dockerfile
+++ b/elasticgraph-local/lib/elastic_graph/local/opensearch/Dockerfile
@@ -3,5 +3,6 @@ FROM opensearchproject/opensearch:${VERSION}
 RUN /usr/share/opensearch/bin/opensearch-plugin remove opensearch-anomaly-detection && \
     /usr/share/opensearch/bin/opensearch-plugin remove opensearch-skills && \
     /usr/share/opensearch/bin/opensearch-plugin remove opensearch-ml && \
+    /usr/share/opensearch/bin/opensearch-plugin remove opensearch-flow-framework && \
     /usr/share/opensearch/bin/opensearch-plugin remove opensearch-security && \
     /usr/share/opensearch/bin/opensearch-plugin install --batch mapper-size analysis-icu

--- a/elasticgraph-local/lib/elastic_graph/local/tested_datastore_versions.yaml
+++ b/elasticgraph-local/lib/elastic_graph/local/tested_datastore_versions.yaml
@@ -2,8 +2,8 @@
 # This file determines the versions the ElasticGraph CI build tests against, and is also
 # used to provide the default versions offered by the `elasticgraph-local` rake tasks.
 elasticsearch:
-- 9.2.0 # latest version as of 2025-10-31.
+- 9.2.4 # latest version as of 2026-01-19.
 - 9.0.0 # lowest version ElasticGraph currently supports
 opensearch:
-- 3.3.0  # latest minor release as of 2025-10-31.
+- 3.4.0  # latest minor release as of 2026-01-19.
 - 2.19.0 # lowest version ElasticGraph currently supports


### PR DESCRIPTION
- Elasticsearch 9.2.0 → 9.2.4
- OpenSearch 3.3.0 → 3.4.0