### PR TITLE
Add `_typename` filter field to abstract type filter inputs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,10 @@ When adding filtering predicates or aggregation functions:
 3. **Query Translation**: Implement GraphQL → datastore query translation with unit, integration, and acceptance tests
 4. **Documentation**: Add user-facing docs with working examples to `config/site/`
 
+### Verification
+
+After completing a chunk of work, run `script/run_specs` and `script/type_check` to verify correctness across all gems and type signatures.
+
 ### Test Strategy
 
 Three layers of testing:
@@ -169,6 +173,10 @@ Custom gems can be added via `Gemfile-custom` (see `Gemfile-custom.example`), th
 - Use `build_*` helper methods from `spec/support/builds_*.rb` to construct test objects. These helpers provide sensible defaults while allowing selective overrides for testing specific scenarios.
 
 ## Important Patterns
+
+### Schema Definition
+
+- When referencing derived type names (e.g. filter input types), never hardcode names like `"StringFilterInput"`. Always use `schema_def_state.type_ref("String").as_filter_input.name` (or similar `as_*` methods on type references). Hardcoded names break when schema element names are customized (e.g. camelCase schemas).
 
 ### Schema Artifacts
 After schema definition changes, always run:

--- a/config/schema/artifacts/schema.graphql
+++ b/config/schema/artifacts/schema.graphql
@@ -3546,6 +3546,12 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input InventorFilterInput {
   """
+  Used to filter `Inventor` documents by which concrete subtype they belong to.
+  Analogous to the `__typename` return field.
+  """
+  _typename: StringFilterInput
+
+  """
   Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
@@ -5698,6 +5704,12 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input NamedEntityFilterInput {
   """
+  Used to filter `NamedEntity` documents by which concrete subtype they belong to.
+  Analogous to the `__typename` return field.
+  """
+  _typename: StringFilterInput
+
+  """
   Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
@@ -6787,6 +6799,12 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input NamedInventorFilterInput {
   """
+  Used to filter `NamedInventor` documents by which concrete subtype they belong to.
+  Analogous to the `__typename` return field.
+  """
+  _typename: StringFilterInput
+
+  """
   Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
@@ -7080,6 +7098,12 @@ Input type used to specify filters on `Part` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input PartFilterInput {
+  """
+  Used to filter `Part` documents by which concrete subtype they belong to.
+  Analogous to the `__typename` return field.
+  """
+  _typename: StringFilterInput
+
   """
   Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
 
@@ -14737,6 +14761,12 @@ Input type used to specify filters on `WidgetOrAddress` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input WidgetOrAddressFilterInput {
+  """
+  Used to filter `WidgetOrAddress` documents by which concrete subtype they belong to.
+  Analogous to the `__typename` return field.
+  """
+  _typename: StringFilterInput
+
   """
   Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
 

--- a/config/schema/artifacts_with_apollo/schema.graphql
+++ b/config/schema/artifacts_with_apollo/schema.graphql
@@ -3828,6 +3828,12 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input InventorFilterInput {
   """
+  Used to filter `Inventor` documents by which concrete subtype they belong to.
+  Analogous to the `__typename` return field.
+  """
+  _typename: StringFilterInput
+
+  """
   Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
@@ -5980,6 +5986,12 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input NamedEntityFilterInput {
   """
+  Used to filter `NamedEntity` documents by which concrete subtype they belong to.
+  Analogous to the `__typename` return field.
+  """
+  _typename: StringFilterInput
+
+  """
   Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
@@ -7069,6 +7081,12 @@ Will match all documents if passed as an empty object (or as `null`).
 """
 input NamedInventorFilterInput {
   """
+  Used to filter `NamedInventor` documents by which concrete subtype they belong to.
+  Analogous to the `__typename` return field.
+  """
+  _typename: StringFilterInput
+
+  """
   Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
@@ -7362,6 +7380,12 @@ Input type used to specify filters on `Part` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input PartFilterInput {
+  """
+  Used to filter `Part` documents by which concrete subtype they belong to.
+  Analogous to the `__typename` return field.
+  """
+  _typename: StringFilterInput
+
   """
   Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
 
@@ -15060,6 +15084,12 @@ Input type used to specify filters on `WidgetOrAddress` fields.
 Will match all documents if passed as an empty object (or as `null`).
 """
 input WidgetOrAddressFilterInput {
+  """
+  Used to filter `WidgetOrAddress` documents by which concrete subtype they belong to.
+  Analogous to the `__typename` return field.
+  """
+  _typename: StringFilterInput
+
   """
   Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
 

--- a/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
+++ b/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
@@ -1317,6 +1317,7 @@ module ElasticGraph
           # the tagging of those source fields. That's why `name`, `options1`, etc are tagged with `public` below.
           expect(type_def_for.call("IdentifiableFilterInput")).to eq(<<~EOS.strip)
             input IdentifiableFilterInput {
+              #{schema_elements._typename}: StringFilterInput
               #{schema_elements.all_of}: [IdentifiableFilterInput!]
               #{schema_elements.any_of}: [IdentifiableFilterInput!]
               id: IDFilterInput

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rb
@@ -123,7 +123,7 @@ module ElasticGraph
           extend self
 
           def normalize_case(name)
-            name.gsub(/_(\w)/) { $1.upcase }
+            name.gsub(/(?<=\w)_(\w)/) { $1.upcase }
           end
         end
 
@@ -136,7 +136,7 @@ module ElasticGraph
       # @private
       SchemaElementNames = SchemaElementNamesDefinition.new(
         # Filter arg and operation names:
-        :filter,
+        :filter, :_typename,
         :equal_to_any_of, :gt, :gte, :lt, :lte, :matches_phrase, :matches_query, :matches_query_with_prefix, :any_of, :all_of, :not,
         :time_of_day, :any_satisfy, :contains, :starts_with, :all_substrings_of, :any_substring_of, :ignore_case, :any_prefix_of,
         # Directives

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rbs
@@ -17,6 +17,7 @@ module ElasticGraph
 
         def canonical_name_for: (::String | ::Symbol) -> ::Symbol
         attr_reader filter: ::String
+        attr_reader _typename: ::String
         attr_reader equal_to_any_of: ::String
         attr_reader gt: ::String
         attr_reader gte: ::String

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names_spec.rb
@@ -12,12 +12,12 @@ module ElasticGraph
   module SchemaArtifacts
     module RuntimeMetadata
       ExampleElementNames = SchemaElementNamesDefinition.new(
-        :foo, :multi_word_snake, :multiWordCamel
+        :foo, :multi_word_snake, :multiWordCamel, :_leading_underscore
       )
 
       RSpec.describe SchemaElementNamesDefinition do
         it "exposes the set of element names via an `ELEMENT_NAMES` constant" do
-          expect(ExampleElementNames::ELEMENT_NAMES).to eq [:foo, :multi_word_snake, :multiWordCamel]
+          expect(ExampleElementNames::ELEMENT_NAMES).to eq [:foo, :multi_word_snake, :multiWordCamel, :_leading_underscore]
         end
 
         it "exposes camelCase element names when so configured, via snake case attributes" do
@@ -26,7 +26,8 @@ module ElasticGraph
           expect(names).to have_attributes(
             foo: "foo",
             multi_word_snake: "multiWordSnake",
-            multi_word_camel: "multiWordCamel"
+            multi_word_camel: "multiWordCamel",
+            _leading_underscore: "_leadingUnderscore"
           )
         end
 
@@ -36,7 +37,8 @@ module ElasticGraph
           expect(names).to have_attributes(
             foo: "foo",
             multi_word_snake: "multi_word_snake",
-            multi_word_camel: "multi_word_camel"
+            multi_word_camel: "multi_word_camel",
+            _leading_underscore: "_leading_underscore"
           )
         end
 
@@ -54,6 +56,7 @@ module ElasticGraph
           expect(names.normalize_case("foo_bar")).to eq "fooBar"
           expect(names.normalize_case("fooBar")).to eq "fooBar"
           expect(names.normalize_case("FooBar")).to eq "FooBar"
+          expect(names.normalize_case("_typename")).to eq "_typename"
         end
 
         it "allows overrides" do

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_filtering_and_aggregation.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_filtering_and_aggregation.rb
@@ -87,6 +87,15 @@ module ElasticGraph
           return [] if does_not_support?(&:filterable?)
 
           schema_def_state.factory.build_standard_filter_input_types_for_index_object_type(name) do |t|
+            if abstract?
+              t.field schema_def_state.schema_elements._typename, schema_def_state.type_ref("String").as_filter_input.name do |f|
+                f.documentation <<~EOS
+                  Used to filter `#{name}` documents by which concrete subtype they belong to.
+                  Analogous to the `__typename` return field.
+                EOS
+              end
+            end
+
             graphql_fields_by_name.values.each do |field|
               if field.filterable?
                 t.graphql_fields_by_name[field.name] = field.to_filter_field(parent_type: t)

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/filters_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/filters_spec.rb
@@ -1148,15 +1148,14 @@ module ElasticGraph
               end
             end
 
-            # Note: we would like to support filtering on `__typename` but this is invalid according to the
-            # GraphQL Spec: http://spec.graphql.org/June2018/#sec-Input-Objects
-            # > For each input field of an Input Object type:
-            # > 2. The input field must not have a name which begins with the characters "__" (two underscores).
+            # Uses `_typename` (single underscore) since the GraphQL spec prohibits `__` prefix on input fields:
+            # http://spec.graphql.org/June2018/#sec-Input-Objects
             expect(filter_type_from(result, "Inventor")).to eq(<<~EOS.strip)
               input InventorFilterInput {
                 #{schema_elements.any_of}: [InventorFilterInput!]
                 #{schema_elements.all_of}: [InventorFilterInput!]
                 #{schema_elements.not}: InventorFilterInput
+                #{schema_elements._typename}: StringFilterInput
                 name: StringFilterInput
                 nationality: StringFilterInput
                 stock_ticker: StringFilterInput
@@ -1222,6 +1221,7 @@ module ElasticGraph
                 #{schema_elements.any_of}: [ClothingItemFilterInput!]
                 #{schema_elements.all_of}: [ClothingItemFilterInput!]
                 #{schema_elements.not}: ClothingItemFilterInput
+                #{schema_elements._typename}: StringFilterInput
                 size: SizeFilterInput
                 shirt_color: StringFilterInput
                 pants_color: StringFilterInput
@@ -1279,6 +1279,7 @@ module ElasticGraph
                 #{schema_elements.any_of}: [InventorFilterInput!]
                 #{schema_elements.all_of}: [InventorFilterInput!]
                 #{schema_elements.not}: InventorFilterInput
+                #{schema_elements._typename}: StringFilterInput
                 name: StringFilterInput
                 stock_ticker: StringFilterInput
               }
@@ -1340,6 +1341,7 @@ module ElasticGraph
                 #{schema_elements.any_of}: [InventorFilterInput!]
                 #{schema_elements.all_of}: [InventorFilterInput!]
                 #{schema_elements.not}: InventorFilterInput
+                #{schema_elements._typename}: StringFilterInput
                 name: StringFilterInput
                 nationality: StringFilterInput
                 stock_ticker: StringFilterInput


### PR DESCRIPTION
Enables filtering union/interface types by concrete subtype. Uses single underscore (`_typename`) since GraphQL spec prohibits `__` prefix on input fields. Also fixes CamelCaseConverter to preserve leading underscores via lookbehind assertion.

This is step 1 for #1024.