### PR TITLE
Fix @key directive missing on deferred indexed types

### DIFF
--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/api_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/api_extension.rb
@@ -336,52 +336,59 @@ module ElasticGraph
             end
           end
 
-          # Add @key directives to all root document types with an id field.
-          # This happens after schema definition is complete so root_document_type? sees the complete type hierarchy.
-          state.object_types_by_name.values
-            .grep(ElasticGraph::SchemaDefinition::SchemaElements::ObjectType)
-            .select { |object_type| object_type.root_document_type? && object_type.graphql_fields_by_name.key?("id") }
-            .each { |object_type| object_type.apollo_key fields: "id" }
+          # Defer @key directive addition and _Entity union creation to a follow-up callback.
+          # This ensures types created by other after_user_definition_complete callbacks
+          # (e.g. dynamically derived aggregation types) exist before we iterate over them.
+          # This works because state.user_definition_complete_callbacks is a plain Array
+          # iterated with #each in Results#after_initialize — appending a new callback here
+          # causes it to be processed after all previously registered callbacks.
+          state.after_user_definition_complete do
+            # Add @key directives to all root document types with an id field.
+            state.object_types_by_name.values
+              .grep(ElasticGraph::SchemaDefinition::SchemaElements::ObjectType)
+              .select { |object_type| object_type.root_document_type? && object_type.graphql_fields_by_name.key?("id") }
+              .each { |object_type| object_type.apollo_key fields: "id" }
 
-          entity_types = state.object_types_by_name.values.select do |object_type|
-            object_type.directives.any? do |directive|
-              directive.name == "key" && directive.arguments.fetch(:resolvable, true)
+            entity_types = state.object_types_by_name.values.select do |object_type|
+              object_type.directives.any? do |directive|
+                directive.name == "key" && directive.arguments.fetch(:resolvable, true)
+              end
             end
-          end
 
-          validate_entity_types_can_all_be_resolved(entity_types)
+            validate_entity_types_can_all_be_resolved(entity_types)
 
-          entity_type_names = entity_types
-            # As per the GraphQL spec[1], only object types can be in a union, and interface
-            # types cannot be in a union. The GraphQL gem has validation[2] for this and will raise
-            # an error if we violate it, so we must filter to only object types here.
-            #
-            # [1] https://spec.graphql.org/October2021/#sec-Unions.Type-Validation
-            # [2] https://github.com/rmosolgo/graphql-ruby/pull/3024
-            .grep(ElasticGraph::SchemaDefinition::SchemaElements::ObjectType)
-            .map(&:name)
+            entity_type_names = entity_types
+              # As per the GraphQL spec[1], only object types can be in a union, and interface
+              # types cannot be in a union. The GraphQL gem has validation[2] for this and will raise
+              # an error if we violate it, so we must filter to only object types here.
+              #
+              # [1] https://spec.graphql.org/October2021/#sec-Unions.Type-Validation
+              # [2] https://github.com/rmosolgo/graphql-ruby/pull/3024
+              .grep(ElasticGraph::SchemaDefinition::SchemaElements::ObjectType)
+              .map(&:name)
 
