### PR TITLE
Allow query_cluster: null in datastore config to hide types

### DIFF
--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/config.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/config.rb
@@ -133,7 +133,7 @@ module ElasticGraph
                 properties: {
                   query_cluster: {
                     type: ["string", "null"],
-                    description: "Named search cluster to be used for queries on this index. The value must match be a key in the `clusters` map. Set to `nil` to hide this index's types from the GraphQL schema.",
+                    description: "Named search cluster to be used for queries on this index. The value must match be a key in the `clusters` map. Set to `null` to hide this index's types in the GraphQL schema returned from the GraphQL endpoint.",
                     examples: ["main", "search_cluster", nil]
                   },
                   index_into_clusters: {

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/config.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/config.rb
@@ -132,9 +132,9 @@ module ElasticGraph
                 }],
                 properties: {
                   query_cluster: {
-                    type: "string",
-                    description: "Named search cluster to be used for queries on this index. The value must match be a key in the `clusters` map.",
-                    examples: ["main", "search_cluster"]
+                    type: ["string", "null"],
+                    description: "Named search cluster to be used for queries on this index. The value must match be a key in the `clusters` map. Set to `nil` to hide this index's types from the GraphQL schema.",
+                    examples: ["main", "search_cluster", nil]
                   },
                   index_into_clusters: {
                     type: "array",

--- a/elasticgraph-datastore_core/sig/elastic_graph/datastore_core/configuration/index_definition.rbs
+++ b/elasticgraph-datastore_core/sig/elastic_graph/datastore_core/configuration/index_definition.rbs
@@ -3,7 +3,7 @@ module ElasticGraph
     module Configuration
       class IndexDefinitionSupertype
         attr_reader ignore_routing_values: ::Set[::String]
-        attr_reader query_cluster: ::String
+        attr_reader query_cluster: ::String?
         attr_reader index_into_clusters: ::Array[::String]
         attr_reader setting_overrides: ::Hash[::String, untyped]
         attr_reader setting_overrides_by_timestamp: ::Hash[::String, ::Hash[::String, untyped]]
@@ -11,7 +11,7 @@ module ElasticGraph
 
         def initialize: (
           ignore_routing_values: ::Set[::String],
-          query_cluster: ::String,
+          query_cluster: ::String?,
           index_into_clusters: ::Array[::String],
           setting_overrides: ::Hash[::String, untyped],
           setting_overrides_by_timestamp: ::Hash[::String, ::Hash[::String, untyped]],
@@ -20,7 +20,7 @@ module ElasticGraph
 
         def with: (
           ?ignore_routing_values: ::Set[::String],
-          ?query_cluster: ::String,
+          ?query_cluster: ::String?,
           ?index_into_clusters: ::Array[::String],
           ?setting_overrides: ::Hash[::String, untyped],
           ?setting_overrides_by_timestamp: ::Hash[::String, ::Hash[::String, untyped]],

--- a/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/config_spec.rb
+++ b/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/config_spec.rb
@@ -97,6 +97,43 @@ module ElasticGraph
         expect(config.max_client_retries).to eq 3
       end
 
+      it "allows `query_cluster: null` to hide index types from GraphQL schema" do
+        config = config_from_yaml(<<~YAML)
+          client_faraday_adapter: {}
+          clusters:
+            main1:
+              url: http://example.com/1234
+              backend: elasticsearch
+              settings:
+                foo: 23
+          index_definitions:
+            widgets:
+              query_cluster: null
+              index_into_clusters: ["main1"]
+              ignore_routing_values: []
+              setting_overrides: {}
+              setting_overrides_by_timestamp: {}
+              custom_timestamp_ranges: []
+        YAML
+
+        widgets_config = config.index_definitions.fetch("widgets")
+
+        # Verify the config was loaded correctly from YAML
+        expect(widgets_config).to eq(Configuration::IndexDefinition.new(
+          ignore_routing_values: [],
+          query_cluster: nil,
+          index_into_clusters: ["main1"],
+          setting_overrides: {},
+          setting_overrides_by_timestamp: {},
+          custom_timestamp_ranges: []
+        ))
+
+        # Verify the key property: query_cluster is nil (not a string, not missing)
+        # This nil value will cause accessible_from_queries? to return false,
+        # which hides the index's types from the GraphQL schema.
+        expect(widgets_config.query_cluster).to be_nil
+      end
+
       it "surfaces misspellings in `backend`" do
         expect {
           config_from_yaml(<<~YAML)

--- a/elasticgraph-local/lib/elastic_graph/local/spec_support/config_schema.yaml
+++ b/elasticgraph-local/lib/elastic_graph/local/spec_support/config_schema.yaml
@@ -145,8 +145,9 @@ properties:
                 - string
                 - 'null'
                 description: Named search cluster to be used for queries on this index.
-                  The value must match be a key in the `clusters` map. Set to `nil`
-                  to hide this index's types from the GraphQL schema.
+                  The value must match be a key in the `clusters` map. Set to `null`
+                  to hide this index's types in the GraphQL schema returned from the
+                  GraphQL endpoint.
                 examples:
                 - main
                 - search_cluster

--- a/elasticgraph-local/lib/elastic_graph/local/spec_support/config_schema.yaml
+++ b/elasticgraph-local/lib/elastic_graph/local/spec_support/config_schema.yaml
@@ -141,12 +141,16 @@ properties:
                   number_of_shards: 32
             properties:
               query_cluster:
-                type: string
+                type:
+                - string
+                - 'null'
                 description: Named search cluster to be used for queries on this index.
-                  The value must match be a key in the `clusters` map.
+                  The value must match be a key in the `clusters` map. Set to `nil`
+                  to hide this index's types from the GraphQL schema.
                 examples:
                 - main
                 - search_cluster
+                -
               index_into_clusters:
                 type: array
                 items:


### PR DESCRIPTION
# Allow `query_cluster: null` in YAML Configuration

## Issue
The hidden type spec acceptance tests specify that `query_cluster: nil` should hide index types from the GraphQL schema (`hidden_types_spec.rb:21`), and this works when modifying configs programatically as is done in the test:
```ruby
config_index_def_of(query_cluster: nil) 
```

However, loading this configuration from YAML fails validation:
```yaml
index_definitions:
  payments:
    query_cluster: null  # fails with Error: "value is not a string"
```

The JSON schema defines the query_cluster type as the non-nullable `type: "string"`, even though `accessible_from_queries?` correctly handles nil at runtime.

## Solution
Updated JSON schemas to accept `["string", "null"]` and RBS signatures to `::String?`. The field remains required to force explicit configuration choices.

**Files changed:**
- `config_schema.yaml` - Allow `['string', 'null']`
- `config.rb` - Allow `["string", "null"]`
- `index_definition.rbs` - Change to `::String?`
- `config_spec.rb` - Add regression test

## Testing

In addition to a new regression test for YAML validation with null, I've tested this locally by modifying the schema in `config/settings/development.yaml`:
```diff
     components: *main_index_settings
     electrical_parts: *main_index_settings
     manufacturers: *main_index_settings
-    mechanical_parts: *main_index_settings
+    mechanical_parts:
+      query_cluster: null
+      index_into_clusters: ["main"]
+      ignore_routing_values: []
+      custom_timestamp_ranges: []
+      setting_overrides:
+        number_of_shards: 1
+      setting_overrides_by_timestamp: {}
     teams: *main_index_settings
     widget_currencies: *main_index_settings
     widgets: *main_index_settings
```

Without the fix, starting elasticgraph locally via `bundle exec boot_locally` fails with 
```
ElasticGraph::Errors::ConfigError: Invalid configuration for `ElasticGraph::DatastoreCore::Config` at `datastore`: Validation errors: (ElasticGraph::Errors::ConfigError)

{
  "data": null,
  "data_pointer": "/index_definitions/mechanical_parts/query_cluster",
  "schema_pointer": "/$defs/config/properties/index_definitions/patternProperties/.+/properties/query_cluster",
  "type": "string",
  "error": "value at `/index_definitions/mechanical_parts/query_cluster` is not a string"
}
```

After applying the fix, `boot_locally` succeeds and hides the `mechanical_parts` index as expected:
<img width="1025" height="552" alt="Screenshot 2026-04-14 at 2 17 22 PM" src="https://github.com/user-attachments/assets/b762b854-c1f8-4d4b-b8d6-8fe270a7d517" />
