### PR TITLE
Fix git diff in dumped artifacts formatting test

### DIFF
--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
@@ -768,7 +768,7 @@ module ElasticGraph
           # which isn't loaded in this test suite. We filter the diff output since `git diff --no-index`
           # doesn't support pathspec exclusions.
           diff = `git diff --no-index #{File.join(config_dir, "schema", "artifacts")} config/schema/artifacts #{"--color" if $stdout.tty?}`
-          filtered_diff = diff.gsub(/^diff --git.*?data_warehouse\.yaml.*?(?=^diff --git|\z)/m, '')
+          filtered_diff = diff.gsub(/^diff --git.*?data_warehouse\.yaml.*?(?=^diff --git|\z)/m, "")
 
           unless filtered_diff == ""
             RSpec.world.reporter.message("\n\nThe schema artifact diff:\n\n#{filtered_diff}")


### PR DESCRIPTION
This test is currently failing. The pathspec exclusion syntax `:!data_warehouse.yaml` doesn't work with `git diff --no-index` since pathspecs only work within a Git working tree: https://git-scm.com/docs/git-diff.

Instead, we filter out the `data_warehouse.yaml` diff hunk with regex.