### PR TITLE
Add `returnable: false` field option

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/index.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/index.rb
@@ -327,13 +327,11 @@ module ElasticGraph
             hash["_routing"] = {"required" => true} if uses_custom_routing?
             hash["_size"] = {"enabled" => true} if schema_def_state.index_document_sizes?
 
-            # Exclude non-fetchable fields from `_source` to save storage. These fields are still
+            # Exclude non-returnable fields from `_source` to save storage. These fields are still
             # indexed (in the inverted index and/or doc_values) for filtering, sorting, and aggregation,
             # but their values are not stored in the compressed `_source` blob.
-            if indexed_type.respond_to?(:non_fetchable_field_paths)
-              source_excludes = indexed_type.non_fetchable_field_paths
-              hash["_source"] = {"excludes" => source_excludes} if source_excludes.any?
-            end
+            source_excludes = indexed_type.source_excludes_paths
+            hash["_source"] = {"excludes" => source_excludes} if source_excludes.any?
           end
         end
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
@@ -292,6 +292,28 @@ module ElasticGraph
           indexing_fields_by_name_in_index.values.reject { |f| f.source.nil? }
         end
 
+        # Returns the list of `_source.excludes` paths for non-returnable fields.
+        #
+        # Uses `indexing_fields_by_name_in_index` for traversal (same as
+        # `index_field_runtime_metadata_tuples`) to avoid infinite recursion
+        # through interface/union subtype cycles.
+        #
+        # @private
+        def source_excludes_paths(path_prefix: "")
+          indexing_fields_by_name_in_index.flat_map do |name, field|
+            path = path_prefix + name
+            object_type = field.type.fully_unwrapped.as_object_type
+
+            if !field.returnable?
+              [object_type ? "#{path}.*" : path]
+            elsif object_type
+              object_type.source_excludes_paths(path_prefix: "#{path}.")
+            else
+              []
+            end
+          end
+        end
+
         private
 
         def initialize_has_indices

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/field.rb
@@ -73,6 +73,8 @@ module ElasticGraph
       #   @private
       # @!attribute [rw] highlightable
       #   @private
+      # @!attribute [rw] returnable
+      #   @private
       # @!attribute [rw] source
       #   @private
       # @!attribute [rw] runtime_field_script
@@ -91,7 +93,7 @@ module ElasticGraph
         :name, :original_type, :parent_type, :original_type_for_derived_types, :schema_def_state, :accuracy_confidence,
         :filter_customizations, :grouped_by_customizations, :highlights_customizations, :sub_aggregations_customizations,
         :aggregated_values_customizations, :sort_order_enum_value_customizations, :args,
-        :sortable, :filterable, :aggregatable, :groupable, :highlightable, :fetchable,
+        :sortable, :filterable, :aggregatable, :groupable, :highlightable, :returnable,
         :graphql_only, :source, :runtime_field_script, :relationship, :singular_name,
         :computation_detail, :non_nullable_in_json_schema, :as_input,
         :name_in_index, :resolver
@@ -106,7 +108,7 @@ module ElasticGraph
           name:, type:, parent_type:, schema_def_state:,
           accuracy_confidence: :high, name_in_index: name,
           type_for_derived_types: nil, graphql_only: nil, singular: nil,
-          sortable: nil, filterable: nil, aggregatable: nil, groupable: nil, highlightable: nil, fetchable: nil,
+          sortable: nil, filterable: nil, aggregatable: nil, groupable: nil, highlightable: nil, returnable: nil,
           as_input: false, resolver: nil
         )
           type_ref = schema_def_state.type_ref(type)
@@ -129,7 +131,7 @@ module ElasticGraph
             aggregatable: aggregatable,
             groupable: groupable,
             highlightable: highlightable,
-            fetchable: fetchable,
+            returnable: returnable,
             graphql_only: graphql_only,
             source: nil,
             runtime_field_script: nil,
@@ -744,14 +746,14 @@ module ElasticGraph
           type_for_derived_types.fully_unwrapped.as_object_type&.supports?(&:highlightable?)
         end
 
-        # Indicates if this field is fetchable in GraphQL query responses. When `false`, the field will
+        # Indicates if this field is returnable in GraphQL query responses. When `false`, the field will
         # still be available for filtering, sorting, grouping, and aggregation, but will not appear in the
         # GraphQL output type and its data will be excluded from `_source` in the datastore for storage savings.
         #
-        # @return [Boolean] true if this field's data can be fetched (default: true)
-        def fetchable?
-          return true if fetchable.nil?
-          fetchable
+        # @return [Boolean] true if this field's data can be returned (default: true)
+        def returnable?
+          return true if returnable.nil?
+          returnable
         end
 
         # Defines an argument on the field.
@@ -905,8 +907,8 @@ module ElasticGraph
             type_for_derived_types: nil,
             resolver: nil,
             # Filter fields should always appear in their parent input type's SDL regardless
