### PR TITLE
Improve release workflow.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
   pull_request:
+  # Allows triggering CI manually or from other workflows. Used by the release workflow
+  # to trigger CI on release PRs, since PRs created by GITHUB_TOKEN don't automatically
+  # trigger the `pull_request` event (GitHub prevents this to avoid infinite loops).
+  workflow_dispatch:
 
 env:
   # It's recommended to run ElasticGraph with this option to get better performance. We want to run

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,7 @@ jobs:
       url: https://rubygems.org/search?query=elasticgraph
 
     permissions:
+      actions: write
       contents: write
       id-token: write
       pull-requests: write
@@ -102,7 +103,7 @@ jobs:
       - name: Create pull request for the version bump
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
         with:
-          sign-commits: true
+          sign-commits: false
           branch: release-v${{ inputs.version }}
           title: "Release v${{ inputs.version }}"
           body: |
@@ -114,6 +115,14 @@ jobs:
             - [ ] Confirm the [release action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) succeeded before merging
             - [ ] Confirm this version bump should be merged into [${{ github.ref_name }}](https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}) or change the base branch
             - [ ] Review and edit the [GitHub Draft Release](https://github.com/${{ github.repository }}/releases) (can be done after this PR is merged)
+
+      # PRs created using GITHUB_TOKEN don't trigger `pull_request` workflows (GitHub prevents
+      # this to avoid infinite loops). We explicitly trigger CI here so that the release PR
+      # gets the required `All CI Checks Passed` status check for branch protection.
+      - name: Trigger CI on release branch
+        run: gh workflow run ci.yaml --ref release-v${{ inputs.version }}
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1.20.0

--- a/config/release/Rakefile
+++ b/config/release/Rakefile
@@ -29,12 +29,21 @@ bump_version = lambda do |version:, message:|
 
     ::Gem::Release::Cmds::Runner.new(:bump, ["elasticgraph-support"], opts).run
 
-    # We also want to commit an update to `Gemfile.lock` as part of the version bump.
+    # We also want to commit updates to `Gemfile.lock` and schema artifacts as part of the version bump.
+    # The runtime_metadata.yaml files embed the ElasticGraph version and must be updated.
     ::Bundler.with_unbundled_env do
       sh "bundle install"
-      sh "git add Gemfile.lock"
-      sh "git commit --amend --no-edit"
     end
+
+    # Update the version in runtime_metadata.yaml files.
+    # (`rake schema_artifacts:dump` isn't available when releasing since it replaces the root `Rakefile` with this one)
+    runtime_metadata_files = ::Dir.glob("#{project_root}/config/schema/**/runtime_metadata.yaml")
+    runtime_metadata_files.each do |path|
+      ::File.write(path, ::File.read(path).sub(/^elasticgraph_version: .+$/, "elasticgraph_version: #{version}"))
+    end
+
+    sh "git add Gemfile.lock #{runtime_metadata_files.join(" ")}"
+    sh "git commit --amend --no-edit"
   end
 end
 


### PR DESCRIPTION
Three related fixes:

1. Bump the version in `runtime_metadata.yaml`. It embeds the EG version,
   so it must be updated during version bump.


2. Trigger CI on release PRs via workflow_dispatch.
   PRs created by GITHUB_TOKEN don't trigger pull_request workflows
   (GitHub prevents infinite loops). Now we explicitly trigger CI
   so release PRs get the required status check.

3. Disable commit signing so tagged commit lands in main.
   create-pull-request with sign-commits: true recreates commits
   via GitHub API with new SHAs, orphaning the tagged commit.

Co-Authored-By: Claude <noreply@anthropic.com>

