### PR TITLE
Split JRuby CI into 4 parallel parts to reduce wall clock time.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,10 +46,25 @@ jobs:
           - build_part: "run_datastore_specs"
             ruby: "4.0"
             datastore: "opensearch:2.19.0"
-          # We have a special build part for JRuby.
+          # We have a special build part for JRuby, split into 4 parallel parts for speed.
+          # Part 1: graphql (excl. acceptance), Part 2: schema_definition+indexer,
+          # Part 3: graphql acceptance + local (halted), Part 4: all remaining gems.
           - build_part: "run_specs_for_jruby"
             ruby: "jruby-10.0"
             datastore: "elasticsearch:9.2.4"
+            build_part_args: "1"
+          - build_part: "run_specs_for_jruby"
+            ruby: "jruby-10.0"
+            datastore: "elasticsearch:9.2.4"
+            build_part_args: "2"
+          - build_part: "run_specs_for_jruby"
+            ruby: "jruby-10.0"
+            datastore: "elasticsearch:9.2.4"
+            build_part_args: "3"
+          - build_part: "run_specs_for_jruby"
+            ruby: "jruby-10.0"
+            datastore: "elasticsearch:9.2.4"
+            build_part_args: "4"
           # Other build parts run on max Ruby and primary datastore only.
           - build_part: "run_misc_checks"
             ruby: "4.0"
@@ -91,7 +106,7 @@ jobs:
         # Note: the `10` argument on the end is a number of seconds to sleep after booting the datastore.
         # We've found that there is a minor race condition where the shards aren't fully ready for the tests
         # to hit them if we don't wait a bit after booting.
-        run: script/ci_parts/${{ matrix.build_part }} ${{ matrix.datastore }} 10
+        run: script/ci_parts/${{ matrix.build_part }} ${{ matrix.datastore }} 10 ${{ matrix.build_part_args }}
 
   docker-demo:
     runs-on: ubuntu-latest

--- a/ai-memory/projects/improve_jruby_ci/research.md
+++ b/ai-memory/projects/improve_jruby_ci/research.md
@@ -92,3 +92,17 @@ Total: ~270 spec files
 
 ### CI Matrix Change
 Replace single JRuby entry with 3 entries, each with different `build_part_args` ("1", "2", "3"). `update_ci_yaml` auto-updates datastore versions for all include entries - no changes needed there.
+
+### Additional Findings (Session 2)
+
+**`flatware_rspec` fallback on JRuby**: `script/flatware_rspec` checks `bundle show flatware` — on JRuby flatware isn't available, so it falls back to `bundle exec rspec`. The plan's `run_gems_with_datastore` function correctly uses `flatware_rspec`, which does the right thing on both platforms.
+
+**`setup_env` positional args**: `setup_env` takes 3 args: `$1`=boot_env ("test"), `$2`=datastore, `$3`=sleep_after_boot (default 0). The part number must be captured in `run_specs_for_jruby` *before* sourcing `setup_env`, since `source` doesn't create a subshell but we pass different args to it.
+
+**`update_ci_yaml` compatibility confirmed**: `update_includes_primary_datastore` uses `gsub` to replace ALL `datastore: "..."` values in the includes section. New JRuby entries will be auto-updated when datastore versions change. No changes needed to `update_ci_yaml`.
+
+**GitHub Actions job naming**: With `build_part_args` in the matrix, jobs will display as e.g. `ci-check (run_specs_for_jruby, jruby-10.0, elasticsearch:9.2.4, 1)`. For entries without `build_part_args`, the field is absent from the name.
+
+**Empty `build_part_args` for non-JRuby entries**: When `build_part_args` isn't defined in a matrix entry, `${{ matrix.build_part_args }}` evaluates to empty string. Shell word-splitting means no extra arg is passed. Other scripts don't reference `$3` so no impact.
+
+**`run_each_gem_spec` uses per-gem bundler contexts** (for dependency verification). Not applicable to JRuby split since JRuby's purpose is just "does it work on JRuby" not "are deps correct".

--- a/ai-memory/projects/improve_jruby_ci/spec.md
+++ b/ai-memory/projects/improve_jruby_ci/spec.md
@@ -2,7 +2,7 @@
 
 We recently added JRuby to the CI build matrix in #999. It's working well but there are a few loose ends to tie up.
 
-## TODO: Remove `:except_jruby` from `elasticgraph-local` specs
+## DONE: Remove `:except_jruby` from `elasticgraph-local` specs
 
 To get the JRuby CI build to pass, we tagged a couple of `elasticgraph-local` specs with `:except_jruby`. These
 specs pass `--daemonize` when booting ElasticGraph locally, and `--daemonize` doesn't work on JRuby because the

--- a/ai-memory/projects/improve_jruby_ci/spec.plan-2.md
+++ b/ai-memory/projects/improve_jruby_ci/spec.plan-2.md
@@ -6,34 +6,52 @@
 
 ## Context
 
