### PR TITLE
Add `skip_failure_categorization` event flag to skip datastore version checks on failures

### DIFF
--- a/config/schema/artifacts/json_schemas.yaml
+++ b/config/schema/artifacts/json_schemas.yaml
@@ -68,6 +68,12 @@ json_schema_version: 1
           messaging system is being used between the publisher and the ElasticGraph
           indexer.
         type: string
+      skip_failure_categorization:
+        description: When true, ElasticGraph will skip checking if a failed event
+          has been superseded by a newer version in the datastore. This is useful
+          to avoid unnecessary datastore queries during normal indexing. When absent
+          or false, the version check runs as usual.
+        type: boolean
     additionalProperties: false
     required:
     - op

--- a/config/schema/artifacts/json_schemas_by_version/v1.yaml
+++ b/config/schema/artifacts/json_schemas_by_version/v1.yaml
@@ -68,6 +68,12 @@ json_schema_version: 1
           messaging system is being used between the publisher and the ElasticGraph
           indexer.
         type: string
+      skip_failure_categorization:
+        description: When true, ElasticGraph will skip checking if a failed event
+          has been superseded by a newer version in the datastore. This is useful
+          to avoid unnecessary datastore queries during normal indexing. When absent
+          or false, the version check runs as usual.
+        type: boolean
     additionalProperties: false
     required:
     - op

--- a/config/schema/artifacts_with_apollo/json_schemas.yaml
+++ b/config/schema/artifacts_with_apollo/json_schemas.yaml
@@ -68,6 +68,12 @@ json_schema_version: 1
           messaging system is being used between the publisher and the ElasticGraph
           indexer.
         type: string
+      skip_failure_categorization:
+        description: When true, ElasticGraph will skip checking if a failed event
+          has been superseded by a newer version in the datastore. This is useful
+          to avoid unnecessary datastore queries during normal indexing. When absent
+          or false, the version check runs as usual.
+        type: boolean
     additionalProperties: false
     required:
     - op

--- a/config/schema/artifacts_with_apollo/json_schemas_by_version/v1.yaml
+++ b/config/schema/artifacts_with_apollo/json_schemas_by_version/v1.yaml
@@ -68,6 +68,12 @@ json_schema_version: 1
           messaging system is being used between the publisher and the ElasticGraph
           indexer.
         type: string
+      skip_failure_categorization:
+        description: When true, ElasticGraph will skip checking if a failed event
+          has been superseded by a newer version in the datastore. This is useful
+          to avoid unnecessary datastore queries during normal indexing. When absent
+          or false, the version check runs as usual.
+        type: boolean
     additionalProperties: false
     required:
     - op

--- a/elasticgraph-indexer/sig/elastic_graph/indexer/processor.rbs
+++ b/elasticgraph-indexer/sig/elastic_graph/indexer/processor.rbs
@@ -21,6 +21,7 @@ module ElasticGraph
       @clock: singleton(::Time)
 
       def categorize_failures: (::Array[FailedEventError], ::Array[event]) -> ::Array[FailedEventError]
+      def categorize_failures_via_datastore: (::Array[FailedEventError]) -> ::Array[FailedEventError]
       def calculate_latency_metrics: (::Array[_Operation], ::Array[Operation::Result]) -> void
     end
   end

--- a/elasticgraph-indexer_lambda/lib/elastic_graph/indexer_lambda/lambda_function.rb
+++ b/elasticgraph-indexer_lambda/lib/elastic_graph/indexer_lambda/lambda_function.rb
@@ -24,10 +24,12 @@ module ElasticGraph
 
         indexer = ElasticGraph::IndexerLambda.indexer_from_env
         ignore_sqs_latency_timestamps_from_arns = ::JSON.parse(ENV.fetch("IGNORE_SQS_LATENCY_TIMESTAMPS_FROM_ARNS", "[]")).to_set
+        categorize_failures_only_from_arns = ::JSON.parse(ENV.fetch("CATEGORIZE_FAILURES_ONLY_FROM_ARNS", "[]")).to_set
 
         @sqs_processor = ElasticGraph::IndexerLambda::SqsProcessor.new(
           indexer.processor,
           ignore_sqs_latency_timestamps_from_arns: ignore_sqs_latency_timestamps_from_arns,
+          categorize_failures_only_from_arns: categorize_failures_only_from_arns,
           logger: indexer.logger
         )
       end

--- a/elasticgraph-indexer_lambda/sig/elastic_graph/indexer_lambda/sqs_processor.rbs
+++ b/elasticgraph-indexer_lambda/sig/elastic_graph/indexer_lambda/sqs_processor.rbs
@@ -5,6 +5,7 @@ module ElasticGraph
         Indexer::Processor,
         logger: ::Logger,
         ignore_sqs_latency_timestamps_from_arns: ::Set[::String],
+        ?categorize_failures_only_from_arns: ::Set[::String],
         ?s3_client: Aws::S3::Client?,
       ) -> void
 
@@ -17,6 +18,7 @@ module ElasticGraph
       @s3_client: Aws::S3::Client?
 
       attr_reader ignore_sqs_latency_timestamps_from_arns: ::Set[::String]
+      attr_reader categorize_failures_only_from_arns: ::Set[::String]
 
       def events_from: (::Hash[::String, untyped]) -> ::Array[::Hash[::String, untyped]]
       S3_OFFLOADING_INDICATOR: String

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/event_envelope.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/event_envelope.rb
@@ -65,6 +65,10 @@ module ElasticGraph
               "message_id" => {
                 "description" => "The optional ID of the message containing this event from whatever messaging system is being used between the publisher and the ElasticGraph indexer.",
                 "type" => "string"
+              },
+              "skip_failure_categorization" => {
+                "description" => "When true, ElasticGraph will skip checking if a failed event has been superseded by a newer version in the datastore. This is useful to avoid unnecessary datastore queries during normal indexing. When absent or false, the version check runs as usual.",
+                "type" => "boolean"
               }
             },
             "additionalProperties" => false,


### PR DESCRIPTION
…When events have `skip_failure_categorization: true`, the indexer skips querying the datastore to check if failures have been superseded by newer versions. This avoids unnecessary datastore queries during normal indexing from non-DLQ SQS queues.

- Add `skip_failure_categorization` boolean to event envelope JSON schema
- Refactor `Processor#categorize_failures` to partition by the flag and extract `categorize_failures_via_datastore` for non-flagged failures only
- Add `categorize_failures_only_from_arns` config to `SqsProcessor` that automatically injects the flag for events from ARNs not in the configured set
- Add `CATEGORIZE_FAILURES_ONLY_FROM_ARNS` env var to the indexer Lambda function
- Regenerate schema artifacts