### PR TITLE
Simplify expectations from #1096: leverage RSpec composability.

### DIFF
--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/graphql_schema_spec_support.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/graphql_schema_spec_support.rb
@@ -126,22 +126,15 @@ module ElasticGraph
       # Connection, Edge, Aggregation, AggregationConnection, AggregationEdge, SortOrderInput.
       # These are distinct from the remaining derived types (GroupedBy, AggregatedValues, Highlights),
       # which are potentially relevant for all types.
-      def expect_root_derived_types_present(sdl, type_name)
-        expect(connection_type_from(sdl, type_name)).not_to be_nil
-        expect(edge_type_from(sdl, type_name)).not_to be_nil
-        expect(aggregation_type_from(sdl, type_name)).not_to be_nil
-        expect(aggregation_connection_type_from(sdl, type_name)).not_to be_nil
-        expect(aggregation_edge_type_from(sdl, type_name)).not_to be_nil
-        expect(sort_order_type_from(sdl, type_name)).not_to be_nil
-      end
-
-      def expect_root_derived_types_absent(sdl, type_name)
-        expect(connection_type_from(sdl, type_name)).to be_nil
-        expect(edge_type_from(sdl, type_name)).to be_nil
-        expect(aggregation_type_from(sdl, type_name)).to be_nil
-        expect(aggregation_connection_type_from(sdl, type_name)).to be_nil
-        expect(aggregation_edge_type_from(sdl, type_name)).to be_nil
-        expect(sort_order_type_from(sdl, type_name)).to be_nil
+      def root_derived_types(sdl, type_name)
+        [
+          connection_type_from(sdl, type_name),
+          edge_type_from(sdl, type_name),
+          aggregation_type_from(sdl, type_name),
+          aggregation_connection_type_from(sdl, type_name),
+          aggregation_edge_type_from(sdl, type_name),
+          sort_order_type_from(sdl, type_name)
+        ]
       end
     end
   end

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/interface_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/interface_type_spec.rb
@@ -189,16 +189,16 @@ module ElasticGraph
           end
 
           # DistributionChannel has index, should have root derived types
-          expect_root_derived_types_present(result, "DistributionChannel")
+          expect(root_derived_types(result, "DistributionChannel")).to all be_present
 
           # Retail is directly queryable (all subtypes indexed), should have root derived types
-          expect_root_derived_types_present(result, "Retail")
+          expect(root_derived_types(result, "Retail")).to all be_present
 
           # OnlineStore only inherits index, should NOT have root derived types
-          expect_root_derived_types_absent(result, "OnlineStore")
+          expect(root_derived_types(result, "OnlineStore")).to all be_nil
 
           # PhysicalStore has own index, should have root derived types
-          expect_root_derived_types_present(result, "PhysicalStore")
+          expect(root_derived_types(result, "PhysicalStore")).to all be_present
 
           # Verify query fields exist for directly queryable types
           query_type = type_def_from(result, "Query")

--- a/spec_support/spec_helper.rb
+++ b/spec_support/spec_helper.rb
@@ -255,6 +255,7 @@ RSpec::Matchers.define_negated_matcher :maintain, :change
 RSpec::Matchers.define_negated_matcher :raise_no_error, :raise_error
 RSpec::Matchers.define_negated_matcher :avoid_outputting, :output
 RSpec::Matchers.define_negated_matcher :have_never_received, :have_received
+RSpec::Matchers.define_negated_matcher :be_present, :be_nil
 
 module ElasticGraph
   module CommonSpecHelpers


### PR DESCRIPTION
This allows us to define the list of root derived types once, and then expect different things of all elements in the list.