### PR TITLE
Make mapping_properties a required positional arg; add test for dual-index __typename

### DIFF
--- a/elasticgraph-indexer/lib/elastic_graph/indexer/operation/update.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/operation/update.rb
@@ -30,7 +30,7 @@ module ElasticGraph
           prepared_record = record_preparer.prepare_for_index(
             event["type"],
             event["record"] || {"id" => event["id"]},
-            mapping_properties: destination_index_mapping.dig("properties")
+            destination_index_mapping.fetch("properties")
           )
 
           Support::HashUtil

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/record_preparer.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/record_preparer.rb
@@ -71,7 +71,7 @@ module ElasticGraph
       # still build operations for it, and the operations require a `RecordPreparer`, but we do
       # not send them to the datastore.
       module Identity
-        def self.prepare_for_index(type_name, record, mapping_properties: nil)
+        def self.prepare_for_index(type_name, record, mapping_properties)
           record
         end
       end
@@ -97,8 +97,8 @@ module ElasticGraph
       #
       # Note: this method does not mutate the given `record`. Instead it returns a
       # copy with any updates applied to it.
-      def prepare_for_index(type_name, record, mapping_properties: nil)
-        prepare_value_for_indexing(record, type_name, mapping_properties) # : ::Hash[::String, untyped]
+      def prepare_for_index(type_name, record, mapping_properties)
+        prepare_value_for_indexing(record, type_name, mapping_properties)
       end
 
       private

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/record_preparer.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/record_preparer.rb
@@ -71,8 +71,8 @@ module ElasticGraph
       # still build operations for it, and the operations require a `RecordPreparer`, but we do
       # not send them to the datastore.
       module Identity
-        def self.prepare_for_index(type_name, record, mapping_properties)
-          record
+        def self.prepare_for_index(type_name, value, mapping_properties)
+          value
         end
       end
 
@@ -95,15 +95,9 @@ module ElasticGraph
       # the set union of fields and this will take care of dropping any unsupported
       # fields before we attempt to index the record.
       #
-      # Note: this method does not mutate the given `record`. Instead it returns a
+      # Note: this method does not mutate the given `value`. Instead it returns a
       # copy with any updates applied to it.
-      def prepare_for_index(type_name, record, mapping_properties)
-        prepare_value_for_indexing(record, type_name, mapping_properties)
-      end
-
-      private
-
-      def prepare_value_for_indexing(value, type_name, mapping_properties)
+      def prepare_for_index(type_name, value, mapping_properties)
         type_name = type_name.delete_suffix("!")
 
         return nil if value.nil?
@@ -115,7 +109,7 @@ module ElasticGraph
         case value
         when ::Array
           element_type_name = type_name.delete_prefix("[").delete_suffix("]")
-          value.map { |v| prepare_value_for_indexing(v, element_type_name, mapping_properties) }
+          value.map { |v| prepare_for_index(element_type_name, v, mapping_properties) }
         when ::Hash
           # `@eg_meta_by_field_name_by_concrete_type` does not have abstract types in it (e.g. type unions).
           # Instead, it'll have each concrete subtype in it.
@@ -134,7 +128,7 @@ module ElasticGraph
             elsif (eg_meta = eg_meta_by_field_name[field_name])
               name_in_index = eg_meta.fetch("nameInIndex")
               nested_mapping_properties = mapping_properties&.dig(name_in_index, "properties")
-              [name_in_index, prepare_value_for_indexing(field_value, eg_meta.fetch("type"), nested_mapping_properties)]
+              [name_in_index, prepare_for_index(eg_meta.fetch("type"), field_value, nested_mapping_properties)]
             end
           end.to_h
 

--- a/elasticgraph-indexer/sig/elastic_graph/indexer/record_preparer.rbs
+++ b/elasticgraph-indexer/sig/elastic_graph/indexer/record_preparer.rbs
@@ -1,7 +1,7 @@
 module ElasticGraph
   class Indexer
     interface _RecordPreparer
