### PR TITLE
Fix site build: update MCP-compatible tools list

### DIFF
--- a/ai_tools/README.md
+++ b/ai_tools/README.md
@@ -14,9 +14,10 @@ Located in [`elasticgraph-mcp-server/`](./elasticgraph-mcp-server/), this provid
 
 You can use the MCP server with a variety of tools and platforms, including:
 
+- in [Cursor](https://www.cursor.com) as an "MCP tool"
 - in [Goose](https://block.github.io/goose/) as an "extension"
-- in [Claude](https://docs.anthropic.com/en/docs/agents-and-tools/mcp) Desktop app as an "MCP server"
-- in [Cursor](https://docs.cursor.com/context/model-context-protocol) as an "MCP tool"
+- in [Claude Code](https://claude.com/product/claude-code) as an "MCP server"
+- in [Codex](https://github.com/openai/codex) as an "MCP server"
 
 ## Additional Resources
 

--- a/config/site/src/guides/ai-tools.md
+++ b/config/site/src/guides/ai-tools.md
@@ -53,9 +53,10 @@ Full documentation for [elasticgraph-mcp-server](https://pypi.org/project/elasti
 
 You can use the ElasticGraph MCP server with:
 
+- [Cursor](https://www.cursor.com) - as an MCP tool
 - [Goose](https://block.github.io/goose/) - as an extension
-- Claude - in the desktop app as an MCP server
-- [Cursor](https://docs.cursor.com/context/model-context-protocol) - as an MCP tool
+- [Claude Code](https://claude.com/product/claude-code) - as an MCP server
+- [Codex](https://github.com/openai/codex) - as an MCP server
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary

- `docs.cursor.com` now 308-redirects to `cursor.com/docs` which returns 429, breaking `site:validate_html_output`
- Replace broken Cursor link with `cursor.com`
- Update MCP-compatible tools list to reflect current ecosystem: Cursor, Goose, Claude Code, Codex (replacing Claude Desktop)

## Test plan

- [x] `bundle exec rake site:build site:validate_html_output` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)