### PR TITLE
Treat shrink/split/clone source settings as read-only in normalizer

### DIFF
--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_config_normalizer.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_config_normalizer.rb
@@ -19,12 +19,21 @@ module ElasticGraph
       # Note: `index.history.uuid` is a weird setting that sometimes shows up in managed AWS OpenSearch
       # clusters, but only on _some_ indices. It's not documented and we don't want to mess with it here,
       # so we want to treat it as a read only setting.
+      #
+      # Note: `index.resize.source.name`, `index.resize.source.uuid`, and
+      # `index.routing.allocation.initial_recovery._id` are set by the datastore on indices produced by
+      # a shrink/split/clone. They are exposed on read but rejected on write (attempting to write
+      # them returns `illegal_argument_exception: unknown setting`), so we must treat them as
+      # read-only to avoid the update loop trying to clear them by writing null.
       READ_ONLY_SETTINGS = %w[
         index.creation_date
         index.history.uuid
         index.provided_name
         index.replication.type
+        index.resize.source.name
+        index.resize.source.uuid
         index.routing.allocation.include._tier_preference
+        index.routing.allocation.initial_recovery._id
         index.uuid
         index.version.created
         index.version.upgraded

--- a/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/index_config_normalizer_spec.rb
+++ b/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/index_config_normalizer_spec.rb
@@ -24,6 +24,9 @@ module ElasticGraph
             "index.creation_date" => "2020-07-20",
             "index.uuid" => "abcdefg",
             "index.history.uuid" => "98765",
+            "index.resize.source.name" => "source_index_v2",
+            "index.resize.source.uuid" => "0iZ0xDBcQwKxtIVDzrELdw",
+            "index.routing.allocation.initial_recovery._id" => nil,
             "index.random.setting" => "random"
           }
         }


### PR DESCRIPTION
## Summary

OpenSearch exposes three settings on indices produced by a shrink (or split/clone) that are rejected on write:

- `index.resize.source.name`
- `index.resize.source.uuid`
- `index.routing.allocation.initial_recovery._id`

`Admin::IndexDefinitionConfigurator::ForIndex#settings_updates` diffs current vs desired settings and PUTs `null` for any setting present in current but absent from desired (to restore its default). When a shrunk index is present, the PUT fails with:

```
[400] illegal_argument_exception: unknown setting [index.resize.source.name]
  please check that any required plugins are installed, or check the
  breaking changes documentation for removed settings
```

…with the other two surfacing as `suppressed` exceptions. This causes the admin lambda's `update_opensearch_config` run to fail hard.

This PR adds the three settings to `IndexConfigNormalizer::READ_ONLY_SETTINGS` so they are dropped from `current_settings` during normalization and the update loop leaves them alone — the same pattern already used for `index.creation_date`, `index.uuid`, `index.history.uuid`, etc.

## Test plan

- [x] Extended the existing "filters out read-only settings" spec in `index_config_normalizer_spec.rb` to cover all three new entries; full `index_config_normalizer_spec.rb` suite passes (10 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)