-          unless entity_type_names.empty?
-            apollo_union_type "_Entity" do |t|
-              t.extend EntityTypeExtension
-              t.documentation <<~EOS
-                A union type required by the [Apollo Federation subgraph
-                spec](https://www.apollographql.com/docs/federation/subgraph-spec/#union-_entity):
+            unless entity_type_names.empty?
+              apollo_union_type "_Entity" do |t|
+                t.extend EntityTypeExtension
+                t.documentation <<~EOS
+                  A union type required by the [Apollo Federation subgraph
+                  spec](https://www.apollographql.com/docs/federation/subgraph-spec/#union-_entity):
 
-                > **⚠️ This union type is generated dynamically based on the input subgraph schema!**
-                >
-                > This union's possible types must include all entities that the subgraph defines.
-                > It's the return type of the `Query._entities` field, which the graph router uses
-                > to directly access a subgraph's entity fields.
-                >
-                > For details, see [Defining the `_Entity` union](https://www.apollographql.com/docs/federation/subgraph-spec/#defining-the-_entity-union).
+                  > **⚠️ This union type is generated dynamically based on the input subgraph schema!**
+                  >
+                  > This union's possible types must include all entities that the subgraph defines.
+                  > It's the return type of the `Query._entities` field, which the graph router uses
+                  > to directly access a subgraph's entity fields.
+                  >
+                  > For details, see [Defining the `_Entity` union](https://www.apollographql.com/docs/federation/subgraph-spec/#defining-the-_entity-union).
 
-                In an ElasticGraph schema, this is a union of all indexed types.
+                  In an ElasticGraph schema, this is a union of all indexed types.
 
-                Not intended for use by clients other than Apollo.
-              EOS
+                  Not intended for use by clients other than Apollo.
+                EOS
 
-              t.subtypes(*entity_type_names)
+                t.subtypes(*entity_type_names)
+              end
             end
           end
 

--- a/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
+++ b/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
@@ -202,6 +202,39 @@ module ElasticGraph
           expect(type_def_from(schema_string, "_Entity")).to eq("union _Entity = IndexedType1 | IndexedType2")
         end
 
+        it 'adds `@key(fields: "id")` to indexed types created in after_user_definition_complete callbacks' do
+          schema_string = graphql_schema_string do |schema|
+            schema.object_type "IndexedType1" do |t|
+              t.field "id", "ID!"
+              t.index "index1"
+            end
+
+            # Simulate a type created by a later callback (e.g. dynamically derived aggregation types).
+            schema.state.after_user_definition_complete do
+              schema.object_type "DeferredIndexedType" do |t|
+                t.field "id", "ID!"
+                t.field "name", "String"
+                t.index "deferred_index"
+              end
+            end
+          end
+
+          expect(type_def_from(schema_string, "IndexedType1")).to eq(<<~EOS.strip)
+            type IndexedType1 @key(fields: "id") {
+              id: ID!
+            }
+          EOS
+
+          expect(type_def_from(schema_string, "DeferredIndexedType")).to eq(<<~EOS.strip)
+            type DeferredIndexedType @key(fields: "id") {
+              id: ID!
+              name: String
+            }
+          EOS
+
+          expect(type_def_from(schema_string, "_Entity")).to eq("union _Entity = DeferredIndexedType | IndexedType1")
+        end
+
         it 'omits the `@key(fields: "id")` directive when the `id` field is indexing-only, since key fields must be GraphQL fields' do
           schema_string = graphql_schema_string { |s| define_some_types_on(s, id_is_indexing_only: ["IndexedType2"]) }
 


### PR DESCRIPTION
## Summary
- Types created in `after_user_definition_complete` callbacks were missing `@key(fields: "id")` directives and excluded from the `_Entity` union. In practice, this affected indexed types that are dynamically derived during schema finalization (e.g. aggregation types for location/merchant filtering).
- **Regression from #1067** ("Schema support for inherited indexes"): that PR moved `@key` directive addition into `define_apollo_schema_elements`, which runs as an early `after_user_definition_complete` callback. Types created by later callbacks don't exist yet when the `@key` logic iterates, so they silently lose their federation key.
- Fix: defer `@key` and `_Entity` logic into a nested `after_user_definition_complete` callback. Ruby's `Array#each` picks up elements appended during iteration, so the nested callback runs after all previously registered callbacks — ensuring all types exist first.

## Test plan
- [x] Added unit test that creates an indexed type in an `after_user_definition_complete` callback and verifies it gets `@key(fields: "id")` and is included in `_Entity`
- [x] All 101 apollo unit tests pass
- [x] Verified end-to-end with tf-sales-eg: `schema_artifacts:dump` produces no `schema.graphql` diff (previously `OrderLocation` and `OrderMerchant` lost their `@key` directives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)