### PR TITLE
Simplify `SupportsDefaultValues`: remove `NO_DEFAULT_PROVIDED`.

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_default_value.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/supports_default_value.rb
@@ -12,14 +12,7 @@ module ElasticGraph
   module SchemaDefinition
     module Mixins
       # A mixin designed to be included in a schema element class that supports default values.
-      # Designed to be `prepended` so that it can hook into `initialize`.
       module SupportsDefaultValue
-        # @private
-        def initialize(...)
-          __skip__ = super # steep can't type this.
-          @default_value = NO_DEFAULT_PROVIDED
-        end
-
         # Used to specify the default value for this field or argument.
         #
         # @param default_value [Object] default value for this field or argument
@@ -32,15 +25,9 @@ module ElasticGraph
         #
         # @return [String]
         def default_value_sdl
-          return nil if @default_value == NO_DEFAULT_PROVIDED
+          return nil unless instance_variable_defined?(:@default_value)
           " = #{Support::GraphQLFormatter.serialize(@default_value)}"
         end
-
-        private
-
-        # A sentinel value that we can use to detect when a default has been provided.
-        # We can't use `nil` to detect if a default has been provided because `nil` is a valid default value!
-        NO_DEFAULT_PROVIDED = Module.new
       end
     end
   end

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/mixins/supports_default_value.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/mixins/supports_default_value.rbs
@@ -2,9 +2,7 @@ module ElasticGraph
   module SchemaDefinition
     module Mixins
       module SupportsDefaultValue
-        NO_DEFAULT_PROVIDED: Module
         @default_value: untyped
-        def initialize: (*untyped, **untyped) ?{ (*untyped, **untyped) -> untyped } -> void
         def default: (untyped) -> void
         def default_value_sdl: () -> ::String?
       end


### PR DESCRIPTION
Instead, we can use `instance_variable_defined?`. This allows us to remove the `initialize` override, which will help us avoid a JRuby bug:

https://github.com/jruby/jruby/issues/9242