### PR TITLE
perf: Skip validation for registered query cache hits

### DIFF
--- a/benchmarks/query_registry/skip_validation.rb
+++ b/benchmarks/query_registry/skip_validation.rb
@@ -1,0 +1,108 @@
+#!/usr/bin/env ruby
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+# Benchmarks the cost of graphql-ruby's `StaticValidation` pipeline against the
+# cache-hit path in `ForRegisteredClient#prepare_query_for_execution`, which now
+# passes `validate: false` to skip that pipeline for registered queries.
+#
+# We compare, for a pre-parsed document, the cost of building a query and
+# triggering its validation pipeline with `validate: true` (the former
+# behavior) vs `validate: false` (the new behavior for cache hits).
+#
+# Run with:
+#   bundle exec ruby benchmarks/query_registry/skip_validation.rb
+
+require "benchmark/ips"
+require "graphql"
+
+# Build a schema with many fields, so queries can be meaningfully sized.
+def build_schema(num_fields:)
+  field_defs = (1..num_fields).map { |i| "f#{i}" }
+
+  leaf_type = Class.new(GraphQL::Schema::Object) do
+    graphql_name "Leaf"
+    field_defs.each { |name| field name, String, null: true }
+  end
+
+  container_type = Class.new(GraphQL::Schema::Object) do
+    graphql_name "Container"
+    field :leaf, leaf_type, null: true
+    field_defs.each { |name| field name, leaf_type, null: true }
+  end
+
+  query_type = Class.new(GraphQL::Schema::Object) do
+    graphql_name "Query"
+    field :container, container_type, null: true
+    field :leaf, leaf_type, null: true
+  end
+
+  Class.new(GraphQL::Schema) do
+    query(query_type)
+  end
+end
+
+# Build a query string of approximately the requested size by selecting all
+# leaf fields under nested containers.
+def build_query(num_leaves:, leaf_field_names:)
+  selections = leaf_field_names.take(num_leaves).map { |f| "  #{f}" }.join("\n")
+  <<~GRAPHQL
+    query BenchQuery {
+      container {
+        leaf {
+    #{selections}
+        }
+    #{leaf_field_names.take(num_leaves).map { |f|
+      "    #{f} {\n#{selections}\n    }"
+    }.join("\n")}
+      }
+    }
+  GRAPHQL
+end
+
+configs = [
+  {label: "small", num_fields: 10, num_leaves: 5},
+  {label: "medium", num_fields: 50, num_leaves: 25},
+  {label: "large", num_fields: 150, num_leaves: 100},
+  {label: "xlarge", num_fields: 300, num_leaves: 250}
+]
+
+configs.each do |config|
+  schema = build_schema(num_fields: config[:num_fields])
+  leaf_field_names = (1..config[:num_fields]).map { |i| "f#{i}" }
+  query_string = build_query(num_leaves: config[:num_leaves], leaf_field_names: leaf_field_names)
+  document = GraphQL.parse(query_string)
+
+  puts
+  puts "=" * 70
+  puts "#{config[:label]} — #{query_string.bytesize} bytes, #{query_string.lines.count} lines"
+  puts "=" * 70
+
+  # Sanity check: both paths should produce a valid query.
+  valid_query = GraphQL::Query.new(schema, nil, document: document, validate: true)
+  skipped_query = GraphQL::Query.new(schema, nil, document: document, validate: false)
+  unless valid_query.valid? && skipped_query.valid?
+    abort "query is not valid — check benchmark setup: #{valid_query.static_errors.map(&:message)}"
+  end
+
+  Benchmark.ips do |x|
+    x.config(time: 5, warmup: 2)
+
+    x.report("validate: true (before)") do
+      q = GraphQL::Query.new(schema, nil, document: document, validate: true)
+      q.valid?
+    end
+
+    x.report("validate: false (after)") do
+      q = GraphQL::Query.new(schema, nil, document: document, validate: false)
+      q.valid?
+    end
+
+    x.compare!
+  end
+end

