### PR TITLE
Update YARD to 0.9.41

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ group :site do
   # TODO: switch back to a release version once that fix is merged and released.
   gem "rouge", github: "myronmarston/rouge", ref: "12c0da6aa98e0d0a0762c47103b64290c88620a1"
 
-  gem "yard", "~> 0.9", ">= 0.9.37", "!= 0.9.38" # https://github.com/lsegal/yard/issues/1639
+  gem "yard", "~> 0.9", ">= 0.9.41"
   gem "yard-doctest", "~> 0.1", ">= 0.1.17"
   gem "yard-markdown", "~> 0.6"
   gem "irb", "~> 1.17" # Needed for yard on Ruby 4.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -648,7 +648,7 @@ GEM
     uri (1.1.1)
     vcr (6.4.0)
     webrick (1.9.2)
-    yard (0.9.37)
+    yard (0.9.41)
     yard-doctest (0.1.17)
       minitest
       yard
@@ -733,7 +733,7 @@ DEPENDENCIES
   steep (~> 1.10.0)
   super_diff (~> 0.18)
   vcr (~> 6.4)
-  yard (~> 0.9, >= 0.9.37, != 0.9.38)
+  yard (~> 0.9, >= 0.9.41)
   yard-doctest (~> 0.1, >= 0.1.17)
   yard-markdown (~> 0.6)
 
@@ -954,7 +954,7 @@ CHECKSUMS
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   vcr (6.4.0) sha256=077ac92cc16efc5904eb90492a18153b5e6ca5398046d8a249a7c96a9ea24ae6
   webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
-  yard (0.9.37) sha256=a6e910399e78e613f80ba9add9ba7c394b1a935f083cccbef82903a3d2a26992
+  yard (0.9.41) sha256=2fad2f362bceb63101f37aeb81d35cfc50b4ae1c11cf22f54b8d46626877a89f
   yard-doctest (0.1.17) sha256=7cb35a75d99f58fc42ee72d3542a36e227237b621a40aebc391c95988b72847f
   yard-markdown (0.6.0) sha256=d01ebb21929f43b4f69e6577dda04b488cd629d623b8367a2835c53cc8b64de3
   yell (2.2.2) sha256=1d166f3cc3b6dc49a59778ea7156ed6d8de794c15106d48ffd6cbb061b9b26bc

--- a/config/release/Gemfile
+++ b/config/release/Gemfile
@@ -14,5 +14,5 @@ gem "json_schemer", "~> 2.5"
 gem "nokogiri", "~> 1.19"
 gem "rake", "~> 13.3"
 gem "redcarpet", "~> 3.6", ">= 3.6.1"
-gem "yard", "~> 0.9", ">= 0.9.37", "!= 0.9.38" # https://github.com/lsegal/yard/issues/1639
+gem "yard", "~> 0.9", ">= 0.9.41"
 gem "yard-markdown", "~> 0.6"

--- a/config/release/Gemfile.lock
+++ b/config/release/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
     simpleidn (0.2.3)
     stringio (3.2.0)
     tsort (0.2.0)
-    yard (0.9.37)
+    yard (0.9.41)
     yard-markdown (0.6.0)
       csv
       rdoc
@@ -61,7 +61,7 @@ DEPENDENCIES
   nokogiri (~> 1.19)
   rake (~> 13.3)
   redcarpet (~> 3.6, >= 3.6.1)
-  yard (~> 0.9, >= 0.9.37, != 0.9.38)
+  yard (~> 0.9, >= 0.9.41)
   yard-markdown (~> 0.6)
 
 CHECKSUMS
@@ -90,7 +90,7 @@ CHECKSUMS
   simpleidn (0.2.3) sha256=08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
-  yard (0.9.37) sha256=a6e910399e78e613f80ba9add9ba7c394b1a935f083cccbef82903a3d2a26992
+  yard (0.9.41) sha256=2fad2f362bceb63101f37aeb81d35cfc50b4ae1c11cf22f54b8d46626877a89f
   yard-markdown (0.6.0) sha256=d01ebb21929f43b4f69e6577dda04b488cd629d623b8367a2835c53cc8b64de3
 
 BUNDLED WITH

--- a/config/site/support/markdown_post_processor.rb
+++ b/config/site/support/markdown_post_processor.rb
@@ -134,32 +134,39 @@ module ElasticGraph
       CSS
       head.add_child(style)
 
-      # Add simple initialization script
+      # Add initialization script that works with both full page loads and YARD's SPA-style navigation.
+      # YARD 0.9.40+ uses postMessage + fetch + innerHTML replacement for sidebar clicks, which means
+      # external <script src="..."> tags aren't loaded and DOMContentLoaded doesn't re-fire.
       init_script = doc.create_element("script", <<~JS.strip)