-      def prepare_for_index: (::String, ::Hash[::String, untyped], ?mapping_properties: ::Hash[::String, untyped]?) -> ::Hash[::String, untyped]
+      def prepare_for_index: (::String, ::Hash[::String, untyped], ::Hash[::String, untyped]) -> ::Hash[::String, untyped]
     end
 
     class RecordPreparer

--- a/elasticgraph-indexer/sig/elastic_graph/indexer/record_preparer.rbs
+++ b/elasticgraph-indexer/sig/elastic_graph/indexer/record_preparer.rbs
@@ -1,7 +1,7 @@
 module ElasticGraph
   class Indexer
     interface _RecordPreparer
-      def prepare_for_index: (::String, ::Hash[::String, untyped], ::Hash[::String, untyped]) -> ::Hash[::String, untyped]
+      def prepare_for_index: [T] (::String, T, ::Hash[::String, untyped]) -> T
     end
 
     class RecordPreparer
@@ -33,13 +33,8 @@ module ElasticGraph
          ::Array[TypeMetadata]
       ) -> void
 
-      private
-
-      INTEGRAL_TYPE_NAMES: ::Set[::String]
       @indexing_preparer_by_scalar_type_name: ::Hash[::String, SchemaArtifacts::RuntimeMetadata::extensionClass?]
       @eg_meta_by_field_name_by_concrete_type: egMetaByFieldByTypeHash
-
-      def prepare_value_for_indexing: (untyped, ::String, ::Hash[::String, untyped]?) -> untyped
 
       class TypeMetadata
         attr_reader name: ::String

--- a/elasticgraph-indexer/spec/support/indexing_preparer.rb
+++ b/elasticgraph-indexer/spec/support/indexing_preparer.rb
@@ -54,7 +54,7 @@ RSpec.shared_context "indexing preparer support" do |scalar_type|
   private
 
   def prepare_field_value(field, value)
-    record = @record_preparer.prepare_for_index("MyType", build_record(field => value))
+    record = @record_preparer.prepare_for_index("MyType", build_record(field => value), {})
     record.fetch(field)
   end
 

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/datastore_indexing_router_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/datastore_indexing_router_spec.rb
@@ -580,16 +580,19 @@ module ElasticGraph
         expect(index_defs.size).to eq 1
         index_def = index_defs.first
 
+        destination_index_mapping = indexer.schema_artifacts.index_mappings_by_index_def_name.fetch(index_def.name)
+
         arguments = {
           event: event,
           prepared_record: indexer.record_preparer_factory.for_latest_json_schema_version.prepare_for_index(
             event.fetch("type"),
-            event.fetch("record")
+            event.fetch("record"),
+            destination_index_mapping.fetch("properties")
           ),
           destination_index_def: index_def,
           update_target: update_target,
           doc_id: event.fetch("id"),
-          destination_index_mapping: indexer.schema_artifacts.index_mappings_by_index_def_name.fetch(index_def.name)
+          destination_index_mapping: destination_index_mapping
         }.merge(overrides)
 
         Operation::Update.new(**arguments)

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/operation/count_accumulator_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/operation/count_accumulator_spec.rb
@@ -295,13 +295,19 @@ module ElasticGraph
             .fetch(source_type)
             .update_targets.find { |ut| ut.type == destination_type }
 
+          destination_index_mapping = indexer.schema_artifacts.index_mappings_by_index_def_name.fetch(destination_index_def.name)
+
           update = Update.new(
             event: {"type" => source_type, "record" => data},
             destination_index_def: destination_index_def,
-            prepared_record: indexer.record_preparer_factory.for_latest_json_schema_version.prepare_for_index(source_type, data),
+            prepared_record: indexer.record_preparer_factory.for_latest_json_schema_version.prepare_for_index(
+              source_type,
+              data,
+              destination_index_mapping.fetch("properties")
+            ),
             update_target: update_target,
             doc_id: "the-id",
-            destination_index_mapping: indexer.schema_artifacts.index_mappings_by_index_def_name.fetch(destination_index_def.name)
+            destination_index_mapping: destination_index_mapping
           )
 
           update.to_datastore_bulk.dig(1, :script, :params)

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/record_preparer_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/record_preparer_spec.rb
@@ -75,7 +75,7 @@ module ElasticGraph
             end
           end
 