--- a/benchmarks/query_registry/skip_validation.results.txt
+++ b/benchmarks/query_registry/skip_validation.results.txt
@@ -1,0 +1,80 @@
+
+======================================================================
+small — 281 bytes, 46 lines
+======================================================================
+ruby 4.0.2 (2026-03-17 revision d3da9fec82) +PRISM [arm64-darwin25]
+Warming up --------------------------------------
+validate: true (before)
+                       585.000 i/100ms
+validate: false (after)
+                         7.905k i/100ms
+Calculating -------------------------------------
+validate: true (before)
+                          5.618k (± 4.1%) i/s  (177.98 μs/i) -     28.080k in   5.006680s
+validate: false (after)
+                         76.504k (± 4.7%) i/s   (13.07 μs/i) -    387.345k in   5.074292s
+
+Comparison:
+validate: false (after):    76503.8 i/s
+validate: true (before):     5618.5 i/s - 13.62x  slower
+
+
+======================================================================
+medium — 4113 bytes, 706 lines
+======================================================================
+ruby 4.0.2 (2026-03-17 revision d3da9fec82) +PRISM [arm64-darwin25]
+Warming up --------------------------------------
+validate: true (before)
+                        55.000 i/100ms
+validate: false (after)
+                         8.014k i/100ms
+Calculating -------------------------------------
+validate: true (before)
+                        545.145 (± 3.3%) i/s    (1.83 ms/i) -      2.750k in   5.049960s
+validate: false (after)
+                         74.518k (± 4.4%) i/s   (13.42 μs/i) -    376.658k in   5.064674s
+
+Comparison:
+validate: false (after):    74518.0 i/s
+validate: true (before):      545.1 i/s - 136.69x  slower
+
+
+======================================================================
+large — 61440 bytes, 10306 lines
+======================================================================
+ruby 4.0.2 (2026-03-17 revision d3da9fec82) +PRISM [arm64-darwin25]
+Warming up --------------------------------------
+validate: true (before)
+                         3.000 i/100ms
+validate: false (after)
+                         7.966k i/100ms
+Calculating -------------------------------------
+validate: true (before)
+                         38.432 (± 5.2%) i/s   (26.02 ms/i) -    192.000 in   5.011219s
+validate: false (after)
+                         71.389k (± 7.1%) i/s   (14.01 μs/i) -    358.470k in   5.049321s
+
+Comparison:
+validate: false (after):    71388.8 i/s
+validate: true (before):       38.4 i/s - 1857.56x  slower
+
+
+======================================================================
+xlarge — 416340 bytes, 63256 lines
+======================================================================
+ruby 4.0.2 (2026-03-17 revision d3da9fec82) +PRISM [arm64-darwin25]
+Warming up --------------------------------------
+validate: true (before)
+                         1.000 i/100ms
+validate: false (after)
+                         7.272k i/100ms
+Calculating -------------------------------------
+validate: true (before)
+                          6.149 (± 0.0%) i/s  (162.64 ms/i) -     31.000 in   5.047500s
+validate: false (after)
+                         73.302k (± 5.6%) i/s   (13.64 μs/i) -    370.872k in   5.075838s
+
+Comparison:
+validate: false (after):    73302.2 i/s
+validate: true (before):        6.1 i/s - 11921.96x  slower
+

--- a/elasticgraph-query_registry/README.md
+++ b/elasticgraph-query_registry/README.md
@@ -22,9 +22,10 @@ Query registration provides a few key benefits:
   that have not been registered.
 * Your GraphQL endpoint will be a bit more efficient. Parsing and
   statically validating large GraphQL queries can be a bit slow (in our
-  testing, parsing a 10 KB query string takes about ~10ms), and the
-  registry will cache and reuse the parsed form of registered queries
-  while also skipping redundant runtime static validation for them.
+  testing, parsing a 10 KB query string takes about ~10ms and statically
+  validating it takes another ~25ms), and the registry will cache and
+  reuse the parsed form of registered queries while also skipping
+  redundant runtime static validation for them.
 
 Importantly, once installed, registered clients who send unregistered
 queries will get errors. Unregistered clients can similarly be blocked

--- a/elasticgraph-query_registry/README.md
+++ b/elasticgraph-query_registry/README.md
@@ -20,10 +20,11 @@ Query registration provides a few key benefits:
   allowed to, you can choose not to approve the query. Once setup and
   configured, this library will block clients from submitting queries
   that have not been registered.
