### PR TITLE
Reduce CI jobs from 11 to 8 and speed up 3 of them

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,14 +34,19 @@ jobs:
           - "4.0"
         datastore:
           - "elasticsearch:9.2.4"
-          - "elasticsearch:9.0.0"
-          - "opensearch:3.4.0"
-          - "opensearch:2.19.0"
         include:
-          # We have 4 build parts. The "primary" one is `run_each_gem_spec`, and we need that to be run on
-          # every supported Ruby version and against every supported datastore. It's not necessary to run
-          # these others against every combination of `ruby` and `datastore` so we just run each with one
-          # configuration here.
+          # Datastore-specific tests on non-primary datastores.
+          # These run only `:uses_datastore` tagged tests since non-datastore tests don't vary by datastore.
+          - build_part: "run_datastore_specs"
+            ruby: "4.0"
+            datastore: "elasticsearch:9.0.0"
+          - build_part: "run_datastore_specs"
+            ruby: "4.0"
+            datastore: "opensearch:3.4.0"
+          - build_part: "run_datastore_specs"
+            ruby: "4.0"
+            datastore: "opensearch:2.19.0"
+          # Other build parts run on max Ruby and primary datastore only.
           - build_part: "run_misc_checks"
             ruby: "4.0"
             datastore: "elasticsearch:9.2.4"

--- a/script/ci_parts/run_datastore_specs
+++ b/script/ci_parts/run_datastore_specs
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# This script runs only the datastore-specific tests (tagged with :uses_datastore).
+# It's used for non-primary datastores where we only need to verify datastore compatibility,
+# not run the full test suite (which would be redundant since non-datastore tests don't vary
+# by datastore).
+
+source "script/ci_parts/setup_env" "test" $1 $2
+
+# No coverage checking for datastore-specific tests. Coverage is verified by run_each_gem_spec
+# on the primary datastore.
+unset COVERAGE
+
+script/run_specs --tag uses_datastore

--- a/script/update_ci_yaml
+++ b/script/update_ci_yaml
@@ -33,8 +33,13 @@ module ElasticGraph
     def updated_content
       content = @content.dup
       content = update_datastore_matrix(content)
-      content = update_primary_datastore(content)
+      content = update_includes_primary_datastore(content)
+      content = update_run_datastore_specs_includes(content)
       update_opensearch_version(content)
+    end
+
+    def non_primary_datastore_versions
+      datastore_versions - [primary_datastore_version]
     end
 
     def show_diff
@@ -76,22 +81,36 @@ module ElasticGraph
     end
 
     def update_datastore_matrix(content)
-      # Find the datastore matrix section and preserve its exact indentation
+      # Matrix now has single primary datastore only.
+      # Non-primary datastores use run_datastore_specs via includes.
       matrix_pattern = /(        datastore:\n)([^\n]*\n)*?        include:/m
       match = content.match(matrix_pattern)
       return content unless match
 
       matrix_start = match[1]
-      new_versions = datastore_versions.map { |v| '          - "' + v + "\"\n" }.join
-      content.sub(matrix_pattern, "#{matrix_start}#{new_versions}        include:")
+      new_version = '          - "' + primary_datastore_version + "\"\n"
+      content.sub(matrix_pattern, "#{matrix_start}#{new_version}        include:")
     end
 
-    def update_primary_datastore(content)
-      # Update each primary datastore version in the includes section
-      content.gsub(
-        /(?<=datastore: ")[^"]+(?="\n)/,
-        primary_datastore_version
-      )
+    def update_includes_primary_datastore(content)
+      # Update ALL datastore entries in includes section to primary.
+      # run_datastore_specs entries will be overridden by update_run_datastore_specs_includes.
+      parts = content.split(/^        include:\n/, 2)
+      return content unless parts.size == 2
+
+      updated = parts[1].gsub(/(?<=datastore: ")[^"]+(?=")/, primary_datastore_version)
+      parts[0] + "        include:\n" + updated
+    end
+
+    def update_run_datastore_specs_includes(content)
+      # Override run_datastore_specs entries with non-primary datastores
+      versions = non_primary_datastore_versions
+      idx = 0
+      content.gsub(/(?<=build_part: "run_datastore_specs"\n            ruby: "4.0"\n            datastore: ")[^"]+(?=")/) do
+        version = versions[idx]
+        idx += 1
+        version
+      end
     end
 
     def update_opensearch_version(content)


### PR DESCRIPTION
- Test Ruby 3.4 on primary datastore only (was testing all 4 datastores)
- Run only :uses_datastore tests on non-primary datastores via new run_datastore_specs script (non-datastore tests don't vary by datastore)

This substantially reduces the total build time.

[Before](https://github.com/block/elasticgraph/actions/runs/21383975843/usage):

<img width="808" height="1001" alt="image" src="https://github.com/user-attachments/assets/fef620fe-402c-4411-93ed-b61b1af6bf7e" />


[After](https://github.com/block/elasticgraph/actions/runs/21461869062/usage?pr=1001):

<img width="805" height="827" alt="image" src="https://github.com/user-attachments/assets/f2404437-f5f0-44a8-b56d-715342bcd88a" />
