### PR TITLE
Memoize schema_def_api to prevent double schema evaluation

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/rake_tasks.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/rake_tasks.rb
@@ -171,18 +171,20 @@ module ElasticGraph
       end
 
       def schema_def_api
-        require "elastic_graph/schema_definition/api"
+        @schema_def_api ||= begin
+          require "elastic_graph/schema_definition/api"
 
-        API.new(
-          @schema_element_names,
-          @index_document_sizes,
-          extension_modules: @extension_modules,
-          derived_type_name_formats: @derived_type_name_formats,
-          type_name_overrides: @type_name_overrides,
-          enum_value_overrides_by_type: @enum_value_overrides_by_type,
-          output: @output
-        ).tap do |api|
-          api.as_active_instance { load @path_to_schema.to_s }
+          API.new(
+            @schema_element_names,
+            @index_document_sizes,
+            extension_modules: @extension_modules,
+            derived_type_name_formats: @derived_type_name_formats,
+            type_name_overrides: @type_name_overrides,
+            enum_value_overrides_by_type: @enum_value_overrides_by_type,
+            output: @output
+          ).tap do |api|
+            api.as_active_instance { load @path_to_schema.to_s }
+          end
         end
       end
     end

--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
@@ -26,6 +26,10 @@ module ElasticGraph
         expect { example.run }.not_to output(/./).to_stderr_from_any_process
       end
 
+      after do
+        Thread.current[:eg_schema_load_count] = nil
+      end
+
       describe "schema_artifacts:dump", :in_temp_dir do
         it "idempotently dumps all schema artifacts, and is able to check if they are current with `:check`" do
           write_elastic_graph_schema_def_code(json_schema_version: 1)
@@ -888,16 +892,21 @@ module ElasticGraph
         end
 
         let(:json_schema_version_setter_location_regex) do
-          # In `write_elastic_graph_schema_def_code` `json_schema_version` is called on the 2nd line of
-          # the file written to `schema.rb`. See below.
+          # In `write_elastic_graph_schema_def_code` `json_schema_version` is called on the 7th line of
+          # the file written to `schema.rb` (after the 5-line double-load guard). See below.
           #
           # Note: on Ruby 3.3, the path here winds up being slightly different; instead of just `schema.rb` it is something like:
           # `../d20240216-23551-cvdjzo/schema.rb`. I think it's related to the temp directory we run these specs within.
-          /line 2 at `(\S*\/?)schema\.rb`/
+          /line 7 at `(\S*\/?)schema\.rb`/
         end
 
         def write_elastic_graph_schema_def_code(json_schema_version:, component_suffix: "", extra_sdl: "", component_name_extras: "", component_extras: "", omit_component_name_field: false)
           code = <<~EOS
+            Thread.current[:eg_schema_load_count] = (Thread.current[:eg_schema_load_count] || 0) + 1
+            if Thread.current[:eg_schema_load_count] > 1
+              raise "Schema file \#{__FILE__} was loaded \#{Thread.current[:eg_schema_load_count]} times in a single run!"
+            end
+
             ElasticGraph.define_schema do |schema|
               schema.json_schema_version #{json_schema_version}
               schema.enum_type "Size" do |t|
@@ -949,6 +958,11 @@ module ElasticGraph
 
         def runtime_metadata_for_elastic_graph_schema_def_code(include_date_time_fields:)
           ::File.write("schema.rb", <<~EOS)
+            Thread.current[:eg_schema_load_count] = (Thread.current[:eg_schema_load_count] || 0) + 1
+            if Thread.current[:eg_schema_load_count] > 1
+              raise "Schema file \#{__FILE__} was loaded \#{Thread.current[:eg_schema_load_count]} times in a single run!"
+            end
+
             ElasticGraph.define_schema do |schema|
               schema.json_schema_version 1
 
@@ -1052,6 +1066,8 @@ module ElasticGraph
         type_name_overrides: {},
         enum_value_overrides_by_type: {}
       )
+        Thread.current[:eg_schema_load_count] = nil
+
         if include_extension_module
           extension_module = Module.new do
             def as_active_instance


### PR DESCRIPTION
## Summary

- Memoize `schema_def_api` in `RakeTasks` so the schema file is only loaded once per rake task invocation, fixing a bug where `require_relative` in user schema files silently fails on the second load
- Add a thread-local double-load guard in integration tests to catch future regressions

## Test plan

- [x] Verified guard detects double-load (10 test failures before fix)
- [x] All 17 `rake_tasks_spec.rb` integration tests pass after memoization

🤖 Generated with [Claude Code](https://claude.com/claude-code)