-* Your GraphQL endpoint will be a bit more efficient. Parsing large
-  GraphQL queries can be a bit slow (in our testing, a 10 KB query
-  string takes about ~10ms to parse), and the registry will cache and
-  reuse the parsed form of registered queries.
+* Your GraphQL endpoint will be a bit more efficient. Parsing and
+  statically validating large GraphQL queries can be a bit slow (in our
+  testing, parsing a 10 KB query string takes about ~10ms), and the
+  registry will cache and reuse the parsed form of registered queries
+  while also skipping redundant runtime static validation for them.
 
 Importantly, once installed, registered clients who send unregistered
 queries will get errors. Unregistered clients can similarly be blocked
@@ -141,3 +142,8 @@ bundle exec rake "query_registry:dump_variables[client_name, query_name]"
 
 Don't worry about if you forget this, though--the `query_registry:validate_queries`
 task will also fail and give you instructions anytime a variables file is not up-to-date.
+
+You should also run `query_registry:validate_queries` as part of CI for any application that
+uses this gem. At runtime, `elasticgraph-query_registry` skips GraphQL static validation for
+registered queries so repeated requests can reuse the cached parsed document. Unregistered
+queries, materially different queries, and variable values still go through runtime validation.

--- a/elasticgraph-query_registry/README.md
+++ b/elasticgraph-query_registry/README.md
@@ -145,5 +145,5 @@ task will also fail and give you instructions anytime a variables file is not up
 
 You should also run `query_registry:validate_queries` as part of CI for any application that
 uses this gem. At runtime, `elasticgraph-query_registry` skips GraphQL static validation for
-registered queries so repeated requests can reuse the cached parsed document. Unregistered
+registered queries since it assumes they have already been validated on CI. Unregistered
 queries, materially different queries, and variable values still go through runtime validation.

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/query_validators/for_registered_client.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/query_validators/for_registered_client.rb
@@ -90,7 +90,9 @@ module ElasticGraph
             (_ = cached_client_data).with_updated_last_query(query_string, cachable_query)
           end
 
-          [query, [], registration_status]
+          prepared_query = prepare_query_for_execution(query, variables: variables, operation_name: operation_name, context: context)
+
+          [prepared_query, [], registration_status]
         end
 
         private
@@ -128,7 +130,14 @@ module ElasticGraph
             document: query.document,
             variables: variables,
             operation_name: operation_name,
-            context: context
+            context: context,
+            # Registered queries are validated at CI time (via the QueryValidator Rake task),
+            # so re-validating at runtime is redundant. Skipping it avoids the cost of running
+            # graphql-ruby's StaticValidation pipeline on every request for known-good queries.
+            # Note: `validate: false` only disables static (query-string) validation; variable
+            # validation still runs via `GraphQL::Query#variables`, so invalid variable values
+            # are still reported as errors on every request.
+            validate: false
           )
         end
       end

--- a/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/registry_spec.rb
+++ b/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/registry_spec.rb
@@ -580,7 +580,30 @@ module ElasticGraph
         end
 
         def execute_allowed_query(registry, query_string, **options)
-          get_allowed_query(registry, query_string, **options).result
+          get_allowed_query(registry, query_string, **options).tap do |query|
+            # Verify that the executed query preserves operation directives from the submitted query
+            # string (not the registered query). This particularly matters for `@eg_latency_slo`—
+            # the client-submitted SLO value must be used at execution time.
+            expect(operation_directives_of(query)).to eq(operation_directives_from_string(query_string, query.selected_operation_name))
+          end.result
+        end
+
+        def operation_directives_of(query)
+          query.selected_operation.directives.to_h { |dir|
+            [dir.name, dir.arguments.to_h { |arg| [arg.name, arg.value] }]
+          } || {}
+        end
+
+        def operation_directives_from_string(query_string, operation_name)
+          # Use the underlying parser directly to avoid interfering with `track_parse_counts`
+          # which mocks `::GraphQL.parse`.
+          doc = ::GraphQL::Language::Parser.parse(query_string)
+          op = doc.definitions.find { |d|
+            d.is_a?(::GraphQL::Language::Nodes::OperationDefinition) && d.name == operation_name
+          }
+          (op.directives || []).to_h { |dir|
+            [dir.name, dir.arguments.to_h { |arg| [arg.name, arg.value] }]
+          }
         end
 
         def result_with_type_name(name)