-The JRuby CI build takes 50+ minutes (single job running all gems sequentially, no flatware parallelization since it requires fork). The longest non-JRuby build part takes ~20 minutes. Goal: split JRuby into parallel jobs so it's no longer the bottleneck.
+The JRuby CI build takes 50+ minutes (single job running all gems sequentially, no flatware parallelization since flatware requires fork). The longest non-JRuby build part takes ~20 minutes. Goal: split JRuby into parallel jobs so it's no longer the bottleneck.
+
+Key constraints:
+- Flatware unavailable on JRuby (uses fork); `script/flatware_rspec` falls back to `bundle exec rspec`
+- `elasticgraph-local` must run with datastore halted (separate from other gems)
+- `script/update_ci_yaml` auto-updates all `datastore:` values in the includes section; no changes needed there
+- The `run` step passes args positionally: `$1`=datastore, `$2`=sleep_after_boot; we add `$3`=part
 
 ## Approach
 
-**Phase A: Measure.** Measure actual per-gem JRuby runtimes first (spec file counts aren't accurate—e.g., elasticgraph-local is particularly slow despite few files). This informs the grouping.
+**Phase A: Measure.** Measure actual per-gem JRuby runtimes to inform grouping. Spec file counts don't correlate well with runtime (e.g., `elasticgraph-local` is slow despite few files). Use a measurement script to time each gem individually.
 
-**Phase B: Split.** Parameterize `run_specs_for_jruby` to accept a part number. Split gems into groups balanced by measured runtime. Initial estimate (to be revised after measurement):
+**Phase B: Split.** Parameterize `run_specs_for_jruby` to accept a part number via `$3`. Split gems into groups balanced by measured runtime. Initial estimate (to be revised after measurement):
 
-- **Part 1** (80 specs): `elasticgraph-graphql`
-- **Part 2** (83 specs): `elasticgraph-schema_definition`, `elasticgraph-indexer`
-- **Part 3** (~107 specs): all remaining gems + `elasticgraph-local`
+- **Part 1** (~80 specs): `elasticgraph-graphql`
+- **Part 2** (~83 specs): `elasticgraph-schema_definition`, `elasticgraph-indexer`
+- **Part 3** (~107 specs): all remaining gems + `elasticgraph-local` (datastore halted)
 
-Add JRuby CI matrix entries with `build_part_args`. Modify the `run` step to pass this extra arg. Keep `*)` default case for standalone runs.
+Add 3 JRuby CI matrix entries with `build_part_args`. Modify `run` step to pass `${{ matrix.build_part_args }}`. Keep `*)` default case for standalone runs.
 
 ## Files to Modify
 
-1. `script/ci_parts/run_specs_for_jruby` - add part-based gem splitting
-2. `.github/workflows/ci.yaml` - multiple JRuby matrix entries, pass `build_part_args`
+1. `script/ci_parts/run_specs_for_jruby` — add part-based gem splitting
+2. `.github/workflows/ci.yaml` — 3 JRuby matrix entries, pass `build_part_args`
 
 ## Detailed Changes
 
 ### Step 1: Measure actual JRuby per-gem runtimes
 
-Run each gem's specs individually on JRuby and record wall clock time. Use results to balance the N-part split. Adjust gem grouping accordingly.
+Boot datastore, then time each gem individually on JRuby. Example:
+
+```bash
+# Boot datastore first, then for each gem:
+for gem in $(script/list_eg_gems.rb | grep -v elasticgraph-local); do
+  if [ -d "$gem/spec" ]; then
+    echo "=== $gem ==="
+    time bundle exec rspec $gem/spec --format progress 2>&1 | tail -1
+  fi
+done
+```
+
+Use results to balance the 3-part split so each part targets ≤20 minutes.
 
 ### Step 2: Parameterize `run_specs_for_jruby`
 
-Rewrite `script/ci_parts/run_specs_for_jruby` (gem grouping subject to adjustment after Step 1 measurements):
+Replace `script/ci_parts/run_specs_for_jruby` with:
 
 ```bash
 #!/usr/bin/env bash
@@ -95,13 +113,20 @@ case "$part" in
 esac
 ```
 
+Notes:
+- `flatware_rspec` automatically falls back to `bundle exec rspec` on JRuby (flatware requires fork)
+- Part 3 uses dynamic filtering via `grep -v` so new gems are automatically included
+- `*)` default preserves standalone usage (e.g., running locally without a part number)
+- Gem grouping subject to adjustment based on Step 1 measurements
+
 ### Step 3: Update CI yaml
 
 In `.github/workflows/ci.yaml`:
 
-1. Replace the single JRuby include entry with 3 entries (number may change based on Step 1):
+1. Replace the single JRuby include entry with 3 entries:
 
 ```yaml
+          # We have a special build part for JRuby, split into 3 parallel parts for speed.
           - build_part: "run_specs_for_jruby"
             ruby: "jruby-10.0"
             datastore: "elasticsearch:9.2.4"
@@ -122,20 +147,24 @@ In `.github/workflows/ci.yaml`:
         run: script/ci_parts/${{ matrix.build_part }} ${{ matrix.datastore }} 10 ${{ matrix.build_part_args }}
 ```
 
+For non-JRuby entries, `build_part_args` is undefined → empty string → shell ignores it. No impact on other build parts.
+
 ### Step 4: Verify `update_ci_yaml` handles new entries
 
-Run `script/update_ci_yaml --verify` to confirm the script still works. The `update_includes_primary_datastore` method replaces ALL `datastore:` values in the includes section, so the new JRuby entries will be auto-updated when datastore versions change. No changes needed to `update_ci_yaml`.
+Run `script/update_ci_yaml --verify`. The `update_includes_primary_datastore` method replaces ALL `datastore:` values in the includes section via `gsub`, so new JRuby entries get auto-updated when datastore versions change. No changes needed to `update_ci_yaml`.
 
 ## Verification
 
-1. Run `script/update_ci_yaml --verify` to confirm CI yaml consistency.
-2. Push branch and verify CI creates separate JRuby jobs with balanced runtimes.
-3. Confirm each JRuby part completes in ~20 minutes or less.
+1. Run `script/update_ci_yaml --verify` — confirms CI yaml consistency.
+2. Push branch and verify CI creates 3 separate JRuby jobs.
+3. Confirm each JRuby part completes in ≤20 minutes.
+4. Verify the `*)` default case still works for standalone local runs.
 
 ## Planning Session
 
-`/Users/myron.marston/.claude/projects/-Users-myron-marston-code-elasticgraph/f2f27953-57fc-4169-8f1d-35ce9c3e571e.jsonl`
+`/Users/myron.marston/.claude/projects/-Users-myron-marston-code-elasticgraph/c6374ad5-86cc-4fa6-8f49-a6aad217f8a6.jsonl`
 
 ## Unresolved Questions
 
-(None — gem grouping will be finalized after runtime measurements in Step 1)
+1. Gem grouping TBD — need Step 1 runtime measurements first. Want to do that now, or just push with the spec-file-count estimate and adjust after seeing CI times?
+2. Number of parts: 3 was chosen assuming ~50 min / 3 ≈ 17 min each. If measurements show lopsided distribution, might want 4 parts instead?

--- a/script/ci_parts/run_specs_for_jruby
+++ b/script/ci_parts/run_specs_for_jruby
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Capture part number before `source` potentially alters positional params.
+part=${3:-}
+
 source "script/ci_parts/setup_env" "test" $1 $2
 
 # We don't want to bother checking coverage on JRuby, for a few reasons:
@@ -12,10 +15,47 @@ unset COVERAGE
 # because 20+ minutes may pass before the line of progress dots completes, and GitHub actions streams build
 # output line-by-line. We use the documentation formatter here so that the output has many lines and there's
 # more obviously ongoing progress on CI.
-script/run_specs --format documentation
+rspec_format="--format documentation"
 
-halt_datastore_daemon
+run_gems() {
+  local spec_dirs=""
+  for gem in "$@"; do
+    if [ -d "$gem/spec" ]; then
+      spec_dirs="$spec_dirs $gem/spec"
+    fi
+  done
+  if [ -n "$spec_dirs" ]; then
+    script/flatware_rspec $spec_dirs $rspec_format
+  fi
+}
 
-for gem in $gems_to_build_with_datastore_halted; do
-  bundle exec rspec $gem/spec --backtrace --format progress
-done
+run_gems_with_datastore_halted() {
+  halt_datastore_daemon
+  run_gems $gems_to_build_with_datastore_halted
+}
+
+case "$part" in
+  1)
+    # graphql excluding acceptance (~19m); acceptance specs split to part 3.
+    script/flatware_rspec elasticgraph-graphql/spec $rspec_format --tag ~type:acceptance
+    ;;
+  2)
+    run_gems elasticgraph-schema_definition elasticgraph-indexer
+    ;;
+  3)
+    # The two slowest individual spec groups: graphql acceptance (~8m) and
+    # elasticgraph-local (~6m, requires halted datastore).
+    script/flatware_rspec elasticgraph-graphql/spec $rspec_format --tag type:acceptance
+    run_gems_with_datastore_halted
+    ;;
+  4)
+    # All remaining gems not covered by parts 1-3.
+    remaining=$(echo $gems_to_build_with_datastore_booted | tr ' ' '\n' | grep -v -E "^(elasticgraph-graphql|elasticgraph-schema_definition|elasticgraph-indexer)$" | tr '\n' ' ')
+    run_gems $remaining
+    ;;
+  *)
+    # Default: run everything (backward-compatible with no part argument).
+    script/run_specs $rspec_format
+    run_gems_with_datastore_halted
+    ;;
+esac


### PR DESCRIPTION
JRuby CI was a ~50min single job bottleneck. Split into 4 parts:
- Part 1: graphql unit+integration (~19m)
- Part 2: schema_definition+indexer (~9m)
- Part 3: graphql acceptance + local/halted (~14m)
- Part 4: all remaining gems (~18m)

This brings all JRuby parts down under our longest build part
(run_specs_file_by_file), which takes ~21m, which means that
JRuby no longer adds to how long builds take (so long as the
parts run in parallel, as they usually do).


🤖 Generated with [Claude Code](https://claude.com/claude-code)