### PR TITLE
Shift duplicate index name validation to schema definition time

### DIFF
--- a/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
+++ b/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
@@ -1442,7 +1442,7 @@ module ElasticGraph
 
           # Ensure there's at least one field defined on the GraphQL type--if `id` is indexing-only, we need another field defined.
           t.field "name", "String" if id_is_indexing_only.include?("IndexedType2")
-          t.index "index1" if define_indexed_types
+          t.index "index2" if define_indexed_types
         end
 
         schema.object_type "EmbeddedObjectType1" do |t|

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
@@ -193,11 +193,7 @@ module ElasticGraph
       def indexed_document_types_by_index_definition_name
         @indexed_document_types_by_index_definition_name ||= indexed_document_types.each_with_object({}) do |type, hash|
           type.index_definitions.each do |index_def|
-            if hash.key?(index_def.name)
-              raise Errors::SchemaError, "DatastoreCore::IndexDefinition #{index_def.name} is used multiple times: #{type} vs #{hash[index_def.name]}"
-            end
-
-            hash[index_def.name] = type
+            hash[index_def.name] ||= type
           end
         end.freeze
       end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/type_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/type_spec.rb
@@ -679,9 +679,16 @@ module ElasticGraph
 
           it "deduplicates the index definitions before returning them" do
             search_index_definitions = search_index_definitions_from do |schema, type|
-              schema.object_type "T1a" do |t|
+              # T1a and T1b both inherit the same index definition from I1, so the union
+              # gets duplicate "t1" entries from its subtypes that need deduplication.
+              schema.interface_type "I1" do |t|
                 t.field "id", "ID!"
                 t.index "t1"
+              end
+
+              schema.object_type "T1a" do |t|
+                t.implements "I1"
+                t.field "id", "ID!"
               end
 
               schema.object_type "T2" do |t|
@@ -690,8 +697,8 @@ module ElasticGraph
               end
 
               schema.object_type "T1b" do |t|
+                t.implements "I1"
                 t.field "id", "ID!"
-                t.index "t1"
               end
 
               schema.object_type "T4" do |t|
@@ -701,7 +708,6 @@ module ElasticGraph
 
               schema.union_type type do |t|
                 t.subtypes "T1a", "T2", "T1b", "T4"
-                t.index "t4"
               end
             end
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
@@ -139,14 +139,6 @@ module ElasticGraph
           }.to raise_error(ArgumentError, a_string_including("widgets#{ROLLOVER_INDEX_INFIX_MARKER}2021-02", "name of a rollover index"))
         end
 
-        it "raises an exception if two GraphQL types are configured to use the same index" do
-          schema = schema_with_indices("Person" => "widgets", "Widget" => "widgets")
-
-          expect {
-            schema.document_type_stored_in("widgets")
-          }.to raise_error(Errors::SchemaError, a_string_including("widgets", "Person", "Widget"))
-        end
-
         def schema_with_indices(index_name_by_type)
           define_schema do |s|
             define_indexed_type(s, "Person", index_name_by_type.fetch("Person"))

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
@@ -73,6 +73,7 @@ module ElasticGraph
               "Only one index per type is supported. An index named `#{@own_index_def.name}` has already been defined."
           end
 
+          schema_def_state.register_index(name, self)
           @own_index_def = schema_def_state.factory.new_index(name, settings, self, &block)
         end
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/state.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/state.rb
@@ -55,7 +55,8 @@ module ElasticGraph
       :type_namer,
       :enum_value_namer,
       :allow_omitted_json_schema_fields,
-      :allow_extra_json_schema_fields
+      :allow_extra_json_schema_fields,
+      :indexed_types_by_index_name
     )
       include Mixins::HasReadableToSAndInspect.new
 
@@ -106,7 +107,8 @@ module ElasticGraph
           enum_value_namer: SchemaElements::EnumValueNamer.new(enum_value_overrides_by_type),
           output: output,
           allow_omitted_json_schema_fields: false,
-          allow_extra_json_schema_fields: true
+          allow_extra_json_schema_fields: true,
+          indexed_types_by_index_name: {}
         )
       end
 
@@ -133,6 +135,13 @@ module ElasticGraph
 
       def register_input_type(type)
         register_type(type)
+      end
+
+      def register_index(name, type)
+        if (existing_type = indexed_types_by_index_name[name])
+          raise Errors::SchemaError, "Duplicate index name `#{name}` defined on `#{type.name}` and `#{existing_type.name}`. Each index can only be defined once."
+        end
+        indexed_types_by_index_name[name] = type
       end
 
       def register_renamed_type(type_name, from:, defined_at:, defined_via:)

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/state.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/state.rbs
@@ -32,6 +32,7 @@ module ElasticGraph
       attr_accessor output: io
       attr_accessor allow_omitted_json_schema_fields: bool
       attr_accessor allow_extra_json_schema_fields: bool