--- a/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/registry_spec.rb
+++ b/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/registry_spec.rb
@@ -404,7 +404,7 @@ module ElasticGraph
               expect(differing_result_query.validate).to eq(true)
             end
 
-            it "still performs static validation for queries that are built from scratch" do
+            it "still performs static validation for unregistered queries" do
               invalid_query_string = <<~EOS.strip
                 query WidgetName {
                   __type(name: "Widget") {
@@ -419,7 +419,7 @@ module ElasticGraph
               expect(errors).to be_empty
               expect(status).to eq(RegistrationStatus::MATCHED_REGISTERED_QUERY)
               expect(registered_query.validate).to eq(false)
-              expect(registered_query.valid?).to eq(true)
+              expect(registered_query.valid?).to eq(true) # Not actually valid, but returns true since we skip validation
 
               unregistered_query, errors, status = registry.build_and_validate_query(invalid_query_string, client: client_named("other_client"))
               expect(errors).to be_empty

--- a/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/registry_spec.rb
+++ b/elasticgraph-query_registry/spec/unit/elastic_graph/query_registry/registry_spec.rb
@@ -380,6 +380,83 @@ module ElasticGraph
               part_name_string => 1
             )
           end
+
+          describe "query validation" do
+            it "returns a query with `validate: false` for registered query forms, but `validate: true` when a registered query differs materially" do
+              registry = registry_with({"my_client" => [part_name_string]})
+
+              # Byte-for-byte registered query → cache hit → validation skipped.
+              registered_query, errors, status = registry.build_and_validate_query(part_name_string, client: client_named("my_client"))
+              expect(errors).to be_empty
+              expect(status).to eq(RegistrationStatus::MATCHED_REGISTERED_QUERY)
+              expect(registered_query.validate).to eq(false)
+
+              # Canonically equivalent alternate form → parsed once, cached, and returned with validation skipped.
+              alternate_form_query_string = "# a leading comment\n#{part_name_string}"
+              alternate_form_query, _, status = registry.build_and_validate_query(alternate_form_query_string, client: client_named("my_client"))
+              expect(status).to eq(RegistrationStatus::MATCHED_REGISTERED_QUERY)
+              expect(alternate_form_query.validate).to eq(false)
+
+              # Substantive difference (same operation name, different shape) → registry rejects it and still validates.
+              differing_query = part_name_string.sub("name\n", "the_name: name\n")
+              differing_result_query, _, status = registry.build_and_validate_query(differing_query, client: client_named("my_client"))
+              expect(status).to eq(RegistrationStatus::DIFFERING_REGISTERED_QUERY)
+              expect(differing_result_query.validate).to eq(true)
+            end
+
+            it "still performs static validation for queries that are built from scratch" do
+              invalid_query_string = <<~EOS.strip
+                query WidgetName {
+                  __type(name: "Widget") {
+                    missingField
+                  }
+                }
+              EOS
+
+              registry = registry_with({"my_client" => [invalid_query_string]}, allow_unregistered_clients: true)
+
+              registered_query, errors, status = registry.build_and_validate_query(invalid_query_string, client: client_named("my_client"))
+              expect(errors).to be_empty
+              expect(status).to eq(RegistrationStatus::MATCHED_REGISTERED_QUERY)
+              expect(registered_query.validate).to eq(false)
+              expect(registered_query.valid?).to eq(true)
+
+              unregistered_query, errors, status = registry.build_and_validate_query(invalid_query_string, client: client_named("other_client"))
+              expect(errors).to be_empty
+              expect(status).to eq(RegistrationStatus::UNREGISTERED_CLIENT)
+              expect(unregistered_query.validate).to eq(true)
+              expect(unregistered_query.valid?).to eq(false)
+              expect(unregistered_query.static_errors.map(&:message).join).to include("missingField")
+            end
+
+            it "still validates variable values even when static validation is skipped" do
+              # `validate: false` disables graphql-ruby's static (query-string) validation pipeline but
+              # not variable validation (see `GraphQL::Query::Variables#initialize`, which coerces and
+              # validates each provided variable against its declared type). This test guards that
+              # contract so we don't silently start accepting malformed variable values for cache hits.
+              query_with_variable = <<~EOS.strip
+                query GetTypeName($name: String!) {
+                  __type(name: $name) {
+                    name
+                  }
+                }
+              EOS
+
+              registry = registry_with({"my_client" => [query_with_variable]})
+
+              # Byte-for-byte cache hit, but with an invalid variable value (Integer where String! is required).
+              query, errors, status = registry.build_and_validate_query(
+                query_with_variable,
+                client: client_named("my_client"),
+                variables: {"name" => 123}
+              )
+
+              expect(errors).to be_empty
+              expect(status).to eq(RegistrationStatus::MATCHED_REGISTERED_QUERY)
+              expect(query.validate).to eq(false)
+              expect(query.static_errors.map(&:message).join).to include("String")
+            end
+          end
         end
 
         it "always allows the internal ElasticGraph client to submit the eager load query that happens at boot time" do
@@ -503,12 +580,7 @@ module ElasticGraph
         end
 
         def execute_allowed_query(registry, query_string, **options)
-          get_allowed_query(registry, query_string, **options).tap do |query|
-            # Verify that the executed query is exactly what was submitted rather than what was registered.
-            # This particularly matters with the `@egLatencySlo` directive. We want the value on the query
-            # to be used when it differs from the SLO threshold on the registered query.
-            expect(query.query_string.strip).to eq(query_string.strip)
-          end.result
+          get_allowed_query(registry, query_string, **options).result
         end
 
         def result_with_type_name(name)


### PR DESCRIPTION
## Summary

Skip graphql-ruby's `StaticValidation` pipeline for registered queries that hit the cache in `ForRegisteredClient#prepare_query_for_execution`. These queries were already validated at CI time via the `QueryValidator` Rake task, so re-validating at runtime on every request is redundant.

The `prepare_query_for_execution` method already passes the cached `document:` to skip re-parsing (~10ms on large queries). This extends that optimization by also passing `validate: false`, avoiding the validation pipeline cost on every cache-hit request.

## Safety

- Only applies to the cache-hit path — queries that exactly match a registered form (or a previously-matched canonical form)
- Unregistered queries and first-time queries still go through full validation via the `yield` path in `build_and_validate_query`
- `allow_any_query_for_clients` queries that don't hit the cache also go through full validation
- Schema and registered queries are deployed as a single artifact, validated together in CI
- `validate: false` only disables static (query-string) validation. Variable validation still runs unconditionally in `GraphQL::Query::ValidationPipeline` via `@query.variables.errors` (which coerces and validates each provided variable against its declared type), so invalid variable values are still reported on every request. There is a regression test covering this.

## Benchmark

`benchmarks/query_registry/skip_validation.rb` measures the cost of `GraphQL::Query.new(document:) + query.valid?` with `validate: true` (prior behavior) vs `validate: false` (new cache-hit behavior). The skip cost is a flat ~13 μs; the `validate: true` cost scales with query complexity:

| Size | Query bytes | validate: true | validate: false | Speedup | Savings/request |
|---|---|---|---|---|---|
| small  | ~280 B   | 178 μs | 13 μs | 13.6× | ~165 μs |
| medium | ~4 KB    | 1.83 ms | 13 μs | 137× | ~1.8 ms |
| large  | ~60 KB   | 26 ms | 14 μs | 1,858× | ~26 ms |
| xlarge | ~416 KB  | 163 ms | 14 μs | 11,922× | ~163 ms |

Full results: `benchmarks/query_registry/skip_validation.results.txt`.

## Test plan

- [x] `elasticgraph-query_registry` specs pass (112 examples, 0 failures) with 100% line and branch coverage
- [x] New unit tests directly assert the validation-skip behavior:
  - `query.validate` is `false` for byte-for-byte cache hits and `true` for the yield path (differing / first-time alternate form)
  - `GraphQL::StaticValidation::BaseVisitor.including_rules` is not called for cache-hit registered queries but is called for unregistered (yielded) queries — without the `validate: false` change these assertions flip
  - Invalid variable values on a cache-hit query still produce static errors (safety test confirming variable validation is unaffected)
- [x] `script/lint` clean
- [x] `script/type_check` clean