-            # of the source field's fetchability.
-            fetchable: nil
+            # of the source field's returnability.
+            returnable: true
           )
 
           schema_def_state.factory.new_field(**params).tap do |f|

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_with_subfields.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_with_subfields.rb
@@ -137,7 +137,7 @@ module ElasticGraph
         #   ElasticGraph will infer field sortability based on the field's GraphQL type and mapping type.
         # @option options [Boolean] highlightable force-enables or disables the ability to request search highlights for this field. When
         #   not provided, ElasticGraph will infer field highlightable based on the field's mapping type.
-        # @option options [Boolean] fetchable when set to `false`, the field will not appear in the GraphQL output type and its data
+        # @option options [Boolean] returnable when set to `false`, the field will not appear in the GraphQL output type and its data
         #   will be excluded from `_source` in the datastore for storage savings. The field will still be available for filtering,
         #   sorting, grouping, and aggregation. Defaults to `true`.
         # @yield [Field] the field for further customization
@@ -485,27 +485,6 @@ module ElasticGraph
           )
         end
 
-        # Returns the list of field paths (in dotted notation) for fields that have `fetchable: false`.
-        # These paths are used to populate `_source.excludes` in the datastore mapping so that
-        # non-fetchable field data is not stored in `_source`, saving storage space.
-        #
-        # Uses `indexing_fields_by_name_in_index` for traversal (same as `index_field_runtime_metadata_tuples`)
-        # to avoid infinite recursion through interface/union subtype cycles.
-        #
-        # @private
-        def non_fetchable_field_paths(path_prefix: "")
-          indexing_fields_by_name_in_index.flat_map do |name, field|
-            path = path_prefix + name
-            if !field.fetchable?
-              [path]
-            elsif (object_type = field.type.fully_unwrapped.as_object_type) && object_type.respond_to?(:non_fetchable_field_paths)
-              object_type.non_fetchable_field_paths(path_prefix: "#{path}.")
-            else
-              []
-            end
-          end
-        end
-
         # @private
         def current_sources
           indexing_fields_by_name_in_index.values.flat_map do |field|
@@ -555,7 +534,7 @@ module ElasticGraph
 
         def fields_sdl(&arg_selector)
           graphql_fields_by_name.values
-            .select(&:fetchable?)
+            .select(&:returnable?)
             .map { |f| f.to_sdl(&arg_selector) }
             .flat_map { |sdl| sdl.split("\n") }
             .join("\n  ")

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/miscellaneous_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/miscellaneous_spec.rb
@@ -117,22 +117,90 @@ module ElasticGraph
         })
       end
 
-      it "includes `_source.excludes` for `fetchable: false` fields" do
+      it "adds `name_in_index` to `_source.excludes` for `returnable: false` fields" do
         mapping = index_mapping_for "my_type" do |s|
           s.object_type "MyType" do |t|
             t.field "id", "ID"
             t.field "name", "String"
-            t.field "internal_code", "String", fetchable: false
+            t.field "internal_code_gql", "String", name_in_index: "internal_code", returnable: false
             t.index "my_type"
           end
         end
 
-        expect(mapping).to include("_source" => {"excludes" => ["internal_code"]})
+        expect(mapping.dig("_source", "excludes")).to contain_exactly("internal_code")
         # The field should still appear in properties (it's indexed, just not in _source)
         expect(mapping.dig("properties", "internal_code")).to eq({"type" => "keyword"})
       end
 
-      it "does not include `_source` config when all fields are fetchable" do
+      it "adds `.*` to `_source.excludes` for `returnable: false` object fields" do
+        mapping = index_mapping_for "my_type" do |s|
+          s.object_type "InternalMetadata" do |t|
+            t.field "internal_code", "String"
+          end
+
+          s.object_type "MyType" do |t|
+            t.field "id", "ID"
+            t.field "internal_metadata", "InternalMetadata", returnable: false
+            t.index "my_type"
+          end
+        end
+
+        expect(mapping).to include("_source" => {"excludes" => ["internal_metadata.*"]})
+        expect(mapping.dig("properties", "internal_metadata", "properties", "internal_code")).to eq({"type" => "keyword"})
+      end
+
+      it "adds `returnable: false` indexing-only fields to `_source.excludes` but not `graphql_only` fields" do
+        mapping = index_mapping_for "my_type" do |s|
+          s.object_type "MyType" do |t|
+            t.field "id", "ID"
+            t.field "name", "String"
+            t.field "legacy_name", "String", graphql_only: true, name_in_index: "name", returnable: false
+            t.field "internal_code", "String", indexing_only: true, returnable: false
+            t.index "my_type"
+          end
+        end
+
+        expect(mapping.dig("_source", "excludes")).to contain_exactly("internal_code")
+        expect(mapping.fetch("properties")).to include(
+          "name" => {"type" => "keyword"},
+          "internal_code" => {"type" => "keyword"}
+        )
+        expect(mapping.fetch("properties")).not_to include("legacy_name")
+      end
+
+      it "adds full indexed paths to `_source.excludes` for `returnable: false` fields under nested mappings" do
+        mapping = index_mapping_for "my_type" do |s|
+          s.object_type "Parent" do |t|
+            t.field "child", "String", name_in_index: "child_in_index", returnable: false
+          end
+
+          s.object_type "Grandparent" do |t|
+            t.field "parent", "Parent!", name_in_index: "parent_in_index"
+          end
+
+          s.object_type "MyType" do |t|
+            t.field "id", "ID!"
+            t.field "grandparents", "[Grandparent!]!", name_in_index: "grandparents_in_index" do |f|
+              f.mapping type: "nested"
+            end
+            t.index "my_type"
+          end
+        end
+
+        expect(mapping.dig("_source", "excludes")).to contain_exactly("grandparents_in_index.parent_in_index.child_in_index")
+        expect(mapping.dig("properties", "grandparents_in_index")).to include(
+          "type" => "nested",
+          "properties" => {
+            "parent_in_index" => {
+              "properties" => {
+                "child_in_index" => {"type" => "keyword"}
+              }
+            }
+          }
+        )
+      end
+
+      it "does not add `_source` config when all fields are returnable" do
         mapping = index_mapping_for "my_type" do |s|
           s.object_type "MyType" do |t|
             t.field "id", "ID"

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/object_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/object_type_spec.rb
@@ -643,12 +643,12 @@ module ElasticGraph
           end
         end
 