-          record = preparer.prepare_for_index("MyType", {"id" => "1", "options" => nil})
+          record = preparer.prepare_for_index("MyType", {"id" => "1", "options" => nil}, {})
 
           expect(record).to eq({"id" => "1", "options" => nil})
         end
@@ -95,7 +95,7 @@ module ElasticGraph
             end
           end
 
-          record = preparer.prepare_for_index("MyType", {"id" => "1", "color" => "GREEN"})
+          record = preparer.prepare_for_index("MyType", {"id" => "1", "color" => "GREEN"}, {})
 
           expect(record).to eq({"id" => "1", "color" => "GREEN"})
         end
@@ -141,7 +141,7 @@ module ElasticGraph
             }
           }
 
-          record = preparer.prepare_for_index("Component", record)
+          record = preparer.prepare_for_index("Component", record, {})
 
           expect(record).to eq({
             "id" => "1",
@@ -178,7 +178,7 @@ module ElasticGraph
             }
           }
 
-          record = preparer.prepare_for_index("Component", record)
+          record = preparer.prepare_for_index("Component", record, {})
 
           expect(record).to eq({
             "id" => "1",
@@ -209,8 +209,8 @@ module ElasticGraph
             end
           end
 
-          type_b_mapping_properties = schema_artifacts.index_mappings_by_index_def_name.fetch("type_b").dig("properties")
-          record = preparer.prepare_for_index("TypeB", {"id" => "1", "size" => 3, "__typename" => "TypeB"}, mapping_properties: type_b_mapping_properties)
+          type_b_mapping_properties = schema_artifacts.index_mappings_by_index_def_name.fetch("type_b").fetch("properties")
+          record = preparer.prepare_for_index("TypeB", {"id" => "1", "size" => 3, "__typename" => "TypeB"}, type_b_mapping_properties)
 
           expect(record).to eq({"id" => "1", "size" => 3})
         end
@@ -234,8 +234,8 @@ module ElasticGraph
             end
           end
 
-          type_a_or_b_mapping_properties = schema_artifacts.index_mappings_by_index_def_name.fetch("type_a_or_b").dig("properties")
-          record = preparer.prepare_for_index("TypeAOrB", {"id" => "1", "size" => 3, "__typename" => "TypeB"}, mapping_properties: type_a_or_b_mapping_properties)
+          type_a_or_b_mapping_properties = schema_artifacts.index_mappings_by_index_def_name.fetch("type_a_or_b").fetch("properties")
+          record = preparer.prepare_for_index("TypeAOrB", {"id" => "1", "size" => 3, "__typename" => "TypeB"}, type_a_or_b_mapping_properties)
 
           expect(record).to eq({"id" => "1", "size" => 3, "__typename" => "TypeB"})
         end
@@ -266,7 +266,7 @@ module ElasticGraph
           type_a_record = preparer.prepare_for_index(
             "TypeA",
             {"id" => "1", "name" => "test"},
-            mapping_properties: mappings.fetch("type_a_or_b").dig("properties")
+            mappings.fetch("type_a_or_b").fetch("properties")
           )
 
           # __typename should be injected since the mixed supertype index requires it
@@ -276,7 +276,7 @@ module ElasticGraph
           type_b_record = preparer.prepare_for_index(
             "TypeB",
             {"id" => "1", "size" => 3, "__typename" => "TypeB"},
-            mapping_properties: mappings.fetch("type_b").dig("properties")
+            mappings.fetch("type_b").fetch("properties")
           )
 
           # __typename should be omitted since type_b is directly indexed
@@ -315,7 +315,7 @@ module ElasticGraph
           person_record = preparer.prepare_for_index(
             "Person",
             {"id" => "2", "name" => "Alice"},
-            mapping_properties: mappings.fetch("inventors").dig("properties")
+            mappings.fetch("inventors").fetch("properties")
           )
           expect(person_record).to include("__typename" => "Person")
 
@@ -328,7 +328,7 @@ module ElasticGraph
               "name" => "ACME",
               "ceo" => {"id" => "2", "name" => "Alice"}
             },
-            mapping_properties: mappings.fetch("manufacturers").dig("properties")
+            mappings.fetch("manufacturers").fetch("properties")
           )
           expect(manufacturer_record).to eq({
             "id" => "1",
@@ -360,7 +360,7 @@ module ElasticGraph
             end
           end
 
-          inventions_mapping_properties = schema_artifacts.index_mappings_by_index_def_name.fetch("inventions").dig("properties")
+          inventions_mapping_properties = schema_artifacts.index_mappings_by_index_def_name.fetch("inventions").fetch("properties")
           record = preparer.prepare_for_index(
             "Invention",
             {
@@ -371,7 +371,7 @@ module ElasticGraph
                 "__typename" => "Company"
               }
             },
-            mapping_properties: inventions_mapping_properties
+            inventions_mapping_properties
           )
 
           expect(record).to eq({
@@ -381,6 +381,96 @@ module ElasticGraph
               "stock_ticker" => "SQ",
               "__typename" => "Company"
             }
+          })
+        end
+
+        it "adapts `__typename` handling per destination index when a type has its own index and is also part of a shared union index" do
+          preparer, schema_artifacts = build_preparer_with_artifacts do |s|
+            s.object_type "Person" do |t|
+              t.field "id", "ID!"
+              t.field "name", "String"
+              t.index "people"
+            end
+
+            s.object_type "Company" do |t|
+              t.field "id", "ID!"
+              t.field "name", "String"
+            end
+
+            s.union_type "Inventor" do |t|
+              t.subtypes "Person", "Company"
+              t.index "inventors"
+            end
+          end
+
+          mappings = schema_artifacts.index_mappings_by_index_def_name
+
+          # When preparing Person for the shared `inventors` index, `__typename` must be injected
+          # so the index can distinguish Person from Company.
+          #
+          # Note: in practice, this call would not happen, because `Person` has its own `people` index.
+          # However, in isolation this is the behavior we'd want if it was called, and it's a useful test
+          # because it requires our implementation to operate based on the mapping rather than the type — which is more sound.
+          inventors_mapping = mappings.fetch("inventors").fetch("properties")
+          person_for_inventors = preparer.prepare_for_index(
+            "Person",
+            {"id" => "1", "name" => "Alice"},
+            inventors_mapping
+          )
+          expect(person_for_inventors).to eq({"id" => "1", "name" => "Alice", "__typename" => "Person"})
+
+          # When preparing Person for its own `people` index, `__typename` must NOT be present
+          # because only Person records go there — no discrimination is needed.
+          people_mapping = mappings.fetch("people").fetch("properties")
+          person_for_people = preparer.prepare_for_index(
+            "Person",
+            {"id" => "1", "name" => "Alice"},
+            people_mapping
+          )
+          expect(person_for_people).to eq({"id" => "1", "name" => "Alice"})
+        end
+
+        it "keeps `__typename` on an embedded union field but strips it from an embedded concrete field of the same type" do
+          preparer, schema_artifacts = build_preparer_with_artifacts do |s|
+            s.object_type "Person" do |t|
+              t.field "id", "ID!"
+              t.field "name", "String"
+            end
+
+            s.object_type "Company" do |t|
+              t.field "id", "ID!"
+              t.field "name", "String"
+            end
+
+            s.union_type "Inventor" do |t|
+              t.subtypes "Person", "Company"
+            end
+
+            s.object_type "Widget" do |t|
+              t.field "id", "ID!"
+              t.field "inventor", "Inventor"
+              t.field "ceo", "Person"
+              t.index "widgets"
+            end
+          end
+
+          widgets_mapping = schema_artifacts.index_mappings_by_index_def_name.fetch("widgets").fetch("properties")
+
+          record = preparer.prepare_for_index(
+            "Widget",
+            {
+              "id" => "1",
+              "inventor" => {"id" => "2", "name" => "Alice", "__typename" => "Person"},
+              "ceo" => {"id" => "3", "name" => "Bob", "__typename" => "Person"}
+            },
+            widgets_mapping
+          )
+
+          # __typename kept on inventor (union field) but stripped from ceo (concrete field)
+          expect(record).to eq({
+            "id" => "1",
+            "inventor" => {"id" => "2", "name" => "Alice", "__typename" => "Person"},
+            "ceo" => {"id" => "3", "name" => "Bob"}
           })
         end
 
