### PR TITLE
Fix LoggerPatch CI failure; bump aws_lambda_ric to 3.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ source "https://rubygems.org"
 
 # Gems needed by the test suite and other CI checks.
 group :development do
-  gem "aws_lambda_ric", "~> 3.1", ">= 3.1.3"
+  gem "aws_lambda_ric", "~> 3.2"
   # graphql-c_parser is no longer a hard dependency, but we include it here for faster CI tests
   gem "graphql-c_parser", "~> 1.1", ">= 1.1.3", platforms: :ruby
   gem "benchmark-ips", "~> 2.14"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,7 +285,8 @@ GEM
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
-    aws_lambda_ric (3.1.3)
+    aws_lambda_ric (3.2.0)
+      logger (>= 1.4, < 2.0)
     base64 (0.3.0)
     benchmark (0.5.0)
     benchmark-ips (2.14.0)
@@ -682,7 +683,7 @@ PLATFORMS
   x86_64-linux-android
 
 DEPENDENCIES
-  aws_lambda_ric (~> 3.1, >= 3.1.3)
+  aws_lambda_ric (~> 3.2)
   benchmark-ips (~> 2.14)
   coderay (~> 1.1, >= 1.1.3)
   elasticgraph (= 1.1.1.pre)!
@@ -758,7 +759,7 @@ CHECKSUMS
   aws-sdk-s3 (1.219.0) sha256=6a755d7377978525758b3c29185ca6a10128ce2b07555ca37c4549de10c2f1c7
   aws-sdk-sqs (1.112.0) sha256=272a2d919fd3daa1c4a8ed0f9a3b765fbb84cce27aaf3b08e6d97edd171bbdae
   aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
-  aws_lambda_ric (3.1.3) sha256=7d7551c91d2070bb1427cd05d7b0b94076d42084f743b117522659a76935dfbc
+  aws_lambda_ric (3.2.0) sha256=fdab2c637bf0aa47b1de795d6fe7244572e9f743ac74eb47e1386e3c4c17c269
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   benchmark-ips (2.14.0) sha256=b72bc8a65d525d5906f8cd94270dccf73452ee3257a32b89fbd6684d3e8a9b1d

--- a/elasticgraph-warehouse_lambda/elasticgraph-warehouse_lambda.gemspec
+++ b/elasticgraph-warehouse_lambda/elasticgraph-warehouse_lambda.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "elasticgraph-lambda_support", ElasticGraph::VERSION
   spec.add_dependency "aws-sdk-s3", "~> 1.219"
 
-  spec.add_development_dependency "aws_lambda_ric", "~> 3.1", ">= 3.1.3"
+  spec.add_development_dependency "aws_lambda_ric", "~> 3.2"
   spec.add_development_dependency "elasticgraph-elasticsearch", ElasticGraph::VERSION
   spec.add_development_dependency "elasticgraph-opensearch", ElasticGraph::VERSION
 end

--- a/spec_support/lib/elastic_graph/spec_support/lambda_function.rb
+++ b/spec_support/lib/elastic_graph/spec_support/lambda_function.rb
@@ -94,22 +94,41 @@ RSpec.shared_context "lambda function" do |config_overrides_in_yaml: {}|
     require "aws_lambda_ric/logger_patch"
     require "aws_lambda_ric"
 
-    # The monkey patches are triggered by the act of instantiating this class:
-    # https://github.com/aws/aws-lambda-ruby-runtime-interface-client/blob/3.0.0/lib/aws_lambda_ric.rb#L141-L152
-    AwsLambdaRIC::TelemetryLogger.new("1") # File descriptor is required but not used in test env
+    # In production, Bootstrap#start calls TelemetryLogger.from_env, which:
+    # 1. Applies LoggerPatch via mutate_std_logger (no IO involved)
+    # 2. Creates a TelemetryLogger instance if _LAMBDA_TELEMETRY_LOG_FD is set,
+    #    which sets up the telemetry sink and calls mutate_kernel_puts
+    # https://github.com/aws/aws-lambda-ruby-runtime-interface-client/blob/f11c2c7/lib/aws_lambda_ric.rb#L164-L175
+    #
+    # We don't set _LAMBDA_TELEMETRY_LOG_FD, so from_env applies LoggerPatch but returns
+    # before creating a TelemetryLogger instance (which would call IO.new(fd, 'wb') —
+    # that raises Errno::EBADF in some CI forked-subprocess environments).
+    AwsLambdaRIC::TelemetryLogger.from_env
 
-    # Here we verify that the Logger monkey patch was indeed installed. The installation of the monkey patch
-    # gets bypassed when certain errors are encountered (which are silently swallowed), so the mere act of
-    # instantiating the class above doesn't guarantee the monkey patches are active.
-    #
-    # Plus, new versions of the `aws_lambda_ric` may change how the monkey patches are installed.
-    #
-    # https://github.com/aws/aws-lambda-ruby-runtime-interface-client/blob/3.0.0/lib/aws_lambda_ric.rb#L150-L152
     expect(::Logger.ancestors).to include(::LoggerPatch)
+
+    # Set up telemetry sink wrapping $stdout, like TelemetryLogger#initialize would have
+    # done with fd 1. This ensures mutated kernel puts output still reaches stdout so that
+    # the caller's `to_stdout_from_any_process` matchers continue to work.
+    AwsLambdaRIC::TelemetryLogger.telemetry_log_fd_file = $stdout
+    AwsLambdaRIC::TelemetryLogger.telemetry_log_sink = TelemetryLogSink.new(file: $stdout)
+
+    # mutate_kernel_puts is normally called by TelemetryLogger#initialize, but we skipped
+    # the constructor (see above). Apply it via send (private) using allocate to bypass it.
+    # https://github.com/aws/aws-lambda-ruby-runtime-interface-client/blob/f11c2c7/lib/aws_lambda_ric.rb#L179-L190
+    expect(kernel_puts_monkey_patched?).to be false
+    AwsLambdaRIC::TelemetryLogger.allocate.send(:mutate_kernel_puts)
+    expect(kernel_puts_monkey_patched?).to be true
 
     expect {
       # Log a message to stdout--this is what triggered a `NoMethodError` when logger 1.6.0 is used.
       ::Logger.new($stdout).error("test log message")
     }.to output(a_string_including("test log message")).to_stdout_from_any_process
+  end
+
+  def kernel_puts_monkey_patched?
+    # The original Kernel#puts is implemented in C (source_location returns nil).
+    # After aws_lambda_ric's mutate_kernel_puts, the source file points into the gem.
+    Kernel.instance_method(:puts).source_location&.first.to_s.include?("aws_lambda_ric")
   end
 end


### PR DESCRIPTION
## Summary
- GHA runner image `ubuntu24/20260413.86` (kernel `6.17.0-1010-azure`) causes `IO.new(fd, 'wb')` to raise `Errno::EBADF` in forked subprocesses, breaking `TelemetryLogger.new("1")` which silently skips applying `LoggerPatch`
- Rework `install_aws_lambda_runtime_monkey_patches` to use the 3.2.0 API: `TelemetryLogger.from_env` applies `LoggerPatch` without any IO; telemetry sink and `mutate_kernel_puts` set up manually
- Bump `aws_lambda_ric` from `~> 3.1` to `~> 3.2`

## Test plan
- [x] All 5 lambda gem specs pass locally (112 examples)
- [x] 100% line+branch coverage via `script/run_gem_specs`
- [x] Lint clean
- [x] CI passes (the whole point of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)