+      attr_accessor indexed_types_by_index_name: ::Hash[::String, indexableType]
 
       def initialize: (
         api: API,
@@ -65,6 +66,7 @@ module ElasticGraph
         output: io,
         allow_omitted_json_schema_fields: bool,
         allow_extra_json_schema_fields: bool,
+        indexed_types_by_index_name: ::Hash[::String, indexableType],
       ) -> void
     end
 
@@ -82,6 +84,7 @@ module ElasticGraph
       def index_document_sizes?: () -> bool
       def type_ref: (::String) -> SchemaElements::TypeReference
 
+      def register_index: (::String, indexableType) -> void
       def register_object_interface_or_union_type: (SchemaElements::ObjectType | SchemaElements::InterfaceType | SchemaElements::UnionType) -> void
       def register_enum_type: (SchemaElements::EnumType) -> void
       def register_scalar_type: (SchemaElements::ScalarType) -> void

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_overview_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_overview_spec.rb
@@ -143,6 +143,22 @@ module ElasticGraph
         }.to raise_error Errors::SchemaError, a_string_including("invalid index definition name", ROLLOVER_INDEX_INFIX_MARKER)
       end
 
+      it "raises an exception if two types are defined with the same index name" do
+        expect {
+          all_index_configs_for do |s|
+            s.object_type "Person" do |t|
+              t.field "id", "ID!"
+              t.index "widgets"
+            end
+
+            s.object_type "Widget" do |t|
+              t.field "id", "ID!"
+              t.index "widgets"
+            end
+          end
+        }.to raise_error(Errors::SchemaError, a_string_including("widgets", "Person", "Widget"))
+      end
+
       it "ignores interface types" do
         configs = all_index_configs_for do |s|
           s.interface_type "MyType" do |t|

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/object_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/object_type_spec.rb
@@ -529,7 +529,7 @@ module ElasticGraph
 
               schema.object_type "Component" do |t|
                 t.field "id", "ID!"
-                t.index "widgets"
+                t.index "components"
               end
             end
 

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/relay_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/relay_types_spec.rb
@@ -419,12 +419,12 @@ module ElasticGraph
           result = define_schema do |api|
             api.object_type "HighlightableWidget" do |t|
               t.field "id", "ID!", highlightable: true
-              t.index "widgets"
+              t.index "highlightable_widgets"
             end
 
             api.object_type "UnhighlightableWidget" do |t|
               t.field "id", "ID!", highlightable: false
-              t.index "widgets"
+              t.index "unhighlightable_widgets"
             end
           end
 

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/json_schema_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/json_schema_spec.rb
@@ -1442,7 +1442,7 @@ module ElasticGraph
               s.object_type "Component" do |t|
                 t.field "id", "ID"
                 t.field "created_on", "Etad"
-                t.index "widgets" do |i|
+                t.index "components" do |i|
                   i.rollover :monthly, "created_on"
                 end
               end
@@ -1450,7 +1450,7 @@ module ElasticGraph
               s.object_type "Part" do |t|
                 t.field "id", "ID"
                 t.field "created_at", "String"
-                t.index "widgets" do |i|
+                t.index "parts" do |i|
                   i.rollover :monthly, "created_at"
                 end
               end
@@ -2201,13 +2201,13 @@ module ElasticGraph
                 t.field "id", "ID!"
                 t.relates_to_one "parent", "MyTypeBothDirections!", via: "children_ids", dir: :in
                 t.relates_to_many "children", "MyTypeBothDirections", via: "children_ids", dir: :out, singular: "child"
-                t.index "my_type2"
+                t.index "my_type3"
               end
 
               s.object_type "MyTypeMany" do |t|
                 t.field "id", "ID!"
                 t.relates_to_many "children", "MyTypeMany", via: "parent_id", dir: :in, singular: "child"
-                t.index "my_type3"
+                t.index "my_type4"
               end
             end
 


### PR DESCRIPTION
With index inheritance on the horizon, the existing query-time check in `GraphQL::Schema#indexed_document_types_by_index_definition_name` would need to grow more complex to distinguish legitimate shared indexes (via inheritance) from accidental duplicates. Moving the check earlier — to `HasIndices#index` via `State#register_index` — keeps that complexity out of the graphql gem entirely and gives schema authors an immediate, clear error at schema definition time.

I pulled this change out from what I thought was going to be the last PR for Issue #1029 because I wanted to make this change first in a clear, dedicated PR. Did I miss something about why this duplicate index validation wasn't already in the schema_definition gem?