### PR TITLE
Validate actual generated JSON schema against meta-schema

### DIFF
--- a/elasticgraph-schema_definition/spec/support/json_schema_matcher.rb
+++ b/elasticgraph-schema_definition/spec/support/json_schema_matcher.rb
@@ -33,13 +33,13 @@ RSpec::Matchers.define :have_json_schema_like do |type, expected_schema, include
 
     @expected = JSON.pretty_generate(modified_expected_schema)
 
-    actual_schema = normalize(full_schema.fetch("$defs").fetch(type))
-    actual_schema = strip_descriptions_from(actual_schema) if ignore_descriptions
+    @raw_actual_schema = normalize(full_schema.fetch("$defs").fetch(type))
+    actual_schema = ignore_descriptions ? strip_descriptions_from(@raw_actual_schema) : @raw_actual_schema
     @actual = JSON.pretty_generate(actual_schema)
 
     @validator_factory = ElasticGraph::Support::JSONSchema::ValidatorFactory.new(schema: full_schema, sanitize_pii: false)
 
-    @meta_schema_validation_errors = ElasticGraph::Support::JSONSchema.elastic_graph_internal_meta_schema_validator.validate(modified_expected_schema)
+    @meta_schema_validation_errors = ElasticGraph::Support::JSONSchema.elastic_graph_internal_meta_schema_validator.validate(@raw_actual_schema)
 
     if @meta_schema_validation_errors.empty? && actual_schema == modified_expected_schema
       validator = @validator_factory.validator_for(type)
@@ -66,16 +66,13 @@ RSpec::Matchers.define :have_json_schema_like do |type, expected_schema, include
   failure_message do |_actual_schema|
     if @meta_schema_validation_errors.any?
       <<~EOS
-        expected valid JSON schema[1] but got validation errors on the expected schema and got JSON schema[2]:
+        expected the generated JSON schema for `#{type}` to be valid according to the JSON schema meta-schema, but got validation errors:
 
         #{@meta_schema_validation_errors.map { |e| JSON.pretty_generate(e) }.join("\n\n")}
 
 
-        [1] The expected schema:
-        #{expected}
-
-        [2] Actual schema:
-        #{actual}
+        Actual schema:
+        #{JSON.pretty_generate(@raw_actual_schema)}
       EOS
     elsif @match_failures.any?
       <<~EOS

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/json_schema_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/json_schema_spec.rb
@@ -77,16 +77,6 @@ module ElasticGraph
           }, include_typename: false, ignore_descriptions: true)
         end
 
-        it "places the `latency_timestamps` `patternProperties` description inside the pattern schema, not as a sibling key" do
-          pattern_properties = json_schema.dig("$defs", EVENT_ENVELOPE_JSON_SCHEMA_NAME, "properties", "latency_timestamps", "patternProperties")
-
-          expect(pattern_properties.keys).to eq(["^\\w+_at$"]),
-            "Expected `patternProperties` to only contain regex pattern keys, but found: #{pattern_properties.keys.inspect}. " \
-            "Per the JSON Schema spec, every key in `patternProperties` must be a regex pattern."
-
-          expect(pattern_properties.dig("^\\w+_at$", "description")).to be_a(String).and(include("latency"))
-        end
-
         %w[ID String].each do |type_name|
           example "for `#{type_name}`" do
             expect(json_schema).to have_json_schema_like(type_name, {


### PR DESCRIPTION
## Summary

- The `have_json_schema_like` test matcher now validates the **actual** generated JSON schema against the JSON Schema meta-schema, instead of only validating the hand-written expected schema.
- This catches any class of invalid JSON schema structurally (not just specific instances like the `patternProperties` bug fixed in #1094).
- Removed the specific `latency_timestamps` test from #1094 since the matcher improvement subsumes it.

## Context

The `ignore_descriptions: true` option on the event envelope test stripped `description` keys before comparison, hiding the structural bug fixed in #1094. By validating the raw actual schema before description stripping, this kind of issue is now caught generically.

## Test plan

- [x] Temporarily reverted the #1094 source fix and confirmed the existing event envelope test now fails with a clear meta-schema validation error
- [x] Restored the fix and confirmed all 134 json_schema_spec examples pass
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)