@@ -398,7 +488,7 @@ module ElasticGraph
             end
           end
 
-          record = preparer.prepare_for_index("MyType", {"id" => "1", "options" => {"color" => "RED"}, "name" => "Winston"})
+          record = preparer.prepare_for_index("MyType", {"id" => "1", "options" => {"color" => "RED"}, "name" => "Winston"}, {})
 
           expect(record).to eq({"id" => "1", "options" => {"clr" => "RED"}, "name2" => "Winston"})
         end
@@ -426,7 +516,7 @@ module ElasticGraph
             }
           )
 
-          record = preparer.prepare_for_index("MyType", {"id" => "1", "name" => "Winston"})
+          record = preparer.prepare_for_index("MyType", {"id" => "1", "name" => "Winston"}, {})
 
           expect(record).to eq({"id" => "1"})
         end
@@ -459,7 +549,7 @@ module ElasticGraph
             }
           )
 
-          record = preparer.prepare_for_index("MyType", {"id" => "1", "cost" => {"amount" => 10, "__typename" => "Money"}})
+          record = preparer.prepare_for_index("MyType", {"id" => "1", "cost" => {"amount" => 10, "__typename" => "Money"}}, {})
 
           expect(record).to eq({"id" => "1", "cost" => {"amount" => 10}})
         end

