### PR TITLE
Add warehouse_column_name support for custom warehouse field naming

### DIFF
--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/factory_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/factory_extension.rb
@@ -7,6 +7,7 @@
 # frozen_string_literal: true
 
 require "elastic_graph/warehouse/schema_definition/enum_type_extension"
+require "elastic_graph/warehouse/schema_definition/field_extension"
 require "elastic_graph/warehouse/schema_definition/index_extension"
 require "elastic_graph/warehouse/schema_definition/object_interface_and_union_extension"
 require "elastic_graph/warehouse/schema_definition/results_extension"
@@ -31,6 +32,18 @@ module ElasticGraph
             # :nocov: -- currently all invocations have a block
             yield type if block_given?
             # :nocov:
+          end
+        end
+
+        # Creates a new field with warehouse extensions.
+        #
+        # @param kwargs [Hash] keyword arguments passed to the field constructor
+        # @yield [ElasticGraph::SchemaDefinition::SchemaElements::Field] the newly created field (optional)
+        # @return [ElasticGraph::SchemaDefinition::SchemaElements::Field] the created field
+        def new_field(**kwargs)
+          super(**kwargs) do |field|
+            field.extend FieldExtension
+            yield field if block_given?
           end
         end
 

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/field_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/field_extension.rb
@@ -1,0 +1,47 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      # Extends {ElasticGraph::SchemaDefinition::SchemaElements::Field} to support custom warehouse column names.
+      #
+      # By default, warehouse tables use the field's `name_in_index` as the column name. This extension
+      # allows overriding that on a per-field basis using {#warehouse_column_name}.
+      #
+      # @example Override the warehouse column name
+      #   ElasticGraph.define_schema do |schema|
+      #     schema.object_type "Widget" do |t|
+      #       t.field "workspace_id", "ID", name_in_index: "workspace_id2" do |f|
+      #         f.warehouse_column_name name: "workspace_id"
+      #       end
+      #       t.index "widgets"
+      #     end
+      #   end
+      module FieldExtension
+        # Returns the warehouse column name to use for this field.
+        # Falls back to {ElasticGraph::SchemaDefinition::SchemaElements::Field#name_in_index} if no custom warehouse name has been configured.
+        #
+        # @return [String] the warehouse column name
+        def name_for_warehouse
+          @warehouse_column_name || name_in_index
+        end
+
+        # Configures a custom warehouse column name for this field.
+        # When set, this name will be used in the generated `CREATE TABLE` statement
+        # instead of the field's `name_in_index`.
+        #
+        # @param name [String] the warehouse column name
+        # @return [void]
+        def warehouse_column_name(name:)
+          @warehouse_column_name = name
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rb
@@ -21,11 +21,10 @@ module ElasticGraph
         # @note For union types, the STRUCT includes all fields from all subtypes, following the same pattern used
         #   in the datastore mapping (see {ElasticGraph::SchemaDefinition::Indexing::FieldType::Union#to_mapping}).
         def to_warehouse_column_type
-          subfields = indexing_fields_by_name_in_index.values.filter_map(&:to_indexing_field)
-
-          struct_field_expressions = subfields.map do |subfield|
-            warehouse_type = FieldTypeConverter.convert(subfield.type)
-            "#{subfield.name_in_index} #{warehouse_type}"
+          struct_field_expressions = indexing_fields_by_name_in_index.values.map do |field|
+            field_name = field.name_for_warehouse
+            warehouse_type = FieldTypeConverter.convert(field.to_indexing_field.type)
+            "#{field_name} #{warehouse_type}"
           end.join(", ")
 
           "STRUCT<#{struct_field_expressions}>"

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/warehouse_table.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/warehouse_table.rb
@@ -31,7 +31,6 @@ module ElasticGraph
           fields = index.indexed_type
             .indexing_fields_by_name_in_index
             .values
-            .filter_map(&:to_indexing_field)
             .map { |field| table_field(field) }
             .join(",\n  ")
 
@@ -43,8 +42,8 @@ module ElasticGraph
         end
 
         def table_field(field)
-          field_name = field.name_in_index
-          warehouse_type = FieldTypeConverter.convert(field.type)
+          field_name = field.name_for_warehouse
+          warehouse_type = FieldTypeConverter.convert(field.to_indexing_field.type)
           "#{field_name} #{warehouse_type}"
         end
       end

--- a/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/factory_extension.rbs
+++ b/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/factory_extension.rbs
@@ -2,6 +2,7 @@ module ElasticGraph
   module Warehouse
     module SchemaDefinition
       module FactoryExtension: ::ElasticGraph::SchemaDefinition::Factory
+        def new_field: (**untyped) ?{ (::ElasticGraph::SchemaDefinition::SchemaElements::Field) -> void } -> ::ElasticGraph::SchemaDefinition::SchemaElements::Field
       end
     end
   end

--- a/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/field_extension.rbs
+++ b/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/field_extension.rbs
@@ -1,0 +1,20 @@
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      # Interface for fields accessed in warehouse context from indexing_fields_by_name_in_index.
+      # These fields are guaranteed to have a FieldExtension (providing name_for_warehouse)
+      # and a non-nil to_indexing_field (since they come from indexing_fields_by_name_in_index).
+      interface _WarehouseField
+        def name_for_warehouse: () -> ::String
+        def to_indexing_field: () -> ::ElasticGraph::SchemaDefinition::Indexing::Field
+      end
+
+      module FieldExtension : ::ElasticGraph::SchemaDefinition::SchemaElements::Field
+        def name_for_warehouse: () -> ::String
+        def warehouse_column_name: (name: ::String) -> void
+
+        @warehouse_column_name: ::String?
+      end
+    end
+  end
+end

--- a/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rbs
+++ b/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/object_interface_and_union_extension.rbs
@@ -6,7 +6,7 @@ module ElasticGraph
       end
 
       interface _ObjectInterfaceAndUnionExtensionInterface
-        def indexing_fields_by_name_in_index: () -> ::Hash[::String, ::ElasticGraph::SchemaDefinition::SchemaElements::Field]
+        def indexing_fields_by_name_in_index: () -> ::Hash[::String, _WarehouseField]
       end
     end
   end

--- a/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/warehouse_table.rbs
+++ b/elasticgraph-warehouse/sig/elastic_graph/warehouse/schema_definition/warehouse_table.rbs
@@ -14,7 +14,7 @@ module ElasticGraph
 
         private
 
-        def table_field: (::ElasticGraph::SchemaDefinition::Indexing::Field) -> ::String
+        def table_field: (untyped) -> ::String
       end
     end
   end


### PR DESCRIPTION
The warehouse gem now supports overriding field names in generated CREATE TABLE statements via `warehouse_column_name(name:)`. Previously, warehouse tables always used `name_in_index`, which could differ from the GraphQL field name. This caused mismatches with existing Databricks tables that were set up using GraphQL names.

Usage:
  t.field "nameText", "String", name_in_index: "nameText2" do |f|
    f.warehouse_column_name name: "nameText"
  end