-        document.addEventListener('DOMContentLoaded', function() {
-          mermaid.initialize({
-            startOnLoad: true,
+        (function() {
+          var mermaidConfig = {
+            startOnLoad: false,
             theme: 'default',
             securityLevel: 'loose',
-            // Better visual configuration
-            flowchart: {
-              useMaxWidth: true,
-              htmlLabels: true,
-              curve: 'basis'
-            },
-            sequence: {
-              useMaxWidth: true,
-              wrap: true
-            },
-            gantt: {
-              useMaxWidth: true
-            },
-            // Improved text handling
+            flowchart: { useMaxWidth: true, htmlLabels: true, curve: 'basis' },
+            sequence: { useMaxWidth: true, wrap: true },
+            gantt: { useMaxWidth: true },
             maxTextSize: 90000,
             suppressErrorRendering: false,
             logLevel: 'error'
-          });
-        });
+          };
+
+          function initMermaid() {
+            mermaid.initialize(mermaidConfig);
+            mermaid.run({ querySelector: '.mermaid' });
+          }
+
+          if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', initMermaid);
+          } else if (typeof mermaid !== 'undefined') {
+            initMermaid();
+          } else {
+            var script = document.createElement('script');
+            script.src = 'assets/mermaid.min.js';
+            script.onload = initMermaid;
+            document.head.appendChild(script);
+          }
+        })();
       JS
       head.add_child(init_script)
     end
@@ -235,22 +242,38 @@ module ElasticGraph
       })
       head.add_child(script)
 
-      # Add initialization script
+      # Add initialization script that works with both full page loads and YARD's SPA-style navigation.
+      # Same 3-branch pattern as mermaid above — see comment there for details.
       init_script = doc.create_element("script", <<~JS.strip)
-        document.addEventListener('DOMContentLoaded', function() {
-          // Configure highlight.js to work with YARD's code block structure
-          document.querySelectorAll('pre.code code').forEach(function(block) {
-            // Get the language from the code element's class
-            const classes = block.className.split(' ');
-            const language = classes.find(cls => cls.match(/^[a-z]+$/) && cls !== 'code');
+        (function() {
+          function highlightCodeBlocks() {
+            document.querySelectorAll('pre.code code').forEach(function(block) {
+              var classes = block.className.split(' ');
+              var language = classes.find(function(cls) { return cls.match(/^[a-z]+$/) && cls !== 'code'; });
 
-            if (language && language !== 'mermaid') {
-              // Set the language class for highlight.js
-              block.className = 'language-' + language;
-              hljs.highlightElement(block);
-            }
-          });
-        });
+              if (language && language !== 'mermaid') {
+                block.className = 'language-' + language;
+                hljs.highlightElement(block);
+              }
+            });
+          }
+
+          if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', highlightCodeBlocks);
+          } else if (typeof hljs !== 'undefined') {
+            highlightCodeBlocks();
+          } else {
+            var cssLink = document.createElement('link');
+            cssLink.rel = 'stylesheet';
+            cssLink.href = 'assets/highlight.min.css';
+            document.head.appendChild(cssLink);
+
+            var script = document.createElement('script');
+            script.src = 'assets/highlight.min.js';
+            script.onload = highlightCodeBlocks;
+            document.head.appendChild(script);
+          }
+        })();
       JS
       head.add_child(init_script)
 

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -6,7 +6,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: addressable
@@ -14,7 +14,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ast
@@ -22,7 +22,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: async
@@ -30,7 +30,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: aws-sdk-cloudwatch
@@ -74,7 +74,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: concurrent-ruby
@@ -82,7 +82,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: connection_pool
@@ -90,7 +90,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: csv
@@ -98,7 +98,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: date
@@ -110,7 +110,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: digest
@@ -126,7 +126,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: faraday
@@ -134,7 +134,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: fileutils
@@ -150,7 +150,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: graphql
@@ -158,7 +158,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: hashdiff
@@ -166,7 +166,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: i18n
@@ -174,7 +174,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: io-console
@@ -190,7 +190,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: listen
@@ -198,7 +198,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: logger
@@ -206,7 +206,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: minitest
@@ -214,7 +214,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: monitor
@@ -234,7 +234,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: openssl
@@ -250,7 +250,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: parser
@@ -258,7 +258,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: pp
@@ -278,7 +278,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rainbow
@@ -286,7 +286,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rake
@@ -294,7 +294,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rdoc
@@ -306,7 +306,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ripper
@@ -318,7 +318,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rubocop-ast
@@ -326,7 +326,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: securerandom
@@ -338,7 +338,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: singleton
@@ -362,7 +362,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: time
@@ -378,7 +378,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: uri
@@ -394,7 +394,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 51d81561ecf995e18b12cd6bba44dba59f0c59ea
+    revision: 291289079f2e89ffb397d73f2da371b2e13555b6
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: yard-markdown


### PR DESCRIPTION
## Summary
- Update YARD from 0.9.37 to 0.9.41
- Fix mermaid.js and highlight.js rendering broken by YARD 0.9.40's SPA-style sidebar navigation (fetch + innerHTML replacement instead of full page loads)
- Replace `DOMContentLoaded`-only init with a 3-branch IIFE handling: full page loads, SPA nav with library already loaded, and SPA nav requiring dynamic script loading

## Test plan
- [x] `bundle exec rake site:build_docs` succeeds
- [x] `script/lint` passes
- [x] Manual browser test: direct load of mermaid page renders diagrams
- [x] Manual browser test: SPA sidebar navigation to mermaid page renders diagrams

🤖 Generated with [Claude Code](https://claude.com/claude-code)