--- a/spec_support/lib/elastic_graph/spec_support/builds_indexer_operation.rb
+++ b/spec_support/lib/elastic_graph/spec_support/builds_indexer_operation.rb
@@ -35,7 +35,7 @@ module ElasticGraph
           prepared_record: idxr.record_preparer_factory.for_latest_json_schema_version.prepare_for_index(
             event.fetch("type"),
             event.fetch("record"),
-            mapping_properties: idxr.schema_artifacts.index_mappings_by_index_def_name.fetch(index_def.name).dig("properties")
+            idxr.schema_artifacts.index_mappings_by_index_def_name.fetch(index_def.name).fetch("properties")
           ),
           destination_index_def: index_def,
           update_target: update_targets.first,

--- a/spec_support/lib/elastic_graph/spec_support/uses_datastore.rb
+++ b/spec_support/lib/elastic_graph/spec_support/uses_datastore.rb
@@ -334,7 +334,7 @@ RSpec.shared_context "datastore support", :capture_logs do
           prepared_record: indexer.record_preparer_factory.for_latest_json_schema_version.prepare_for_index(
             event.fetch("type"),
             event.fetch("record"),
-            mapping_properties: destination_index_mapping.dig("properties")
+            destination_index_mapping.fetch("properties")
           ),
           destination_index_def: index_def,
           update_target: update_target,


### PR DESCRIPTION
## Summary

Followup to #1109. Three changes:

- **Make `mapping_properties` a required positional arg** instead of an optional keyword arg with `nil` default. A default value is wrong here: omitting it silently disables all `__typename` handling, reverting to broken behavior. Also switches call sites from `.dig("properties")` to `.fetch("properties")` so a missing key raises immediately rather than producing a nil that propagates silently.

- **Add a unit test demonstrating the dual-index scenario**: a type (`Person`) with its own `people` index that is also part of a shared `inventors` union index must get `__typename` injected only when prepared for the union index. This test fails on the pre-#1109 implementation and passes on the current one, confirming the mapping-based approach is necessary.

- **Collapse `prepare_for_index` and `prepare_value_for_indexing` into one method**: the public `prepare_for_index` was a thin wrapper that swapped args and delegated to the private `prepare_value_for_indexing`. Since the method is naturally recursive, there's no need for two separate methods.

## Test plan

- [x] New unit test passes: `bundle exec rspec spec/unit/elastic_graph/indexer/record_preparer_spec.rb`
- [x] Verified new test fails against the old (pre-#1109) implementation
- [x] Full `script/quick_build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)