### PR TITLE
Treat static, index-creation-only settings as read-only in normalizer

### DIFF
--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_config_normalizer.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_config_normalizer.rb
@@ -25,7 +25,17 @@ module ElasticGraph
       # a shrink/split/clone. They are exposed on read but rejected on write (attempting to write
       # them returns `illegal_argument_exception: unknown setting`), so we must treat them as
       # read-only to avoid the update loop trying to clear them by writing null.
+      #
+      # Note: `index.routing_partition_size` is a static, index-creation-only setting. Once the index
+      # exists it cannot be changed, so PUTs against `_settings` for it (including PUTs of null to
+      # restore the default) are rejected. Treat it as read-only so the update loop leaves it alone.
+      #
+      # Note: `index.codec` is a static (non-dynamic) setting. It is exposed on read but can only be
+      # changed on a closed index, so PUTs against `_settings` for it on an open index are rejected
+      # with `Can't update non dynamic settings`. Treat it as read-only so the update loop leaves it
+      # alone.
       READ_ONLY_SETTINGS = %w[
+        index.codec
         index.creation_date
         index.history.uuid
         index.provided_name
@@ -34,6 +44,7 @@ module ElasticGraph
         index.resize.source.uuid
         index.routing.allocation.include._tier_preference
         index.routing.allocation.initial_recovery._id
+        index.routing_partition_size
         index.uuid
         index.version.created
         index.version.upgraded

--- a/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/index_config_normalizer_spec.rb
+++ b/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/index_config_normalizer_spec.rb
@@ -21,12 +21,14 @@ module ElasticGraph
       it "filters out read-only settings" do
         index_config = {
           "settings" => {
+            "index.codec" => "best_compression",
             "index.creation_date" => "2020-07-20",
             "index.uuid" => "abcdefg",
             "index.history.uuid" => "98765",
             "index.resize.source.name" => "source_index_v2",
             "index.resize.source.uuid" => "0iZ0xDBcQwKxtIVDzrELdw",
             "index.routing.allocation.initial_recovery._id" => nil,
+            "index.routing_partition_size" => "1",
             "index.random.setting" => "random"
           }
         }


### PR DESCRIPTION
## Summary
- `index.routing_partition_size` and `index.codec` are both static (non-dynamic) index settings. OpenSearch exposes them on read but rejects PUTs against `_settings` for them on an open index.
  - `routing_partition_size` is index-creation-only and defaults to `1` when unset, so any PUT (including PUTs of null to restore the default) is rejected outright.
  - `index.codec` can only be changed on a closed index, so PUTs against an open index fail with `Can't update non dynamic settings [[index.codec]] for open indices [...]`.
- The admin update loop diffs current vs desired settings and PUTs null for anything present in current but missing from desired, so running `clusters:configure:perform` against a cluster that surfaces either setting fails with a 400.
- Adds both settings to `READ_ONLY_SETTINGS` in `IndexConfigNormalizer` so they are dropped from current_settings and the update loop leaves them alone. Follows the pattern established in #1144.

## Observed failure (motivating `index.codec`)
```
[400] {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"Can't update non dynamic settings [[index.codec]] for open indices [[orders_rollover__2026/aq2jMQpZTRiLiBhsCaRbUA]]"}],"type":"illegal_argument_exception","reason":"Can't update non dynamic settings [[index.codec]] for open indices [[orders_rollover__2026/aq2jMQpZTRiLiBhsCaRbUA]]"},"status":400}
```
Surfaced from `ElasticGraph::OpenSearch::Client#put_index_settings` via `IndexDefinitionConfigurator::ForIndex#update_settings` while running `clusters:configure:perform`.

## Test plan
- [x] Updated `index_config_normalizer_spec.rb` to include both `index.routing_partition_size` and `index.codec` in the read-only filter case; `bundle exec rspec spec/unit/elastic_graph/datastore_core/index_config_normalizer_spec.rb` passes (10 examples, 0 failures).

References:
- OpenSearch index settings: https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/index-settings/
- Elasticsearch `_routing` / `routing_partition_size`: https://www.elastic.co/guide/en/elasticsearch/reference/master/mapping-routing-field.html