-        it "excludes `fetchable: false` fields from the output type but keeps them in filter, sort, grouped_by, aggregated_values, and highlights types" do
+        it "excludes `returnable: false` fields from the output type but keeps them in filter, sort, grouped_by, aggregated_values, and highlights types" do
           result = define_schema do |api|
             api.object_type "Widget" do |t|
               t.field "id", "ID"
               t.field "name", "String"
-              t.field "internal_code", "String", fetchable: false
+              t.field "internal_code", "String", returnable: false
               t.index "widgets"
             end
           end
@@ -660,19 +660,19 @@ module ElasticGraph
             }
           EOS
 
-          # fetchable: false field should still appear in filter input
+          # returnable: false field should still appear in filter input
           expect(filter_type_from(result, "Widget")).to include("internal_code: StringFilterInput")
 
-          # fetchable: false field should still appear in sort order
+          # returnable: false field should still appear in sort order
           expect(sort_order_type_from(result, "Widget")).to include("internal_code_ASC")
 
-          # fetchable: false field should still appear in grouped_by
+          # returnable: false field should still appear in grouped_by
           expect(grouped_by_type_from(result, "Widget")).to include("internal_code: String")
 
-          # fetchable: false field should still appear in aggregated_values
+          # returnable: false field should still appear in aggregated_values
           expect(aggregated_values_type_from(result, "Widget")).to include("internal_code: NonNumericAggregatedValues")
 
-          # fetchable: false field should still appear in highlights
+          # returnable: false field should still appear in highlights
           expect(highlights_type_from(result, "Widget")).to include("internal_code: [String!]!")
         end
 


### PR DESCRIPTION
## Summary

This PR adds a `returnable: false` option to field definitions in the schema definition DSL.

```ruby
t.field "internal_code", "String", returnable: false
```

When a field is marked `returnable: false`, ElasticGraph:

- excludes the field from GraphQL output types
- keeps the field available for filtering, sorting, grouping, aggregations, and highlights
- excludes the field from datastore `_source` via `_source.excludes`

This supports fields that are useful for query behavior but should not be returned in GraphQL responses, while also reducing stored `_source` size for those fields.

## Implementation

The change is intentionally narrow:

- `Field` now exposes a `returnable?` predicate with a default of `true`
- output type SDL generation filters out non-returnable fields
- generated datastore mappings emit `_source.excludes` for non-returnable field paths
- generated filter fields explicitly reset `returnable` so they still appear in input types

Because the field remains part of the schema metadata used for non-output GraphQL features, existing generation for filter inputs, sort enums, grouped-by types, aggregated-values types, and highlights continues to work.

## Tests

Updated unit specs cover:

- excluding `returnable: false` fields from GraphQL output types
- retaining those fields in filter, sort, grouped-by, aggregated-values, and highlights types
- emitting `_source.excludes` in generated datastore mappings
- using `name_in_index` rather than the public GraphQL field name for `_source.excludes`
- excluding `indexing_only: true, returnable: false` fields while skipping `graphql_only: true, returnable: false` fields
- emitting full nested index paths for `returnable: false` fields under datastore `nested` mappings

Verified locally with:

- `bundle exec rspec elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/miscellaneous_spec.rb`
- `bundle exec rspec elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/object_type_spec.rb -e returnable`


## Update (2026-04-10)

- Rebases cleanly onto the latest `main`.
- The mapping-spec coverage for the review comment is present on the branch and verified after the rebase.
- `_source.excludes` is asserted to use `name_in_index`, not the public GraphQL field name.
- `graphql_only: true, returnable: false` is asserted to produce no `_source.excludes` entry, while `indexing_only: true, returnable: false` is asserted to produce one.
- Nested-path coverage now exercises a full dotted exclude path under an actual datastore `nested` mapping: `grandparents_in_index.parent_in_index.child_in_index`.

Re-verified locally after rebasing with:

- `bundle exec rspec elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/miscellaneous_spec.rb`
- `bundle exec rspec elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/object_type_spec.rb -e returnable`
