### PR TITLE
Fix null-over-null writes in min/max derived index update scripts

### DIFF
--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -1709,7 +1709,7 @@ indices:
       index.number_of_shards: 1
       index.max_result_window: 10000
 scripts:
-  update_WidgetCurrency_from_Widget_70a98186a925c781260b3d3532ce0208:
+  update_WidgetCurrency_from_Widget_a63538953d45f84cba67edd655d129a8:
     context: update
     script:
       lang: painless
@@ -1817,7 +1817,7 @@ scripts:
             coercedCurrentFieldValue = (currentFieldValue instanceof Number) ? ((Number)currentFieldValue).longValue() : currentFieldValue;
           }
 
-          if (coercedCurrentFieldValue == null || (maxNewValue != null && maxNewValue.compareTo(coercedCurrentFieldValue) > 0)) {
+          if (maxNewValue != null && (coercedCurrentFieldValue == null || maxNewValue.compareTo(coercedCurrentFieldValue) > 0)) {
             parentObject[fieldName] = maxNewValue;
             return true;
           }
@@ -1845,7 +1845,7 @@ scripts:
             coercedCurrentFieldValue = (currentFieldValue instanceof Number) ? ((Number)currentFieldValue).longValue() : currentFieldValue;
           }
 
-          if (coercedCurrentFieldValue == null || (minNewValue != null && minNewValue.compareTo(coercedCurrentFieldValue) < 0)) {
+          if (minNewValue != null && (coercedCurrentFieldValue == null || minNewValue.compareTo(coercedCurrentFieldValue) < 0)) {
             parentObject[fieldName] = minNewValue;
             return true;
           }

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -6274,7 +6274,7 @@ object_types_by_name:
       id_source: cost.currency
       rollover_timestamp_value_source: cost_currency_introduced_on
       routing_value_source: cost_currency_primary_continent
-      script_id: update_WidgetCurrency_from_Widget_70a98186a925c781260b3d3532ce0208
+      script_id: update_WidgetCurrency_from_Widget_a63538953d45f84cba67edd655d129a8
       type: WidgetCurrency
     - data_params:
         amount_cents:

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -1709,7 +1709,7 @@ indices:
       index.number_of_shards: 1
       index.max_result_window: 10000
 scripts:
-  update_WidgetCurrency_from_Widget_70a98186a925c781260b3d3532ce0208:
+  update_WidgetCurrency_from_Widget_a63538953d45f84cba67edd655d129a8:
     context: update
     script:
       lang: painless
@@ -1817,7 +1817,7 @@ scripts:
             coercedCurrentFieldValue = (currentFieldValue instanceof Number) ? ((Number)currentFieldValue).longValue() : currentFieldValue;
           }
 
-          if (coercedCurrentFieldValue == null || (maxNewValue != null && maxNewValue.compareTo(coercedCurrentFieldValue) > 0)) {
+          if (maxNewValue != null && (coercedCurrentFieldValue == null || maxNewValue.compareTo(coercedCurrentFieldValue) > 0)) {
             parentObject[fieldName] = maxNewValue;
             return true;
           }
@@ -1845,7 +1845,7 @@ scripts:
             coercedCurrentFieldValue = (currentFieldValue instanceof Number) ? ((Number)currentFieldValue).longValue() : currentFieldValue;
           }
 
-          if (coercedCurrentFieldValue == null || (minNewValue != null && minNewValue.compareTo(coercedCurrentFieldValue) < 0)) {
+          if (minNewValue != null && (coercedCurrentFieldValue == null || minNewValue.compareTo(coercedCurrentFieldValue) < 0)) {
             parentObject[fieldName] = minNewValue;
             return true;
           }

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -6403,7 +6403,7 @@ object_types_by_name:
       id_source: cost.currency
       rollover_timestamp_value_source: cost_currency_introduced_on
       routing_value_source: cost_currency_primary_continent
-      script_id: update_WidgetCurrency_from_Widget_70a98186a925c781260b3d3532ce0208
+      script_id: update_WidgetCurrency_from_Widget_a63538953d45f84cba67edd655d129a8
       type: WidgetCurrency
     - data_params:
         amount_cents:

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_fields/min_or_max_value.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_fields/min_or_max_value.rb
@@ -62,7 +62,7 @@ module ElasticGraph
                   coercedCurrentFieldValue = (currentFieldValue instanceof Number) ? ((Number)currentFieldValue).longValue() : currentFieldValue;
                 }
 
-                if (coercedCurrentFieldValue == null || (#{min_or_max}NewValue != null && #{min_or_max}NewValue.compareTo(coercedCurrentFieldValue) #{operator} 0)) {
+                if (#{min_or_max}NewValue != null && (coercedCurrentFieldValue == null || #{min_or_max}NewValue.compareTo(coercedCurrentFieldValue) #{operator} 0)) {
                   parentObject[fieldName] = #{min_or_max}NewValue;
                   return true;
                 }


### PR DESCRIPTION
The `minValue_idempotentlyUpdateValue` and `maxValue_idempotentlyUpdateValue` painless functions incorrectly treated null-over-null writes as updates instead of no-ops. This caused unnecessary document writes to derived indexes, leading to version conflict errors under concurrent indexing.

Root cause:
The condition `if (coercedCurrentFieldValue == null || ...)` short-circuits when the current stored value is null, always entering the update branch — even when the incoming new value is also null. This writes null over null, increments the document's seqNo, and returns true ("updated"). The calling script then skips the no-op optimization (`ctx.op = 'none'`), resulting in an actual write for every event.

In production, this manifests when a derived min/max field's source data is always null (e.g. `localInternalReportingTimestampDeltaFromCreatedAt` on order events). Every order processed triggers a write to the merchant/location derived document, and concurrent writes to the same merchant produce `version_conflict_engine_exception` errors.

Fix:
Reorder the condition to check `newValue != null` first:
  Before: `if (currentFieldValue == null || (newValue != null && ...))`
  After:  `if (newValue != null && (currentFieldValue == null || ...))`

This ensures that when the incoming value is null, the function immediately returns false (no-op), regardless of the current stored value. The behavior for all other cases (first non-null value, new min/max, same value) is unchanged.