### PR TITLE
Handle ANSI color codes in dumped artifacts formatting test

### DIFF
--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
@@ -768,7 +768,9 @@ module ElasticGraph
           # which isn't loaded in this test suite. We filter the diff output since `git diff --no-index`
           # doesn't support pathspec exclusions.
           diff = `git diff --no-index #{File.join(config_dir, "schema", "artifacts")} config/schema/artifacts #{"--color" if $stdout.tty?}`
-          filtered_diff = diff.gsub(/^diff --git.*?data_warehouse\.yaml.*?(?=^diff --git|\z)/m, "")
+          # Strip ANSI color codes so the regex can match when --color is enabled.
+          diff_without_colors = diff.gsub(/\e\[\d*m/, "")
+          filtered_diff = diff_without_colors.gsub(/^diff --git.*?data_warehouse\.yaml.*?(?=^diff --git|\z)/m, "")
 
           unless filtered_diff == ""
             RSpec.world.reporter.message("\n\nThe schema artifact diff:\n\n#{filtered_diff}")


### PR DESCRIPTION
Follow up to https://github.com/block/elasticgraph/pull/1040.

The regex filter for excluding data_warehouse.yaml from `git diff` output can fail when color codes are enabled. The regex pattern `^diff --git` couldn't match `^\e[1mdiff --git` because the escape sequence appeared at the start of the line.

This PR strips the ANSI color codes before applying the regex filter to handle both colored and non-colored diff output correctly.