### PR TITLE
Add OpenSearch boot test to ensure OpenSearch docker files work

### DIFF
--- a/elasticgraph-local/spec/acceptance/rake_tasks_spec.rb
+++ b/elasticgraph-local/spec/acceptance/rake_tasks_spec.rb
@@ -103,6 +103,13 @@ module ElasticGraph
             run_rake "elasticsearch:example:9.0.0:daemon", daemon_timeout: 0.1
           }.to raise_error a_string_including("Timed out after 0.1 seconds.")
         end
+
+        it "supports booting OpenSearch" do
+          halt_datastore_daemon_after :opensearch do
+            output = run_rake "opensearch:local:2.19.0:daemon"
+            expect(output).to include("Success! opensearch")
+          end
+        end
       end
 
       def run_rake(*cli_args, daemon_timeout: nil, batch_size: 1)
@@ -129,7 +136,7 @@ module ElasticGraph
               t.schema_element_name_form = :snake_case
               t.env_port_mapping = {"example" => 9615}
               t.elasticsearch_versions = ["8.18.0", "9.0.0"]
-              t.opensearch_versions = ["2.7.0"]
+              t.opensearch_versions = ["2.19.0"]
               t.output = output
               t.daemon_timeout = daemon_timeout
 


### PR DESCRIPTION
Previously only Elasticsearch was tested; OpenSearch docker config could break without CI catching it. Also updates test config to use supported OpenSearch version (2.19.0 instead of 2.7.0).