### PR TITLE
Optimize Painless update scripts to reduce per-execution overhead

### DIFF
--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -1709,7 +1709,7 @@ indices:
       index.number_of_shards: 1
       index.max_result_window: 10000
 scripts:
-  update_WidgetCurrency_from_Widget_70a98186a925c781260b3d3532ce0208:
+  update_WidgetCurrency_from_Widget_a821ae84f3419b2b26025a44dc432bed:
     context: update
     script:
       lang: painless
@@ -1799,18 +1799,18 @@ scripts:
 
         boolean maxValue_idempotentlyUpdateValue(List values, def parentObject, String fieldName) {
           def currentFieldValue = parentObject[fieldName];
-          // Normalize incoming list numerics to long to avoid Integer/Long class cast issues
-          List coercedValues = new ArrayList();
+
+          // Find the max of incoming values inline, avoiding ArrayList allocation and Collections.max() overhead.
+          // Normalize numerics to long to avoid Integer/Long class cast issues.
+          def maxNewValue = null;
           for (def v : values) {
             if (v != null) {
-              if (v instanceof Number) {
-                coercedValues.add(((Number)v).longValue());
-              } else {
-                coercedValues.add(v);
+              def coerced = (v instanceof Number) ? ((Number)v).longValue() : v;
+              if (maxNewValue == null || coerced.compareTo(maxNewValue) > 0) {
+                maxNewValue = coerced;
               }
             }
           }
-          def maxNewValue = coercedValues.isEmpty() ? null : Collections.max(coercedValues);
 
           def coercedCurrentFieldValue = null;
           if (currentFieldValue != null) {
@@ -1827,18 +1827,18 @@ scripts:
 
         boolean minValue_idempotentlyUpdateValue(List values, def parentObject, String fieldName) {
           def currentFieldValue = parentObject[fieldName];
-          // Normalize incoming list numerics to long to avoid Integer/Long class cast issues
-          List coercedValues = new ArrayList();
+
+          // Find the min of incoming values inline, avoiding ArrayList allocation and Collections.min() overhead.
+          // Normalize numerics to long to avoid Integer/Long class cast issues.
+          def minNewValue = null;
           for (def v : values) {
             if (v != null) {
-              if (v instanceof Number) {
-                coercedValues.add(((Number)v).longValue());
-              } else {
-                coercedValues.add(v);
+              def coerced = (v instanceof Number) ? ((Number)v).longValue() : v;
+              if (minNewValue == null || coerced.compareTo(minNewValue) < 0) {
+                minNewValue = coerced;
               }
             }
           }
-          def minNewValue = coercedValues.isEmpty() ? null : Collections.min(coercedValues);
 
           def coercedCurrentFieldValue = null;
           if (currentFieldValue != null) {
@@ -2013,7 +2013,7 @@ scripts:
 
         // No timestamp values matched the params, so return `false`.
         return false;
-  update_index_data_1fdfaf1c9261c96019decc89b515bd9a:
+  update_index_data_d0404c93a835e5127dd8c11f4d7c511d:
     context: update
     script:
       lang: painless
@@ -2038,9 +2038,25 @@ scripts:
         }
 
         Map relationshipVersionsMap = source.__versions.get(relationship);
-        List previousSourceIdsForRelationship = relationshipVersionsMap.keySet().stream().filter(id -> id != sourceId).collect(Collectors.toList());
 
-        if (previousSourceIdsForRelationship.size() > 0) {
+        // Check if any other source IDs exist for this relationship (indicating a forbidden mutation).
+        // Uses a simple loop instead of stream().filter().collect() to avoid lambda/stream allocation overhead on every update.
+        String firstOtherSourceId = null;
+        for (String id : relationshipVersionsMap.keySet()) {
+          if (id != sourceId) {
+            firstOtherSourceId = id;
+            break;
+          }
+        }
+
+        if (firstOtherSourceId != null) {
+          // Build the full previous IDs list only in the rare error case.
+          List previousSourceIdsForRelationship = new ArrayList();
+          for (String id : relationshipVersionsMap.keySet()) {
+            if (id != sourceId) {
+              previousSourceIdsForRelationship.add(id);
+            }
+          }
           String previousIdDescription = previousSourceIdsForRelationship.size() == 1 ? previousSourceIdsForRelationship.get(0) : previousSourceIdsForRelationship.toString();
           throw new IllegalArgumentException(
             "Cannot update document " + params.id + " " +

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -2670,7 +2670,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: Address
   AddressAggregatedValues:
     graphql_fields_by_name:
@@ -2942,7 +2942,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: Component
   ComponentAggregatedValues:
     graphql_fields_by_name:
@@ -3270,7 +3270,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: ElectricalPart
   ElectricalPartAggregatedValues:
     graphql_fields_by_name:
@@ -3671,7 +3671,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: Manufacturer
   ManufacturerAggregatedValues:
     graphql_fields_by_name:
@@ -3822,7 +3822,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: MechanicalPart
   MechanicalPartAggregatedValues:
     graphql_fields_by_name:
@@ -5063,7 +5063,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: Sponsor
   SponsorAggregatedValues:
     graphql_fields_by_name:
@@ -5328,7 +5328,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: formed_on
       routing_value_source: league
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: Team
   TeamAggregatedValues:
     graphql_fields_by_name:
@@ -6274,7 +6274,7 @@ object_types_by_name:
       id_source: cost.currency
       rollover_timestamp_value_source: cost_currency_introduced_on
       routing_value_source: cost_currency_primary_continent
-      script_id: update_WidgetCurrency_from_Widget_70a98186a925c781260b3d3532ce0208
+      script_id: update_WidgetCurrency_from_Widget_a821ae84f3419b2b26025a44dc432bed
       type: WidgetCurrency
     - data_params:
         amount_cents:
@@ -6346,7 +6346,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: created_at
       routing_value_source: workspace_id2
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: Widget
     - data_params:
         widget_cost:
@@ -6377,7 +6377,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: widget
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: Component
   WidgetAggregatedValues:
     graphql_fields_by_name:
@@ -6602,7 +6602,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: introduced_on
       routing_value_source: primary_continent
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: WidgetCurrency
   WidgetCurrencyAggregatedValues:
     graphql_fields_by_name:
@@ -7558,7 +7558,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: WidgetWorkspace
     - data_params:
         workspace_name:
@@ -7579,7 +7579,7 @@ object_types_by_name:
       relationship: workspace
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: Widget
   WidgetWorkspaceAggregatedValues:
     graphql_fields_by_name:
@@ -7810,4 +7810,4 @@ static_script_ids_by_scoped_name:
   field/as_day_of_week: field_as_day_of_week_f2b5c7d9e8f75bf2457b52412bfb6537
   field/as_time_of_day: field_as_time_of_day_ed82aba44fc66bff5635bec4305c1c66
   filter/by_time_of_day: filter_by_time_of_day_ea12d0561b24961789ab68ed38435612
-  update/index_data: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+  update/index_data: update_index_data_d0404c93a835e5127dd8c11f4d7c511d

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -1709,7 +1709,7 @@ indices:
       index.number_of_shards: 1
       index.max_result_window: 10000
 scripts:
-  update_WidgetCurrency_from_Widget_70a98186a925c781260b3d3532ce0208:
+  update_WidgetCurrency_from_Widget_a821ae84f3419b2b26025a44dc432bed:
     context: update
     script:
       lang: painless
@@ -1799,18 +1799,18 @@ scripts:
 
         boolean maxValue_idempotentlyUpdateValue(List values, def parentObject, String fieldName) {
           def currentFieldValue = parentObject[fieldName];
-          // Normalize incoming list numerics to long to avoid Integer/Long class cast issues
-          List coercedValues = new ArrayList();
+
+          // Find the max of incoming values inline, avoiding ArrayList allocation and Collections.max() overhead.
+          // Normalize numerics to long to avoid Integer/Long class cast issues.
+          def maxNewValue = null;
           for (def v : values) {
             if (v != null) {
-              if (v instanceof Number) {
-                coercedValues.add(((Number)v).longValue());
-              } else {
-                coercedValues.add(v);
+              def coerced = (v instanceof Number) ? ((Number)v).longValue() : v;
+              if (maxNewValue == null || coerced.compareTo(maxNewValue) > 0) {
+                maxNewValue = coerced;
               }
             }
           }
-          def maxNewValue = coercedValues.isEmpty() ? null : Collections.max(coercedValues);
 
           def coercedCurrentFieldValue = null;
           if (currentFieldValue != null) {
@@ -1827,18 +1827,18 @@ scripts:
 
         boolean minValue_idempotentlyUpdateValue(List values, def parentObject, String fieldName) {
           def currentFieldValue = parentObject[fieldName];
-          // Normalize incoming list numerics to long to avoid Integer/Long class cast issues
-          List coercedValues = new ArrayList();
+
+          // Find the min of incoming values inline, avoiding ArrayList allocation and Collections.min() overhead.
+          // Normalize numerics to long to avoid Integer/Long class cast issues.
+          def minNewValue = null;
           for (def v : values) {
             if (v != null) {
-              if (v instanceof Number) {
-                coercedValues.add(((Number)v).longValue());
-              } else {
-                coercedValues.add(v);
+              def coerced = (v instanceof Number) ? ((Number)v).longValue() : v;
+              if (minNewValue == null || coerced.compareTo(minNewValue) < 0) {
+                minNewValue = coerced;
               }
             }
           }
-          def minNewValue = coercedValues.isEmpty() ? null : Collections.min(coercedValues);
 
           def coercedCurrentFieldValue = null;
           if (currentFieldValue != null) {
@@ -2013,7 +2013,7 @@ scripts:
 
         // No timestamp values matched the params, so return `false`.
         return false;
-  update_index_data_1fdfaf1c9261c96019decc89b515bd9a:
+  update_index_data_d0404c93a835e5127dd8c11f4d7c511d:
     context: update
     script:
       lang: painless
@@ -2038,9 +2038,25 @@ scripts:
         }
 
         Map relationshipVersionsMap = source.__versions.get(relationship);
-        List previousSourceIdsForRelationship = relationshipVersionsMap.keySet().stream().filter(id -> id != sourceId).collect(Collectors.toList());
 
-        if (previousSourceIdsForRelationship.size() > 0) {
+        // Check if any other source IDs exist for this relationship (indicating a forbidden mutation).
+        // Uses a simple loop instead of stream().filter().collect() to avoid lambda/stream allocation overhead on every update.
+        String firstOtherSourceId = null;
+        for (String id : relationshipVersionsMap.keySet()) {
+          if (id != sourceId) {
+            firstOtherSourceId = id;
+            break;
+          }
+        }
+
+        if (firstOtherSourceId != null) {
+          // Build the full previous IDs list only in the rare error case.
+          List previousSourceIdsForRelationship = new ArrayList();
+          for (String id : relationshipVersionsMap.keySet()) {
+            if (id != sourceId) {
+              previousSourceIdsForRelationship.add(id);
+            }
+          }
           String previousIdDescription = previousSourceIdsForRelationship.size() == 1 ? previousSourceIdsForRelationship.get(0) : previousSourceIdsForRelationship.toString();
           throw new IllegalArgumentException(
             "Cannot update document " + params.id + " " +

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -2699,7 +2699,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: Address
   AddressAggregatedValues:
     graphql_fields_by_name:
@@ -2992,7 +2992,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: Component
   ComponentAggregatedValues:
     graphql_fields_by_name:
@@ -3372,7 +3372,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: ElectricalPart
   ElectricalPartAggregatedValues:
     graphql_fields_by_name:
@@ -3773,7 +3773,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: Manufacturer
   ManufacturerAggregatedValues:
     graphql_fields_by_name:
@@ -3924,7 +3924,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: MechanicalPart
   MechanicalPartAggregatedValues:
     graphql_fields_by_name:
@@ -5192,7 +5192,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: Sponsor
   SponsorAggregatedValues:
     graphql_fields_by_name:
@@ -5457,7 +5457,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: formed_on
       routing_value_source: league
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: Team
   TeamAggregatedValues:
     graphql_fields_by_name:
@@ -6403,7 +6403,7 @@ object_types_by_name:
       id_source: cost.currency
       rollover_timestamp_value_source: cost_currency_introduced_on
       routing_value_source: cost_currency_primary_continent
-      script_id: update_WidgetCurrency_from_Widget_70a98186a925c781260b3d3532ce0208
+      script_id: update_WidgetCurrency_from_Widget_a821ae84f3419b2b26025a44dc432bed
       type: WidgetCurrency
     - data_params:
         amount_cents:
@@ -6475,7 +6475,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: created_at
       routing_value_source: workspace_id2
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: Widget
     - data_params:
         widget_cost:
@@ -6506,7 +6506,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: widget
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: Component
   WidgetAggregatedValues:
     graphql_fields_by_name:
@@ -6731,7 +6731,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: introduced_on
       routing_value_source: primary_continent
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: WidgetCurrency
   WidgetCurrencyAggregatedValues:
     graphql_fields_by_name:
@@ -7687,7 +7687,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: WidgetWorkspace
     - data_params:
         workspace_name:
@@ -7708,7 +7708,7 @@ object_types_by_name:
       relationship: workspace
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_d0404c93a835e5127dd8c11f4d7c511d
       type: Widget
   WidgetWorkspaceAggregatedValues:
     graphql_fields_by_name:
@@ -7982,4 +7982,4 @@ static_script_ids_by_scoped_name:
   field/as_day_of_week: field_as_day_of_week_f2b5c7d9e8f75bf2457b52412bfb6537
   field/as_time_of_day: field_as_time_of_day_ed82aba44fc66bff5635bec4305c1c66
   filter/by_time_of_day: filter_by_time_of_day_ea12d0561b24961789ab68ed38435612
-  update/index_data: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+  update/index_data: update_index_data_d0404c93a835e5127dd8c11f4d7c511d

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_fields/min_or_max_value.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_fields/min_or_max_value.rb
@@ -44,18 +44,18 @@ module ElasticGraph
             <<~EOS
               boolean #{min_or_max}Value_idempotentlyUpdateValue(List values, def parentObject, String fieldName) {
                 def currentFieldValue = parentObject[fieldName];
-                // Normalize incoming list numerics to long to avoid Integer/Long class cast issues
-                List coercedValues = new ArrayList();
+
+                // Find the #{min_or_max} of incoming values inline, avoiding ArrayList allocation and Collections.#{min_or_max}() overhead.
+                // Normalize numerics to long to avoid Integer/Long class cast issues.
+                def #{min_or_max}NewValue = null;
                 for (def v : values) {
                   if (v != null) {
-                    if (v instanceof Number) {
-                      coercedValues.add(((Number)v).longValue());
-                    } else {
-                      coercedValues.add(v);
+                    def coerced = (v instanceof Number) ? ((Number)v).longValue() : v;
+                    if (#{min_or_max}NewValue == null || coerced.compareTo(#{min_or_max}NewValue) #{operator} 0) {
+                      #{min_or_max}NewValue = coerced;
                     }
                   }
                 }
-                def #{min_or_max}NewValue = coercedValues.isEmpty() ? null : Collections.#{min_or_max}(coercedValues);
 
                 def coercedCurrentFieldValue = null;
                 if (currentFieldValue != null) {

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/scripts/update/index_data.painless
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/scripts/update/index_data.painless
@@ -18,9 +18,25 @@ if (source.__versions[relationship] == null) {
 }
 
 Map relationshipVersionsMap = source.__versions.get(relationship);
-List previousSourceIdsForRelationship = relationshipVersionsMap.keySet().stream().filter(id -> id != sourceId).collect(Collectors.toList());
 
-if (previousSourceIdsForRelationship.size() > 0) {
+// Check if any other source IDs exist for this relationship (indicating a forbidden mutation).
+// Uses a simple loop instead of stream().filter().collect() to avoid lambda/stream allocation overhead on every update.
+String firstOtherSourceId = null;
+for (String id : relationshipVersionsMap.keySet()) {
+  if (id != sourceId) {
+    firstOtherSourceId = id;
+    break;
+  }
+}
+
+if (firstOtherSourceId != null) {
+  // Build the full previous IDs list only in the rare error case.
+  List previousSourceIdsForRelationship = new ArrayList();
+  for (String id : relationshipVersionsMap.keySet()) {
+    if (id != sourceId) {
+      previousSourceIdsForRelationship.add(id);
+    }
+  }
   String previousIdDescription = previousSourceIdsForRelationship.size() == 1 ? previousSourceIdsForRelationship.get(0) : previousSourceIdsForRelationship.toString();
   throw new IllegalArgumentException(
     "Cannot update document " + params.id + " " +

--- a/elasticgraph-support/lib/elastic_graph/constants.rb
+++ b/elasticgraph-support/lib/elastic_graph/constants.rb
@@ -136,7 +136,7 @@ module ElasticGraph
   #
   # Note: this constant is automatically kept up-to-date by our `schema_artifacts:dump` rake task.
   # @private
-  INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_1fdfaf1c9261c96019decc89b515bd9a"
+  INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_d0404c93a835e5127dd8c11f4d7c511d"
 
   # When an update script has a no-op result we often want to communicate more information about
   # why it was a no-op back to ElatsicGraph from the script. The only way to do that is to throw


### PR DESCRIPTION
Replace stream().filter().collect() in index_data.painless with a simple loop and deferred list construction, avoiding lambda/stream allocation on every indexed event. Replace ArrayList + Collections.min/max in min_or_max_value.rb with an inline loop that tracks the min/max during coercion, eliminating collection allocation for the common single-element case.