### PR TITLE
Fix broken Goose doc links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ To understand how the different parts of the codebase fit together, see the [cod
 
 ## Using AI Tools
 
-Using AI tools such as [Goose](https://block.github.io/goose/), [ChatGPT](https://chatgpt.com/), [Cursor](https://cursor.com/),
+Using AI tools such as [Goose](https://goose-docs.ai/), [ChatGPT](https://chatgpt.com/), [Cursor](https://cursor.com/),
 or [Claude](https://claude.ai/) to contribute is encouraged. However:
 
 * AI tools are assistants and should not replace critical thinking and judgement.

--- a/ai_tools/README.md
+++ b/ai_tools/README.md
@@ -15,7 +15,7 @@ Located in [`elasticgraph-mcp-server/`](./elasticgraph-mcp-server/), this provid
 You can use the MCP server with a variety of tools and platforms, including:
 
 - in [Cursor](https://www.cursor.com) as an "MCP tool"
-- in [Goose](https://block.github.io/goose/) as an "extension"
+- in [Goose](https://goose-docs.ai/) as an "extension"
 - in [Claude Code](https://claude.com/product/claude-code) as an "MCP server"
 - in [Codex](https://github.com/openai/codex) as an "MCP server"
 

--- a/ai_tools/elasticgraph-mcp-server/README.md
+++ b/ai_tools/elasticgraph-mcp-server/README.md
@@ -66,7 +66,7 @@ make help
 
 ## Using Goose to help with development
 
-You can use [Goose](https://block.github.io/goose/) to improve this MCP server. To teach goose about MCP, follow these steps:
+You can use [Goose](https://goose-docs.ai/) to improve this MCP server. To teach goose about MCP, follow these steps:
 
 ### Setting Up a Goose Session
 

--- a/config/site/src/getting-started.md
+++ b/config/site/src/getting-started.md
@@ -132,7 +132,7 @@ Delete the `artist` schema definition:
 Then define your own schema in a Ruby file under `config/schema`.
 
 * Use the [schema definition API docs](/elasticgraph/api-docs/{{ site.data.doc_versions.latest_version }}/ElasticGraph/SchemaDefinition/API.html) as a reference.
-* Use our [AI Tools]({% link guides/ai-tools.md %}) together with an AI agent such as [Goose](https://block.github.io/goose/) to translate a schema from an existing format such as protocol buffers, JSON schema, or SQL.
+* Use our [AI Tools]({% link guides/ai-tools.md %}) together with an AI agent such as [Goose](https://goose-docs.ai/) to translate a schema from an existing format such as protocol buffers, JSON schema, or SQL.
 * Run `bundle exec rake` and deal with any errors that are reported.
 * Hint: search the project codebase for `TODO` comments to find things that need updating.
 

--- a/config/site/src/guides/ai-tools.md
+++ b/config/site/src/guides/ai-tools.md
@@ -43,7 +43,7 @@ The [elasticgraph-mcp-server](https://pypi.org/project/elasticgraph-mcp-server/)
 
 ### Installation
 
-Install and run the MCP server, for example as a [Goose extension](https://block.github.io/goose/docs/getting-started/using-extensions), using:
+Install and run the MCP server, for example as a [Goose extension](https://goose-docs.ai/docs/getting-started/using-extensions), using:
 
 {% include copyable_code_snippet.html language="shell" code="uvx elasticgraph-mcp-server" %}
 
@@ -54,7 +54,7 @@ Full documentation for [elasticgraph-mcp-server](https://pypi.org/project/elasti
 You can use the ElasticGraph MCP server with:
 
 - [Cursor](https://www.cursor.com) - as an MCP tool
-- [Goose](https://block.github.io/goose/) - as an extension
+- [Goose](https://goose-docs.ai/) - as an extension
 - [Claude Code](https://claude.com/product/claude-code) - as an MCP server
 - [Codex](https://github.com/openai/codex) - as an MCP server
 

--- a/script/update_gem_constraints
+++ b/script/update_gem_constraints
@@ -15,7 +15,7 @@ require "rubygems/version"
 #
 # After updating version constraints, it runs bundle install to update Gemfile.lock.
 #
-# This script was created by Goose (https://block.github.io/goose/) and can be updated using Goose.
+# This script was created by Goose (https://goose-docs.ai/) and can be updated using Goose.
 class DependencyUpdater
   def initialize
     @changes = Hash.new do |hash, key|


### PR DESCRIPTION
## Summary
- Goose docs moved from `block.github.io/goose/` to `goose-docs.ai/`
- Updated all 7 references across 6 files
- `site:validate_html_output` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)