### PR TITLE
Add query-time __typename filtering and end-to-end tests for index inheritance

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -77,6 +77,11 @@ configure_local_rake_tasks = ->(tasks) do
       FactoryBot.build(:widget, components: widget_components, inventor: Faker::Base.sample(inventors))
     end)
 
+    batch.concat(Array.new(10) { FactoryBot.build(:online_store) })
+    batch.concat(Array.new(10) { FactoryBot.build(:physical_store) })
+    batch.concat(Array.new(10) { FactoryBot.build(:mobile_store) })
+    batch.concat(Array.new(10) { FactoryBot.build(:third_party_wholesale) })
+
     batch.concat(sponsors = Array.new(10) { FactoryBot.build(:sponsor) })
     batch.concat(Array.new(10) { FactoryBot.build(:team, sponsors: sponsors.sample(rand(3))) })
     batch

--- a/Rakefile
+++ b/Rakefile
@@ -79,7 +79,6 @@ configure_local_rake_tasks = ->(tasks) do
 
     batch.concat(Array.new(10) { FactoryBot.build(:online_store) })
     batch.concat(Array.new(10) { FactoryBot.build(:physical_store) })
-    batch.concat(Array.new(10) { FactoryBot.build(:mobile_store) })
     batch.concat(Array.new(10) { FactoryBot.build(:third_party_wholesale) })
 
     batch.concat(sponsors = Array.new(10) { FactoryBot.build(:sponsor) })

--- a/ai-memory/README.md
+++ b/ai-memory/README.md
@@ -301,6 +301,16 @@ The project is a monorepo composed of many gems. Each gem typically resides in i
     -   **Dependencies**: `elasticgraph-graphql`, `elasticgraph-indexer`, `elasticgraph-schema_artifacts`, `elasticgraph-support`, `graphql`, `graphql-c_parser`, `rake`.
     -   **Provides**: The schema definition framework and artifact generation capabilities.
 
+### Index Inheritance
+
+Abstract types (interfaces and unions) can declare an index that their concrete subtypes inherit, rather than each subtype declaring its own. Multiple concrete types then share a single datastore index. A subtype may still declare its own dedicated index, which overrides the inherited one — those documents are stored in a separate index and do not have `__typename` stored in them.
+
+**`__typename` injection (indexer)**: When a record is indexed into a shared (inherited) index, the indexer automatically injects `__typename` into the document so the datastore can distinguish between concrete types at query time.
+
+**Query-time scoping**: When an abstract type shares an index with types outside its subtype hierarchy, `QueryAdapter::AbstractTypeFilter` automatically injects an internal `__typename` filter scoped to the queried type's concrete subtypes.
+
+**Key files**: `schema_definition/indexing/index.rb`, `schema_definition/mixins/has_indices.rb`, `schema_definition/schema_elements/type_with_subfields.rb`, `indexer/record_preparer.rb`, `graphql/query_adapter/abstract_type_filter.rb`, `graphql/schema/type.rb`.
+
 ## Other Key Information
 
 This section highlights other important aspects of the ElasticGraph project:

--- a/config/schema/artifacts/data_warehouse.yaml
+++ b/config/schema/artifacts/data_warehouse.yaml
@@ -14,13 +14,6 @@ tables:
         shapes ARRAY<STRUCT<type STRING, coordinates ARRAY<FLOAT>>>,
         manufacturer_id STRING
       )
-  companies:
-    table_schema: |-
-      CREATE TABLE IF NOT EXISTS companies (
-        id STRING,
-        name STRING,
-        stock_ticker STRING
-      )
   components:
     table_schema: |-
       CREATE TABLE IF NOT EXISTS components (
@@ -38,6 +31,23 @@ tables:
         owner_ids ARRAY<STRING>,
         owner_id STRING
       )
+  distribution_channels:
+    table_schema: |-
+      CREATE TABLE IF NOT EXISTS distribution_channels (
+        id STRING,
+        url STRING,
+        platform STRING,
+        established_on DATE,
+        active BOOLEAN,
+        customer_facing BOOLEAN,
+        __typename STRING,
+        address STRING,
+        square_footage INT,
+        vehicle_type STRING,
+        current_location STRING,
+        partner_name STRING,
+        contract_terms STRING
+      )
   electrical_parts:
     table_schema: |-
       CREATE TABLE IF NOT EXISTS electrical_parts (
@@ -53,7 +63,7 @@ tables:
         id STRING,
         name STRING,
         created_at TIMESTAMP,
-        ceo STRUCT<id STRING, name STRING, nationality STRING>
+        ceo STRUCT<id STRING, name STRING, nationality STRING, __typename STRING>
       )
   mechanical_parts:
     table_schema: |-
@@ -64,12 +74,24 @@ tables:
         material STRING,
         manufacturer_id STRING
       )
-  people:
+  named_inventors:
     table_schema: |-
-      CREATE TABLE IF NOT EXISTS people (
+      CREATE TABLE IF NOT EXISTS named_inventors (
         id STRING,
         name STRING,
-        nationality STRING
+        nationality STRING,
+        __typename STRING,
+        stock_ticker STRING
+      )
+  physical_stores:
+    table_schema: |-
+      CREATE TABLE IF NOT EXISTS physical_stores (
+        id STRING,
+        address STRING,
+        square_footage INT,
+        established_on DATE,
+        active BOOLEAN,
+        customer_facing BOOLEAN
       )
   sponsors:
     table_schema: |-
@@ -142,8 +164,8 @@ tables:
         internal_details STRUCT<name STRING>,
         internal_highlightable_details STRUCT<name STRING>,
         the_opts STRUCT<size STRING, the_sighs STRING, color STRING, is_draft BOOLEAN>,
-        inventor STRUCT<id STRING, name STRING, nationality STRING, stock_ticker STRING, __typename STRING>,
-        named_inventor STRUCT<id STRING, name STRING, nationality STRING, stock_ticker STRING, __typename STRING>,
+        inventor STRUCT<id STRING, name STRING, nationality STRING, __typename STRING, stock_ticker STRING>,
+        named_inventor STRUCT<id STRING, name STRING, nationality STRING, __typename STRING, stock_ticker STRING>,
         weight_in_ng_str BIGINT,
         weight_in_ng BIGINT,
         tags ARRAY<STRING>,

--- a/config/schema/artifacts/data_warehouse.yaml
+++ b/config/schema/artifacts/data_warehouse.yaml
@@ -35,18 +35,9 @@ tables:
     table_schema: |-
       CREATE TABLE IF NOT EXISTS distribution_channels (
         id STRING,
-        url STRING,
-        platform STRING,
         established_on DATE,
         active BOOLEAN,
-        customer_facing BOOLEAN,
-        __typename STRING,
-        address STRING,
-        square_footage INT,
-        vehicle_type STRING,
-        current_location STRING,
-        partner_name STRING,
-        contract_terms STRING
+        __typename STRING
       )
   electrical_parts:
     table_schema: |-
@@ -87,11 +78,8 @@ tables:
     table_schema: |-
       CREATE TABLE IF NOT EXISTS physical_stores (
         id STRING,
-        address STRING,
-        square_footage INT,
         established_on DATE,
-        active BOOLEAN,
-        customer_facing BOOLEAN
+        active BOOLEAN
       )
   sponsors:
     table_schema: |-

--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -1601,29 +1601,11 @@ indices:
       properties:
         id:
           type: keyword
-        url:
-          type: keyword
-        platform:
-          type: keyword
         established_on:
           type: date
           format: strict_date
         active:
           type: boolean
-        customer_facing:
-          type: boolean
-        address:
-          type: keyword
-        square_footage:
-          type: integer
-        vehicle_type:
-          type: keyword
-        current_location:
-          type: keyword
-        partner_name:
-          type: keyword
-        contract_terms:
-          type: keyword
         __typename:
           type: keyword
         __sources:
@@ -1765,16 +1747,10 @@ indices:
       properties:
         id:
           type: keyword
-        address:
-          type: keyword
-        square_footage:
-          type: integer
         established_on:
           type: date
           format: strict_date
         active:
-          type: boolean
-        customer_facing:
           type: boolean
         __sources:
           type: keyword

--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -1531,30 +1531,6 @@ indices:
       index.number_of_replicas: 1
       index.number_of_shards: 1
       index.max_result_window: 10000
-  companies:
-    aliases: {}
-    mappings:
-      dynamic: strict
-      properties:
-        id:
-          type: keyword
-        name:
-          type: keyword
-        stock_ticker:
-          type: keyword
-        __sources:
-          type: keyword
-        __versions:
-          type: object
-          dynamic: 'false'
-      _size:
-        enabled: true
-    settings:
-      index.mapping.ignore_malformed: false
-      index.mapping.coerce: false
-      index.number_of_replicas: 1
-      index.number_of_shards: 1
-      index.max_result_window: 10000
   components:
     aliases: {}
     mappings:
@@ -1605,6 +1581,51 @@ indices:
               type: integer
             owner_ids:
               type: integer
+        __sources:
+          type: keyword
+        __versions:
+          type: object
+          dynamic: 'false'
+      _size:
+        enabled: true
+    settings:
+      index.mapping.ignore_malformed: false
+      index.mapping.coerce: false
+      index.number_of_replicas: 1
+      index.number_of_shards: 1
+      index.max_result_window: 10000
+  distribution_channels:
+    aliases: {}
+    mappings:
+      dynamic: strict
+      properties:
+        id:
+          type: keyword
+        url:
+          type: keyword
+        platform:
+          type: keyword
+        established_on:
+          type: date
+          format: strict_date
+        active:
+          type: boolean
+        customer_facing:
+          type: boolean
+        address:
+          type: keyword
+        square_footage:
+          type: integer
+        vehicle_type:
+          type: keyword
+        current_location:
+          type: keyword
+        partner_name:
+          type: keyword
+        contract_terms:
+          type: keyword
+        __typename:
+          type: keyword
         __sources:
           type: keyword
         __versions:
@@ -1709,7 +1730,7 @@ indices:
       index.number_of_replicas: 1
       index.number_of_shards: 1
       index.max_result_window: 10000
-  people:
+  named_inventors:
     aliases: {}
     mappings:
       dynamic: strict
@@ -1720,6 +1741,41 @@ indices:
           type: keyword
         nationality:
           type: keyword
+        stock_ticker:
+          type: keyword
+        __typename:
+          type: keyword
+        __sources:
+          type: keyword
+        __versions:
+          type: object
+          dynamic: 'false'
+      _size:
+        enabled: true
+    settings:
+      index.mapping.ignore_malformed: false
+      index.mapping.coerce: false
+      index.number_of_replicas: 1
+      index.number_of_shards: 1
+      index.max_result_window: 10000
+  physical_stores:
+    aliases: {}
+    mappings:
+      dynamic: strict
+      properties:
+        id:
+          type: keyword
+        address:
+          type: keyword
+        square_footage:
+          type: integer
+        established_on:
+          type: date
+          format: strict_date
+        active:
+          type: boolean
+        customer_facing:
+          type: boolean
         __sources:
           type: keyword
         __versions:

--- a/config/schema/artifacts/json_schemas.yaml
+++ b/config/schema/artifacts/json_schemas.yaml
@@ -28,7 +28,6 @@ json_schema_version: 1
         - ElectricalPart
         - Manufacturer
         - MechanicalPart
-        - MobileStore
         - OnlineStore
         - Person
         - PhysicalStore
@@ -425,46 +424,6 @@ json_schema_version: 1
     - created_at
     - material
     - manufacturer_id
-  MobileStore:
-    type: object
-    properties:
-      id:
-        allOf:
-        - "$ref": "#/$defs/ID"
-        - maxLength: 8191
-      vehicle_type:
-        allOf:
-        - "$ref": "#/$defs/String"
-        - maxLength: 8191
-      current_location:
-        anyOf:
-        - allOf:
-          - "$ref": "#/$defs/String"
-          - maxLength: 8191
-        - type: 'null'
-      established_on:
-        anyOf:
-        - "$ref": "#/$defs/Date"
-        - type: 'null'
-      active:
-        anyOf:
-        - "$ref": "#/$defs/Boolean"
-        - type: 'null'
-      customer_facing:
-        anyOf:
-        - "$ref": "#/$defs/Boolean"
-        - type: 'null'
-      __typename:
-        type: string
-        const: MobileStore
-        default: MobileStore
-    required:
-    - id
-    - vehicle_type
-    - current_location
-    - established_on
-    - active
-    - customer_facing
   Money:
     type: object
     properties:
@@ -496,25 +455,11 @@ json_schema_version: 1
         allOf:
         - "$ref": "#/$defs/ID"
         - maxLength: 8191
-      url:
-        allOf:
-        - "$ref": "#/$defs/String"
-        - maxLength: 8191
-      platform:
-        anyOf:
-        - allOf:
-          - "$ref": "#/$defs/String"
-          - maxLength: 8191
-        - type: 'null'
       established_on:
         anyOf:
         - "$ref": "#/$defs/Date"
         - type: 'null'
       active:
-        anyOf:
-        - "$ref": "#/$defs/Boolean"
-        - type: 'null'
-      customer_facing:
         anyOf:
         - "$ref": "#/$defs/Boolean"
         - type: 'null'
@@ -524,11 +469,8 @@ json_schema_version: 1
         default: OnlineStore
     required:
     - id
-    - url
-    - platform
     - established_on
     - active
-    - customer_facing
   Person:
     type: object
     properties:
@@ -563,23 +505,11 @@ json_schema_version: 1
         allOf:
         - "$ref": "#/$defs/ID"
         - maxLength: 8191
-      address:
-        allOf:
-        - "$ref": "#/$defs/String"
-        - maxLength: 8191
-      square_footage:
-        anyOf:
-        - "$ref": "#/$defs/Int"
-        - type: 'null'
       established_on:
         anyOf:
         - "$ref": "#/$defs/Date"
         - type: 'null'
       active:
-        anyOf:
-        - "$ref": "#/$defs/Boolean"
-        - type: 'null'
-      customer_facing:
         anyOf:
         - "$ref": "#/$defs/Boolean"
         - type: 'null'
@@ -589,11 +519,8 @@ json_schema_version: 1
         default: PhysicalStore
     required:
     - id
-    - address
-    - square_footage
     - established_on
     - active
-    - customer_facing
   Player:
     type: object
     properties:
@@ -952,18 +879,6 @@ json_schema_version: 1
         anyOf:
         - "$ref": "#/$defs/Boolean"
         - type: 'null'
-      partner_name:
-        anyOf:
-        - allOf:
-          - "$ref": "#/$defs/String"
-          - maxLength: 8191
-        - type: 'null'
-      contract_terms:
-        anyOf:
-        - allOf:
-          - "$ref": "#/$defs/String"
-          - maxLength: 8191
-        - type: 'null'
       __typename:
         type: string
         const: ThirdPartyWholesale
@@ -971,8 +886,6 @@ json_schema_version: 1
     required:
     - id
     - active
-    - partner_name
-    - contract_terms
   Untyped:
     type:
     - array

--- a/config/schema/artifacts/json_schemas.yaml
+++ b/config/schema/artifacts/json_schemas.yaml
@@ -28,9 +28,13 @@ json_schema_version: 1
         - ElectricalPart
         - Manufacturer
         - MechanicalPart
+        - MobileStore
+        - OnlineStore
         - Person
+        - PhysicalStore
         - Sponsor
         - Team
+        - ThirdPartyWholesale
         - Widget
         - WidgetWorkspace
       id:
@@ -421,6 +425,46 @@ json_schema_version: 1
     - created_at
     - material
     - manufacturer_id
+  MobileStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+      vehicle_type:
+        allOf:
+        - "$ref": "#/$defs/String"
+        - maxLength: 8191
+      current_location:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      customer_facing:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      __typename:
+        type: string
+        const: MobileStore
+        default: MobileStore
+    required:
+    - id
+    - vehicle_type
+    - current_location
+    - established_on
+    - active
+    - customer_facing
   Money:
     type: object
     properties:
@@ -445,6 +489,46 @@ json_schema_version: 1
     oneOf:
     - "$ref": "#/$defs/Person"
     - "$ref": "#/$defs/Company"
+  OnlineStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+      url:
+        allOf:
+        - "$ref": "#/$defs/String"
+        - maxLength: 8191
+      platform:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      customer_facing:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      __typename:
+        type: string
+        const: OnlineStore
+        default: OnlineStore
+    required:
+    - id
+    - url
+    - platform
+    - established_on
+    - active
+    - customer_facing
   Person:
     type: object
     properties:
@@ -472,6 +556,44 @@ json_schema_version: 1
     - id
     - name
     - nationality
+  PhysicalStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+      address:
+        allOf:
+        - "$ref": "#/$defs/String"
+        - maxLength: 8191
+      square_footage:
+        anyOf:
+        - "$ref": "#/$defs/Int"
+        - type: 'null'
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      customer_facing:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      __typename:
+        type: string
+        const: PhysicalStore
+        default: PhysicalStore
+    required:
+    - id
+    - address
+    - square_footage
+    - established_on
+    - active
+    - customer_facing
   Player:
     type: object
     properties:
@@ -819,6 +941,38 @@ json_schema_version: 1
     - was_shortened
     - players_nested
     - players_object
+  ThirdPartyWholesale:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      partner_name:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+      contract_terms:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+      __typename:
+        type: string
+        const: ThirdPartyWholesale
+        default: ThirdPartyWholesale
+    required:
+    - id
+    - active
+    - partner_name
+    - contract_terms
   Untyped:
     type:
     - array

--- a/config/schema/artifacts/json_schemas_by_version/v1.yaml
+++ b/config/schema/artifacts/json_schemas_by_version/v1.yaml
@@ -28,9 +28,13 @@ json_schema_version: 1
         - ElectricalPart
         - Manufacturer
         - MechanicalPart
+        - MobileStore
+        - OnlineStore
         - Person
+        - PhysicalStore
         - Sponsor
         - Team
+        - ThirdPartyWholesale
         - Widget
         - WidgetWorkspace
       id:
@@ -535,6 +539,64 @@ json_schema_version: 1
     - created_at
     - material
     - manufacturer_id
+  MobileStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+        ElasticGraph:
+          type: ID!
+          nameInIndex: id
+      vehicle_type:
+        allOf:
+        - "$ref": "#/$defs/String"
+        - maxLength: 8191
+        ElasticGraph:
+          type: String!
+          nameInIndex: vehicle_type
+      current_location:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+        ElasticGraph:
+          type: String
+          nameInIndex: current_location
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+        ElasticGraph:
+          type: Date
+          nameInIndex: established_on
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: active
+      customer_facing:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: customer_facing
+      __typename:
+        type: string
+        const: MobileStore
+        default: MobileStore
+    required:
+    - id
+    - vehicle_type
+    - current_location
+    - established_on
+    - active
+    - customer_facing
   Money:
     type: object
     properties:
@@ -565,6 +627,64 @@ json_schema_version: 1
     oneOf:
     - "$ref": "#/$defs/Person"
     - "$ref": "#/$defs/Company"
+  OnlineStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+        ElasticGraph:
+          type: ID!
+          nameInIndex: id
+      url:
+        allOf:
+        - "$ref": "#/$defs/String"
+        - maxLength: 8191
+        ElasticGraph:
+          type: String!
+          nameInIndex: url
+      platform:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+        ElasticGraph:
+          type: String
+          nameInIndex: platform
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+        ElasticGraph:
+          type: Date
+          nameInIndex: established_on
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: active
+      customer_facing:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: customer_facing
+      __typename:
+        type: string
+        const: OnlineStore
+        default: OnlineStore
+    required:
+    - id
+    - url
+    - platform
+    - established_on
+    - active
+    - customer_facing
   Person:
     type: object
     properties:
@@ -601,6 +721,62 @@ json_schema_version: 1
     - id
     - name
     - nationality
+  PhysicalStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+        ElasticGraph:
+          type: ID!
+          nameInIndex: id
+      address:
+        allOf:
+        - "$ref": "#/$defs/String"
+        - maxLength: 8191
+        ElasticGraph:
+          type: String!
+          nameInIndex: address
+      square_footage:
+        anyOf:
+        - "$ref": "#/$defs/Int"
+        - type: 'null'
+        ElasticGraph:
+          type: Int
+          nameInIndex: square_footage
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+        ElasticGraph:
+          type: Date
+          nameInIndex: established_on
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: active
+      customer_facing:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: customer_facing
+      __typename:
+        type: string
+        const: PhysicalStore
+        default: PhysicalStore
+    required:
+    - id
+    - address
+    - square_footage
+    - established_on
+    - active
+    - customer_facing
   Player:
     type: object
     properties:
@@ -1098,6 +1274,50 @@ json_schema_version: 1
     - was_shortened
     - players_nested
     - players_object
+  ThirdPartyWholesale:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+        ElasticGraph:
+          type: ID!
+          nameInIndex: id
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: active
+      partner_name:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+        ElasticGraph:
+          type: String
+          nameInIndex: partner_name
+      contract_terms:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+        ElasticGraph:
+          type: String
+          nameInIndex: contract_terms
+      __typename:
+        type: string
+        const: ThirdPartyWholesale
+        default: ThirdPartyWholesale
+    required:
+    - id
+    - active
+    - partner_name
+    - contract_terms
   Untyped:
     type:
     - array

--- a/config/schema/artifacts/json_schemas_by_version/v1.yaml
+++ b/config/schema/artifacts/json_schemas_by_version/v1.yaml
@@ -28,7 +28,6 @@ json_schema_version: 1
         - ElectricalPart
         - Manufacturer
         - MechanicalPart
-        - MobileStore
         - OnlineStore
         - Person
         - PhysicalStore
@@ -539,64 +538,6 @@ json_schema_version: 1
     - created_at
     - material
     - manufacturer_id
-  MobileStore:
-    type: object
-    properties:
-      id:
-        allOf:
-        - "$ref": "#/$defs/ID"
-        - maxLength: 8191
-        ElasticGraph:
-          type: ID!
-          nameInIndex: id
-      vehicle_type:
-        allOf:
-        - "$ref": "#/$defs/String"
-        - maxLength: 8191
-        ElasticGraph:
-          type: String!
-          nameInIndex: vehicle_type
-      current_location:
-        anyOf:
-        - allOf:
-          - "$ref": "#/$defs/String"
-          - maxLength: 8191
-        - type: 'null'
-        ElasticGraph:
-          type: String
-          nameInIndex: current_location
-      established_on:
-        anyOf:
-        - "$ref": "#/$defs/Date"
-        - type: 'null'
-        ElasticGraph:
-          type: Date
-          nameInIndex: established_on
-      active:
-        anyOf:
-        - "$ref": "#/$defs/Boolean"
-        - type: 'null'
-        ElasticGraph:
-          type: Boolean
-          nameInIndex: active
-      customer_facing:
-        anyOf:
-        - "$ref": "#/$defs/Boolean"
-        - type: 'null'
-        ElasticGraph:
-          type: Boolean
-          nameInIndex: customer_facing
-      __typename:
-        type: string
-        const: MobileStore
-        default: MobileStore
-    required:
-    - id
-    - vehicle_type
-    - current_location
-    - established_on
-    - active
-    - customer_facing
   Money:
     type: object
     properties:
@@ -637,22 +578,6 @@ json_schema_version: 1
         ElasticGraph:
           type: ID!
           nameInIndex: id
-      url:
-        allOf:
-        - "$ref": "#/$defs/String"
-        - maxLength: 8191
-        ElasticGraph:
-          type: String!
-          nameInIndex: url
-      platform:
-        anyOf:
-        - allOf:
-          - "$ref": "#/$defs/String"
-          - maxLength: 8191
-        - type: 'null'
-        ElasticGraph:
-          type: String
-          nameInIndex: platform
       established_on:
         anyOf:
         - "$ref": "#/$defs/Date"
@@ -667,24 +592,14 @@ json_schema_version: 1
         ElasticGraph:
           type: Boolean
           nameInIndex: active
-      customer_facing:
-        anyOf:
-        - "$ref": "#/$defs/Boolean"
-        - type: 'null'
-        ElasticGraph:
-          type: Boolean
-          nameInIndex: customer_facing
       __typename:
         type: string
         const: OnlineStore
         default: OnlineStore
     required:
     - id
-    - url
-    - platform
     - established_on
     - active
-    - customer_facing
   Person:
     type: object
     properties:
@@ -731,20 +646,6 @@ json_schema_version: 1
         ElasticGraph:
           type: ID!
           nameInIndex: id
-      address:
-        allOf:
-        - "$ref": "#/$defs/String"
-        - maxLength: 8191
-        ElasticGraph:
-          type: String!
-          nameInIndex: address
-      square_footage:
-        anyOf:
-        - "$ref": "#/$defs/Int"
-        - type: 'null'
-        ElasticGraph:
-          type: Int
-          nameInIndex: square_footage
       established_on:
         anyOf:
         - "$ref": "#/$defs/Date"
@@ -759,24 +660,14 @@ json_schema_version: 1
         ElasticGraph:
           type: Boolean
           nameInIndex: active
-      customer_facing:
-        anyOf:
-        - "$ref": "#/$defs/Boolean"
-        - type: 'null'
-        ElasticGraph:
-          type: Boolean
-          nameInIndex: customer_facing
       __typename:
         type: string
         const: PhysicalStore
         default: PhysicalStore
     required:
     - id
-    - address
-    - square_footage
     - established_on
     - active
-    - customer_facing
   Player:
     type: object
     properties:
@@ -1291,24 +1182,6 @@ json_schema_version: 1
         ElasticGraph:
           type: Boolean
           nameInIndex: active
-      partner_name:
-        anyOf:
-        - allOf:
-          - "$ref": "#/$defs/String"
-          - maxLength: 8191
-        - type: 'null'
-        ElasticGraph:
-          type: String
-          nameInIndex: partner_name
-      contract_terms:
-        anyOf:
-        - allOf:
-          - "$ref": "#/$defs/String"
-          - maxLength: 8191
-        - type: 'null'
-        ElasticGraph:
-          type: String
-          nameInIndex: contract_terms
       __typename:
         type: string
         const: ThirdPartyWholesale
@@ -1316,8 +1189,6 @@ json_schema_version: 1
     required:
     - id
     - active
-    - partner_name
-    - contract_terms
   Untyped:
     type:
     - array

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -177,30 +177,6 @@ enum_types_by_name:
         datastore_abbreviation: yd
   DistributionChannelSortOrderInput:
     values_by_name:
-      address_ASC:
-        sort_field:
-          direction: asc
-          field_path: address
-      address_DESC:
-        sort_field:
-          direction: desc
-          field_path: address
-      contract_terms_ASC:
-        sort_field:
-          direction: asc
-          field_path: contract_terms
-      contract_terms_DESC:
-        sort_field:
-          direction: desc
-          field_path: contract_terms
-      current_location_ASC:
-        sort_field:
-          direction: asc
-          field_path: current_location
-      current_location_DESC:
-        sort_field:
-          direction: desc
-          field_path: current_location
       established_on_ASC:
         sort_field:
           direction: asc
@@ -217,46 +193,6 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: id
-      partner_name_ASC:
-        sort_field:
-          direction: asc
-          field_path: partner_name
-      partner_name_DESC:
-        sort_field:
-          direction: desc
-          field_path: partner_name
-      platform_ASC:
-        sort_field:
-          direction: asc
-          field_path: platform
-      platform_DESC:
-        sort_field:
-          direction: desc
-          field_path: platform
-      square_footage_ASC:
-        sort_field:
-          direction: asc
-          field_path: square_footage
-      square_footage_DESC:
-        sort_field:
-          direction: desc
-          field_path: square_footage
-      url_ASC:
-        sort_field:
-          direction: asc
-          field_path: url
-      url_DESC:
-        sort_field:
-          direction: desc
-          field_path: url
-      vehicle_type_ASC:
-        sort_field:
-          direction: asc
-          field_path: vehicle_type
-      vehicle_type_DESC:
-        sort_field:
-          direction: desc
-          field_path: vehicle_type
   ElectricalPartSortOrderInput:
     values_by_name:
       created_at_ASC:
@@ -929,14 +865,6 @@ enum_types_by_name:
           field_path: voltage
   PhysicalStoreSortOrderInput:
     values_by_name:
-      address_ASC:
-        sort_field:
-          direction: asc
-          field_path: address
-      address_DESC:
-        sort_field:
-          direction: desc
-          field_path: address
       established_on_ASC:
         sort_field:
           direction: asc
@@ -953,32 +881,8 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: id
-      square_footage_ASC:
-        sort_field:
-          direction: asc
-          field_path: square_footage
-      square_footage_DESC:
-        sort_field:
-          direction: desc
-          field_path: square_footage
   RetailSortOrderInput:
     values_by_name:
-      address_ASC:
-        sort_field:
-          direction: asc
-          field_path: address
-      address_DESC:
-        sort_field:
-          direction: desc
-          field_path: address
-      current_location_ASC:
-        sort_field:
-          direction: asc
-          field_path: current_location
-      current_location_DESC:
-        sort_field:
-          direction: desc
-          field_path: current_location
       established_on_ASC:
         sort_field:
           direction: asc
@@ -995,38 +899,6 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: id
-      platform_ASC:
-        sort_field:
-          direction: asc
-          field_path: platform
-      platform_DESC:
-        sort_field:
-          direction: desc
-          field_path: platform
-      square_footage_ASC:
-        sort_field:
-          direction: asc
-          field_path: square_footage
-      square_footage_DESC:
-        sort_field:
-          direction: desc
-          field_path: square_footage
-      url_ASC:
-        sort_field:
-          direction: asc
-          field_path: url
-      url_DESC:
-        sort_field:
-          direction: desc
-          field_path: url
-      vehicle_type_ASC:
-        sort_field:
-          direction: asc
-          field_path: vehicle_type
-      vehicle_type_DESC:
-        sort_field:
-          direction: desc
-          field_path: vehicle_type
   SponsorSortOrderInput:
     values_by_name:
       id_ASC:
@@ -1047,22 +919,6 @@ enum_types_by_name:
           field_path: name
   StoreSortOrderInput:
     values_by_name:
-      address_ASC:
-        sort_field:
-          direction: asc
-          field_path: address
-      address_DESC:
-        sort_field:
-          direction: desc
-          field_path: address
-      current_location_ASC:
-        sort_field:
-          direction: asc
-          field_path: current_location
-      current_location_DESC:
-        sort_field:
-          direction: desc
-          field_path: current_location
       established_on_ASC:
         sort_field:
           direction: asc
@@ -1079,38 +935,6 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: id
-      platform_ASC:
-        sort_field:
-          direction: asc
-          field_path: platform
-      platform_DESC:
-        sort_field:
-          direction: desc
-          field_path: platform
-      square_footage_ASC:
-        sort_field:
-          direction: asc
-          field_path: square_footage
-      square_footage_DESC:
-        sort_field:
-          direction: desc
-          field_path: square_footage
-      url_ASC:
-        sort_field:
-          direction: asc
-          field_path: url
-      url_DESC:
-        sort_field:
-          direction: desc
-          field_path: url
-      vehicle_type_ASC:
-        sort_field:
-          direction: asc
-          field_path: vehicle_type
-      vehicle_type_DESC:
-        sort_field:
-          direction: desc
-          field_path: vehicle_type
   TeamSortOrderInput:
     values_by_name:
       country_code_ASC:
@@ -2024,27 +1848,9 @@ index_definitions_by_name:
     fields_by_path:
       active:
         source: __self
-      address:
-        source: __self
-      contract_terms:
-        source: __self
-      current_location:
-        source: __self
-      customer_facing:
-        source: __self
       established_on:
         source: __self
       id:
-        source: __self
-      partner_name:
-        source: __self
-      platform:
-        source: __self
-      square_footage:
-        source: __self
-      url:
-        source: __self
-      vehicle_type:
         source: __self
     route_with: id
   electrical_parts:
@@ -2122,15 +1928,9 @@ index_definitions_by_name:
     fields_by_path:
       active:
         source: __self
-      address:
-        source: __self
-      customer_facing:
-        source: __self
       established_on:
         source: __self
       id:
-        source: __self
-      square_footage:
         source: __self
     route_with: id
   sponsors:
@@ -3831,37 +3631,10 @@ object_types_by_name:
       active:
         resolver:
           name: get_record_field_value
-      address:
-        resolver:
-          name: get_record_field_value
-      contract_terms:
-        resolver:
-          name: get_record_field_value
-      current_location:
-        resolver:
-          name: get_record_field_value
-      customer_facing:
-        resolver:
-          name: get_record_field_value
       established_on:
         resolver:
           name: get_record_field_value
       id:
-        resolver:
-          name: get_record_field_value
-      partner_name:
-        resolver:
-          name: get_record_field_value
-      platform:
-        resolver:
-          name: get_record_field_value
-      square_footage:
-        resolver:
-          name: get_record_field_value
-      url:
-        resolver:
-          name: get_record_field_value
-      vehicle_type:
         resolver:
           name: get_record_field_value
     index_definition_names:
@@ -3871,37 +3644,10 @@ object_types_by_name:
       active:
         resolver:
           name: object_with_lookahead
-      address:
-        resolver:
-          name: object_with_lookahead
-      contract_terms:
-        resolver:
-          name: object_with_lookahead
-      current_location:
-        resolver:
-          name: object_with_lookahead
-      customer_facing:
-        resolver:
-          name: object_with_lookahead
       established_on:
         resolver:
           name: object_with_lookahead
       id:
-        resolver:
-          name: object_with_lookahead
-      partner_name:
-        resolver:
-          name: object_with_lookahead
-      platform:
-        resolver:
-          name: object_with_lookahead
-      square_footage:
-        resolver:
-          name: object_with_lookahead
-      url:
-        resolver:
-          name: object_with_lookahead
-      vehicle_type:
         resolver:
           name: object_with_lookahead
   DistributionChannelAggregation:
@@ -3973,60 +3719,12 @@ object_types_by_name:
       active:
         resolver:
           name: object_with_lookahead
-      address:
-        resolver:
-          name: object_with_lookahead
-      contract_terms:
-        resolver:
-          name: object_with_lookahead
-      current_location:
-        resolver:
-          name: object_with_lookahead
-      customer_facing:
-        resolver:
-          name: object_with_lookahead
       established_on:
-        resolver:
-          name: object_with_lookahead
-      partner_name:
-        resolver:
-          name: object_with_lookahead
-      platform:
-        resolver:
-          name: object_with_lookahead
-      square_footage:
-        resolver:
-          name: object_with_lookahead
-      url:
-        resolver:
-          name: object_with_lookahead
-      vehicle_type:
         resolver:
           name: object_with_lookahead
   DistributionChannelHighlights:
     graphql_fields_by_name:
-      address:
-        resolver:
-          name: get_record_field_value
-      contract_terms:
-        resolver:
-          name: get_record_field_value
-      current_location:
-        resolver:
-          name: get_record_field_value
       id:
-        resolver:
-          name: get_record_field_value
-      partner_name:
-        resolver:
-          name: get_record_field_value
-      platform:
-        resolver:
-          name: get_record_field_value
-      url:
-        resolver:
-          name: get_record_field_value
-      vehicle_type:
         resolver:
           name: get_record_field_value
   ElectricalPart:
@@ -4828,58 +4526,6 @@ object_types_by_name:
       name:
         resolver:
           name: get_record_field_value
-  MobileStore:
-    graphql_fields_by_name:
-      active:
-        resolver:
-          name: get_record_field_value
-      current_location:
-        resolver:
-          name: get_record_field_value
-      customer_facing:
-        resolver:
-          name: get_record_field_value
-      established_on:
-        resolver:
-          name: get_record_field_value
-      id:
-        resolver:
-          name: get_record_field_value
-      vehicle_type:
-        resolver:
-          name: get_record_field_value
-    index_definition_names:
-    - distribution_channels
-    update_targets:
-    - data_params:
-        __typename:
-          cardinality: one
-        active:
-          cardinality: one
-        current_location:
-          cardinality: one
-        customer_facing:
-          cardinality: one
-        established_on:
-          cardinality: one
-        vehicle_type:
-          cardinality: one
-      id_source: id
-      metadata_params:
-        relationship:
-          value: __self
-        sourceId:
-          cardinality: one
-          source_path: id
-        sourceType:
-          cardinality: one
-          source_path: type
-        version:
-          cardinality: one
-      relationship: __self
-      routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
-      type: MobileStore
   Money:
     graphql_fields_by_name:
       amount_cents:
@@ -5704,19 +5350,10 @@ object_types_by_name:
       active:
         resolver:
           name: get_record_field_value
-      customer_facing:
-        resolver:
-          name: get_record_field_value
       established_on:
         resolver:
           name: get_record_field_value
       id:
-        resolver:
-          name: get_record_field_value
-      platform:
-        resolver:
-          name: get_record_field_value
-      url:
         resolver:
           name: get_record_field_value
     index_definition_names:
@@ -5727,13 +5364,7 @@ object_types_by_name:
           cardinality: one
         active:
           cardinality: one
-        customer_facing:
-          cardinality: one
         established_on:
-          cardinality: one
-        platform:
-          cardinality: one
-        url:
           cardinality: one
       id_source: id
       metadata_params:
@@ -5979,19 +5610,10 @@ object_types_by_name:
       active:
         resolver:
           name: get_record_field_value
-      address:
-        resolver:
-          name: get_record_field_value
-      customer_facing:
-        resolver:
-          name: get_record_field_value
       established_on:
         resolver:
           name: get_record_field_value
       id:
-        resolver:
-          name: get_record_field_value
-      square_footage:
         resolver:
           name: get_record_field_value
     index_definition_names:
@@ -6000,13 +5622,7 @@ object_types_by_name:
     - data_params:
         active:
           cardinality: one
-        address:
-          cardinality: one
-        customer_facing:
-          cardinality: one
         established_on:
-          cardinality: one
-        square_footage:
           cardinality: one
       id_source: id
       metadata_params:
@@ -6029,19 +5645,10 @@ object_types_by_name:
       active:
         resolver:
           name: object_with_lookahead
-      address:
-        resolver:
-          name: object_with_lookahead
-      customer_facing:
-        resolver:
-          name: object_with_lookahead
       established_on:
         resolver:
           name: object_with_lookahead
       id:
-        resolver:
-          name: object_with_lookahead
-      square_footage:
         resolver:
           name: object_with_lookahead
   PhysicalStoreAggregation:
@@ -6113,23 +5720,11 @@ object_types_by_name:
       active:
         resolver:
           name: object_with_lookahead
-      address:
-        resolver:
-          name: object_with_lookahead
-      customer_facing:
-        resolver:
-          name: object_with_lookahead
       established_on:
-        resolver:
-          name: object_with_lookahead
-      square_footage:
         resolver:
           name: object_with_lookahead
   PhysicalStoreHighlights:
     graphql_fields_by_name:
-      address:
-        resolver:
-          name: get_record_field_value
       id:
         resolver:
           name: get_record_field_value
@@ -6388,31 +5983,10 @@ object_types_by_name:
       active:
         resolver:
           name: get_record_field_value
-      address:
-        resolver:
-          name: get_record_field_value
-      current_location:
-        resolver:
-          name: get_record_field_value
-      customer_facing:
-        resolver:
-          name: get_record_field_value
       established_on:
         resolver:
           name: get_record_field_value
       id:
-        resolver:
-          name: get_record_field_value
-      platform:
-        resolver:
-          name: get_record_field_value
-      square_footage:
-        resolver:
-          name: get_record_field_value
-      url:
-        resolver:
-          name: get_record_field_value
-      vehicle_type:
         resolver:
           name: get_record_field_value
     index_definition_names:
@@ -6422,31 +5996,10 @@ object_types_by_name:
       active:
         resolver:
           name: object_with_lookahead
-      address:
-        resolver:
-          name: object_with_lookahead
-      current_location:
-        resolver:
-          name: object_with_lookahead
-      customer_facing:
-        resolver:
-          name: object_with_lookahead
       established_on:
         resolver:
           name: object_with_lookahead
       id:
-        resolver:
-          name: object_with_lookahead
-      platform:
-        resolver:
-          name: object_with_lookahead
-      square_footage:
-        resolver:
-          name: object_with_lookahead
-      url:
-        resolver:
-          name: object_with_lookahead
-      vehicle_type:
         resolver:
           name: object_with_lookahead
   RetailAggregation:
@@ -6518,48 +6071,12 @@ object_types_by_name:
       active:
         resolver:
           name: object_with_lookahead
-      address:
-        resolver:
-          name: object_with_lookahead
-      current_location:
-        resolver:
-          name: object_with_lookahead
-      customer_facing:
-        resolver:
-          name: object_with_lookahead
       established_on:
-        resolver:
-          name: object_with_lookahead
-      platform:
-        resolver:
-          name: object_with_lookahead
-      square_footage:
-        resolver:
-          name: object_with_lookahead
-      url:
-        resolver:
-          name: object_with_lookahead
-      vehicle_type:
         resolver:
           name: object_with_lookahead
   RetailHighlights:
     graphql_fields_by_name:
-      address:
-        resolver:
-          name: get_record_field_value
-      current_location:
-        resolver:
-          name: get_record_field_value
       id:
-        resolver:
-          name: get_record_field_value
-      platform:
-        resolver:
-          name: get_record_field_value
-      url:
-        resolver:
-          name: get_record_field_value
-      vehicle_type:
         resolver:
           name: get_record_field_value
   SearchHighlight:
@@ -6765,31 +6282,10 @@ object_types_by_name:
       active:
         resolver:
           name: get_record_field_value
-      address:
-        resolver:
-          name: get_record_field_value
-      current_location:
-        resolver:
-          name: get_record_field_value
-      customer_facing:
-        resolver:
-          name: get_record_field_value
       established_on:
         resolver:
           name: get_record_field_value
       id:
-        resolver:
-          name: get_record_field_value
-      platform:
-        resolver:
-          name: get_record_field_value
-      square_footage:
-        resolver:
-          name: get_record_field_value
-      url:
-        resolver:
-          name: get_record_field_value
-      vehicle_type:
         resolver:
           name: get_record_field_value
     index_definition_names:
@@ -6799,31 +6295,10 @@ object_types_by_name:
       active:
         resolver:
           name: object_with_lookahead
-      address:
-        resolver:
-          name: object_with_lookahead
-      current_location:
-        resolver:
-          name: object_with_lookahead
-      customer_facing:
-        resolver:
-          name: object_with_lookahead
       established_on:
         resolver:
           name: object_with_lookahead
       id:
-        resolver:
-          name: object_with_lookahead
-      platform:
-        resolver:
-          name: object_with_lookahead
-      square_footage:
-        resolver:
-          name: object_with_lookahead
-      url:
-        resolver:
-          name: object_with_lookahead
-      vehicle_type:
         resolver:
           name: object_with_lookahead
   StoreAggregation:
@@ -6895,48 +6370,12 @@ object_types_by_name:
       active:
         resolver:
           name: object_with_lookahead
-      address:
-        resolver:
-          name: object_with_lookahead
-      current_location:
-        resolver:
-          name: object_with_lookahead
-      customer_facing:
-        resolver:
-          name: object_with_lookahead
       established_on:
-        resolver:
-          name: object_with_lookahead
-      platform:
-        resolver:
-          name: object_with_lookahead
-      square_footage:
-        resolver:
-          name: object_with_lookahead
-      url:
-        resolver:
-          name: object_with_lookahead
-      vehicle_type:
         resolver:
           name: object_with_lookahead
   StoreHighlights:
     graphql_fields_by_name:
-      address:
-        resolver:
-          name: get_record_field_value
-      current_location:
-        resolver:
-          name: get_record_field_value
       id:
-        resolver:
-          name: get_record_field_value
-      platform:
-        resolver:
-          name: get_record_field_value
-      url:
-        resolver:
-          name: get_record_field_value
-      vehicle_type:
         resolver:
           name: get_record_field_value
   StringConnection:
@@ -7877,13 +7316,7 @@ object_types_by_name:
       active:
         resolver:
           name: get_record_field_value
-      contract_terms:
-        resolver:
-          name: get_record_field_value
       id:
-        resolver:
-          name: get_record_field_value
-      partner_name:
         resolver:
           name: get_record_field_value
     index_definition_names:
@@ -7893,10 +7326,6 @@ object_types_by_name:
         __typename:
           cardinality: one
         active:
-          cardinality: one
-        contract_terms:
-          cardinality: one
-        partner_name:
           cardinality: one
       id_source: id
       metadata_params:

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -21,32 +21,6 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: timestamps.created_at
-  CompanySortOrderInput:
-    values_by_name:
-      id_ASC:
-        sort_field:
-          direction: asc
-          field_path: id
-      id_DESC:
-        sort_field:
-          direction: desc
-          field_path: id
-      name_ASC:
-        sort_field:
-          direction: asc
-          field_path: name
-      name_DESC:
-        sort_field:
-          direction: desc
-          field_path: name
-      stock_ticker_ASC:
-        sort_field:
-          direction: asc
-          field_path: stock_ticker
-      stock_ticker_DESC:
-        sort_field:
-          direction: desc
-          field_path: stock_ticker
   ComponentSortOrderInput:
     values_by_name:
       created_at_ASC:
@@ -201,6 +175,88 @@ enum_types_by_name:
         datastore_abbreviation: nmi
       YARD:
         datastore_abbreviation: yd
+  DistributionChannelSortOrderInput:
+    values_by_name:
+      address_ASC:
+        sort_field:
+          direction: asc
+          field_path: address
+      address_DESC:
+        sort_field:
+          direction: desc
+          field_path: address
+      contract_terms_ASC:
+        sort_field:
+          direction: asc
+          field_path: contract_terms
+      contract_terms_DESC:
+        sort_field:
+          direction: desc
+          field_path: contract_terms
+      current_location_ASC:
+        sort_field:
+          direction: asc
+          field_path: current_location
+      current_location_DESC:
+        sort_field:
+          direction: desc
+          field_path: current_location
+      established_on_ASC:
+        sort_field:
+          direction: asc
+          field_path: established_on
+      established_on_DESC:
+        sort_field:
+          direction: desc
+          field_path: established_on
+      id_ASC:
+        sort_field:
+          direction: asc
+          field_path: id
+      id_DESC:
+        sort_field:
+          direction: desc
+          field_path: id
+      partner_name_ASC:
+        sort_field:
+          direction: asc
+          field_path: partner_name
+      partner_name_DESC:
+        sort_field:
+          direction: desc
+          field_path: partner_name
+      platform_ASC:
+        sort_field:
+          direction: asc
+          field_path: platform
+      platform_DESC:
+        sort_field:
+          direction: desc
+          field_path: platform
+      square_footage_ASC:
+        sort_field:
+          direction: asc
+          field_path: square_footage
+      square_footage_DESC:
+        sort_field:
+          direction: desc
+          field_path: square_footage
+      url_ASC:
+        sort_field:
+          direction: asc
+          field_path: url
+      url_DESC:
+        sort_field:
+          direction: desc
+          field_path: url
+      vehicle_type_ASC:
+        sort_field:
+          direction: asc
+          field_path: vehicle_type
+      vehicle_type_DESC:
+        sort_field:
+          direction: desc
+          field_path: vehicle_type
   ElectricalPartSortOrderInput:
     values_by_name:
       created_at_ASC:
@@ -871,8 +927,24 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: voltage
-  PersonSortOrderInput:
+  PhysicalStoreSortOrderInput:
     values_by_name:
+      address_ASC:
+        sort_field:
+          direction: asc
+          field_path: address
+      address_DESC:
+        sort_field:
+          direction: desc
+          field_path: address
+      established_on_ASC:
+        sort_field:
+          direction: asc
+          field_path: established_on
+      established_on_DESC:
+        sort_field:
+          direction: desc
+          field_path: established_on
       id_ASC:
         sort_field:
           direction: asc
@@ -881,22 +953,80 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: id
-      name_ASC:
+      square_footage_ASC:
         sort_field:
           direction: asc
-          field_path: name
-      name_DESC:
+          field_path: square_footage
+      square_footage_DESC:
         sort_field:
           direction: desc
-          field_path: name
-      nationality_ASC:
+          field_path: square_footage
+  RetailSortOrderInput:
+    values_by_name:
+      address_ASC:
         sort_field:
           direction: asc
-          field_path: nationality
-      nationality_DESC:
+          field_path: address
+      address_DESC:
         sort_field:
           direction: desc
-          field_path: nationality
+          field_path: address
+      current_location_ASC:
+        sort_field:
+          direction: asc
+          field_path: current_location
+      current_location_DESC:
+        sort_field:
+          direction: desc
+          field_path: current_location
+      established_on_ASC:
+        sort_field:
+          direction: asc
+          field_path: established_on
+      established_on_DESC:
+        sort_field:
+          direction: desc
+          field_path: established_on
+      id_ASC:
+        sort_field:
+          direction: asc
+          field_path: id
+      id_DESC:
+        sort_field:
+          direction: desc
+          field_path: id
+      platform_ASC:
+        sort_field:
+          direction: asc
+          field_path: platform
+      platform_DESC:
+        sort_field:
+          direction: desc
+          field_path: platform
+      square_footage_ASC:
+        sort_field:
+          direction: asc
+          field_path: square_footage
+      square_footage_DESC:
+        sort_field:
+          direction: desc
+          field_path: square_footage
+      url_ASC:
+        sort_field:
+          direction: asc
+          field_path: url
+      url_DESC:
+        sort_field:
+          direction: desc
+          field_path: url
+      vehicle_type_ASC:
+        sort_field:
+          direction: asc
+          field_path: vehicle_type
+      vehicle_type_DESC:
+        sort_field:
+          direction: desc
+          field_path: vehicle_type
   SponsorSortOrderInput:
     values_by_name:
       id_ASC:
@@ -915,6 +1045,72 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: name
+  StoreSortOrderInput:
+    values_by_name:
+      address_ASC:
+        sort_field:
+          direction: asc
+          field_path: address
+      address_DESC:
+        sort_field:
+          direction: desc
+          field_path: address
+      current_location_ASC:
+        sort_field:
+          direction: asc
+          field_path: current_location
+      current_location_DESC:
+        sort_field:
+          direction: desc
+          field_path: current_location
+      established_on_ASC:
+        sort_field:
+          direction: asc
+          field_path: established_on
+      established_on_DESC:
+        sort_field:
+          direction: desc
+          field_path: established_on
+      id_ASC:
+        sort_field:
+          direction: asc
+          field_path: id
+      id_DESC:
+        sort_field:
+          direction: desc
+          field_path: id
+      platform_ASC:
+        sort_field:
+          direction: asc
+          field_path: platform
+      platform_DESC:
+        sort_field:
+          direction: desc
+          field_path: platform
+      square_footage_ASC:
+        sort_field:
+          direction: asc
+          field_path: square_footage
+      square_footage_DESC:
+        sort_field:
+          direction: desc
+          field_path: square_footage
+      url_ASC:
+        sort_field:
+          direction: asc
+          field_path: url
+      url_DESC:
+        sort_field:
+          direction: desc
+          field_path: url
+      vehicle_type_ASC:
+        sort_field:
+          direction: asc
+          field_path: vehicle_type
+      vehicle_type_DESC:
+        sort_field:
+          direction: desc
+          field_path: vehicle_type
   TeamSortOrderInput:
     values_by_name:
       country_code_ASC:
@@ -1774,17 +1970,6 @@ index_definitions_by_name:
       timestamps.created_at:
         source: __self
     route_with: id
-  companies:
-    current_sources:
-    - __self
-    fields_by_path:
-      id:
-        source: __self
-      name:
-        source: __self
-      stock_ticker:
-        source: __self
-    route_with: id
   components:
     current_sources:
     - __self
@@ -1832,6 +2017,35 @@ index_definitions_by_name:
       widget_workspace_id3:
         source: widget
     has_had_multiple_sources: true
+    route_with: id
+  distribution_channels:
+    current_sources:
+    - __self
+    fields_by_path:
+      active:
+        source: __self
+      address:
+        source: __self
+      contract_terms:
+        source: __self
+      current_location:
+        source: __self
+      customer_facing:
+        source: __self
+      established_on:
+        source: __self
+      id:
+        source: __self
+      partner_name:
+        source: __self
+      platform:
+        source: __self
+      square_footage:
+        source: __self
+      url:
+        source: __self
+      vehicle_type:
+        source: __self
     route_with: id
   electrical_parts:
     current_sources:
@@ -1889,7 +2103,7 @@ index_definitions_by_name:
       name:
         source: __self
     route_with: id
-  people:
+  named_inventors:
     current_sources:
     - __self
     fields_by_path:
@@ -1898,6 +2112,25 @@ index_definitions_by_name:
       name:
         source: __self
       nationality:
+        source: __self
+      stock_ticker:
+        source: __self
+    route_with: id
+  physical_stores:
+    current_sources:
+    - __self
+    fields_by_path:
+      active:
+        source: __self
+      address:
+        source: __self
+      customer_facing:
+        source: __self
+      established_on:
+        source: __self
+      id:
+        source: __self
+      square_footage:
         source: __self
     route_with: id
   sponsors:
@@ -3192,9 +3425,11 @@ object_types_by_name:
         resolver:
           name: get_record_field_value
     index_definition_names:
-    - companies
+    - named_inventors
     update_targets:
     - data_params:
+        __typename:
+          cardinality: one
         name:
           cardinality: one
         stock_ticker:
@@ -3215,100 +3450,6 @@ object_types_by_name:
       routing_value_source: id
       script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: Company
-  CompanyAggregatedValues:
-    graphql_fields_by_name:
-      id:
-        resolver:
-          name: object_with_lookahead
-      name:
-        resolver:
-          name: object_with_lookahead
-      stock_ticker:
-        resolver:
-          name: object_with_lookahead
-  CompanyAggregation:
-    elasticgraph_category: indexed_aggregation
-    graphql_fields_by_name:
-      aggregated_values:
-        resolver:
-          name: object_without_lookahead
-      count:
-        resolver:
-          name: object_without_lookahead
-      grouped_by:
-        resolver:
-          name: object_without_lookahead
-    source_type: Company
-  CompanyAggregationConnection:
-    elasticgraph_category: relay_connection
-    graphql_fields_by_name:
-      edges:
-        resolver:
-          name: object_without_lookahead
-      nodes:
-        resolver:
-          name: object_without_lookahead
-      page_info:
-        resolver:
-          name: object_without_lookahead
-  CompanyAggregationEdge:
-    elasticgraph_category: relay_edge
-    graphql_fields_by_name:
-      cursor:
-        resolver:
-          name: object_without_lookahead
-      node:
-        resolver:
-          name: object_without_lookahead
-  CompanyConnection:
-    elasticgraph_category: relay_connection
-    graphql_fields_by_name:
-      edges:
-        resolver:
-          name: object_without_lookahead
-      nodes:
-        resolver:
-          name: object_without_lookahead
-      page_info:
-        resolver:
-          name: object_without_lookahead
-      total_edge_count:
-        resolver:
-          name: object_without_lookahead
-  CompanyEdge:
-    elasticgraph_category: relay_edge
-    graphql_fields_by_name:
-      all_highlights:
-        resolver:
-          name: object_without_lookahead
-      cursor:
-        resolver:
-          name: object_without_lookahead
-      highlights:
-        resolver:
-          name: object_without_lookahead
-      node:
-        resolver:
-          name: object_without_lookahead
-  CompanyGroupedBy:
-    graphql_fields_by_name:
-      name:
-        resolver:
-          name: object_with_lookahead
-      stock_ticker:
-        resolver:
-          name: object_with_lookahead
-  CompanyHighlights:
-    graphql_fields_by_name:
-      id:
-        resolver:
-          name: get_record_field_value
-      name:
-        resolver:
-          name: get_record_field_value
-      stock_ticker:
-        resolver:
-          name: get_record_field_value
   Component:
     graphql_fields_by_name:
       created_at:
@@ -3685,6 +3826,209 @@ object_types_by_name:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  DistributionChannel:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      address:
+        resolver:
+          name: get_record_field_value
+      contract_terms:
+        resolver:
+          name: get_record_field_value
+      current_location:
+        resolver:
+          name: get_record_field_value
+      customer_facing:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      partner_name:
+        resolver:
+          name: get_record_field_value
+      platform:
+        resolver:
+          name: get_record_field_value
+      square_footage:
+        resolver:
+          name: get_record_field_value
+      url:
+        resolver:
+          name: get_record_field_value
+      vehicle_type:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+  DistributionChannelAggregatedValues:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      address:
+        resolver:
+          name: object_with_lookahead
+      contract_terms:
+        resolver:
+          name: object_with_lookahead
+      current_location:
+        resolver:
+          name: object_with_lookahead
+      customer_facing:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      id:
+        resolver:
+          name: object_with_lookahead
+      partner_name:
+        resolver:
+          name: object_with_lookahead
+      platform:
+        resolver:
+          name: object_with_lookahead
+      square_footage:
+        resolver:
+          name: object_with_lookahead
+      url:
+        resolver:
+          name: object_with_lookahead
+      vehicle_type:
+        resolver:
+          name: object_with_lookahead
+  DistributionChannelAggregation:
+    elasticgraph_category: indexed_aggregation
+    graphql_fields_by_name:
+      aggregated_values:
+        resolver:
+          name: object_without_lookahead
+      count:
+        resolver:
+          name: object_without_lookahead
+      grouped_by:
+        resolver:
+          name: object_without_lookahead
+    source_type: DistributionChannel
+  DistributionChannelAggregationConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+  DistributionChannelAggregationEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  DistributionChannelConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+      total_edge_count:
+        resolver:
+          name: object_without_lookahead
+  DistributionChannelEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      all_highlights:
+        resolver:
+          name: object_without_lookahead
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      highlights:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  DistributionChannelGroupedBy:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      address:
+        resolver:
+          name: object_with_lookahead
+      contract_terms:
+        resolver:
+          name: object_with_lookahead
+      current_location:
+        resolver:
+          name: object_with_lookahead
+      customer_facing:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      partner_name:
+        resolver:
+          name: object_with_lookahead
+      platform:
+        resolver:
+          name: object_with_lookahead
+      square_footage:
+        resolver:
+          name: object_with_lookahead
+      url:
+        resolver:
+          name: object_with_lookahead
+      vehicle_type:
+        resolver:
+          name: object_with_lookahead
+  DistributionChannelHighlights:
+    graphql_fields_by_name:
+      address:
+        resolver:
+          name: get_record_field_value
+      contract_terms:
+        resolver:
+          name: get_record_field_value
+      current_location:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      partner_name:
+        resolver:
+          name: get_record_field_value
+      platform:
+        resolver:
+          name: get_record_field_value
+      url:
+        resolver:
+          name: get_record_field_value
+      vehicle_type:
+        resolver:
+          name: get_record_field_value
   ElectricalPart:
     graphql_fields_by_name:
       component_aggregations:
@@ -4484,6 +4828,58 @@ object_types_by_name:
       name:
         resolver:
           name: get_record_field_value
+  MobileStore:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      current_location:
+        resolver:
+          name: get_record_field_value
+      customer_facing:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      vehicle_type:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+    update_targets:
+    - data_params:
+        __typename:
+          cardinality: one
+        active:
+          cardinality: one
+        current_location:
+          cardinality: one
+        customer_facing:
+          cardinality: one
+        established_on:
+          cardinality: one
+        vehicle_type:
+          cardinality: one
+      id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      routing_value_source: id
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      type: MobileStore
   Money:
     graphql_fields_by_name:
       amount_cents:
@@ -5188,6 +5584,8 @@ object_types_by_name:
       stock_ticker:
         resolver:
           name: get_record_field_value
+    index_definition_names:
+    - named_inventors
   NamedInventorAggregatedValues:
     graphql_fields_by_name:
       id:
@@ -5301,6 +5699,58 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
     graphql_only_return_type: true
+  OnlineStore:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      customer_facing:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      platform:
+        resolver:
+          name: get_record_field_value
+      url:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+    update_targets:
+    - data_params:
+        __typename:
+          cardinality: one
+        active:
+          cardinality: one
+        customer_facing:
+          cardinality: one
+        established_on:
+          cardinality: one
+        platform:
+          cardinality: one
+        url:
+          cardinality: one
+      id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      routing_value_source: id
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      type: OnlineStore
   PageInfo:
     graphql_fields_by_name:
       end_cursor:
@@ -5469,9 +5919,11 @@ object_types_by_name:
         resolver:
           name: get_record_field_value
     index_definition_names:
-    - people
+    - named_inventors
     update_targets:
     - data_params:
+        __typename:
+          cardinality: one
         name:
           cardinality: one
         nationality:
@@ -5503,70 +5955,6 @@ object_types_by_name:
       nationality:
         resolver:
           name: object_with_lookahead
-  PersonAggregation:
-    elasticgraph_category: indexed_aggregation
-    graphql_fields_by_name:
-      aggregated_values:
-        resolver:
-          name: object_without_lookahead
-      count:
-        resolver:
-          name: object_without_lookahead
-      grouped_by:
-        resolver:
-          name: object_without_lookahead
-    source_type: Person
-  PersonAggregationConnection:
-    elasticgraph_category: relay_connection
-    graphql_fields_by_name:
-      edges:
-        resolver:
-          name: object_without_lookahead
-      nodes:
-        resolver:
-          name: object_without_lookahead
-      page_info:
-        resolver:
-          name: object_without_lookahead
-  PersonAggregationEdge:
-    elasticgraph_category: relay_edge
-    graphql_fields_by_name:
-      cursor:
-        resolver:
-          name: object_without_lookahead
-      node:
-        resolver:
-          name: object_without_lookahead
-  PersonConnection:
-    elasticgraph_category: relay_connection
-    graphql_fields_by_name:
-      edges:
-        resolver:
-          name: object_without_lookahead
-      nodes:
-        resolver:
-          name: object_without_lookahead
-      page_info:
-        resolver:
-          name: object_without_lookahead
-      total_edge_count:
-        resolver:
-          name: object_without_lookahead
-  PersonEdge:
-    elasticgraph_category: relay_edge
-    graphql_fields_by_name:
-      all_highlights:
-        resolver:
-          name: object_without_lookahead
-      cursor:
-        resolver:
-          name: object_without_lookahead
-      highlights:
-        resolver:
-          name: object_without_lookahead
-      node:
-        resolver:
-          name: object_without_lookahead
   PersonGroupedBy:
     graphql_fields_by_name:
       name:
@@ -5584,6 +5972,165 @@ object_types_by_name:
         resolver:
           name: get_record_field_value
       nationality:
+        resolver:
+          name: get_record_field_value
+  PhysicalStore:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      address:
+        resolver:
+          name: get_record_field_value
+      customer_facing:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      square_footage:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - physical_stores
+    update_targets:
+    - data_params:
+        active:
+          cardinality: one
+        address:
+          cardinality: one
+        customer_facing:
+          cardinality: one
+        established_on:
+          cardinality: one
+        square_footage:
+          cardinality: one
+      id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      routing_value_source: id
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      type: PhysicalStore
+  PhysicalStoreAggregatedValues:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      address:
+        resolver:
+          name: object_with_lookahead
+      customer_facing:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      id:
+        resolver:
+          name: object_with_lookahead
+      square_footage:
+        resolver:
+          name: object_with_lookahead
+  PhysicalStoreAggregation:
+    elasticgraph_category: indexed_aggregation
+    graphql_fields_by_name:
+      aggregated_values:
+        resolver:
+          name: object_without_lookahead
+      count:
+        resolver:
+          name: object_without_lookahead
+      grouped_by:
+        resolver:
+          name: object_without_lookahead
+    source_type: PhysicalStore
+  PhysicalStoreAggregationConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+  PhysicalStoreAggregationEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  PhysicalStoreConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+      total_edge_count:
+        resolver:
+          name: object_without_lookahead
+  PhysicalStoreEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      all_highlights:
+        resolver:
+          name: object_without_lookahead
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      highlights:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  PhysicalStoreGroupedBy:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      address:
+        resolver:
+          name: object_with_lookahead
+      customer_facing:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      square_footage:
+        resolver:
+          name: object_with_lookahead
+  PhysicalStoreHighlights:
+    graphql_fields_by_name:
+      address:
+        resolver:
+          name: get_record_field_value
+      id:
         resolver:
           name: get_record_field_value
   Player:
@@ -5728,16 +6275,16 @@ object_types_by_name:
       addresses:
         resolver:
           name: list_records
-      companies:
-        resolver:
-          name: list_records
-      company_aggregations:
-        resolver:
-          name: list_records
       component_aggregations:
         resolver:
           name: list_records
       components:
+        resolver:
+          name: list_records
+      distribution_channel_aggregations:
+        resolver:
+          name: list_records
+      distribution_channels:
         resolver:
           name: list_records
       electrical_part_aggregations:
@@ -5782,16 +6329,28 @@ object_types_by_name:
       parts:
         resolver:
           name: list_records
-      people:
+      physical_store_aggregations:
         resolver:
           name: list_records
-      person_aggregations:
+      physical_stores:
+        resolver:
+          name: list_records
+      retail_aggregations:
+        resolver:
+          name: list_records
+      retailers:
         resolver:
           name: list_records
       sponsor_aggregations:
         resolver:
           name: list_records
       sponsors:
+        resolver:
+          name: list_records
+      store_aggregations:
+        resolver:
+          name: list_records
+      stores:
         resolver:
           name: list_records
       team_aggregations:
@@ -5824,6 +6383,185 @@ object_types_by_name:
       widgets_or_addresses:
         resolver:
           name: list_records
+  Retail:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      address:
+        resolver:
+          name: get_record_field_value
+      current_location:
+        resolver:
+          name: get_record_field_value
+      customer_facing:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      platform:
+        resolver:
+          name: get_record_field_value
+      square_footage:
+        resolver:
+          name: get_record_field_value
+      url:
+        resolver:
+          name: get_record_field_value
+      vehicle_type:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+  RetailAggregatedValues:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      address:
+        resolver:
+          name: object_with_lookahead
+      current_location:
+        resolver:
+          name: object_with_lookahead
+      customer_facing:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      id:
+        resolver:
+          name: object_with_lookahead
+      platform:
+        resolver:
+          name: object_with_lookahead
+      square_footage:
+        resolver:
+          name: object_with_lookahead
+      url:
+        resolver:
+          name: object_with_lookahead
+      vehicle_type:
+        resolver:
+          name: object_with_lookahead
+  RetailAggregation:
+    elasticgraph_category: indexed_aggregation
+    graphql_fields_by_name:
+      aggregated_values:
+        resolver:
+          name: object_without_lookahead
+      count:
+        resolver:
+          name: object_without_lookahead
+      grouped_by:
+        resolver:
+          name: object_without_lookahead
+    source_type: Retail
+  RetailAggregationConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+  RetailAggregationEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  RetailConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+      total_edge_count:
+        resolver:
+          name: object_without_lookahead
+  RetailEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      all_highlights:
+        resolver:
+          name: object_without_lookahead
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      highlights:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  RetailGroupedBy:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      address:
+        resolver:
+          name: object_with_lookahead
+      current_location:
+        resolver:
+          name: object_with_lookahead
+      customer_facing:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      platform:
+        resolver:
+          name: object_with_lookahead
+      square_footage:
+        resolver:
+          name: object_with_lookahead
+      url:
+        resolver:
+          name: object_with_lookahead
+      vehicle_type:
+        resolver:
+          name: object_with_lookahead
+  RetailHighlights:
+    graphql_fields_by_name:
+      address:
+        resolver:
+          name: get_record_field_value
+      current_location:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      platform:
+        resolver:
+          name: get_record_field_value
+      url:
+        resolver:
+          name: get_record_field_value
+      vehicle_type:
+        resolver:
+          name: get_record_field_value
   SearchHighlight:
     graphql_fields_by_name:
       path:
@@ -6022,6 +6760,185 @@ object_types_by_name:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  Store:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      address:
+        resolver:
+          name: get_record_field_value
+      current_location:
+        resolver:
+          name: get_record_field_value
+      customer_facing:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      platform:
+        resolver:
+          name: get_record_field_value
+      square_footage:
+        resolver:
+          name: get_record_field_value
+      url:
+        resolver:
+          name: get_record_field_value
+      vehicle_type:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+  StoreAggregatedValues:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      address:
+        resolver:
+          name: object_with_lookahead
+      current_location:
+        resolver:
+          name: object_with_lookahead
+      customer_facing:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      id:
+        resolver:
+          name: object_with_lookahead
+      platform:
+        resolver:
+          name: object_with_lookahead
+      square_footage:
+        resolver:
+          name: object_with_lookahead
+      url:
+        resolver:
+          name: object_with_lookahead
+      vehicle_type:
+        resolver:
+          name: object_with_lookahead
+  StoreAggregation:
+    elasticgraph_category: indexed_aggregation
+    graphql_fields_by_name:
+      aggregated_values:
+        resolver:
+          name: object_without_lookahead
+      count:
+        resolver:
+          name: object_without_lookahead
+      grouped_by:
+        resolver:
+          name: object_without_lookahead
+    source_type: Store
+  StoreAggregationConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+  StoreAggregationEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  StoreConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+      total_edge_count:
+        resolver:
+          name: object_without_lookahead
+  StoreEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      all_highlights:
+        resolver:
+          name: object_without_lookahead
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      highlights:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  StoreGroupedBy:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      address:
+        resolver:
+          name: object_with_lookahead
+      current_location:
+        resolver:
+          name: object_with_lookahead
+      customer_facing:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      platform:
+        resolver:
+          name: object_with_lookahead
+      square_footage:
+        resolver:
+          name: object_with_lookahead
+      url:
+        resolver:
+          name: object_with_lookahead
+      vehicle_type:
+        resolver:
+          name: object_with_lookahead
+  StoreHighlights:
+    graphql_fields_by_name:
+      address:
+        resolver:
+          name: get_record_field_value
+      current_location:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      platform:
+        resolver:
+          name: get_record_field_value
+      url:
+        resolver:
+          name: get_record_field_value
+      vehicle_type:
+        resolver:
+          name: get_record_field_value
   StringConnection:
     elasticgraph_category: relay_connection
     graphql_fields_by_name:
@@ -6955,6 +7872,48 @@ object_types_by_name:
       players_object:
         resolver:
           name: object_with_lookahead
+  ThirdPartyWholesale:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      contract_terms:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      partner_name:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+    update_targets:
+    - data_params:
+        __typename:
+          cardinality: one
+        active:
+          cardinality: one
+        contract_terms:
+          cardinality: one
+        partner_name:
+          cardinality: one
+      id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      routing_value_source: id
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      type: ThirdPartyWholesale
   Widget:
     graphql_fields_by_name:
       amount_cents:

--- a/config/schema/artifacts/schema.graphql
+++ b/config/schema/artifacts/schema.graphql
@@ -820,274 +820,6 @@ type Company implements NamedInventor {
   stock_ticker: String
 }
 
-"""
-Type used to perform aggregation computations on `Company` fields.
-"""
-type CompanyAggregatedValues {
-  """
-  Computed aggregate values for the `id` field.
-  """
-  id: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `name` field.
-  """
-  name: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `stock_ticker` field.
-  """
-  stock_ticker: NonNumericAggregatedValues
-}
-
-"""
-Return type representing a bucket of `Company` documents for an aggregations query.
-"""
-type CompanyAggregation {
-  """
-  Provides computed aggregated values over all `Company` documents in an aggregation bucket.
-  """
-  aggregated_values: CompanyAggregatedValues
-
-  """
-  The count of `Company` documents in an aggregation bucket.
-  """
-  count: JsonSafeLong!
-
-  """
-  Used to specify the `Company` fields to group by. The returned values identify each aggregation bucket.
-  """
-  grouped_by: CompanyGroupedBy
-}
-
-"""
-Represents a paginated collection of `CompanyAggregation` results.
-
-See the [Relay GraphQL Cursor Connections
-Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
-"""
-type CompanyAggregationConnection {
-  """
-  Wraps a specific `CompanyAggregation` to pair it with its pagination cursor.
-  """
-  edges: [CompanyAggregationEdge!]!
-
-  """
-  The list of `CompanyAggregation` results.
-  """
-  nodes: [CompanyAggregation!]!
-
-  """
-  Provides pagination-related information.
-  """
-  page_info: PageInfo!
-}
-
-"""
-Represents a specific `CompanyAggregation` in the context of a `CompanyAggregationConnection`,
-providing access to both the `CompanyAggregation` and query-specific information such as the pagination `Cursor`.
-
-See the [Relay GraphQL Cursor Connections
-Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
-"""
-type CompanyAggregationEdge {
-  """
-  The `Cursor` of this `CompanyAggregation`. This can be passed in the next query as
-  a `before` or `after` argument to continue paginating from this `CompanyAggregation`.
-  """
-  cursor: Cursor
-
-  """
-  The `CompanyAggregation` of this edge.
-  """
-  node: CompanyAggregation
-}
-
-"""
-Represents a paginated collection of `Company` results.
-
-See the [Relay GraphQL Cursor Connections
-Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
-"""
-type CompanyConnection {
-  """
-  Wraps a specific `Company` to pair it with its pagination cursor.
-  """
-  edges: [CompanyEdge!]!
-
-  """
-  The list of `Company` results.
-  """
-  nodes: [Company!]!
-
-  """
-  Provides pagination-related information.
-  """
-  page_info: PageInfo!
-
-  """
-  The total number of edges available in this connection to paginate over.
-  """
-  total_edge_count: JsonSafeLong!
-}
-
-"""
-Represents a specific `Company` in the context of a `CompanyConnection`,
-providing access to both the `Company` and query-specific information such as the pagination `Cursor`.
-
-See the [Relay GraphQL Cursor Connections
-Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
-"""
-type CompanyEdge {
-  """
-  All search highlights for this `Company`, indicating where in the indexed document the query matched.
-  """
-  all_highlights: [SearchHighlight!]!
-
-  """
-  The `Cursor` of this `Company`. This can be passed in the next query as
-  a `before` or `after` argument to continue paginating from this `Company`.
-  """
-  cursor: Cursor
-
-  """
-  Specific search highlights for this `Company`, providing matching snippets for the requested fields.
-  """
-  highlights: CompanyHighlights
-
-  """
-  The `Company` of this edge.
-  """
-  node: Company
-}
-
-"""
-Input type used to specify filters on `Company` fields.
-
-Will match all documents if passed as an empty object (or as `null`).
-"""
-input CompanyFilterInput {
-  """
-  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
-
-  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
-  be provided on a single `CompanyFilterInput` input because of collisions
-  between key names. For example, if you want to AND multiple
-  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
-
-  When `null` or an empty list is passed, matches all documents.
-  """
-  all_of: [CompanyFilterInput!]
-
-  """
-  Matches records where any of the provided sub-filters evaluate to true.
-  This works just like an OR operator in SQL.
-
-  When `null` is passed, matches all documents.
-  When an empty list is passed, this part of the filter matches no documents.
-  """
-  any_of: [CompanyFilterInput!]
-
-  """
-  Used to filter on the `id` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  id: IDFilterInput
-
-  """
-  Used to filter on the `name` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  name: StringFilterInput
-
-  """
-  Matches records where the provided sub-filter evaluates to false.
-  This works just like a NOT operator in SQL.
-
-  When `null` or an empty object is passed, matches no documents.
-  """
-  not: CompanyFilterInput
-
-  """
-  Used to filter on the `stock_ticker` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  stock_ticker: StringFilterInput
-}
-
-"""
-Type used to specify the `Company` fields to group by for aggregations.
-"""
-type CompanyGroupedBy {
-  """
-  The `name` field value for this group.
-  """
-  name: String
-
-  """
-  The `stock_ticker` field value for this group.
-  """
-  stock_ticker: String
-}
-
-"""
-Type used to request desired `Company` search highlight fields.
-"""
-type CompanyHighlights {
-  """
-  Search highlights for the `id`, providing snippets of the matching text.
-  """
-  id: [String!]!
-
-  """
-  Search highlights for the `name`, providing snippets of the matching text.
-  """
-  name: [String!]!
-
-  """
-  Search highlights for the `stock_ticker`, providing snippets of the matching text.
-  """
-  stock_ticker: [String!]!
-}
-
-"""
-Enumerates the ways `Company`s can be sorted.
-"""
-enum CompanySortOrderInput {
-  """
-  Sorts ascending by the `id` field.
-  """
-  id_ASC
-
-  """
-  Sorts descending by the `id` field.
-  """
-  id_DESC
-
-  """
-  Sorts ascending by the `name` field.
-  """
-  name_ASC
-
-  """
-  Sorts descending by the `name` field.
-  """
-  name_DESC
-
-  """
-  Sorts ascending by the `stock_ticker` field.
-  """
-  stock_ticker_ASC
-
-  """
-  Sorts descending by the `stock_ticker` field.
-  """
-  stock_ticker_DESC
-}
-
 type Component implements NamedEntity {
   created_at: DateTime!
   dollar_widget: Widget
@@ -2792,6 +2524,528 @@ enum DistanceUnitInput {
   A United States customary unit of 3 feet.
   """
   YARD
+}
+
+interface DistributionChannel {
+  active: Boolean
+  id: ID!
+}
+
+"""
+Type used to perform aggregation computations on `DistributionChannel` fields.
+"""
+type DistributionChannelAggregatedValues {
+  """
+  Computed aggregate values for the `active` field.
+  """
+  active: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `address` field.
+  """
+  address: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `contract_terms` field.
+  """
+  contract_terms: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `current_location` field.
+  """
+  current_location: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `customer_facing` field.
+  """
+  customer_facing: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `established_on` field.
+  """
+  established_on: DateAggregatedValues
+
+  """
+  Computed aggregate values for the `id` field.
+  """
+  id: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `partner_name` field.
+  """
+  partner_name: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `platform` field.
+  """
+  platform: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `square_footage` field.
+  """
+  square_footage: IntAggregatedValues
+
+  """
+  Computed aggregate values for the `url` field.
+  """
+  url: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `vehicle_type` field.
+  """
+  vehicle_type: NonNumericAggregatedValues
+}
+
+"""
+Return type representing a bucket of `DistributionChannel` documents for an aggregations query.
+"""
+type DistributionChannelAggregation {
+  """
+  Provides computed aggregated values over all `DistributionChannel` documents in an aggregation bucket.
+  """
+  aggregated_values: DistributionChannelAggregatedValues
+
+  """
+  The count of `DistributionChannel` documents in an aggregation bucket.
+  """
+  count: JsonSafeLong!
+
+  """
+  Used to specify the `DistributionChannel` fields to group by. The returned values identify each aggregation bucket.
+  """
+  grouped_by: DistributionChannelGroupedBy
+}
+
+"""
+Represents a paginated collection of `DistributionChannelAggregation` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type DistributionChannelAggregationConnection {
+  """
+  Wraps a specific `DistributionChannelAggregation` to pair it with its pagination cursor.
+  """
+  edges: [DistributionChannelAggregationEdge!]!
+
+  """
+  The list of `DistributionChannelAggregation` results.
+  """
+  nodes: [DistributionChannelAggregation!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+}
+
+"""
+Represents a specific `DistributionChannelAggregation` in the context of a `DistributionChannelAggregationConnection`,
+providing access to both the `DistributionChannelAggregation` and query-specific
+information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type DistributionChannelAggregationEdge {
+  """
+  The `Cursor` of this `DistributionChannelAggregation`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `DistributionChannelAggregation`.
+  """
+  cursor: Cursor
+
+  """
+  The `DistributionChannelAggregation` of this edge.
+  """
+  node: DistributionChannelAggregation
+}
+
+"""
+Represents a paginated collection of `DistributionChannel` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type DistributionChannelConnection {
+  """
+  Wraps a specific `DistributionChannel` to pair it with its pagination cursor.
+  """
+  edges: [DistributionChannelEdge!]!
+
+  """
+  The list of `DistributionChannel` results.
+  """
+  nodes: [DistributionChannel!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+
+  """
+  The total number of edges available in this connection to paginate over.
+  """
+  total_edge_count: JsonSafeLong!
+}
+
+"""
+Represents a specific `DistributionChannel` in the context of a `DistributionChannelConnection`,
+providing access to both the `DistributionChannel` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type DistributionChannelEdge {
+  """
+  All search highlights for this `DistributionChannel`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
+  The `Cursor` of this `DistributionChannel`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `DistributionChannel`.
+  """
+  cursor: Cursor
+
+  """
+  Specific search highlights for this `DistributionChannel`, providing matching snippets for the requested fields.
+  """
+  highlights: DistributionChannelHighlights
+
+  """
+  The `DistributionChannel` of this edge.
+  """
+  node: DistributionChannel
+}
+
+"""
+Input type used to specify filters on `DistributionChannel` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input DistributionChannelFilterInput {
+  """
+  Used to filter on the `active` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  active: BooleanFilterInput
+
+  """
+  Used to filter on the `address` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  address: StringFilterInput
+
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `DistributionChannelFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [DistributionChannelFilterInput!]
+
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [DistributionChannelFilterInput!]
+
+  """
+  Used to filter on the `contract_terms` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  contract_terms: StringFilterInput
+
+  """
+  Used to filter on the `current_location` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  current_location: StringFilterInput
+
+  """
+  Used to filter on the `customer_facing` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  customer_facing: BooleanFilterInput
+
+  """
+  Used to filter on the `established_on` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  established_on: DateFilterInput
+
+  """
+  Used to filter on the `id` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  id: IDFilterInput
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: DistributionChannelFilterInput
+
+  """
+  Used to filter on the `partner_name` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  partner_name: StringFilterInput
+
+  """
+  Used to filter on the `platform` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  platform: StringFilterInput
+
+  """
+  Used to filter on the `square_footage` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  square_footage: IntFilterInput
+
+  """
+  Used to filter on the `url` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  url: StringFilterInput
+
+  """
+  Used to filter on the `vehicle_type` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  vehicle_type: StringFilterInput
+}
+
+"""
+Type used to specify the `DistributionChannel` fields to group by for aggregations.
+"""
+type DistributionChannelGroupedBy {
+  """
+  The `active` field value for this group.
+  """
+  active: Boolean
+
+  """
+  The `address` field value for this group.
+  """
+  address: String
+
+  """
+  The `contract_terms` field value for this group.
+  """
+  contract_terms: String
+
+  """
+  The `current_location` field value for this group.
+  """
+  current_location: String
+
+  """
+  The `customer_facing` field value for this group.
+  """
+  customer_facing: Boolean
+
+  """
+  Offers the different grouping options for the `established_on` value within this group.
+  """
+  established_on: DateGroupedBy
+
+  """
+  The `partner_name` field value for this group.
+  """
+  partner_name: String
+
+  """
+  The `platform` field value for this group.
+  """
+  platform: String
+
+  """
+  The `square_footage` field value for this group.
+  """
+  square_footage: Int
+
+  """
+  The `url` field value for this group.
+  """
+  url: String
+
+  """
+  The `vehicle_type` field value for this group.
+  """
+  vehicle_type: String
+}
+
+"""
+Type used to request desired `DistributionChannel` search highlight fields.
+"""
+type DistributionChannelHighlights {
+  """
+  Search highlights for the `address`, providing snippets of the matching text.
+  """
+  address: [String!]!
+
+  """
+  Search highlights for the `contract_terms`, providing snippets of the matching text.
+  """
+  contract_terms: [String!]!
+
+  """
+  Search highlights for the `current_location`, providing snippets of the matching text.
+  """
+  current_location: [String!]!
+
+  """
+  Search highlights for the `id`, providing snippets of the matching text.
+  """
+  id: [String!]!
+
+  """
+  Search highlights for the `partner_name`, providing snippets of the matching text.
+  """
+  partner_name: [String!]!
+
+  """
+  Search highlights for the `platform`, providing snippets of the matching text.
+  """
+  platform: [String!]!
+
+  """
+  Search highlights for the `url`, providing snippets of the matching text.
+  """
+  url: [String!]!
+
+  """
+  Search highlights for the `vehicle_type`, providing snippets of the matching text.
+  """
+  vehicle_type: [String!]!
+}
+
+"""
+Enumerates the ways `DistributionChannel`s can be sorted.
+"""
+enum DistributionChannelSortOrderInput {
+  """
+  Sorts ascending by the `address` field.
+  """
+  address_ASC
+
+  """
+  Sorts descending by the `address` field.
+  """
+  address_DESC
+
+  """
+  Sorts ascending by the `contract_terms` field.
+  """
+  contract_terms_ASC
+
+  """
+  Sorts descending by the `contract_terms` field.
+  """
+  contract_terms_DESC
+
+  """
+  Sorts ascending by the `current_location` field.
+  """
+  current_location_ASC
+
+  """
+  Sorts descending by the `current_location` field.
+  """
+  current_location_DESC
+
+  """
+  Sorts ascending by the `established_on` field.
+  """
+  established_on_ASC
+
+  """
+  Sorts descending by the `established_on` field.
+  """
+  established_on_DESC
+
+  """
+  Sorts ascending by the `id` field.
+  """
+  id_ASC
+
+  """
+  Sorts descending by the `id` field.
+  """
+  id_DESC
+
+  """
+  Sorts ascending by the `partner_name` field.
+  """
+  partner_name_ASC
+
+  """
+  Sorts descending by the `partner_name` field.
+  """
+  partner_name_DESC
+
+  """
+  Sorts ascending by the `platform` field.
+  """
+  platform_ASC
+
+  """
+  Sorts descending by the `platform` field.
+  """
+  platform_DESC
+
+  """
+  Sorts ascending by the `square_footage` field.
+  """
+  square_footage_ASC
+
+  """
+  Sorts descending by the `square_footage` field.
+  """
+  square_footage_DESC
+
+  """
+  Sorts ascending by the `url` field.
+  """
+  url_ASC
+
+  """
+  Sorts descending by the `url` field.
+  """
+  url_DESC
+
+  """
+  Sorts ascending by the `vehicle_type` field.
+  """
+  vehicle_type_ASC
+
+  """
+  Sorts descending by the `vehicle_type` field.
+  """
+  vehicle_type_DESC
 }
 
 type ElectricalPart implements NamedEntity {
@@ -5676,6 +5930,15 @@ enum MechanicalPartSortOrderInput {
   name_DESC
 }
 
+type MobileStore implements DistributionChannel & Retail & Store {
+  active: Boolean
+  current_location: String
+  customer_facing: Boolean
+  established_on: Date
+  id: ID!
+  vehicle_type: String!
+}
+
 type Money {
   amount_cents: Int
   currency: String!
@@ -7771,6 +8034,15 @@ type NonNumericAggregatedValues {
   approximate_distinct_value_count: JsonSafeLong
 }
 
+type OnlineStore implements DistributionChannel & Retail & Store {
+  active: Boolean
+  customer_facing: Boolean
+  established_on: Date
+  id: ID!
+  platform: String
+  url: String!
+}
+
 """
 Provides information about the specific fetched page. This implements the `PageInfo`
 specification from the [Relay GraphQL Cursor Connections
@@ -8151,127 +8423,6 @@ type PersonAggregatedValues {
 }
 
 """
-Return type representing a bucket of `Person` documents for an aggregations query.
-"""
-type PersonAggregation {
-  """
-  Provides computed aggregated values over all `Person` documents in an aggregation bucket.
-  """
-  aggregated_values: PersonAggregatedValues
-
-  """
-  The count of `Person` documents in an aggregation bucket.
-  """
-  count: JsonSafeLong!
-
-  """
-  Used to specify the `Person` fields to group by. The returned values identify each aggregation bucket.
-  """
-  grouped_by: PersonGroupedBy
-}
-
-"""
-Represents a paginated collection of `PersonAggregation` results.
-
-See the [Relay GraphQL Cursor Connections
-Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
-"""
-type PersonAggregationConnection {
-  """
-  Wraps a specific `PersonAggregation` to pair it with its pagination cursor.
-  """
-  edges: [PersonAggregationEdge!]!
-
-  """
-  The list of `PersonAggregation` results.
-  """
-  nodes: [PersonAggregation!]!
-
-  """
-  Provides pagination-related information.
-  """
-  page_info: PageInfo!
-}
-
-"""
-Represents a specific `PersonAggregation` in the context of a `PersonAggregationConnection`,
-providing access to both the `PersonAggregation` and query-specific information such as the pagination `Cursor`.
-
-See the [Relay GraphQL Cursor Connections
-Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
-"""
-type PersonAggregationEdge {
-  """
-  The `Cursor` of this `PersonAggregation`. This can be passed in the next query as
-  a `before` or `after` argument to continue paginating from this `PersonAggregation`.
-  """
-  cursor: Cursor
-
-  """
-  The `PersonAggregation` of this edge.
-  """
-  node: PersonAggregation
-}
-
-"""
-Represents a paginated collection of `Person` results.
-
-See the [Relay GraphQL Cursor Connections
-Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
-"""
-type PersonConnection {
-  """
-  Wraps a specific `Person` to pair it with its pagination cursor.
-  """
-  edges: [PersonEdge!]!
-
-  """
-  The list of `Person` results.
-  """
-  nodes: [Person!]!
-
-  """
-  Provides pagination-related information.
-  """
-  page_info: PageInfo!
-
-  """
-  The total number of edges available in this connection to paginate over.
-  """
-  total_edge_count: JsonSafeLong!
-}
-
-"""
-Represents a specific `Person` in the context of a `PersonConnection`,
-providing access to both the `Person` and query-specific information such as the pagination `Cursor`.
-
-See the [Relay GraphQL Cursor Connections
-Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
-"""
-type PersonEdge {
-  """
-  All search highlights for this `Person`, indicating where in the indexed document the query matched.
-  """
-  all_highlights: [SearchHighlight!]!
-
-  """
-  The `Cursor` of this `Person`. This can be passed in the next query as
-  a `before` or `after` argument to continue paginating from this `Person`.
-  """
-  cursor: Cursor
-
-  """
-  Specific search highlights for this `Person`, providing matching snippets for the requested fields.
-  """
-  highlights: PersonHighlights
-
-  """
-  The `Person` of this edge.
-  """
-  node: Person
-}
-
-"""
 Input type used to specify filters on `Person` fields.
 
 Will match all documents if passed as an empty object (or as `null`).
@@ -8363,10 +8514,318 @@ type PersonHighlights {
   nationality: [String!]!
 }
 
+type PhysicalStore implements DistributionChannel & Retail & Store {
+  active: Boolean
+  address: String!
+  customer_facing: Boolean
+  established_on: Date
+  id: ID!
+  square_footage: Int
+}
+
 """
-Enumerates the ways `Person`s can be sorted.
+Type used to perform aggregation computations on `PhysicalStore` fields.
 """
-enum PersonSortOrderInput {
+type PhysicalStoreAggregatedValues {
+  """
+  Computed aggregate values for the `active` field.
+  """
+  active: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `address` field.
+  """
+  address: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `customer_facing` field.
+  """
+  customer_facing: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `established_on` field.
+  """
+  established_on: DateAggregatedValues
+
+  """
+  Computed aggregate values for the `id` field.
+  """
+  id: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `square_footage` field.
+  """
+  square_footage: IntAggregatedValues
+}
+
+"""
+Return type representing a bucket of `PhysicalStore` documents for an aggregations query.
+"""
+type PhysicalStoreAggregation {
+  """
+  Provides computed aggregated values over all `PhysicalStore` documents in an aggregation bucket.
+  """
+  aggregated_values: PhysicalStoreAggregatedValues
+
+  """
+  The count of `PhysicalStore` documents in an aggregation bucket.
+  """
+  count: JsonSafeLong!
+
+  """
+  Used to specify the `PhysicalStore` fields to group by. The returned values identify each aggregation bucket.
+  """
+  grouped_by: PhysicalStoreGroupedBy
+}
+
+"""
+Represents a paginated collection of `PhysicalStoreAggregation` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type PhysicalStoreAggregationConnection {
+  """
+  Wraps a specific `PhysicalStoreAggregation` to pair it with its pagination cursor.
+  """
+  edges: [PhysicalStoreAggregationEdge!]!
+
+  """
+  The list of `PhysicalStoreAggregation` results.
+  """
+  nodes: [PhysicalStoreAggregation!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+}
+
+"""
+Represents a specific `PhysicalStoreAggregation` in the context of a `PhysicalStoreAggregationConnection`,
+providing access to both the `PhysicalStoreAggregation` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type PhysicalStoreAggregationEdge {
+  """
+  The `Cursor` of this `PhysicalStoreAggregation`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `PhysicalStoreAggregation`.
+  """
+  cursor: Cursor
+
+  """
+  The `PhysicalStoreAggregation` of this edge.
+  """
+  node: PhysicalStoreAggregation
+}
+
+"""
+Represents a paginated collection of `PhysicalStore` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type PhysicalStoreConnection {
+  """
+  Wraps a specific `PhysicalStore` to pair it with its pagination cursor.
+  """
+  edges: [PhysicalStoreEdge!]!
+
+  """
+  The list of `PhysicalStore` results.
+  """
+  nodes: [PhysicalStore!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+
+  """
+  The total number of edges available in this connection to paginate over.
+  """
+  total_edge_count: JsonSafeLong!
+}
+
+"""
+Represents a specific `PhysicalStore` in the context of a `PhysicalStoreConnection`,
+providing access to both the `PhysicalStore` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type PhysicalStoreEdge {
+  """
+  All search highlights for this `PhysicalStore`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
+  The `Cursor` of this `PhysicalStore`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `PhysicalStore`.
+  """
+  cursor: Cursor
+
+  """
+  Specific search highlights for this `PhysicalStore`, providing matching snippets for the requested fields.
+  """
+  highlights: PhysicalStoreHighlights
+
+  """
+  The `PhysicalStore` of this edge.
+  """
+  node: PhysicalStore
+}
+
+"""
+Input type used to specify filters on `PhysicalStore` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input PhysicalStoreFilterInput {
+  """
+  Used to filter on the `active` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  active: BooleanFilterInput
+
+  """
+  Used to filter on the `address` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  address: StringFilterInput
+
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `PhysicalStoreFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [PhysicalStoreFilterInput!]
+
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [PhysicalStoreFilterInput!]
+
+  """
+  Used to filter on the `customer_facing` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  customer_facing: BooleanFilterInput
+
+  """
+  Used to filter on the `established_on` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  established_on: DateFilterInput
+
+  """
+  Used to filter on the `id` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  id: IDFilterInput
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: PhysicalStoreFilterInput
+
+  """
+  Used to filter on the `square_footage` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  square_footage: IntFilterInput
+}
+
+"""
+Type used to specify the `PhysicalStore` fields to group by for aggregations.
+"""
+type PhysicalStoreGroupedBy {
+  """
+  The `active` field value for this group.
+  """
+  active: Boolean
+
+  """
+  The `address` field value for this group.
+  """
+  address: String
+
+  """
+  The `customer_facing` field value for this group.
+  """
+  customer_facing: Boolean
+
+  """
+  Offers the different grouping options for the `established_on` value within this group.
+  """
+  established_on: DateGroupedBy
+
+  """
+  The `square_footage` field value for this group.
+  """
+  square_footage: Int
+}
+
+"""
+Type used to request desired `PhysicalStore` search highlight fields.
+"""
+type PhysicalStoreHighlights {
+  """
+  Search highlights for the `address`, providing snippets of the matching text.
+  """
+  address: [String!]!
+
+  """
+  Search highlights for the `id`, providing snippets of the matching text.
+  """
+  id: [String!]!
+}
+
+"""
+Enumerates the ways `PhysicalStore`s can be sorted.
+"""
+enum PhysicalStoreSortOrderInput {
+  """
+  Sorts ascending by the `address` field.
+  """
+  address_ASC
+
+  """
+  Sorts descending by the `address` field.
+  """
+  address_DESC
+
+  """
+  Sorts ascending by the `established_on` field.
+  """
+  established_on_ASC
+
+  """
+  Sorts descending by the `established_on` field.
+  """
+  established_on_DESC
+
   """
   Sorts ascending by the `id` field.
   """
@@ -8378,24 +8837,14 @@ enum PersonSortOrderInput {
   id_DESC
 
   """
-  Sorts ascending by the `name` field.
+  Sorts ascending by the `square_footage` field.
   """
-  name_ASC
+  square_footage_ASC
 
   """
-  Sorts descending by the `name` field.
+  Sorts descending by the `square_footage` field.
   """
-  name_DESC
-
-  """
-  Sorts ascending by the `nationality` field.
-  """
-  nationality_ASC
-
-  """
-  Sorts descending by the `nationality` field.
-  """
-  nationality_DESC
+  square_footage_DESC
 }
 
 type Player {
@@ -9144,109 +9593,6 @@ type Query {
   ): AddressConnection
 
   """
-  Fetches `Company`s based on the provided arguments.
-  """
-  companies(
-    """
-    Used to forward-paginate through the `companies`. When provided, the next page after the
-    provided cursor will be returned.
-
-    See the [Relay GraphQL Cursor Connections
-    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
-    """
-    after: Cursor
-
-    """
-    Used to backward-paginate through the `companies`. When provided, the previous page before the
-    provided cursor will be returned.
-
-    See the [Relay GraphQL Cursor Connections
-    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
-    """
-    before: Cursor
-
-    """
-    Used to filter the returned `companies` based on the provided criteria.
-    """
-    filter: CompanyFilterInput
-
-    """
-    Used in conjunction with the `after` argument to forward-paginate through the `companies`.
-    When provided, limits the number of returned results to the first `n` after the provided
-    `after` cursor (or from the start of the `companies`, if no `after` cursor is provided).
-
-    See the [Relay GraphQL Cursor Connections
-    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
-    """
-    first: Int
-
-    """
-    Used in conjunction with the `before` argument to backward-paginate through the `companies`.
-    When provided, limits the number of returned results to the last `n` before the provided
-    `before` cursor (or from the end of the `companies`, if no `before` cursor is provided).
-
-    See the [Relay GraphQL Cursor Connections
-    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
-    """
-    last: Int
-
-    """
-    Used to specify how the returned `companies` should be sorted.
-    """
-    order_by: [CompanySortOrderInput!]
-  ): CompanyConnection
-
-  """
-  Aggregations over the `companies` data:
-
-  > Fetches `Company`s based on the provided arguments.
-  """
-  company_aggregations(
-    """
-    Used to forward-paginate through the `company_aggregations`. When provided, the next page after the
-    provided cursor will be returned.
-
-    See the [Relay GraphQL Cursor Connections
-    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
-    """
-    after: Cursor
-
-    """
-    Used to backward-paginate through the `company_aggregations`. When provided, the previous page before the
-    provided cursor will be returned.
-
-    See the [Relay GraphQL Cursor Connections
-    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
-    """
-    before: Cursor
-
-    """
-    Used to filter the `Company` documents that get aggregated over based on the provided criteria.
-    """
-    filter: CompanyFilterInput
-
-    """
-    Used in conjunction with the `after` argument to forward-paginate through the `company_aggregations`.
-    When provided, limits the number of returned results to the first `n` after the provided
-    `after` cursor (or from the start of the `company_aggregations`, if no `after` cursor is provided).
-
-    See the [Relay GraphQL Cursor Connections
-    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
-    """
-    first: Int
-
-    """
-    Used in conjunction with the `before` argument to backward-paginate through the `company_aggregations`.
-    When provided, limits the number of returned results to the last `n` before the provided
-    `before` cursor (or from the end of the `company_aggregations`, if no `before` cursor is provided).
-
-    See the [Relay GraphQL Cursor Connections
-    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
-    """
-    last: Int
-  ): CompanyAggregationConnection
-
-  """
   Aggregations over the `components` data:
 
   > Fetches `Component`s based on the provided arguments.
@@ -9348,6 +9694,109 @@ type Query {
     """
     order_by: [ComponentSortOrderInput!]
   ): ComponentConnection
+
+  """
+  Aggregations over the `distribution_channels` data:
+
+  > Fetches `DistributionChannel`s based on the provided arguments.
+  """
+  distribution_channel_aggregations(
+    """
+    Used to forward-paginate through the `distribution_channel_aggregations`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `distribution_channel_aggregations`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the `DistributionChannel` documents that get aggregated over based on the provided criteria.
+    """
+    filter: DistributionChannelFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `distribution_channel_aggregations`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `distribution_channel_aggregations`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `distribution_channel_aggregations`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `distribution_channel_aggregations`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+  ): DistributionChannelAggregationConnection
+
+  """
+  Fetches `DistributionChannel`s based on the provided arguments.
+  """
+  distribution_channels(
+    """
+    Used to forward-paginate through the `distribution_channels`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `distribution_channels`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the returned `distribution_channels` based on the provided criteria.
+    """
+    filter: DistributionChannelFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `distribution_channels`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `distribution_channels`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `distribution_channels`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `distribution_channels`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+
+    """
+    Used to specify how the returned `distribution_channels` should be sorted.
+    """
+    order_by: [DistributionChannelSortOrderInput!]
+  ): DistributionChannelConnection
 
   """
   Aggregations over the `electrical_parts` data:
@@ -10071,11 +10520,13 @@ type Query {
   ): PartConnection
 
   """
-  Fetches `Person`s based on the provided arguments.
+  Aggregations over the `physical_stores` data:
+
+  > Fetches `PhysicalStore`s based on the provided arguments.
   """
-  people(
+  physical_store_aggregations(
     """
-    Used to forward-paginate through the `people`. When provided, the next page after the
+    Used to forward-paginate through the `physical_store_aggregations`. When provided, the next page after the
     provided cursor will be returned.
 
     See the [Relay GraphQL Cursor Connections
@@ -10084,7 +10535,7 @@ type Query {
     after: Cursor
 
     """
-    Used to backward-paginate through the `people`. When provided, the previous page before the
+    Used to backward-paginate through the `physical_store_aggregations`. When provided, the previous page before the
     provided cursor will be returned.
 
     See the [Relay GraphQL Cursor Connections
@@ -10093,14 +10544,14 @@ type Query {
     before: Cursor
 
     """
-    Used to filter the returned `people` based on the provided criteria.
+    Used to filter the `PhysicalStore` documents that get aggregated over based on the provided criteria.
     """
-    filter: PersonFilterInput
+    filter: PhysicalStoreFilterInput
 
     """
-    Used in conjunction with the `after` argument to forward-paginate through the `people`.
+    Used in conjunction with the `after` argument to forward-paginate through the `physical_store_aggregations`.
     When provided, limits the number of returned results to the first `n` after the provided
-    `after` cursor (or from the start of the `people`, if no `after` cursor is provided).
+    `after` cursor (or from the start of the `physical_store_aggregations`, if no `after` cursor is provided).
 
     See the [Relay GraphQL Cursor Connections
     Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
@@ -10108,29 +10559,22 @@ type Query {
     first: Int
 
     """
-    Used in conjunction with the `before` argument to backward-paginate through the `people`.
+    Used in conjunction with the `before` argument to backward-paginate through the `physical_store_aggregations`.
     When provided, limits the number of returned results to the last `n` before the provided
-    `before` cursor (or from the end of the `people`, if no `before` cursor is provided).
+    `before` cursor (or from the end of the `physical_store_aggregations`, if no `before` cursor is provided).
 
     See the [Relay GraphQL Cursor Connections
     Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
     """
     last: Int
-
-    """
-    Used to specify how the returned `people` should be sorted.
-    """
-    order_by: [PersonSortOrderInput!]
-  ): PersonConnection
+  ): PhysicalStoreAggregationConnection
 
   """
-  Aggregations over the `people` data:
-
-  > Fetches `Person`s based on the provided arguments.
+  Fetches `PhysicalStore`s based on the provided arguments.
   """
-  person_aggregations(
+  physical_stores(
     """
-    Used to forward-paginate through the `person_aggregations`. When provided, the next page after the
+    Used to forward-paginate through the `physical_stores`. When provided, the next page after the
     provided cursor will be returned.
 
     See the [Relay GraphQL Cursor Connections
@@ -10139,7 +10583,7 @@ type Query {
     after: Cursor
 
     """
-    Used to backward-paginate through the `person_aggregations`. When provided, the previous page before the
+    Used to backward-paginate through the `physical_stores`. When provided, the previous page before the
     provided cursor will be returned.
 
     See the [Relay GraphQL Cursor Connections
@@ -10148,14 +10592,14 @@ type Query {
     before: Cursor
 
     """
-    Used to filter the `Person` documents that get aggregated over based on the provided criteria.
+    Used to filter the returned `physical_stores` based on the provided criteria.
     """
-    filter: PersonFilterInput
+    filter: PhysicalStoreFilterInput
 
     """
-    Used in conjunction with the `after` argument to forward-paginate through the `person_aggregations`.
+    Used in conjunction with the `after` argument to forward-paginate through the `physical_stores`.
     When provided, limits the number of returned results to the first `n` after the provided
-    `after` cursor (or from the start of the `person_aggregations`, if no `after` cursor is provided).
+    `after` cursor (or from the start of the `physical_stores`, if no `after` cursor is provided).
 
     See the [Relay GraphQL Cursor Connections
     Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
@@ -10163,15 +10607,123 @@ type Query {
     first: Int
 
     """
-    Used in conjunction with the `before` argument to backward-paginate through the `person_aggregations`.
+    Used in conjunction with the `before` argument to backward-paginate through the `physical_stores`.
     When provided, limits the number of returned results to the last `n` before the provided
-    `before` cursor (or from the end of the `person_aggregations`, if no `before` cursor is provided).
+    `before` cursor (or from the end of the `physical_stores`, if no `before` cursor is provided).
 
     See the [Relay GraphQL Cursor Connections
     Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
     """
     last: Int
-  ): PersonAggregationConnection
+
+    """
+    Used to specify how the returned `physical_stores` should be sorted.
+    """
+    order_by: [PhysicalStoreSortOrderInput!]
+  ): PhysicalStoreConnection
+
+  """
+  Aggregations over the `retailers` data:
+
+  > Fetches `Retail`s based on the provided arguments.
+  """
+  retail_aggregations(
+    """
+    Used to forward-paginate through the `retail_aggregations`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `retail_aggregations`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the `Retail` documents that get aggregated over based on the provided criteria.
+    """
+    filter: RetailFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `retail_aggregations`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `retail_aggregations`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `retail_aggregations`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `retail_aggregations`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+  ): RetailAggregationConnection
+
+  """
+  Fetches `Retail`s based on the provided arguments.
+  """
+  retailers(
+    """
+    Used to forward-paginate through the `retailers`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `retailers`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the returned `retailers` based on the provided criteria.
+    """
+    filter: RetailFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `retailers`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `retailers`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `retailers`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `retailers`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+
+    """
+    Used to specify how the returned `retailers` should be sorted.
+    """
+    order_by: [RetailSortOrderInput!]
+  ): RetailConnection
 
   """
   Aggregations over the `sponsors` data:
@@ -10275,6 +10827,109 @@ type Query {
     """
     order_by: [SponsorSortOrderInput!]
   ): SponsorConnection
+
+  """
+  Aggregations over the `stores` data:
+
+  > Fetches `Store`s based on the provided arguments.
+  """
+  store_aggregations(
+    """
+    Used to forward-paginate through the `store_aggregations`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `store_aggregations`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the `Store` documents that get aggregated over based on the provided criteria.
+    """
+    filter: StoreFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `store_aggregations`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `store_aggregations`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `store_aggregations`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `store_aggregations`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+  ): StoreAggregationConnection
+
+  """
+  Fetches `Store`s based on the provided arguments.
+  """
+  stores(
+    """
+    Used to forward-paginate through the `stores`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `stores`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the returned `stores` based on the provided criteria.
+    """
+    filter: StoreFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `stores`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `stores`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `stores`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `stores`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+
+    """
+    Used to specify how the returned `stores` should be sorted.
+    """
+    order_by: [StoreSortOrderInput!]
+  ): StoreConnection
 
   """
   Aggregations over the `teams` data:
@@ -10795,6 +11450,464 @@ type Query {
     """
     order_by: [WidgetOrAddressSortOrderInput!]
   ): WidgetOrAddressConnection
+}
+
+interface Retail implements DistributionChannel {
+  active: Boolean
+  established_on: Date
+  id: ID!
+}
+
+"""
+Type used to perform aggregation computations on `Retail` fields.
+"""
+type RetailAggregatedValues {
+  """
+  Computed aggregate values for the `active` field.
+  """
+  active: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `address` field.
+  """
+  address: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `current_location` field.
+  """
+  current_location: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `customer_facing` field.
+  """
+  customer_facing: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `established_on` field.
+  """
+  established_on: DateAggregatedValues
+
+  """
+  Computed aggregate values for the `id` field.
+  """
+  id: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `platform` field.
+  """
+  platform: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `square_footage` field.
+  """
+  square_footage: IntAggregatedValues
+
+  """
+  Computed aggregate values for the `url` field.
+  """
+  url: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `vehicle_type` field.
+  """
+  vehicle_type: NonNumericAggregatedValues
+}
+
+"""
+Return type representing a bucket of `Retail` documents for an aggregations query.
+"""
+type RetailAggregation {
+  """
+  Provides computed aggregated values over all `Retail` documents in an aggregation bucket.
+  """
+  aggregated_values: RetailAggregatedValues
+
+  """
+  The count of `Retail` documents in an aggregation bucket.
+  """
+  count: JsonSafeLong!
+
+  """
+  Used to specify the `Retail` fields to group by. The returned values identify each aggregation bucket.
+  """
+  grouped_by: RetailGroupedBy
+}
+
+"""
+Represents a paginated collection of `RetailAggregation` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type RetailAggregationConnection {
+  """
+  Wraps a specific `RetailAggregation` to pair it with its pagination cursor.
+  """
+  edges: [RetailAggregationEdge!]!
+
+  """
+  The list of `RetailAggregation` results.
+  """
+  nodes: [RetailAggregation!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+}
+
+"""
+Represents a specific `RetailAggregation` in the context of a `RetailAggregationConnection`,
+providing access to both the `RetailAggregation` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type RetailAggregationEdge {
+  """
+  The `Cursor` of this `RetailAggregation`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `RetailAggregation`.
+  """
+  cursor: Cursor
+
+  """
+  The `RetailAggregation` of this edge.
+  """
+  node: RetailAggregation
+}
+
+"""
+Represents a paginated collection of `Retail` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type RetailConnection {
+  """
+  Wraps a specific `Retail` to pair it with its pagination cursor.
+  """
+  edges: [RetailEdge!]!
+
+  """
+  The list of `Retail` results.
+  """
+  nodes: [Retail!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+
+  """
+  The total number of edges available in this connection to paginate over.
+  """
+  total_edge_count: JsonSafeLong!
+}
+
+"""
+Represents a specific `Retail` in the context of a `RetailConnection`,
+providing access to both the `Retail` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type RetailEdge {
+  """
+  All search highlights for this `Retail`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
+  The `Cursor` of this `Retail`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `Retail`.
+  """
+  cursor: Cursor
+
+  """
+  Specific search highlights for this `Retail`, providing matching snippets for the requested fields.
+  """
+  highlights: RetailHighlights
+
+  """
+  The `Retail` of this edge.
+  """
+  node: Retail
+}
+
+"""
+Input type used to specify filters on `Retail` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input RetailFilterInput {
+  """
+  Used to filter on the `active` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  active: BooleanFilterInput
+
+  """
+  Used to filter on the `address` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  address: StringFilterInput
+
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `RetailFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [RetailFilterInput!]
+
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [RetailFilterInput!]
+
+  """
+  Used to filter on the `current_location` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  current_location: StringFilterInput
+
+  """
+  Used to filter on the `customer_facing` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  customer_facing: BooleanFilterInput
+
+  """
+  Used to filter on the `established_on` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  established_on: DateFilterInput
+
+  """
+  Used to filter on the `id` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  id: IDFilterInput
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: RetailFilterInput
+
+  """
+  Used to filter on the `platform` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  platform: StringFilterInput
+
+  """
+  Used to filter on the `square_footage` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  square_footage: IntFilterInput
+
+  """
+  Used to filter on the `url` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  url: StringFilterInput
+
+  """
+  Used to filter on the `vehicle_type` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  vehicle_type: StringFilterInput
+}
+
+"""
+Type used to specify the `Retail` fields to group by for aggregations.
+"""
+type RetailGroupedBy {
+  """
+  The `active` field value for this group.
+  """
+  active: Boolean
+
+  """
+  The `address` field value for this group.
+  """
+  address: String
+
+  """
+  The `current_location` field value for this group.
+  """
+  current_location: String
+
+  """
+  The `customer_facing` field value for this group.
+  """
+  customer_facing: Boolean
+
+  """
+  Offers the different grouping options for the `established_on` value within this group.
+  """
+  established_on: DateGroupedBy
+
+  """
+  The `platform` field value for this group.
+  """
+  platform: String
+
+  """
+  The `square_footage` field value for this group.
+  """
+  square_footage: Int
+
+  """
+  The `url` field value for this group.
+  """
+  url: String
+
+  """
+  The `vehicle_type` field value for this group.
+  """
+  vehicle_type: String
+}
+
+"""
+Type used to request desired `Retail` search highlight fields.
+"""
+type RetailHighlights {
+  """
+  Search highlights for the `address`, providing snippets of the matching text.
+  """
+  address: [String!]!
+
+  """
+  Search highlights for the `current_location`, providing snippets of the matching text.
+  """
+  current_location: [String!]!
+
+  """
+  Search highlights for the `id`, providing snippets of the matching text.
+  """
+  id: [String!]!
+
+  """
+  Search highlights for the `platform`, providing snippets of the matching text.
+  """
+  platform: [String!]!
+
+  """
+  Search highlights for the `url`, providing snippets of the matching text.
+  """
+  url: [String!]!
+
+  """
+  Search highlights for the `vehicle_type`, providing snippets of the matching text.
+  """
+  vehicle_type: [String!]!
+}
+
+"""
+Enumerates the ways `Retail`s can be sorted.
+"""
+enum RetailSortOrderInput {
+  """
+  Sorts ascending by the `address` field.
+  """
+  address_ASC
+
+  """
+  Sorts descending by the `address` field.
+  """
+  address_DESC
+
+  """
+  Sorts ascending by the `current_location` field.
+  """
+  current_location_ASC
+
+  """
+  Sorts descending by the `current_location` field.
+  """
+  current_location_DESC
+
+  """
+  Sorts ascending by the `established_on` field.
+  """
+  established_on_ASC
+
+  """
+  Sorts descending by the `established_on` field.
+  """
+  established_on_DESC
+
+  """
+  Sorts ascending by the `id` field.
+  """
+  id_ASC
+
+  """
+  Sorts descending by the `id` field.
+  """
+  id_DESC
+
+  """
+  Sorts ascending by the `platform` field.
+  """
+  platform_ASC
+
+  """
+  Sorts descending by the `platform` field.
+  """
+  platform_DESC
+
+  """
+  Sorts ascending by the `square_footage` field.
+  """
+  square_footage_ASC
+
+  """
+  Sorts descending by the `square_footage` field.
+  """
+  square_footage_DESC
+
+  """
+  Sorts ascending by the `url` field.
+  """
+  url_ASC
+
+  """
+  Sorts descending by the `url` field.
+  """
+  url_DESC
+
+  """
+  Sorts ascending by the `vehicle_type` field.
+  """
+  vehicle_type_ASC
+
+  """
+  Sorts descending by the `vehicle_type` field.
+  """
+  vehicle_type_DESC
 }
 
 """
@@ -11606,6 +12719,465 @@ input SponsorshipListFilterInput {
   When `null` or an empty object is passed, matches no documents.
   """
   not: SponsorshipListFilterInput
+}
+
+interface Store implements DistributionChannel & Retail {
+  active: Boolean
+  customer_facing: Boolean
+  established_on: Date
+  id: ID!
+}
+
+"""
+Type used to perform aggregation computations on `Store` fields.
+"""
+type StoreAggregatedValues {
+  """
+  Computed aggregate values for the `active` field.
+  """
+  active: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `address` field.
+  """
+  address: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `current_location` field.
+  """
+  current_location: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `customer_facing` field.
+  """
+  customer_facing: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `established_on` field.
+  """
+  established_on: DateAggregatedValues
+
+  """
+  Computed aggregate values for the `id` field.
+  """
+  id: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `platform` field.
+  """
+  platform: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `square_footage` field.
+  """
+  square_footage: IntAggregatedValues
+
+  """
+  Computed aggregate values for the `url` field.
+  """
+  url: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `vehicle_type` field.
+  """
+  vehicle_type: NonNumericAggregatedValues
+}
+
+"""
+Return type representing a bucket of `Store` documents for an aggregations query.
+"""
+type StoreAggregation {
+  """
+  Provides computed aggregated values over all `Store` documents in an aggregation bucket.
+  """
+  aggregated_values: StoreAggregatedValues
+
+  """
+  The count of `Store` documents in an aggregation bucket.
+  """
+  count: JsonSafeLong!
+
+  """
+  Used to specify the `Store` fields to group by. The returned values identify each aggregation bucket.
+  """
+  grouped_by: StoreGroupedBy
+}
+
+"""
+Represents a paginated collection of `StoreAggregation` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type StoreAggregationConnection {
+  """
+  Wraps a specific `StoreAggregation` to pair it with its pagination cursor.
+  """
+  edges: [StoreAggregationEdge!]!
+
+  """
+  The list of `StoreAggregation` results.
+  """
+  nodes: [StoreAggregation!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+}
+
+"""
+Represents a specific `StoreAggregation` in the context of a `StoreAggregationConnection`,
+providing access to both the `StoreAggregation` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type StoreAggregationEdge {
+  """
+  The `Cursor` of this `StoreAggregation`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `StoreAggregation`.
+  """
+  cursor: Cursor
+
+  """
+  The `StoreAggregation` of this edge.
+  """
+  node: StoreAggregation
+}
+
+"""
+Represents a paginated collection of `Store` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type StoreConnection {
+  """
+  Wraps a specific `Store` to pair it with its pagination cursor.
+  """
+  edges: [StoreEdge!]!
+
+  """
+  The list of `Store` results.
+  """
+  nodes: [Store!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+
+  """
+  The total number of edges available in this connection to paginate over.
+  """
+  total_edge_count: JsonSafeLong!
+}
+
+"""
+Represents a specific `Store` in the context of a `StoreConnection`,
+providing access to both the `Store` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type StoreEdge {
+  """
+  All search highlights for this `Store`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
+  The `Cursor` of this `Store`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `Store`.
+  """
+  cursor: Cursor
+
+  """
+  Specific search highlights for this `Store`, providing matching snippets for the requested fields.
+  """
+  highlights: StoreHighlights
+
+  """
+  The `Store` of this edge.
+  """
+  node: Store
+}
+
+"""
+Input type used to specify filters on `Store` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input StoreFilterInput {
+  """
+  Used to filter on the `active` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  active: BooleanFilterInput
+
+  """
+  Used to filter on the `address` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  address: StringFilterInput
+
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `StoreFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [StoreFilterInput!]
+
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [StoreFilterInput!]
+
+  """
+  Used to filter on the `current_location` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  current_location: StringFilterInput
+
+  """
+  Used to filter on the `customer_facing` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  customer_facing: BooleanFilterInput
+
+  """
+  Used to filter on the `established_on` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  established_on: DateFilterInput
+
+  """
+  Used to filter on the `id` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  id: IDFilterInput
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: StoreFilterInput
+
+  """
+  Used to filter on the `platform` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  platform: StringFilterInput
+
+  """
+  Used to filter on the `square_footage` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  square_footage: IntFilterInput
+
+  """
+  Used to filter on the `url` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  url: StringFilterInput
+
+  """
+  Used to filter on the `vehicle_type` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  vehicle_type: StringFilterInput
+}
+
+"""
+Type used to specify the `Store` fields to group by for aggregations.
+"""
+type StoreGroupedBy {
+  """
+  The `active` field value for this group.
+  """
+  active: Boolean
+
+  """
+  The `address` field value for this group.
+  """
+  address: String
+
+  """
+  The `current_location` field value for this group.
+  """
+  current_location: String
+
+  """
+  The `customer_facing` field value for this group.
+  """
+  customer_facing: Boolean
+
+  """
+  Offers the different grouping options for the `established_on` value within this group.
+  """
+  established_on: DateGroupedBy
+
+  """
+  The `platform` field value for this group.
+  """
+  platform: String
+
+  """
+  The `square_footage` field value for this group.
+  """
+  square_footage: Int
+
+  """
+  The `url` field value for this group.
+  """
+  url: String
+
+  """
+  The `vehicle_type` field value for this group.
+  """
+  vehicle_type: String
+}
+
+"""
+Type used to request desired `Store` search highlight fields.
+"""
+type StoreHighlights {
+  """
+  Search highlights for the `address`, providing snippets of the matching text.
+  """
+  address: [String!]!
+
+  """
+  Search highlights for the `current_location`, providing snippets of the matching text.
+  """
+  current_location: [String!]!
+
+  """
+  Search highlights for the `id`, providing snippets of the matching text.
+  """
+  id: [String!]!
+
+  """
+  Search highlights for the `platform`, providing snippets of the matching text.
+  """
+  platform: [String!]!
+
+  """
+  Search highlights for the `url`, providing snippets of the matching text.
+  """
+  url: [String!]!
+
+  """
+  Search highlights for the `vehicle_type`, providing snippets of the matching text.
+  """
+  vehicle_type: [String!]!
+}
+
+"""
+Enumerates the ways `Store`s can be sorted.
+"""
+enum StoreSortOrderInput {
+  """
+  Sorts ascending by the `address` field.
+  """
+  address_ASC
+
+  """
+  Sorts descending by the `address` field.
+  """
+  address_DESC
+
+  """
+  Sorts ascending by the `current_location` field.
+  """
+  current_location_ASC
+
+  """
+  Sorts descending by the `current_location` field.
+  """
+  current_location_DESC
+
+  """
+  Sorts ascending by the `established_on` field.
+  """
+  established_on_ASC
+
+  """
+  Sorts descending by the `established_on` field.
+  """
+  established_on_DESC
+
+  """
+  Sorts ascending by the `id` field.
+  """
+  id_ASC
+
+  """
+  Sorts descending by the `id` field.
+  """
+  id_DESC
+
+  """
+  Sorts ascending by the `platform` field.
+  """
+  platform_ASC
+
+  """
+  Sorts descending by the `platform` field.
+  """
+  platform_DESC
+
+  """
+  Sorts ascending by the `square_footage` field.
+  """
+  square_footage_ASC
+
+  """
+  Sorts descending by the `square_footage` field.
+  """
+  square_footage_DESC
+
+  """
+  Sorts ascending by the `url` field.
+  """
+  url_ASC
+
+  """
+  Sorts descending by the `url` field.
+  """
+  url_DESC
+
+  """
+  Sorts ascending by the `vehicle_type` field.
+  """
+  vehicle_type_ASC
+
+  """
+  Sorts descending by the `vehicle_type` field.
+  """
+  vehicle_type_DESC
 }
 
 """
@@ -14158,6 +15730,13 @@ input TextFilterInput {
   When `null` or an empty object is passed, matches no documents.
   """
   not: TextFilterInput
+}
+
+type ThirdPartyWholesale implements DistributionChannel {
+  active: Boolean
+  contract_terms: String
+  id: ID!
+  partner_name: String
 }
 
 """

--- a/config/schema/artifacts/schema.graphql
+++ b/config/schema/artifacts/schema.graphql
@@ -2541,26 +2541,6 @@ type DistributionChannelAggregatedValues {
   active: NonNumericAggregatedValues
 
   """
-  Computed aggregate values for the `address` field.
-  """
-  address: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `contract_terms` field.
-  """
-  contract_terms: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `current_location` field.
-  """
-  current_location: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `customer_facing` field.
-  """
-  customer_facing: NonNumericAggregatedValues
-
-  """
   Computed aggregate values for the `established_on` field.
   """
   established_on: DateAggregatedValues
@@ -2569,31 +2549,6 @@ type DistributionChannelAggregatedValues {
   Computed aggregate values for the `id` field.
   """
   id: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `partner_name` field.
-  """
-  partner_name: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `platform` field.
-  """
-  platform: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `square_footage` field.
-  """
-  square_footage: IntAggregatedValues
-
-  """
-  Computed aggregate values for the `url` field.
-  """
-  url: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `vehicle_type` field.
-  """
-  vehicle_type: NonNumericAggregatedValues
 }
 
 """
@@ -2732,13 +2687,6 @@ input DistributionChannelFilterInput {
   active: BooleanFilterInput
 
   """
-  Used to filter on the `address` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  address: StringFilterInput
-
-  """
   Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
@@ -2758,27 +2706,6 @@ input DistributionChannelFilterInput {
   When an empty list is passed, this part of the filter matches no documents.
   """
   any_of: [DistributionChannelFilterInput!]
-
-  """
-  Used to filter on the `contract_terms` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  contract_terms: StringFilterInput
-
-  """
-  Used to filter on the `current_location` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  current_location: StringFilterInput
-
-  """
-  Used to filter on the `customer_facing` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  customer_facing: BooleanFilterInput
 
   """
   Used to filter on the `established_on` field.
@@ -2801,41 +2728,6 @@ input DistributionChannelFilterInput {
   When `null` or an empty object is passed, matches no documents.
   """
   not: DistributionChannelFilterInput
-
-  """
-  Used to filter on the `partner_name` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  partner_name: StringFilterInput
-
-  """
-  Used to filter on the `platform` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  platform: StringFilterInput
-
-  """
-  Used to filter on the `square_footage` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  square_footage: IntFilterInput
-
-  """
-  Used to filter on the `url` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  url: StringFilterInput
-
-  """
-  Used to filter on the `vehicle_type` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  vehicle_type: StringFilterInput
 }
 
 """
@@ -2848,54 +2740,9 @@ type DistributionChannelGroupedBy {
   active: Boolean
 
   """
-  The `address` field value for this group.
-  """
-  address: String
-
-  """
-  The `contract_terms` field value for this group.
-  """
-  contract_terms: String
-
-  """
-  The `current_location` field value for this group.
-  """
-  current_location: String
-
-  """
-  The `customer_facing` field value for this group.
-  """
-  customer_facing: Boolean
-
-  """
   Offers the different grouping options for the `established_on` value within this group.
   """
   established_on: DateGroupedBy
-
-  """
-  The `partner_name` field value for this group.
-  """
-  partner_name: String
-
-  """
-  The `platform` field value for this group.
-  """
-  platform: String
-
-  """
-  The `square_footage` field value for this group.
-  """
-  square_footage: Int
-
-  """
-  The `url` field value for this group.
-  """
-  url: String
-
-  """
-  The `vehicle_type` field value for this group.
-  """
-  vehicle_type: String
 }
 
 """
@@ -2903,80 +2750,15 @@ Type used to request desired `DistributionChannel` search highlight fields.
 """
 type DistributionChannelHighlights {
   """
-  Search highlights for the `address`, providing snippets of the matching text.
-  """
-  address: [String!]!
-
-  """
-  Search highlights for the `contract_terms`, providing snippets of the matching text.
-  """
-  contract_terms: [String!]!
-
-  """
-  Search highlights for the `current_location`, providing snippets of the matching text.
-  """
-  current_location: [String!]!
-
-  """
   Search highlights for the `id`, providing snippets of the matching text.
   """
   id: [String!]!
-
-  """
-  Search highlights for the `partner_name`, providing snippets of the matching text.
-  """
-  partner_name: [String!]!
-
-  """
-  Search highlights for the `platform`, providing snippets of the matching text.
-  """
-  platform: [String!]!
-
-  """
-  Search highlights for the `url`, providing snippets of the matching text.
-  """
-  url: [String!]!
-
-  """
-  Search highlights for the `vehicle_type`, providing snippets of the matching text.
-  """
-  vehicle_type: [String!]!
 }
 
 """
 Enumerates the ways `DistributionChannel`s can be sorted.
 """
 enum DistributionChannelSortOrderInput {
-  """
-  Sorts ascending by the `address` field.
-  """
-  address_ASC
-
-  """
-  Sorts descending by the `address` field.
-  """
-  address_DESC
-
-  """
-  Sorts ascending by the `contract_terms` field.
-  """
-  contract_terms_ASC
-
-  """
-  Sorts descending by the `contract_terms` field.
-  """
-  contract_terms_DESC
-
-  """
-  Sorts ascending by the `current_location` field.
-  """
-  current_location_ASC
-
-  """
-  Sorts descending by the `current_location` field.
-  """
-  current_location_DESC
-
   """
   Sorts ascending by the `established_on` field.
   """
@@ -2996,56 +2778,6 @@ enum DistributionChannelSortOrderInput {
   Sorts descending by the `id` field.
   """
   id_DESC
-
-  """
-  Sorts ascending by the `partner_name` field.
-  """
-  partner_name_ASC
-
-  """
-  Sorts descending by the `partner_name` field.
-  """
-  partner_name_DESC
-
-  """
-  Sorts ascending by the `platform` field.
-  """
-  platform_ASC
-
-  """
-  Sorts descending by the `platform` field.
-  """
-  platform_DESC
-
-  """
-  Sorts ascending by the `square_footage` field.
-  """
-  square_footage_ASC
-
-  """
-  Sorts descending by the `square_footage` field.
-  """
-  square_footage_DESC
-
-  """
-  Sorts ascending by the `url` field.
-  """
-  url_ASC
-
-  """
-  Sorts descending by the `url` field.
-  """
-  url_DESC
-
-  """
-  Sorts ascending by the `vehicle_type` field.
-  """
-  vehicle_type_ASC
-
-  """
-  Sorts descending by the `vehicle_type` field.
-  """
-  vehicle_type_DESC
 }
 
 type ElectricalPart implements NamedEntity {
@@ -5930,15 +5662,6 @@ enum MechanicalPartSortOrderInput {
   name_DESC
 }
 
-type MobileStore implements DistributionChannel & Retail & Store {
-  active: Boolean
-  current_location: String
-  customer_facing: Boolean
-  established_on: Date
-  id: ID!
-  vehicle_type: String!
-}
-
 type Money {
   amount_cents: Int
   currency: String!
@@ -8036,11 +7759,8 @@ type NonNumericAggregatedValues {
 
 type OnlineStore implements DistributionChannel & Retail & Store {
   active: Boolean
-  customer_facing: Boolean
   established_on: Date
   id: ID!
-  platform: String
-  url: String!
 }
 
 """
@@ -8516,11 +8236,8 @@ type PersonHighlights {
 
 type PhysicalStore implements DistributionChannel & Retail & Store {
   active: Boolean
-  address: String!
-  customer_facing: Boolean
   established_on: Date
   id: ID!
-  square_footage: Int
 }
 
 """
@@ -8533,16 +8250,6 @@ type PhysicalStoreAggregatedValues {
   active: NonNumericAggregatedValues
 
   """
-  Computed aggregate values for the `address` field.
-  """
-  address: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `customer_facing` field.
-  """
-  customer_facing: NonNumericAggregatedValues
-
-  """
   Computed aggregate values for the `established_on` field.
   """
   established_on: DateAggregatedValues
@@ -8551,11 +8258,6 @@ type PhysicalStoreAggregatedValues {
   Computed aggregate values for the `id` field.
   """
   id: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `square_footage` field.
-  """
-  square_footage: IntAggregatedValues
 }
 
 """
@@ -8693,13 +8395,6 @@ input PhysicalStoreFilterInput {
   active: BooleanFilterInput
 
   """
-  Used to filter on the `address` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  address: StringFilterInput
-
-  """
   Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
@@ -8719,13 +8414,6 @@ input PhysicalStoreFilterInput {
   When an empty list is passed, this part of the filter matches no documents.
   """
   any_of: [PhysicalStoreFilterInput!]
-
-  """
-  Used to filter on the `customer_facing` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  customer_facing: BooleanFilterInput
 
   """
   Used to filter on the `established_on` field.
@@ -8748,13 +8436,6 @@ input PhysicalStoreFilterInput {
   When `null` or an empty object is passed, matches no documents.
   """
   not: PhysicalStoreFilterInput
-
-  """
-  Used to filter on the `square_footage` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  square_footage: IntFilterInput
 }
 
 """
@@ -8767,35 +8448,15 @@ type PhysicalStoreGroupedBy {
   active: Boolean
 
   """
-  The `address` field value for this group.
-  """
-  address: String
-
-  """
-  The `customer_facing` field value for this group.
-  """
-  customer_facing: Boolean
-
-  """
   Offers the different grouping options for the `established_on` value within this group.
   """
   established_on: DateGroupedBy
-
-  """
-  The `square_footage` field value for this group.
-  """
-  square_footage: Int
 }
 
 """
 Type used to request desired `PhysicalStore` search highlight fields.
 """
 type PhysicalStoreHighlights {
-  """
-  Search highlights for the `address`, providing snippets of the matching text.
-  """
-  address: [String!]!
-
   """
   Search highlights for the `id`, providing snippets of the matching text.
   """
@@ -8806,16 +8467,6 @@ type PhysicalStoreHighlights {
 Enumerates the ways `PhysicalStore`s can be sorted.
 """
 enum PhysicalStoreSortOrderInput {
-  """
-  Sorts ascending by the `address` field.
-  """
-  address_ASC
-
-  """
-  Sorts descending by the `address` field.
-  """
-  address_DESC
-
   """
   Sorts ascending by the `established_on` field.
   """
@@ -8835,16 +8486,6 @@ enum PhysicalStoreSortOrderInput {
   Sorts descending by the `id` field.
   """
   id_DESC
-
-  """
-  Sorts ascending by the `square_footage` field.
-  """
-  square_footage_ASC
-
-  """
-  Sorts descending by the `square_footage` field.
-  """
-  square_footage_DESC
 }
 
 type Player {
@@ -11468,21 +11109,6 @@ type RetailAggregatedValues {
   active: NonNumericAggregatedValues
 
   """
-  Computed aggregate values for the `address` field.
-  """
-  address: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `current_location` field.
-  """
-  current_location: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `customer_facing` field.
-  """
-  customer_facing: NonNumericAggregatedValues
-
-  """
   Computed aggregate values for the `established_on` field.
   """
   established_on: DateAggregatedValues
@@ -11491,26 +11117,6 @@ type RetailAggregatedValues {
   Computed aggregate values for the `id` field.
   """
   id: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `platform` field.
-  """
-  platform: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `square_footage` field.
-  """
-  square_footage: IntAggregatedValues
-
-  """
-  Computed aggregate values for the `url` field.
-  """
-  url: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `vehicle_type` field.
-  """
-  vehicle_type: NonNumericAggregatedValues
 }
 
 """
@@ -11648,13 +11254,6 @@ input RetailFilterInput {
   active: BooleanFilterInput
 
   """
-  Used to filter on the `address` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  address: StringFilterInput
-
-  """
   Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
@@ -11674,20 +11273,6 @@ input RetailFilterInput {
   When an empty list is passed, this part of the filter matches no documents.
   """
   any_of: [RetailFilterInput!]
-
-  """
-  Used to filter on the `current_location` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  current_location: StringFilterInput
-
-  """
-  Used to filter on the `customer_facing` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  customer_facing: BooleanFilterInput
 
   """
   Used to filter on the `established_on` field.
@@ -11710,34 +11295,6 @@ input RetailFilterInput {
   When `null` or an empty object is passed, matches no documents.
   """
   not: RetailFilterInput
-
-  """
-  Used to filter on the `platform` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  platform: StringFilterInput
-
-  """
-  Used to filter on the `square_footage` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  square_footage: IntFilterInput
-
-  """
-  Used to filter on the `url` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  url: StringFilterInput
-
-  """
-  Used to filter on the `vehicle_type` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  vehicle_type: StringFilterInput
 }
 
 """
@@ -11750,44 +11307,9 @@ type RetailGroupedBy {
   active: Boolean
 
   """
-  The `address` field value for this group.
-  """
-  address: String
-
-  """
-  The `current_location` field value for this group.
-  """
-  current_location: String
-
-  """
-  The `customer_facing` field value for this group.
-  """
-  customer_facing: Boolean
-
-  """
   Offers the different grouping options for the `established_on` value within this group.
   """
   established_on: DateGroupedBy
-
-  """
-  The `platform` field value for this group.
-  """
-  platform: String
-
-  """
-  The `square_footage` field value for this group.
-  """
-  square_footage: Int
-
-  """
-  The `url` field value for this group.
-  """
-  url: String
-
-  """
-  The `vehicle_type` field value for this group.
-  """
-  vehicle_type: String
 }
 
 """
@@ -11795,60 +11317,15 @@ Type used to request desired `Retail` search highlight fields.
 """
 type RetailHighlights {
   """
-  Search highlights for the `address`, providing snippets of the matching text.
-  """
-  address: [String!]!
-
-  """
-  Search highlights for the `current_location`, providing snippets of the matching text.
-  """
-  current_location: [String!]!
-
-  """
   Search highlights for the `id`, providing snippets of the matching text.
   """
   id: [String!]!
-
-  """
-  Search highlights for the `platform`, providing snippets of the matching text.
-  """
-  platform: [String!]!
-
-  """
-  Search highlights for the `url`, providing snippets of the matching text.
-  """
-  url: [String!]!
-
-  """
-  Search highlights for the `vehicle_type`, providing snippets of the matching text.
-  """
-  vehicle_type: [String!]!
 }
 
 """
 Enumerates the ways `Retail`s can be sorted.
 """
 enum RetailSortOrderInput {
-  """
-  Sorts ascending by the `address` field.
-  """
-  address_ASC
-
-  """
-  Sorts descending by the `address` field.
-  """
-  address_DESC
-
-  """
-  Sorts ascending by the `current_location` field.
-  """
-  current_location_ASC
-
-  """
-  Sorts descending by the `current_location` field.
-  """
-  current_location_DESC
-
   """
   Sorts ascending by the `established_on` field.
   """
@@ -11868,46 +11345,6 @@ enum RetailSortOrderInput {
   Sorts descending by the `id` field.
   """
   id_DESC
-
-  """
-  Sorts ascending by the `platform` field.
-  """
-  platform_ASC
-
-  """
-  Sorts descending by the `platform` field.
-  """
-  platform_DESC
-
-  """
-  Sorts ascending by the `square_footage` field.
-  """
-  square_footage_ASC
-
-  """
-  Sorts descending by the `square_footage` field.
-  """
-  square_footage_DESC
-
-  """
-  Sorts ascending by the `url` field.
-  """
-  url_ASC
-
-  """
-  Sorts descending by the `url` field.
-  """
-  url_DESC
-
-  """
-  Sorts ascending by the `vehicle_type` field.
-  """
-  vehicle_type_ASC
-
-  """
-  Sorts descending by the `vehicle_type` field.
-  """
-  vehicle_type_DESC
 }
 
 """
@@ -12723,7 +12160,6 @@ input SponsorshipListFilterInput {
 
 interface Store implements DistributionChannel & Retail {
   active: Boolean
-  customer_facing: Boolean
   established_on: Date
   id: ID!
 }
@@ -12738,21 +12174,6 @@ type StoreAggregatedValues {
   active: NonNumericAggregatedValues
 
   """
-  Computed aggregate values for the `address` field.
-  """
-  address: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `current_location` field.
-  """
-  current_location: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `customer_facing` field.
-  """
-  customer_facing: NonNumericAggregatedValues
-
-  """
   Computed aggregate values for the `established_on` field.
   """
   established_on: DateAggregatedValues
@@ -12761,26 +12182,6 @@ type StoreAggregatedValues {
   Computed aggregate values for the `id` field.
   """
   id: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `platform` field.
-  """
-  platform: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `square_footage` field.
-  """
-  square_footage: IntAggregatedValues
-
-  """
-  Computed aggregate values for the `url` field.
-  """
-  url: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `vehicle_type` field.
-  """
-  vehicle_type: NonNumericAggregatedValues
 }
 
 """
@@ -12918,13 +12319,6 @@ input StoreFilterInput {
   active: BooleanFilterInput
 
   """
-  Used to filter on the `address` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  address: StringFilterInput
-
-  """
   Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
@@ -12944,20 +12338,6 @@ input StoreFilterInput {
   When an empty list is passed, this part of the filter matches no documents.
   """
   any_of: [StoreFilterInput!]
-
-  """
-  Used to filter on the `current_location` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  current_location: StringFilterInput
-
-  """
-  Used to filter on the `customer_facing` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  customer_facing: BooleanFilterInput
 
   """
   Used to filter on the `established_on` field.
@@ -12980,34 +12360,6 @@ input StoreFilterInput {
   When `null` or an empty object is passed, matches no documents.
   """
   not: StoreFilterInput
-
-  """
-  Used to filter on the `platform` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  platform: StringFilterInput
-
-  """
-  Used to filter on the `square_footage` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  square_footage: IntFilterInput
-
-  """
-  Used to filter on the `url` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  url: StringFilterInput
-
-  """
-  Used to filter on the `vehicle_type` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  vehicle_type: StringFilterInput
 }
 
 """
@@ -13020,44 +12372,9 @@ type StoreGroupedBy {
   active: Boolean
 
   """
-  The `address` field value for this group.
-  """
-  address: String
-
-  """
-  The `current_location` field value for this group.
-  """
-  current_location: String
-
-  """
-  The `customer_facing` field value for this group.
-  """
-  customer_facing: Boolean
-
-  """
   Offers the different grouping options for the `established_on` value within this group.
   """
   established_on: DateGroupedBy
-
-  """
-  The `platform` field value for this group.
-  """
-  platform: String
-
-  """
-  The `square_footage` field value for this group.
-  """
-  square_footage: Int
-
-  """
-  The `url` field value for this group.
-  """
-  url: String
-
-  """
-  The `vehicle_type` field value for this group.
-  """
-  vehicle_type: String
 }
 
 """
@@ -13065,60 +12382,15 @@ Type used to request desired `Store` search highlight fields.
 """
 type StoreHighlights {
   """
-  Search highlights for the `address`, providing snippets of the matching text.
-  """
-  address: [String!]!
-
-  """
-  Search highlights for the `current_location`, providing snippets of the matching text.
-  """
-  current_location: [String!]!
-
-  """
   Search highlights for the `id`, providing snippets of the matching text.
   """
   id: [String!]!
-
-  """
-  Search highlights for the `platform`, providing snippets of the matching text.
-  """
-  platform: [String!]!
-
-  """
-  Search highlights for the `url`, providing snippets of the matching text.
-  """
-  url: [String!]!
-
-  """
-  Search highlights for the `vehicle_type`, providing snippets of the matching text.
-  """
-  vehicle_type: [String!]!
 }
 
 """
 Enumerates the ways `Store`s can be sorted.
 """
 enum StoreSortOrderInput {
-  """
-  Sorts ascending by the `address` field.
-  """
-  address_ASC
-
-  """
-  Sorts descending by the `address` field.
-  """
-  address_DESC
-
-  """
-  Sorts ascending by the `current_location` field.
-  """
-  current_location_ASC
-
-  """
-  Sorts descending by the `current_location` field.
-  """
-  current_location_DESC
-
   """
   Sorts ascending by the `established_on` field.
   """
@@ -13138,46 +12410,6 @@ enum StoreSortOrderInput {
   Sorts descending by the `id` field.
   """
   id_DESC
-
-  """
-  Sorts ascending by the `platform` field.
-  """
-  platform_ASC
-
-  """
-  Sorts descending by the `platform` field.
-  """
-  platform_DESC
-
-  """
-  Sorts ascending by the `square_footage` field.
-  """
-  square_footage_ASC
-
-  """
-  Sorts descending by the `square_footage` field.
-  """
-  square_footage_DESC
-
-  """
-  Sorts ascending by the `url` field.
-  """
-  url_ASC
-
-  """
-  Sorts descending by the `url` field.
-  """
-  url_DESC
-
-  """
-  Sorts ascending by the `vehicle_type` field.
-  """
-  vehicle_type_ASC
-
-  """
-  Sorts descending by the `vehicle_type` field.
-  """
-  vehicle_type_DESC
 }
 
 """
@@ -15734,9 +14966,7 @@ input TextFilterInput {
 
 type ThirdPartyWholesale implements DistributionChannel {
   active: Boolean
-  contract_terms: String
   id: ID!
-  partner_name: String
 }
 
 """

--- a/config/schema/artifacts_with_apollo/data_warehouse.yaml
+++ b/config/schema/artifacts_with_apollo/data_warehouse.yaml
@@ -14,13 +14,6 @@ tables:
         shapes ARRAY<STRUCT<type STRING, coordinates ARRAY<FLOAT>>>,
         manufacturer_id STRING
       )
-  companies:
-    table_schema: |-
-      CREATE TABLE IF NOT EXISTS companies (
-        id STRING,
-        name STRING,
-        stock_ticker STRING
-      )
   components:
     table_schema: |-
       CREATE TABLE IF NOT EXISTS components (
@@ -38,6 +31,23 @@ tables:
         owner_ids ARRAY<STRING>,
         owner_id STRING
       )
+  distribution_channels:
+    table_schema: |-
+      CREATE TABLE IF NOT EXISTS distribution_channels (
+        id STRING,
+        url STRING,
+        platform STRING,
+        established_on DATE,
+        active BOOLEAN,
+        customer_facing BOOLEAN,
+        __typename STRING,
+        address STRING,
+        square_footage INT,
+        vehicle_type STRING,
+        current_location STRING,
+        partner_name STRING,
+        contract_terms STRING
+      )
   electrical_parts:
     table_schema: |-
       CREATE TABLE IF NOT EXISTS electrical_parts (
@@ -53,7 +63,7 @@ tables:
         id STRING,
         name STRING,
         created_at TIMESTAMP,
-        ceo STRUCT<id STRING, name STRING, nationality STRING>
+        ceo STRUCT<id STRING, name STRING, nationality STRING, __typename STRING>
       )
   mechanical_parts:
     table_schema: |-
@@ -64,12 +74,24 @@ tables:
         material STRING,
         manufacturer_id STRING
       )
-  people:
+  named_inventors:
     table_schema: |-
-      CREATE TABLE IF NOT EXISTS people (
+      CREATE TABLE IF NOT EXISTS named_inventors (
         id STRING,
         name STRING,
-        nationality STRING
+        nationality STRING,
+        __typename STRING,
+        stock_ticker STRING
+      )
+  physical_stores:
+    table_schema: |-
+      CREATE TABLE IF NOT EXISTS physical_stores (
+        id STRING,
+        address STRING,
+        square_footage INT,
+        established_on DATE,
+        active BOOLEAN,
+        customer_facing BOOLEAN
       )
   sponsors:
     table_schema: |-
@@ -142,8 +164,8 @@ tables:
         internal_details STRUCT<name STRING>,
         internal_highlightable_details STRUCT<name STRING>,
         the_opts STRUCT<size STRING, the_sighs STRING, color STRING, is_draft BOOLEAN>,
-        inventor STRUCT<id STRING, name STRING, nationality STRING, stock_ticker STRING, __typename STRING>,
-        named_inventor STRUCT<id STRING, name STRING, nationality STRING, stock_ticker STRING, __typename STRING>,
+        inventor STRUCT<id STRING, name STRING, nationality STRING, __typename STRING, stock_ticker STRING>,
+        named_inventor STRUCT<id STRING, name STRING, nationality STRING, __typename STRING, stock_ticker STRING>,
         weight_in_ng_str BIGINT,
         weight_in_ng BIGINT,
         tags ARRAY<STRING>,

--- a/config/schema/artifacts_with_apollo/data_warehouse.yaml
+++ b/config/schema/artifacts_with_apollo/data_warehouse.yaml
@@ -35,18 +35,9 @@ tables:
     table_schema: |-
       CREATE TABLE IF NOT EXISTS distribution_channels (
         id STRING,
-        url STRING,
-        platform STRING,
         established_on DATE,
         active BOOLEAN,
-        customer_facing BOOLEAN,
-        __typename STRING,
-        address STRING,
-        square_footage INT,
-        vehicle_type STRING,
-        current_location STRING,
-        partner_name STRING,
-        contract_terms STRING
+        __typename STRING
       )
   electrical_parts:
     table_schema: |-
@@ -87,11 +78,8 @@ tables:
     table_schema: |-
       CREATE TABLE IF NOT EXISTS physical_stores (
         id STRING,
-        address STRING,
-        square_footage INT,
         established_on DATE,
-        active BOOLEAN,
-        customer_facing BOOLEAN
+        active BOOLEAN
       )
   sponsors:
     table_schema: |-

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -1601,29 +1601,11 @@ indices:
       properties:
         id:
           type: keyword
-        url:
-          type: keyword
-        platform:
-          type: keyword
         established_on:
           type: date
           format: strict_date
         active:
           type: boolean
-        customer_facing:
-          type: boolean
-        address:
-          type: keyword
-        square_footage:
-          type: integer
-        vehicle_type:
-          type: keyword
-        current_location:
-          type: keyword
-        partner_name:
-          type: keyword
-        contract_terms:
-          type: keyword
         __typename:
           type: keyword
         __sources:
@@ -1765,16 +1747,10 @@ indices:
       properties:
         id:
           type: keyword
-        address:
-          type: keyword
-        square_footage:
-          type: integer
         established_on:
           type: date
           format: strict_date
         active:
-          type: boolean
-        customer_facing:
           type: boolean
         __sources:
           type: keyword

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -1531,30 +1531,6 @@ indices:
       index.number_of_replicas: 1
       index.number_of_shards: 1
       index.max_result_window: 10000
-  companies:
-    aliases: {}
-    mappings:
-      dynamic: strict
-      properties:
-        id:
-          type: keyword
-        name:
-          type: keyword
-        stock_ticker:
-          type: keyword
-        __sources:
-          type: keyword
-        __versions:
-          type: object
-          dynamic: 'false'
-      _size:
-        enabled: true
-    settings:
-      index.mapping.ignore_malformed: false
-      index.mapping.coerce: false
-      index.number_of_replicas: 1
-      index.number_of_shards: 1
-      index.max_result_window: 10000
   components:
     aliases: {}
     mappings:
@@ -1605,6 +1581,51 @@ indices:
               type: integer
             owner_ids:
               type: integer
+        __sources:
+          type: keyword
+        __versions:
+          type: object
+          dynamic: 'false'
+      _size:
+        enabled: true
+    settings:
+      index.mapping.ignore_malformed: false
+      index.mapping.coerce: false
+      index.number_of_replicas: 1
+      index.number_of_shards: 1
+      index.max_result_window: 10000
+  distribution_channels:
+    aliases: {}
+    mappings:
+      dynamic: strict
+      properties:
+        id:
+          type: keyword
+        url:
+          type: keyword
+        platform:
+          type: keyword
+        established_on:
+          type: date
+          format: strict_date
+        active:
+          type: boolean
+        customer_facing:
+          type: boolean
+        address:
+          type: keyword
+        square_footage:
+          type: integer
+        vehicle_type:
+          type: keyword
+        current_location:
+          type: keyword
+        partner_name:
+          type: keyword
+        contract_terms:
+          type: keyword
+        __typename:
+          type: keyword
         __sources:
           type: keyword
         __versions:
@@ -1709,7 +1730,7 @@ indices:
       index.number_of_replicas: 1
       index.number_of_shards: 1
       index.max_result_window: 10000
-  people:
+  named_inventors:
     aliases: {}
     mappings:
       dynamic: strict
@@ -1720,6 +1741,41 @@ indices:
           type: keyword
         nationality:
           type: keyword
+        stock_ticker:
+          type: keyword
+        __typename:
+          type: keyword
+        __sources:
+          type: keyword
+        __versions:
+          type: object
+          dynamic: 'false'
+      _size:
+        enabled: true
+    settings:
+      index.mapping.ignore_malformed: false
+      index.mapping.coerce: false
+      index.number_of_replicas: 1
+      index.number_of_shards: 1
+      index.max_result_window: 10000
+  physical_stores:
+    aliases: {}
+    mappings:
+      dynamic: strict
+      properties:
+        id:
+          type: keyword
+        address:
+          type: keyword
+        square_footage:
+          type: integer
+        established_on:
+          type: date
+          format: strict_date
+        active:
+          type: boolean
+        customer_facing:
+          type: boolean
         __sources:
           type: keyword
         __versions:

--- a/config/schema/artifacts_with_apollo/json_schemas.yaml
+++ b/config/schema/artifacts_with_apollo/json_schemas.yaml
@@ -28,7 +28,6 @@ json_schema_version: 1
         - ElectricalPart
         - Manufacturer
         - MechanicalPart
-        - MobileStore
         - OnlineStore
         - Person
         - PhysicalStore
@@ -425,46 +424,6 @@ json_schema_version: 1
     - created_at
     - material
     - manufacturer_id
-  MobileStore:
-    type: object
-    properties:
-      id:
-        allOf:
-        - "$ref": "#/$defs/ID"
-        - maxLength: 8191
-      vehicle_type:
-        allOf:
-        - "$ref": "#/$defs/String"
-        - maxLength: 8191
-      current_location:
-        anyOf:
-        - allOf:
-          - "$ref": "#/$defs/String"
-          - maxLength: 8191
-        - type: 'null'
-      established_on:
-        anyOf:
-        - "$ref": "#/$defs/Date"
-        - type: 'null'
-      active:
-        anyOf:
-        - "$ref": "#/$defs/Boolean"
-        - type: 'null'
-      customer_facing:
-        anyOf:
-        - "$ref": "#/$defs/Boolean"
-        - type: 'null'
-      __typename:
-        type: string
-        const: MobileStore
-        default: MobileStore
-    required:
-    - id
-    - vehicle_type
-    - current_location
-    - established_on
-    - active
-    - customer_facing
   Money:
     type: object
     properties:
@@ -496,25 +455,11 @@ json_schema_version: 1
         allOf:
         - "$ref": "#/$defs/ID"
         - maxLength: 8191
-      url:
-        allOf:
-        - "$ref": "#/$defs/String"
-        - maxLength: 8191
-      platform:
-        anyOf:
-        - allOf:
-          - "$ref": "#/$defs/String"
-          - maxLength: 8191
-        - type: 'null'
       established_on:
         anyOf:
         - "$ref": "#/$defs/Date"
         - type: 'null'
       active:
-        anyOf:
-        - "$ref": "#/$defs/Boolean"
-        - type: 'null'
-      customer_facing:
         anyOf:
         - "$ref": "#/$defs/Boolean"
         - type: 'null'
@@ -524,11 +469,8 @@ json_schema_version: 1
         default: OnlineStore
     required:
     - id
-    - url
-    - platform
     - established_on
     - active
-    - customer_facing
   Person:
     type: object
     properties:
@@ -563,23 +505,11 @@ json_schema_version: 1
         allOf:
         - "$ref": "#/$defs/ID"
         - maxLength: 8191
-      address:
-        allOf:
-        - "$ref": "#/$defs/String"
-        - maxLength: 8191
-      square_footage:
-        anyOf:
-        - "$ref": "#/$defs/Int"
-        - type: 'null'
       established_on:
         anyOf:
         - "$ref": "#/$defs/Date"
         - type: 'null'
       active:
-        anyOf:
-        - "$ref": "#/$defs/Boolean"
-        - type: 'null'
-      customer_facing:
         anyOf:
         - "$ref": "#/$defs/Boolean"
         - type: 'null'
@@ -589,11 +519,8 @@ json_schema_version: 1
         default: PhysicalStore
     required:
     - id
-    - address
-    - square_footage
     - established_on
     - active
-    - customer_facing
   Player:
     type: object
     properties:
@@ -952,18 +879,6 @@ json_schema_version: 1
         anyOf:
         - "$ref": "#/$defs/Boolean"
         - type: 'null'
-      partner_name:
-        anyOf:
-        - allOf:
-          - "$ref": "#/$defs/String"
-          - maxLength: 8191
-        - type: 'null'
-      contract_terms:
-        anyOf:
-        - allOf:
-          - "$ref": "#/$defs/String"
-          - maxLength: 8191
-        - type: 'null'
       __typename:
         type: string
         const: ThirdPartyWholesale
@@ -971,8 +886,6 @@ json_schema_version: 1
     required:
     - id
     - active
-    - partner_name
-    - contract_terms
   Untyped:
     type:
     - array

--- a/config/schema/artifacts_with_apollo/json_schemas.yaml
+++ b/config/schema/artifacts_with_apollo/json_schemas.yaml
@@ -28,9 +28,13 @@ json_schema_version: 1
         - ElectricalPart
         - Manufacturer
         - MechanicalPart
+        - MobileStore
+        - OnlineStore
         - Person
+        - PhysicalStore
         - Sponsor
         - Team
+        - ThirdPartyWholesale
         - Widget
         - WidgetWorkspace
       id:
@@ -421,6 +425,46 @@ json_schema_version: 1
     - created_at
     - material
     - manufacturer_id
+  MobileStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+      vehicle_type:
+        allOf:
+        - "$ref": "#/$defs/String"
+        - maxLength: 8191
+      current_location:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      customer_facing:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      __typename:
+        type: string
+        const: MobileStore
+        default: MobileStore
+    required:
+    - id
+    - vehicle_type
+    - current_location
+    - established_on
+    - active
+    - customer_facing
   Money:
     type: object
     properties:
@@ -445,6 +489,46 @@ json_schema_version: 1
     oneOf:
     - "$ref": "#/$defs/Person"
     - "$ref": "#/$defs/Company"
+  OnlineStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+      url:
+        allOf:
+        - "$ref": "#/$defs/String"
+        - maxLength: 8191
+      platform:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      customer_facing:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      __typename:
+        type: string
+        const: OnlineStore
+        default: OnlineStore
+    required:
+    - id
+    - url
+    - platform
+    - established_on
+    - active
+    - customer_facing
   Person:
     type: object
     properties:
@@ -472,6 +556,44 @@ json_schema_version: 1
     - id
     - name
     - nationality
+  PhysicalStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+      address:
+        allOf:
+        - "$ref": "#/$defs/String"
+        - maxLength: 8191
+      square_footage:
+        anyOf:
+        - "$ref": "#/$defs/Int"
+        - type: 'null'
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      customer_facing:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      __typename:
+        type: string
+        const: PhysicalStore
+        default: PhysicalStore
+    required:
+    - id
+    - address
+    - square_footage
+    - established_on
+    - active
+    - customer_facing
   Player:
     type: object
     properties:
@@ -819,6 +941,38 @@ json_schema_version: 1
     - was_shortened
     - players_nested
     - players_object
+  ThirdPartyWholesale:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      partner_name:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+      contract_terms:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+      __typename:
+        type: string
+        const: ThirdPartyWholesale
+        default: ThirdPartyWholesale
+    required:
+    - id
+    - active
+    - partner_name
+    - contract_terms
   Untyped:
     type:
     - array

--- a/config/schema/artifacts_with_apollo/json_schemas_by_version/v1.yaml
+++ b/config/schema/artifacts_with_apollo/json_schemas_by_version/v1.yaml
@@ -28,9 +28,13 @@ json_schema_version: 1
         - ElectricalPart
         - Manufacturer
         - MechanicalPart
+        - MobileStore
+        - OnlineStore
         - Person
+        - PhysicalStore
         - Sponsor
         - Team
+        - ThirdPartyWholesale
         - Widget
         - WidgetWorkspace
       id:
@@ -535,6 +539,64 @@ json_schema_version: 1
     - created_at
     - material
     - manufacturer_id
+  MobileStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+        ElasticGraph:
+          type: ID!
+          nameInIndex: id
+      vehicle_type:
+        allOf:
+        - "$ref": "#/$defs/String"
+        - maxLength: 8191
+        ElasticGraph:
+          type: String!
+          nameInIndex: vehicle_type
+      current_location:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+        ElasticGraph:
+          type: String
+          nameInIndex: current_location
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+        ElasticGraph:
+          type: Date
+          nameInIndex: established_on
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: active
+      customer_facing:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: customer_facing
+      __typename:
+        type: string
+        const: MobileStore
+        default: MobileStore
+    required:
+    - id
+    - vehicle_type
+    - current_location
+    - established_on
+    - active
+    - customer_facing
   Money:
     type: object
     properties:
@@ -565,6 +627,64 @@ json_schema_version: 1
     oneOf:
     - "$ref": "#/$defs/Person"
     - "$ref": "#/$defs/Company"
+  OnlineStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+        ElasticGraph:
+          type: ID!
+          nameInIndex: id
+      url:
+        allOf:
+        - "$ref": "#/$defs/String"
+        - maxLength: 8191
+        ElasticGraph:
+          type: String!
+          nameInIndex: url
+      platform:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+        ElasticGraph:
+          type: String
+          nameInIndex: platform
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+        ElasticGraph:
+          type: Date
+          nameInIndex: established_on
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: active
+      customer_facing:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: customer_facing
+      __typename:
+        type: string
+        const: OnlineStore
+        default: OnlineStore
+    required:
+    - id
+    - url
+    - platform
+    - established_on
+    - active
+    - customer_facing
   Person:
     type: object
     properties:
@@ -601,6 +721,62 @@ json_schema_version: 1
     - id
     - name
     - nationality
+  PhysicalStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+        ElasticGraph:
+          type: ID!
+          nameInIndex: id
+      address:
+        allOf:
+        - "$ref": "#/$defs/String"
+        - maxLength: 8191
+        ElasticGraph:
+          type: String!
+          nameInIndex: address
+      square_footage:
+        anyOf:
+        - "$ref": "#/$defs/Int"
+        - type: 'null'
+        ElasticGraph:
+          type: Int
+          nameInIndex: square_footage
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+        ElasticGraph:
+          type: Date
+          nameInIndex: established_on
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: active
+      customer_facing:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: customer_facing
+      __typename:
+        type: string
+        const: PhysicalStore
+        default: PhysicalStore
+    required:
+    - id
+    - address
+    - square_footage
+    - established_on
+    - active
+    - customer_facing
   Player:
     type: object
     properties:
@@ -1098,6 +1274,50 @@ json_schema_version: 1
     - was_shortened
     - players_nested
     - players_object
+  ThirdPartyWholesale:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+        ElasticGraph:
+          type: ID!
+          nameInIndex: id
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: active
+      partner_name:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+        ElasticGraph:
+          type: String
+          nameInIndex: partner_name
+      contract_terms:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+        ElasticGraph:
+          type: String
+          nameInIndex: contract_terms
+      __typename:
+        type: string
+        const: ThirdPartyWholesale
+        default: ThirdPartyWholesale
+    required:
+    - id
+    - active
+    - partner_name
+    - contract_terms
   Untyped:
     type:
     - array

--- a/config/schema/artifacts_with_apollo/json_schemas_by_version/v1.yaml
+++ b/config/schema/artifacts_with_apollo/json_schemas_by_version/v1.yaml
@@ -28,7 +28,6 @@ json_schema_version: 1
         - ElectricalPart
         - Manufacturer
         - MechanicalPart
-        - MobileStore
         - OnlineStore
         - Person
         - PhysicalStore
@@ -539,64 +538,6 @@ json_schema_version: 1
     - created_at
     - material
     - manufacturer_id
-  MobileStore:
-    type: object
-    properties:
-      id:
-        allOf:
-        - "$ref": "#/$defs/ID"
-        - maxLength: 8191
-        ElasticGraph:
-          type: ID!
-          nameInIndex: id
-      vehicle_type:
-        allOf:
-        - "$ref": "#/$defs/String"
-        - maxLength: 8191
-        ElasticGraph:
-          type: String!
-          nameInIndex: vehicle_type
-      current_location:
-        anyOf:
-        - allOf:
-          - "$ref": "#/$defs/String"
-          - maxLength: 8191
-        - type: 'null'
-        ElasticGraph:
-          type: String
-          nameInIndex: current_location
-      established_on:
-        anyOf:
-        - "$ref": "#/$defs/Date"
-        - type: 'null'
-        ElasticGraph:
-          type: Date
-          nameInIndex: established_on
-      active:
-        anyOf:
-        - "$ref": "#/$defs/Boolean"
-        - type: 'null'
-        ElasticGraph:
-          type: Boolean
-          nameInIndex: active
-      customer_facing:
-        anyOf:
-        - "$ref": "#/$defs/Boolean"
-        - type: 'null'
-        ElasticGraph:
-          type: Boolean
-          nameInIndex: customer_facing
-      __typename:
-        type: string
-        const: MobileStore
-        default: MobileStore
-    required:
-    - id
-    - vehicle_type
-    - current_location
-    - established_on
-    - active
-    - customer_facing
   Money:
     type: object
     properties:
@@ -637,22 +578,6 @@ json_schema_version: 1
         ElasticGraph:
           type: ID!
           nameInIndex: id
-      url:
-        allOf:
-        - "$ref": "#/$defs/String"
-        - maxLength: 8191
-        ElasticGraph:
-          type: String!
-          nameInIndex: url
-      platform:
-        anyOf:
-        - allOf:
-          - "$ref": "#/$defs/String"
-          - maxLength: 8191
-        - type: 'null'
-        ElasticGraph:
-          type: String
-          nameInIndex: platform
       established_on:
         anyOf:
         - "$ref": "#/$defs/Date"
@@ -667,24 +592,14 @@ json_schema_version: 1
         ElasticGraph:
           type: Boolean
           nameInIndex: active
-      customer_facing:
-        anyOf:
-        - "$ref": "#/$defs/Boolean"
-        - type: 'null'
-        ElasticGraph:
-          type: Boolean
-          nameInIndex: customer_facing
       __typename:
         type: string
         const: OnlineStore
         default: OnlineStore
     required:
     - id
-    - url
-    - platform
     - established_on
     - active
-    - customer_facing
   Person:
     type: object
     properties:
@@ -731,20 +646,6 @@ json_schema_version: 1
         ElasticGraph:
           type: ID!
           nameInIndex: id
-      address:
-        allOf:
-        - "$ref": "#/$defs/String"
-        - maxLength: 8191
-        ElasticGraph:
-          type: String!
-          nameInIndex: address
-      square_footage:
-        anyOf:
-        - "$ref": "#/$defs/Int"
-        - type: 'null'
-        ElasticGraph:
-          type: Int
-          nameInIndex: square_footage
       established_on:
         anyOf:
         - "$ref": "#/$defs/Date"
@@ -759,24 +660,14 @@ json_schema_version: 1
         ElasticGraph:
           type: Boolean
           nameInIndex: active
-      customer_facing:
-        anyOf:
-        - "$ref": "#/$defs/Boolean"
-        - type: 'null'
-        ElasticGraph:
-          type: Boolean
-          nameInIndex: customer_facing
       __typename:
         type: string
         const: PhysicalStore
         default: PhysicalStore
     required:
     - id
-    - address
-    - square_footage
     - established_on
     - active
-    - customer_facing
   Player:
     type: object
     properties:
@@ -1291,24 +1182,6 @@ json_schema_version: 1
         ElasticGraph:
           type: Boolean
           nameInIndex: active
-      partner_name:
-        anyOf:
-        - allOf:
-          - "$ref": "#/$defs/String"
-          - maxLength: 8191
-        - type: 'null'
-        ElasticGraph:
-          type: String
-          nameInIndex: partner_name
-      contract_terms:
-        anyOf:
-        - allOf:
-          - "$ref": "#/$defs/String"
-          - maxLength: 8191
-        - type: 'null'
-        ElasticGraph:
-          type: String
-          nameInIndex: contract_terms
       __typename:
         type: string
         const: ThirdPartyWholesale
@@ -1316,8 +1189,6 @@ json_schema_version: 1
     required:
     - id
     - active
-    - partner_name
-    - contract_terms
   Untyped:
     type:
     - array

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -177,30 +177,6 @@ enum_types_by_name:
         datastore_abbreviation: yd
   DistributionChannelSortOrderInput:
     values_by_name:
-      address_ASC:
-        sort_field:
-          direction: asc
-          field_path: address
-      address_DESC:
-        sort_field:
-          direction: desc
-          field_path: address
-      contract_terms_ASC:
-        sort_field:
-          direction: asc
-          field_path: contract_terms
-      contract_terms_DESC:
-        sort_field:
-          direction: desc
-          field_path: contract_terms
-      current_location_ASC:
-        sort_field:
-          direction: asc
-          field_path: current_location
-      current_location_DESC:
-        sort_field:
-          direction: desc
-          field_path: current_location
       established_on_ASC:
         sort_field:
           direction: asc
@@ -217,46 +193,6 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: id
-      partner_name_ASC:
-        sort_field:
-          direction: asc
-          field_path: partner_name
-      partner_name_DESC:
-        sort_field:
-          direction: desc
-          field_path: partner_name
-      platform_ASC:
-        sort_field:
-          direction: asc
-          field_path: platform
-      platform_DESC:
-        sort_field:
-          direction: desc
-          field_path: platform
-      square_footage_ASC:
-        sort_field:
-          direction: asc
-          field_path: square_footage
-      square_footage_DESC:
-        sort_field:
-          direction: desc
-          field_path: square_footage
-      url_ASC:
-        sort_field:
-          direction: asc
-          field_path: url
-      url_DESC:
-        sort_field:
-          direction: desc
-          field_path: url
-      vehicle_type_ASC:
-        sort_field:
-          direction: asc
-          field_path: vehicle_type
-      vehicle_type_DESC:
-        sort_field:
-          direction: desc
-          field_path: vehicle_type
   ElectricalPartSortOrderInput:
     values_by_name:
       created_at_ASC:
@@ -929,14 +865,6 @@ enum_types_by_name:
           field_path: voltage
   PhysicalStoreSortOrderInput:
     values_by_name:
-      address_ASC:
-        sort_field:
-          direction: asc
-          field_path: address
-      address_DESC:
-        sort_field:
-          direction: desc
-          field_path: address
       established_on_ASC:
         sort_field:
           direction: asc
@@ -953,32 +881,8 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: id
-      square_footage_ASC:
-        sort_field:
-          direction: asc
-          field_path: square_footage
-      square_footage_DESC:
-        sort_field:
-          direction: desc
-          field_path: square_footage
   RetailSortOrderInput:
     values_by_name:
-      address_ASC:
-        sort_field:
-          direction: asc
-          field_path: address
-      address_DESC:
-        sort_field:
-          direction: desc
-          field_path: address
-      current_location_ASC:
-        sort_field:
-          direction: asc
-          field_path: current_location
-      current_location_DESC:
-        sort_field:
-          direction: desc
-          field_path: current_location
       established_on_ASC:
         sort_field:
           direction: asc
@@ -995,38 +899,6 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: id
-      platform_ASC:
-        sort_field:
-          direction: asc
-          field_path: platform
-      platform_DESC:
-        sort_field:
-          direction: desc
-          field_path: platform
-      square_footage_ASC:
-        sort_field:
-          direction: asc
-          field_path: square_footage
-      square_footage_DESC:
-        sort_field:
-          direction: desc
-          field_path: square_footage
-      url_ASC:
-        sort_field:
-          direction: asc
-          field_path: url
-      url_DESC:
-        sort_field:
-          direction: desc
-          field_path: url
-      vehicle_type_ASC:
-        sort_field:
-          direction: asc
-          field_path: vehicle_type
-      vehicle_type_DESC:
-        sort_field:
-          direction: desc
-          field_path: vehicle_type
   SponsorSortOrderInput:
     values_by_name:
       id_ASC:
@@ -1047,22 +919,6 @@ enum_types_by_name:
           field_path: name
   StoreSortOrderInput:
     values_by_name:
-      address_ASC:
-        sort_field:
-          direction: asc
-          field_path: address
-      address_DESC:
-        sort_field:
-          direction: desc
-          field_path: address
-      current_location_ASC:
-        sort_field:
-          direction: asc
-          field_path: current_location
-      current_location_DESC:
-        sort_field:
-          direction: desc
-          field_path: current_location
       established_on_ASC:
         sort_field:
           direction: asc
@@ -1079,38 +935,6 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: id
-      platform_ASC:
-        sort_field:
-          direction: asc
-          field_path: platform
-      platform_DESC:
-        sort_field:
-          direction: desc
-          field_path: platform
-      square_footage_ASC:
-        sort_field:
-          direction: asc
-          field_path: square_footage
-      square_footage_DESC:
-        sort_field:
-          direction: desc
-          field_path: square_footage
-      url_ASC:
-        sort_field:
-          direction: asc
-          field_path: url
-      url_DESC:
-        sort_field:
-          direction: desc
-          field_path: url
-      vehicle_type_ASC:
-        sort_field:
-          direction: asc
-          field_path: vehicle_type
-      vehicle_type_DESC:
-        sort_field:
-          direction: desc
-          field_path: vehicle_type
   TeamSortOrderInput:
     values_by_name:
       country_code_ASC:
@@ -2053,27 +1877,9 @@ index_definitions_by_name:
     fields_by_path:
       active:
         source: __self
-      address:
-        source: __self
-      contract_terms:
-        source: __self
-      current_location:
-        source: __self
-      customer_facing:
-        source: __self
       established_on:
         source: __self
       id:
-        source: __self
-      partner_name:
-        source: __self
-      platform:
-        source: __self
-      square_footage:
-        source: __self
-      url:
-        source: __self
-      vehicle_type:
         source: __self
     route_with: id
   electrical_parts:
@@ -2151,15 +1957,9 @@ index_definitions_by_name:
     fields_by_path:
       active:
         source: __self
-      address:
-        source: __self
-      customer_facing:
-        source: __self
       established_on:
         source: __self
       id:
-        source: __self
-      square_footage:
         source: __self
     route_with: id
   sponsors:
@@ -3933,37 +3733,10 @@ object_types_by_name:
       active:
         resolver:
           name: get_record_field_value
-      address:
-        resolver:
-          name: get_record_field_value
-      contract_terms:
-        resolver:
-          name: get_record_field_value
-      current_location:
-        resolver:
-          name: get_record_field_value
-      customer_facing:
-        resolver:
-          name: get_record_field_value
       established_on:
         resolver:
           name: get_record_field_value
       id:
-        resolver:
-          name: get_record_field_value
-      partner_name:
-        resolver:
-          name: get_record_field_value
-      platform:
-        resolver:
-          name: get_record_field_value
-      square_footage:
-        resolver:
-          name: get_record_field_value
-      url:
-        resolver:
-          name: get_record_field_value
-      vehicle_type:
         resolver:
           name: get_record_field_value
     index_definition_names:
@@ -3973,37 +3746,10 @@ object_types_by_name:
       active:
         resolver:
           name: object_with_lookahead
-      address:
-        resolver:
-          name: object_with_lookahead
-      contract_terms:
-        resolver:
-          name: object_with_lookahead
-      current_location:
-        resolver:
-          name: object_with_lookahead
-      customer_facing:
-        resolver:
-          name: object_with_lookahead
       established_on:
         resolver:
           name: object_with_lookahead
       id:
-        resolver:
-          name: object_with_lookahead
-      partner_name:
-        resolver:
-          name: object_with_lookahead
-      platform:
-        resolver:
-          name: object_with_lookahead
-      square_footage:
-        resolver:
-          name: object_with_lookahead
-      url:
-        resolver:
-          name: object_with_lookahead
-      vehicle_type:
         resolver:
           name: object_with_lookahead
   DistributionChannelAggregation:
@@ -4075,60 +3821,12 @@ object_types_by_name:
       active:
         resolver:
           name: object_with_lookahead
-      address:
-        resolver:
-          name: object_with_lookahead
-      contract_terms:
-        resolver:
-          name: object_with_lookahead
-      current_location:
-        resolver:
-          name: object_with_lookahead
-      customer_facing:
-        resolver:
-          name: object_with_lookahead
       established_on:
-        resolver:
-          name: object_with_lookahead
-      partner_name:
-        resolver:
-          name: object_with_lookahead
-      platform:
-        resolver:
-          name: object_with_lookahead
-      square_footage:
-        resolver:
-          name: object_with_lookahead
-      url:
-        resolver:
-          name: object_with_lookahead
-      vehicle_type:
         resolver:
           name: object_with_lookahead
   DistributionChannelHighlights:
     graphql_fields_by_name:
-      address:
-        resolver:
-          name: get_record_field_value
-      contract_terms:
-        resolver:
-          name: get_record_field_value
-      current_location:
-        resolver:
-          name: get_record_field_value
       id:
-        resolver:
-          name: get_record_field_value
-      partner_name:
-        resolver:
-          name: get_record_field_value
-      platform:
-        resolver:
-          name: get_record_field_value
-      url:
-        resolver:
-          name: get_record_field_value
-      vehicle_type:
         resolver:
           name: get_record_field_value
   ElectricalPart:
@@ -4930,58 +4628,6 @@ object_types_by_name:
       name:
         resolver:
           name: get_record_field_value
-  MobileStore:
-    graphql_fields_by_name:
-      active:
-        resolver:
-          name: get_record_field_value
-      current_location:
-        resolver:
-          name: get_record_field_value
-      customer_facing:
-        resolver:
-          name: get_record_field_value
-      established_on:
-        resolver:
-          name: get_record_field_value
-      id:
-        resolver:
-          name: get_record_field_value
-      vehicle_type:
-        resolver:
-          name: get_record_field_value
-    index_definition_names:
-    - distribution_channels
-    update_targets:
-    - data_params:
-        __typename:
-          cardinality: one
-        active:
-          cardinality: one
-        current_location:
-          cardinality: one
-        customer_facing:
-          cardinality: one
-        established_on:
-          cardinality: one
-        vehicle_type:
-          cardinality: one
-      id_source: id
-      metadata_params:
-        relationship:
-          value: __self
-        sourceId:
-          cardinality: one
-          source_path: id
-        sourceType:
-          cardinality: one
-          source_path: type
-        version:
-          cardinality: one
-      relationship: __self
-      routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
-      type: MobileStore
   Money:
     graphql_fields_by_name:
       amount_cents:
@@ -5827,19 +5473,10 @@ object_types_by_name:
       active:
         resolver:
           name: get_record_field_value
-      customer_facing:
-        resolver:
-          name: get_record_field_value
       established_on:
         resolver:
           name: get_record_field_value
       id:
-        resolver:
-          name: get_record_field_value
-      platform:
-        resolver:
-          name: get_record_field_value
-      url:
         resolver:
           name: get_record_field_value
     index_definition_names:
@@ -5850,13 +5487,7 @@ object_types_by_name:
           cardinality: one
         active:
           cardinality: one
-        customer_facing:
-          cardinality: one
         established_on:
-          cardinality: one
-        platform:
-          cardinality: one
-        url:
           cardinality: one
       id_source: id
       metadata_params:
@@ -6102,19 +5733,10 @@ object_types_by_name:
       active:
         resolver:
           name: get_record_field_value
-      address:
-        resolver:
-          name: get_record_field_value
-      customer_facing:
-        resolver:
-          name: get_record_field_value
       established_on:
         resolver:
           name: get_record_field_value
       id:
-        resolver:
-          name: get_record_field_value
-      square_footage:
         resolver:
           name: get_record_field_value
     index_definition_names:
@@ -6123,13 +5745,7 @@ object_types_by_name:
     - data_params:
         active:
           cardinality: one
-        address:
-          cardinality: one
-        customer_facing:
-          cardinality: one
         established_on:
-          cardinality: one
-        square_footage:
           cardinality: one
       id_source: id
       metadata_params:
@@ -6152,19 +5768,10 @@ object_types_by_name:
       active:
         resolver:
           name: object_with_lookahead
-      address:
-        resolver:
-          name: object_with_lookahead
-      customer_facing:
-        resolver:
-          name: object_with_lookahead
       established_on:
         resolver:
           name: object_with_lookahead
       id:
-        resolver:
-          name: object_with_lookahead
-      square_footage:
         resolver:
           name: object_with_lookahead
   PhysicalStoreAggregation:
@@ -6236,23 +5843,11 @@ object_types_by_name:
       active:
         resolver:
           name: object_with_lookahead
-      address:
-        resolver:
-          name: object_with_lookahead
-      customer_facing:
-        resolver:
-          name: object_with_lookahead
       established_on:
-        resolver:
-          name: object_with_lookahead
-      square_footage:
         resolver:
           name: object_with_lookahead
   PhysicalStoreHighlights:
     graphql_fields_by_name:
-      address:
-        resolver:
-          name: get_record_field_value
       id:
         resolver:
           name: get_record_field_value
@@ -6517,31 +6112,10 @@ object_types_by_name:
       active:
         resolver:
           name: get_record_field_value
-      address:
-        resolver:
-          name: get_record_field_value
-      current_location:
-        resolver:
-          name: get_record_field_value
-      customer_facing:
-        resolver:
-          name: get_record_field_value
       established_on:
         resolver:
           name: get_record_field_value
       id:
-        resolver:
-          name: get_record_field_value
-      platform:
-        resolver:
-          name: get_record_field_value
-      square_footage:
-        resolver:
-          name: get_record_field_value
-      url:
-        resolver:
-          name: get_record_field_value
-      vehicle_type:
         resolver:
           name: get_record_field_value
     index_definition_names:
@@ -6551,31 +6125,10 @@ object_types_by_name:
       active:
         resolver:
           name: object_with_lookahead
-      address:
-        resolver:
-          name: object_with_lookahead
-      current_location:
-        resolver:
-          name: object_with_lookahead
-      customer_facing:
-        resolver:
-          name: object_with_lookahead
       established_on:
         resolver:
           name: object_with_lookahead
       id:
-        resolver:
-          name: object_with_lookahead
-      platform:
-        resolver:
-          name: object_with_lookahead
-      square_footage:
-        resolver:
-          name: object_with_lookahead
-      url:
-        resolver:
-          name: object_with_lookahead
-      vehicle_type:
         resolver:
           name: object_with_lookahead
   RetailAggregation:
@@ -6647,48 +6200,12 @@ object_types_by_name:
       active:
         resolver:
           name: object_with_lookahead
-      address:
-        resolver:
-          name: object_with_lookahead
-      current_location:
-        resolver:
-          name: object_with_lookahead
-      customer_facing:
-        resolver:
-          name: object_with_lookahead
       established_on:
-        resolver:
-          name: object_with_lookahead
-      platform:
-        resolver:
-          name: object_with_lookahead
-      square_footage:
-        resolver:
-          name: object_with_lookahead
-      url:
-        resolver:
-          name: object_with_lookahead
-      vehicle_type:
         resolver:
           name: object_with_lookahead
   RetailHighlights:
     graphql_fields_by_name:
-      address:
-        resolver:
-          name: get_record_field_value
-      current_location:
-        resolver:
-          name: get_record_field_value
       id:
-        resolver:
-          name: get_record_field_value
-      platform:
-        resolver:
-          name: get_record_field_value
-      url:
-        resolver:
-          name: get_record_field_value
-      vehicle_type:
         resolver:
           name: get_record_field_value
   SearchHighlight:
@@ -6894,31 +6411,10 @@ object_types_by_name:
       active:
         resolver:
           name: get_record_field_value
-      address:
-        resolver:
-          name: get_record_field_value
-      current_location:
-        resolver:
-          name: get_record_field_value
-      customer_facing:
-        resolver:
-          name: get_record_field_value
       established_on:
         resolver:
           name: get_record_field_value
       id:
-        resolver:
-          name: get_record_field_value
-      platform:
-        resolver:
-          name: get_record_field_value
-      square_footage:
-        resolver:
-          name: get_record_field_value
-      url:
-        resolver:
-          name: get_record_field_value
-      vehicle_type:
         resolver:
           name: get_record_field_value
     index_definition_names:
@@ -6928,31 +6424,10 @@ object_types_by_name:
       active:
         resolver:
           name: object_with_lookahead
-      address:
-        resolver:
-          name: object_with_lookahead
-      current_location:
-        resolver:
-          name: object_with_lookahead
-      customer_facing:
-        resolver:
-          name: object_with_lookahead
       established_on:
         resolver:
           name: object_with_lookahead
       id:
-        resolver:
-          name: object_with_lookahead
-      platform:
-        resolver:
-          name: object_with_lookahead
-      square_footage:
-        resolver:
-          name: object_with_lookahead
-      url:
-        resolver:
-          name: object_with_lookahead
-      vehicle_type:
         resolver:
           name: object_with_lookahead
   StoreAggregation:
@@ -7024,48 +6499,12 @@ object_types_by_name:
       active:
         resolver:
           name: object_with_lookahead
-      address:
-        resolver:
-          name: object_with_lookahead
-      current_location:
-        resolver:
-          name: object_with_lookahead
-      customer_facing:
-        resolver:
-          name: object_with_lookahead
       established_on:
-        resolver:
-          name: object_with_lookahead
-      platform:
-        resolver:
-          name: object_with_lookahead
-      square_footage:
-        resolver:
-          name: object_with_lookahead
-      url:
-        resolver:
-          name: object_with_lookahead
-      vehicle_type:
         resolver:
           name: object_with_lookahead
   StoreHighlights:
     graphql_fields_by_name:
-      address:
-        resolver:
-          name: get_record_field_value
-      current_location:
-        resolver:
-          name: get_record_field_value
       id:
-        resolver:
-          name: get_record_field_value
-      platform:
-        resolver:
-          name: get_record_field_value
-      url:
-        resolver:
-          name: get_record_field_value
-      vehicle_type:
         resolver:
           name: get_record_field_value
   StringConnection:
@@ -8006,13 +7445,7 @@ object_types_by_name:
       active:
         resolver:
           name: get_record_field_value
-      contract_terms:
-        resolver:
-          name: get_record_field_value
       id:
-        resolver:
-          name: get_record_field_value
-      partner_name:
         resolver:
           name: get_record_field_value
     index_definition_names:
@@ -8022,10 +7455,6 @@ object_types_by_name:
         __typename:
           cardinality: one
         active:
-          cardinality: one
-        contract_terms:
-          cardinality: one
-        partner_name:
           cardinality: one
       id_source: id
       metadata_params:

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -21,32 +21,6 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: timestamps.created_at
-  CompanySortOrderInput:
-    values_by_name:
-      id_ASC:
-        sort_field:
-          direction: asc
-          field_path: id
-      id_DESC:
-        sort_field:
-          direction: desc
-          field_path: id
-      name_ASC:
-        sort_field:
-          direction: asc
-          field_path: name
-      name_DESC:
-        sort_field:
-          direction: desc
-          field_path: name
-      stock_ticker_ASC:
-        sort_field:
-          direction: asc
-          field_path: stock_ticker
-      stock_ticker_DESC:
-        sort_field:
-          direction: desc
-          field_path: stock_ticker
   ComponentSortOrderInput:
     values_by_name:
       created_at_ASC:
@@ -201,6 +175,88 @@ enum_types_by_name:
         datastore_abbreviation: nmi
       YARD:
         datastore_abbreviation: yd
+  DistributionChannelSortOrderInput:
+    values_by_name:
+      address_ASC:
+        sort_field:
+          direction: asc
+          field_path: address
+      address_DESC:
+        sort_field:
+          direction: desc
+          field_path: address
+      contract_terms_ASC:
+        sort_field:
+          direction: asc
+          field_path: contract_terms
+      contract_terms_DESC:
+        sort_field:
+          direction: desc
+          field_path: contract_terms
+      current_location_ASC:
+        sort_field:
+          direction: asc
+          field_path: current_location
+      current_location_DESC:
+        sort_field:
+          direction: desc
+          field_path: current_location
+      established_on_ASC:
+        sort_field:
+          direction: asc
+          field_path: established_on
+      established_on_DESC:
+        sort_field:
+          direction: desc
+          field_path: established_on
+      id_ASC:
+        sort_field:
+          direction: asc
+          field_path: id
+      id_DESC:
+        sort_field:
+          direction: desc
+          field_path: id
+      partner_name_ASC:
+        sort_field:
+          direction: asc
+          field_path: partner_name
+      partner_name_DESC:
+        sort_field:
+          direction: desc
+          field_path: partner_name
+      platform_ASC:
+        sort_field:
+          direction: asc
+          field_path: platform
+      platform_DESC:
+        sort_field:
+          direction: desc
+          field_path: platform
+      square_footage_ASC:
+        sort_field:
+          direction: asc
+          field_path: square_footage
+      square_footage_DESC:
+        sort_field:
+          direction: desc
+          field_path: square_footage
+      url_ASC:
+        sort_field:
+          direction: asc
+          field_path: url
+      url_DESC:
+        sort_field:
+          direction: desc
+          field_path: url
+      vehicle_type_ASC:
+        sort_field:
+          direction: asc
+          field_path: vehicle_type
+      vehicle_type_DESC:
+        sort_field:
+          direction: desc
+          field_path: vehicle_type
   ElectricalPartSortOrderInput:
     values_by_name:
       created_at_ASC:
@@ -871,8 +927,24 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: voltage
-  PersonSortOrderInput:
+  PhysicalStoreSortOrderInput:
     values_by_name:
+      address_ASC:
+        sort_field:
+          direction: asc
+          field_path: address
+      address_DESC:
+        sort_field:
+          direction: desc
+          field_path: address
+      established_on_ASC:
+        sort_field:
+          direction: asc
+          field_path: established_on
+      established_on_DESC:
+        sort_field:
+          direction: desc
+          field_path: established_on
       id_ASC:
         sort_field:
           direction: asc
@@ -881,22 +953,80 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: id
-      name_ASC:
+      square_footage_ASC:
         sort_field:
           direction: asc
-          field_path: name
-      name_DESC:
+          field_path: square_footage
+      square_footage_DESC:
         sort_field:
           direction: desc
-          field_path: name
-      nationality_ASC:
+          field_path: square_footage
+  RetailSortOrderInput:
+    values_by_name:
+      address_ASC:
         sort_field:
           direction: asc
-          field_path: nationality
-      nationality_DESC:
+          field_path: address
+      address_DESC:
         sort_field:
           direction: desc
-          field_path: nationality
+          field_path: address
+      current_location_ASC:
+        sort_field:
+          direction: asc
+          field_path: current_location
+      current_location_DESC:
+        sort_field:
+          direction: desc
+          field_path: current_location
+      established_on_ASC:
+        sort_field:
+          direction: asc
+          field_path: established_on
+      established_on_DESC:
+        sort_field:
+          direction: desc
+          field_path: established_on
+      id_ASC:
+        sort_field:
+          direction: asc
+          field_path: id
+      id_DESC:
+        sort_field:
+          direction: desc
+          field_path: id
+      platform_ASC:
+        sort_field:
+          direction: asc
+          field_path: platform
+      platform_DESC:
+        sort_field:
+          direction: desc
+          field_path: platform
+      square_footage_ASC:
+        sort_field:
+          direction: asc
+          field_path: square_footage
+      square_footage_DESC:
+        sort_field:
+          direction: desc
+          field_path: square_footage
+      url_ASC:
+        sort_field:
+          direction: asc
+          field_path: url
+      url_DESC:
+        sort_field:
+          direction: desc
+          field_path: url
+      vehicle_type_ASC:
+        sort_field:
+          direction: asc
+          field_path: vehicle_type
+      vehicle_type_DESC:
+        sort_field:
+          direction: desc
+          field_path: vehicle_type
   SponsorSortOrderInput:
     values_by_name:
       id_ASC:
@@ -915,6 +1045,72 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: name
+  StoreSortOrderInput:
+    values_by_name:
+      address_ASC:
+        sort_field:
+          direction: asc
+          field_path: address
+      address_DESC:
+        sort_field:
+          direction: desc
+          field_path: address
+      current_location_ASC:
+        sort_field:
+          direction: asc
+          field_path: current_location
+      current_location_DESC:
+        sort_field:
+          direction: desc
+          field_path: current_location
+      established_on_ASC:
+        sort_field:
+          direction: asc
+          field_path: established_on
+      established_on_DESC:
+        sort_field:
+          direction: desc
+          field_path: established_on
+      id_ASC:
+        sort_field:
+          direction: asc
+          field_path: id
+      id_DESC:
+        sort_field:
+          direction: desc
+          field_path: id
+      platform_ASC:
+        sort_field:
+          direction: asc
+          field_path: platform
+      platform_DESC:
+        sort_field:
+          direction: desc
+          field_path: platform
+      square_footage_ASC:
+        sort_field:
+          direction: asc
+          field_path: square_footage
+      square_footage_DESC:
+        sort_field:
+          direction: desc
+          field_path: square_footage
+      url_ASC:
+        sort_field:
+          direction: asc
+          field_path: url
+      url_DESC:
+        sort_field:
+          direction: desc
+          field_path: url
+      vehicle_type_ASC:
+        sort_field:
+          direction: asc
+          field_path: vehicle_type
+      vehicle_type_DESC:
+        sort_field:
+          direction: desc
+          field_path: vehicle_type
   TeamSortOrderInput:
     values_by_name:
       country_code_ASC:
@@ -1803,17 +1999,6 @@ index_definitions_by_name:
       timestamps.created_at:
         source: __self
     route_with: id
-  companies:
-    current_sources:
-    - __self
-    fields_by_path:
-      id:
-        source: __self
-      name:
-        source: __self
-      stock_ticker:
-        source: __self
-    route_with: id
   components:
     current_sources:
     - __self
@@ -1861,6 +2046,35 @@ index_definitions_by_name:
       widget_workspace_id3:
         source: widget
     has_had_multiple_sources: true
+    route_with: id
+  distribution_channels:
+    current_sources:
+    - __self
+    fields_by_path:
+      active:
+        source: __self
+      address:
+        source: __self
+      contract_terms:
+        source: __self
+      current_location:
+        source: __self
+      customer_facing:
+        source: __self
+      established_on:
+        source: __self
+      id:
+        source: __self
+      partner_name:
+        source: __self
+      platform:
+        source: __self
+      square_footage:
+        source: __self
+      url:
+        source: __self
+      vehicle_type:
+        source: __self
     route_with: id
   electrical_parts:
     current_sources:
@@ -1918,7 +2132,7 @@ index_definitions_by_name:
       name:
         source: __self
     route_with: id
-  people:
+  named_inventors:
     current_sources:
     - __self
     fields_by_path:
@@ -1927,6 +2141,25 @@ index_definitions_by_name:
       name:
         source: __self
       nationality:
+        source: __self
+      stock_ticker:
+        source: __self
+    route_with: id
+  physical_stores:
+    current_sources:
+    - __self
+    fields_by_path:
+      active:
+        source: __self
+      address:
+        source: __self
+      customer_facing:
+        source: __self
+      established_on:
+        source: __self
+      id:
+        source: __self
+      square_footage:
         source: __self
     route_with: id
   sponsors:
@@ -3221,9 +3454,11 @@ object_types_by_name:
         resolver:
           name: get_record_field_value
     index_definition_names:
-    - companies
+    - named_inventors
     update_targets:
     - data_params:
+        __typename:
+          cardinality: one
         name:
           cardinality: one
         stock_ticker:
@@ -3244,100 +3479,6 @@ object_types_by_name:
       routing_value_source: id
       script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
       type: Company
-  CompanyAggregatedValues:
-    graphql_fields_by_name:
-      id:
-        resolver:
-          name: object_with_lookahead
-      name:
-        resolver:
-          name: object_with_lookahead
-      stock_ticker:
-        resolver:
-          name: object_with_lookahead
-  CompanyAggregation:
-    elasticgraph_category: indexed_aggregation
-    graphql_fields_by_name:
-      aggregated_values:
-        resolver:
-          name: object_without_lookahead
-      count:
-        resolver:
-          name: object_without_lookahead
-      grouped_by:
-        resolver:
-          name: object_without_lookahead
-    source_type: Company
-  CompanyAggregationConnection:
-    elasticgraph_category: relay_connection
-    graphql_fields_by_name:
-      edges:
-        resolver:
-          name: object_without_lookahead
-      nodes:
-        resolver:
-          name: object_without_lookahead
-      page_info:
-        resolver:
-          name: object_without_lookahead
-  CompanyAggregationEdge:
-    elasticgraph_category: relay_edge
-    graphql_fields_by_name:
-      cursor:
-        resolver:
-          name: object_without_lookahead
-      node:
-        resolver:
-          name: object_without_lookahead
-  CompanyConnection:
-    elasticgraph_category: relay_connection
-    graphql_fields_by_name:
-      edges:
-        resolver:
-          name: object_without_lookahead
-      nodes:
-        resolver:
-          name: object_without_lookahead
-      page_info:
-        resolver:
-          name: object_without_lookahead
-      total_edge_count:
-        resolver:
-          name: object_without_lookahead
-  CompanyEdge:
-    elasticgraph_category: relay_edge
-    graphql_fields_by_name:
-      all_highlights:
-        resolver:
-          name: object_without_lookahead
-      cursor:
-        resolver:
-          name: object_without_lookahead
-      highlights:
-        resolver:
-          name: object_without_lookahead
-      node:
-        resolver:
-          name: object_without_lookahead
-  CompanyGroupedBy:
-    graphql_fields_by_name:
-      name:
-        resolver:
-          name: object_with_lookahead
-      stock_ticker:
-        resolver:
-          name: object_with_lookahead
-  CompanyHighlights:
-    graphql_fields_by_name:
-      id:
-        resolver:
-          name: get_record_field_value
-      name:
-        resolver:
-          name: get_record_field_value
-      stock_ticker:
-        resolver:
-          name: get_record_field_value
   Component:
     graphql_fields_by_name:
       created_at:
@@ -3787,6 +3928,209 @@ object_types_by_name:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  DistributionChannel:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      address:
+        resolver:
+          name: get_record_field_value
+      contract_terms:
+        resolver:
+          name: get_record_field_value
+      current_location:
+        resolver:
+          name: get_record_field_value
+      customer_facing:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      partner_name:
+        resolver:
+          name: get_record_field_value
+      platform:
+        resolver:
+          name: get_record_field_value
+      square_footage:
+        resolver:
+          name: get_record_field_value
+      url:
+        resolver:
+          name: get_record_field_value
+      vehicle_type:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+  DistributionChannelAggregatedValues:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      address:
+        resolver:
+          name: object_with_lookahead
+      contract_terms:
+        resolver:
+          name: object_with_lookahead
+      current_location:
+        resolver:
+          name: object_with_lookahead
+      customer_facing:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      id:
+        resolver:
+          name: object_with_lookahead
+      partner_name:
+        resolver:
+          name: object_with_lookahead
+      platform:
+        resolver:
+          name: object_with_lookahead
+      square_footage:
+        resolver:
+          name: object_with_lookahead
+      url:
+        resolver:
+          name: object_with_lookahead
+      vehicle_type:
+        resolver:
+          name: object_with_lookahead
+  DistributionChannelAggregation:
+    elasticgraph_category: indexed_aggregation
+    graphql_fields_by_name:
+      aggregated_values:
+        resolver:
+          name: object_without_lookahead
+      count:
+        resolver:
+          name: object_without_lookahead
+      grouped_by:
+        resolver:
+          name: object_without_lookahead
+    source_type: DistributionChannel
+  DistributionChannelAggregationConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+  DistributionChannelAggregationEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  DistributionChannelConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+      total_edge_count:
+        resolver:
+          name: object_without_lookahead
+  DistributionChannelEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      all_highlights:
+        resolver:
+          name: object_without_lookahead
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      highlights:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  DistributionChannelGroupedBy:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      address:
+        resolver:
+          name: object_with_lookahead
+      contract_terms:
+        resolver:
+          name: object_with_lookahead
+      current_location:
+        resolver:
+          name: object_with_lookahead
+      customer_facing:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      partner_name:
+        resolver:
+          name: object_with_lookahead
+      platform:
+        resolver:
+          name: object_with_lookahead
+      square_footage:
+        resolver:
+          name: object_with_lookahead
+      url:
+        resolver:
+          name: object_with_lookahead
+      vehicle_type:
+        resolver:
+          name: object_with_lookahead
+  DistributionChannelHighlights:
+    graphql_fields_by_name:
+      address:
+        resolver:
+          name: get_record_field_value
+      contract_terms:
+        resolver:
+          name: get_record_field_value
+      current_location:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      partner_name:
+        resolver:
+          name: get_record_field_value
+      platform:
+        resolver:
+          name: get_record_field_value
+      url:
+        resolver:
+          name: get_record_field_value
+      vehicle_type:
+        resolver:
+          name: get_record_field_value
   ElectricalPart:
     graphql_fields_by_name:
       component_aggregations:
@@ -4586,6 +4930,58 @@ object_types_by_name:
       name:
         resolver:
           name: get_record_field_value
+  MobileStore:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      current_location:
+        resolver:
+          name: get_record_field_value
+      customer_facing:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      vehicle_type:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+    update_targets:
+    - data_params:
+        __typename:
+          cardinality: one
+        active:
+          cardinality: one
+        current_location:
+          cardinality: one
+        customer_facing:
+          cardinality: one
+        established_on:
+          cardinality: one
+        vehicle_type:
+          cardinality: one
+      id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      routing_value_source: id
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      type: MobileStore
   Money:
     graphql_fields_by_name:
       amount_cents:
@@ -5311,6 +5707,8 @@ object_types_by_name:
       stock_ticker:
         resolver:
           name: get_record_field_value
+    index_definition_names:
+    - named_inventors
   NamedInventorAggregatedValues:
     graphql_fields_by_name:
       id:
@@ -5424,6 +5822,58 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
     graphql_only_return_type: true
+  OnlineStore:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      customer_facing:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      platform:
+        resolver:
+          name: get_record_field_value
+      url:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+    update_targets:
+    - data_params:
+        __typename:
+          cardinality: one
+        active:
+          cardinality: one
+        customer_facing:
+          cardinality: one
+        established_on:
+          cardinality: one
+        platform:
+          cardinality: one
+        url:
+          cardinality: one
+      id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      routing_value_source: id
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      type: OnlineStore
   PageInfo:
     graphql_fields_by_name:
       end_cursor:
@@ -5592,9 +6042,11 @@ object_types_by_name:
         resolver:
           name: get_record_field_value
     index_definition_names:
-    - people
+    - named_inventors
     update_targets:
     - data_params:
+        __typename:
+          cardinality: one
         name:
           cardinality: one
         nationality:
@@ -5626,70 +6078,6 @@ object_types_by_name:
       nationality:
         resolver:
           name: object_with_lookahead
-  PersonAggregation:
-    elasticgraph_category: indexed_aggregation
-    graphql_fields_by_name:
-      aggregated_values:
-        resolver:
-          name: object_without_lookahead
-      count:
-        resolver:
-          name: object_without_lookahead
-      grouped_by:
-        resolver:
-          name: object_without_lookahead
-    source_type: Person
-  PersonAggregationConnection:
-    elasticgraph_category: relay_connection
-    graphql_fields_by_name:
-      edges:
-        resolver:
-          name: object_without_lookahead
-      nodes:
-        resolver:
-          name: object_without_lookahead
-      page_info:
-        resolver:
-          name: object_without_lookahead
-  PersonAggregationEdge:
-    elasticgraph_category: relay_edge
-    graphql_fields_by_name:
-      cursor:
-        resolver:
-          name: object_without_lookahead
-      node:
-        resolver:
-          name: object_without_lookahead
-  PersonConnection:
-    elasticgraph_category: relay_connection
-    graphql_fields_by_name:
-      edges:
-        resolver:
-          name: object_without_lookahead
-      nodes:
-        resolver:
-          name: object_without_lookahead
-      page_info:
-        resolver:
-          name: object_without_lookahead
-      total_edge_count:
-        resolver:
-          name: object_without_lookahead
-  PersonEdge:
-    elasticgraph_category: relay_edge
-    graphql_fields_by_name:
-      all_highlights:
-        resolver:
-          name: object_without_lookahead
-      cursor:
-        resolver:
-          name: object_without_lookahead
-      highlights:
-        resolver:
-          name: object_without_lookahead
-      node:
-        resolver:
-          name: object_without_lookahead
   PersonGroupedBy:
     graphql_fields_by_name:
       name:
@@ -5707,6 +6095,165 @@ object_types_by_name:
         resolver:
           name: get_record_field_value
       nationality:
+        resolver:
+          name: get_record_field_value
+  PhysicalStore:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      address:
+        resolver:
+          name: get_record_field_value
+      customer_facing:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      square_footage:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - physical_stores
+    update_targets:
+    - data_params:
+        active:
+          cardinality: one
+        address:
+          cardinality: one
+        customer_facing:
+          cardinality: one
+        established_on:
+          cardinality: one
+        square_footage:
+          cardinality: one
+      id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      routing_value_source: id
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      type: PhysicalStore
+  PhysicalStoreAggregatedValues:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      address:
+        resolver:
+          name: object_with_lookahead
+      customer_facing:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      id:
+        resolver:
+          name: object_with_lookahead
+      square_footage:
+        resolver:
+          name: object_with_lookahead
+  PhysicalStoreAggregation:
+    elasticgraph_category: indexed_aggregation
+    graphql_fields_by_name:
+      aggregated_values:
+        resolver:
+          name: object_without_lookahead
+      count:
+        resolver:
+          name: object_without_lookahead
+      grouped_by:
+        resolver:
+          name: object_without_lookahead
+    source_type: PhysicalStore
+  PhysicalStoreAggregationConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+  PhysicalStoreAggregationEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  PhysicalStoreConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+      total_edge_count:
+        resolver:
+          name: object_without_lookahead
+  PhysicalStoreEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      all_highlights:
+        resolver:
+          name: object_without_lookahead
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      highlights:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  PhysicalStoreGroupedBy:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      address:
+        resolver:
+          name: object_with_lookahead
+      customer_facing:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      square_footage:
+        resolver:
+          name: object_with_lookahead
+  PhysicalStoreHighlights:
+    graphql_fields_by_name:
+      address:
+        resolver:
+          name: get_record_field_value
+      id:
         resolver:
           name: get_record_field_value
   Player:
@@ -5857,16 +6404,16 @@ object_types_by_name:
       addresses:
         resolver:
           name: list_records
-      companies:
-        resolver:
-          name: list_records
-      company_aggregations:
-        resolver:
-          name: list_records
       component_aggregations:
         resolver:
           name: list_records
       components:
+        resolver:
+          name: list_records
+      distribution_channel_aggregations:
+        resolver:
+          name: list_records
+      distribution_channels:
         resolver:
           name: list_records
       electrical_part_aggregations:
@@ -5911,16 +6458,28 @@ object_types_by_name:
       parts:
         resolver:
           name: list_records
-      people:
+      physical_store_aggregations:
         resolver:
           name: list_records
-      person_aggregations:
+      physical_stores:
+        resolver:
+          name: list_records
+      retail_aggregations:
+        resolver:
+          name: list_records
+      retailers:
         resolver:
           name: list_records
       sponsor_aggregations:
         resolver:
           name: list_records
       sponsors:
+        resolver:
+          name: list_records
+      store_aggregations:
+        resolver:
+          name: list_records
+      stores:
         resolver:
           name: list_records
       team_aggregations:
@@ -5953,6 +6512,185 @@ object_types_by_name:
       widgets_or_addresses:
         resolver:
           name: list_records
+  Retail:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      address:
+        resolver:
+          name: get_record_field_value
+      current_location:
+        resolver:
+          name: get_record_field_value
+      customer_facing:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      platform:
+        resolver:
+          name: get_record_field_value
+      square_footage:
+        resolver:
+          name: get_record_field_value
+      url:
+        resolver:
+          name: get_record_field_value
+      vehicle_type:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+  RetailAggregatedValues:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      address:
+        resolver:
+          name: object_with_lookahead
+      current_location:
+        resolver:
+          name: object_with_lookahead
+      customer_facing:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      id:
+        resolver:
+          name: object_with_lookahead
+      platform:
+        resolver:
+          name: object_with_lookahead
+      square_footage:
+        resolver:
+          name: object_with_lookahead
+      url:
+        resolver:
+          name: object_with_lookahead
+      vehicle_type:
+        resolver:
+          name: object_with_lookahead
+  RetailAggregation:
+    elasticgraph_category: indexed_aggregation
+    graphql_fields_by_name:
+      aggregated_values:
+        resolver:
+          name: object_without_lookahead
+      count:
+        resolver:
+          name: object_without_lookahead
+      grouped_by:
+        resolver:
+          name: object_without_lookahead
+    source_type: Retail
+  RetailAggregationConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+  RetailAggregationEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  RetailConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+      total_edge_count:
+        resolver:
+          name: object_without_lookahead
+  RetailEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      all_highlights:
+        resolver:
+          name: object_without_lookahead
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      highlights:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  RetailGroupedBy:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      address:
+        resolver:
+          name: object_with_lookahead
+      current_location:
+        resolver:
+          name: object_with_lookahead
+      customer_facing:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      platform:
+        resolver:
+          name: object_with_lookahead
+      square_footage:
+        resolver:
+          name: object_with_lookahead
+      url:
+        resolver:
+          name: object_with_lookahead
+      vehicle_type:
+        resolver:
+          name: object_with_lookahead
+  RetailHighlights:
+    graphql_fields_by_name:
+      address:
+        resolver:
+          name: get_record_field_value
+      current_location:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      platform:
+        resolver:
+          name: get_record_field_value
+      url:
+        resolver:
+          name: get_record_field_value
+      vehicle_type:
+        resolver:
+          name: get_record_field_value
   SearchHighlight:
     graphql_fields_by_name:
       path:
@@ -6151,6 +6889,185 @@ object_types_by_name:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  Store:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      address:
+        resolver:
+          name: get_record_field_value
+      current_location:
+        resolver:
+          name: get_record_field_value
+      customer_facing:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      platform:
+        resolver:
+          name: get_record_field_value
+      square_footage:
+        resolver:
+          name: get_record_field_value
+      url:
+        resolver:
+          name: get_record_field_value
+      vehicle_type:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+  StoreAggregatedValues:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      address:
+        resolver:
+          name: object_with_lookahead
+      current_location:
+        resolver:
+          name: object_with_lookahead
+      customer_facing:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      id:
+        resolver:
+          name: object_with_lookahead
+      platform:
+        resolver:
+          name: object_with_lookahead
+      square_footage:
+        resolver:
+          name: object_with_lookahead
+      url:
+        resolver:
+          name: object_with_lookahead
+      vehicle_type:
+        resolver:
+          name: object_with_lookahead
+  StoreAggregation:
+    elasticgraph_category: indexed_aggregation
+    graphql_fields_by_name:
+      aggregated_values:
+        resolver:
+          name: object_without_lookahead
+      count:
+        resolver:
+          name: object_without_lookahead
+      grouped_by:
+        resolver:
+          name: object_without_lookahead
+    source_type: Store
+  StoreAggregationConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+  StoreAggregationEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  StoreConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+      total_edge_count:
+        resolver:
+          name: object_without_lookahead
+  StoreEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      all_highlights:
+        resolver:
+          name: object_without_lookahead
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      highlights:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  StoreGroupedBy:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      address:
+        resolver:
+          name: object_with_lookahead
+      current_location:
+        resolver:
+          name: object_with_lookahead
+      customer_facing:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      platform:
+        resolver:
+          name: object_with_lookahead
+      square_footage:
+        resolver:
+          name: object_with_lookahead
+      url:
+        resolver:
+          name: object_with_lookahead
+      vehicle_type:
+        resolver:
+          name: object_with_lookahead
+  StoreHighlights:
+    graphql_fields_by_name:
+      address:
+        resolver:
+          name: get_record_field_value
+      current_location:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      platform:
+        resolver:
+          name: get_record_field_value
+      url:
+        resolver:
+          name: get_record_field_value
+      vehicle_type:
+        resolver:
+          name: get_record_field_value
   StringConnection:
     elasticgraph_category: relay_connection
     graphql_fields_by_name:
@@ -7084,6 +8001,48 @@ object_types_by_name:
       players_object:
         resolver:
           name: object_with_lookahead
+  ThirdPartyWholesale:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      contract_terms:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      partner_name:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+    update_targets:
+    - data_params:
+        __typename:
+          cardinality: one
+        active:
+          cardinality: one
+        contract_terms:
+          cardinality: one
+        partner_name:
+          cardinality: one
+      id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      routing_value_source: id
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      type: ThirdPartyWholesale
   Widget:
     graphql_fields_by_name:
       amount_cents:

--- a/config/schema/artifacts_with_apollo/schema.graphql
+++ b/config/schema/artifacts_with_apollo/schema.graphql
@@ -853,274 +853,6 @@ type Company implements NamedInventor @key(fields: "id") {
   stock_ticker: String
 }
 
-"""
-Type used to perform aggregation computations on `Company` fields.
-"""
-type CompanyAggregatedValues {
-  """
-  Computed aggregate values for the `id` field.
-  """
-  id: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `name` field.
-  """
-  name: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `stock_ticker` field.
-  """
-  stock_ticker: NonNumericAggregatedValues
-}
-
-"""
-Return type representing a bucket of `Company` documents for an aggregations query.
-"""
-type CompanyAggregation {
-  """
-  Provides computed aggregated values over all `Company` documents in an aggregation bucket.
-  """
-  aggregated_values: CompanyAggregatedValues
-
-  """
-  The count of `Company` documents in an aggregation bucket.
-  """
-  count: JsonSafeLong!
-
-  """
-  Used to specify the `Company` fields to group by. The returned values identify each aggregation bucket.
-  """
-  grouped_by: CompanyGroupedBy
-}
-
-"""
-Represents a paginated collection of `CompanyAggregation` results.
-
-See the [Relay GraphQL Cursor Connections
-Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
-"""
-type CompanyAggregationConnection {
-  """
-  Wraps a specific `CompanyAggregation` to pair it with its pagination cursor.
-  """
-  edges: [CompanyAggregationEdge!]!
-
-  """
-  The list of `CompanyAggregation` results.
-  """
-  nodes: [CompanyAggregation!]!
-
-  """
-  Provides pagination-related information.
-  """
-  page_info: PageInfo!
-}
-
-"""
-Represents a specific `CompanyAggregation` in the context of a `CompanyAggregationConnection`,
-providing access to both the `CompanyAggregation` and query-specific information such as the pagination `Cursor`.
-
-See the [Relay GraphQL Cursor Connections
-Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
-"""
-type CompanyAggregationEdge {
-  """
-  The `Cursor` of this `CompanyAggregation`. This can be passed in the next query as
-  a `before` or `after` argument to continue paginating from this `CompanyAggregation`.
-  """
-  cursor: Cursor
-
-  """
-  The `CompanyAggregation` of this edge.
-  """
-  node: CompanyAggregation
-}
-
-"""
-Represents a paginated collection of `Company` results.
-
-See the [Relay GraphQL Cursor Connections
-Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
-"""
-type CompanyConnection {
-  """
-  Wraps a specific `Company` to pair it with its pagination cursor.
-  """
-  edges: [CompanyEdge!]!
-
-  """
-  The list of `Company` results.
-  """
-  nodes: [Company!]!
-
-  """
-  Provides pagination-related information.
-  """
-  page_info: PageInfo!
-
-  """
-  The total number of edges available in this connection to paginate over.
-  """
-  total_edge_count: JsonSafeLong!
-}
-
-"""
-Represents a specific `Company` in the context of a `CompanyConnection`,
-providing access to both the `Company` and query-specific information such as the pagination `Cursor`.
-
-See the [Relay GraphQL Cursor Connections
-Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
-"""
-type CompanyEdge {
-  """
-  All search highlights for this `Company`, indicating where in the indexed document the query matched.
-  """
-  all_highlights: [SearchHighlight!]!
-
-  """
-  The `Cursor` of this `Company`. This can be passed in the next query as
-  a `before` or `after` argument to continue paginating from this `Company`.
-  """
-  cursor: Cursor
-
-  """
-  Specific search highlights for this `Company`, providing matching snippets for the requested fields.
-  """
-  highlights: CompanyHighlights
-
-  """
-  The `Company` of this edge.
-  """
-  node: Company
-}
-
-"""
-Input type used to specify filters on `Company` fields.
-
-Will match all documents if passed as an empty object (or as `null`).
-"""
-input CompanyFilterInput {
-  """
-  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
-
-  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
-  be provided on a single `CompanyFilterInput` input because of collisions
-  between key names. For example, if you want to AND multiple
-  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
-
-  When `null` or an empty list is passed, matches all documents.
-  """
-  all_of: [CompanyFilterInput!]
-
-  """
-  Matches records where any of the provided sub-filters evaluate to true.
-  This works just like an OR operator in SQL.
-
-  When `null` is passed, matches all documents.
-  When an empty list is passed, this part of the filter matches no documents.
-  """
-  any_of: [CompanyFilterInput!]
-
-  """
-  Used to filter on the `id` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  id: IDFilterInput
-
-  """
-  Used to filter on the `name` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  name: StringFilterInput
-
-  """
-  Matches records where the provided sub-filter evaluates to false.
-  This works just like a NOT operator in SQL.
-
-  When `null` or an empty object is passed, matches no documents.
-  """
-  not: CompanyFilterInput
-
-  """
-  Used to filter on the `stock_ticker` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  stock_ticker: StringFilterInput
-}
-
-"""
-Type used to specify the `Company` fields to group by for aggregations.
-"""
-type CompanyGroupedBy {
-  """
-  The `name` field value for this group.
-  """
-  name: String
-
-  """
-  The `stock_ticker` field value for this group.
-  """
-  stock_ticker: String
-}
-
-"""
-Type used to request desired `Company` search highlight fields.
-"""
-type CompanyHighlights {
-  """
-  Search highlights for the `id`, providing snippets of the matching text.
-  """
-  id: [String!]!
-
-  """
-  Search highlights for the `name`, providing snippets of the matching text.
-  """
-  name: [String!]!
-
-  """
-  Search highlights for the `stock_ticker`, providing snippets of the matching text.
-  """
-  stock_ticker: [String!]!
-}
-
-"""
-Enumerates the ways `Company`s can be sorted.
-"""
-enum CompanySortOrderInput {
-  """
-  Sorts ascending by the `id` field.
-  """
-  id_ASC
-
-  """
-  Sorts descending by the `id` field.
-  """
-  id_DESC
-
-  """
-  Sorts ascending by the `name` field.
-  """
-  name_ASC
-
-  """
-  Sorts descending by the `name` field.
-  """
-  name_DESC
-
-  """
-  Sorts ascending by the `stock_ticker` field.
-  """
-  stock_ticker_ASC
-
-  """
-  Sorts descending by the `stock_ticker` field.
-  """
-  stock_ticker_DESC
-}
-
 type Component implements NamedEntity @key(fields: "id") {
   created_at: DateTime!
   dollar_widget: Widget
@@ -3059,6 +2791,528 @@ enum DistanceUnitInput {
   A United States customary unit of 3 feet.
   """
   YARD
+}
+
+interface DistributionChannel {
+  active: Boolean
+  id: ID!
+}
+
+"""
+Type used to perform aggregation computations on `DistributionChannel` fields.
+"""
+type DistributionChannelAggregatedValues {
+  """
+  Computed aggregate values for the `active` field.
+  """
+  active: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `address` field.
+  """
+  address: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `contract_terms` field.
+  """
+  contract_terms: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `current_location` field.
+  """
+  current_location: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `customer_facing` field.
+  """
+  customer_facing: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `established_on` field.
+  """
+  established_on: DateAggregatedValues
+
+  """
+  Computed aggregate values for the `id` field.
+  """
+  id: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `partner_name` field.
+  """
+  partner_name: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `platform` field.
+  """
+  platform: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `square_footage` field.
+  """
+  square_footage: IntAggregatedValues
+
+  """
+  Computed aggregate values for the `url` field.
+  """
+  url: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `vehicle_type` field.
+  """
+  vehicle_type: NonNumericAggregatedValues
+}
+
+"""
+Return type representing a bucket of `DistributionChannel` documents for an aggregations query.
+"""
+type DistributionChannelAggregation {
+  """
+  Provides computed aggregated values over all `DistributionChannel` documents in an aggregation bucket.
+  """
+  aggregated_values: DistributionChannelAggregatedValues
+
+  """
+  The count of `DistributionChannel` documents in an aggregation bucket.
+  """
+  count: JsonSafeLong!
+
+  """
+  Used to specify the `DistributionChannel` fields to group by. The returned values identify each aggregation bucket.
+  """
+  grouped_by: DistributionChannelGroupedBy
+}
+
+"""
+Represents a paginated collection of `DistributionChannelAggregation` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type DistributionChannelAggregationConnection {
+  """
+  Wraps a specific `DistributionChannelAggregation` to pair it with its pagination cursor.
+  """
+  edges: [DistributionChannelAggregationEdge!]!
+
+  """
+  The list of `DistributionChannelAggregation` results.
+  """
+  nodes: [DistributionChannelAggregation!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+}
+
+"""
+Represents a specific `DistributionChannelAggregation` in the context of a `DistributionChannelAggregationConnection`,
+providing access to both the `DistributionChannelAggregation` and query-specific
+information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type DistributionChannelAggregationEdge {
+  """
+  The `Cursor` of this `DistributionChannelAggregation`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `DistributionChannelAggregation`.
+  """
+  cursor: Cursor
+
+  """
+  The `DistributionChannelAggregation` of this edge.
+  """
+  node: DistributionChannelAggregation
+}
+
+"""
+Represents a paginated collection of `DistributionChannel` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type DistributionChannelConnection {
+  """
+  Wraps a specific `DistributionChannel` to pair it with its pagination cursor.
+  """
+  edges: [DistributionChannelEdge!]!
+
+  """
+  The list of `DistributionChannel` results.
+  """
+  nodes: [DistributionChannel!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+
+  """
+  The total number of edges available in this connection to paginate over.
+  """
+  total_edge_count: JsonSafeLong!
+}
+
+"""
+Represents a specific `DistributionChannel` in the context of a `DistributionChannelConnection`,
+providing access to both the `DistributionChannel` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type DistributionChannelEdge {
+  """
+  All search highlights for this `DistributionChannel`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
+  The `Cursor` of this `DistributionChannel`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `DistributionChannel`.
+  """
+  cursor: Cursor
+
+  """
+  Specific search highlights for this `DistributionChannel`, providing matching snippets for the requested fields.
+  """
+  highlights: DistributionChannelHighlights
+
+  """
+  The `DistributionChannel` of this edge.
+  """
+  node: DistributionChannel
+}
+
+"""
+Input type used to specify filters on `DistributionChannel` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input DistributionChannelFilterInput {
+  """
+  Used to filter on the `active` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  active: BooleanFilterInput
+
+  """
+  Used to filter on the `address` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  address: StringFilterInput
+
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `DistributionChannelFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [DistributionChannelFilterInput!]
+
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [DistributionChannelFilterInput!]
+
+  """
+  Used to filter on the `contract_terms` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  contract_terms: StringFilterInput
+
+  """
+  Used to filter on the `current_location` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  current_location: StringFilterInput
+
+  """
+  Used to filter on the `customer_facing` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  customer_facing: BooleanFilterInput
+
+  """
+  Used to filter on the `established_on` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  established_on: DateFilterInput
+
+  """
+  Used to filter on the `id` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  id: IDFilterInput
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: DistributionChannelFilterInput
+
+  """
+  Used to filter on the `partner_name` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  partner_name: StringFilterInput
+
+  """
+  Used to filter on the `platform` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  platform: StringFilterInput
+
+  """
+  Used to filter on the `square_footage` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  square_footage: IntFilterInput
+
+  """
+  Used to filter on the `url` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  url: StringFilterInput
+
+  """
+  Used to filter on the `vehicle_type` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  vehicle_type: StringFilterInput
+}
+
+"""
+Type used to specify the `DistributionChannel` fields to group by for aggregations.
+"""
+type DistributionChannelGroupedBy {
+  """
+  The `active` field value for this group.
+  """
+  active: Boolean
+
+  """
+  The `address` field value for this group.
+  """
+  address: String
+
+  """
+  The `contract_terms` field value for this group.
+  """
+  contract_terms: String
+
+  """
+  The `current_location` field value for this group.
+  """
+  current_location: String
+
+  """
+  The `customer_facing` field value for this group.
+  """
+  customer_facing: Boolean
+
+  """
+  Offers the different grouping options for the `established_on` value within this group.
+  """
+  established_on: DateGroupedBy
+
+  """
+  The `partner_name` field value for this group.
+  """
+  partner_name: String
+
+  """
+  The `platform` field value for this group.
+  """
+  platform: String
+
+  """
+  The `square_footage` field value for this group.
+  """
+  square_footage: Int
+
+  """
+  The `url` field value for this group.
+  """
+  url: String
+
+  """
+  The `vehicle_type` field value for this group.
+  """
+  vehicle_type: String
+}
+
+"""
+Type used to request desired `DistributionChannel` search highlight fields.
+"""
+type DistributionChannelHighlights {
+  """
+  Search highlights for the `address`, providing snippets of the matching text.
+  """
+  address: [String!]!
+
+  """
+  Search highlights for the `contract_terms`, providing snippets of the matching text.
+  """
+  contract_terms: [String!]!
+
+  """
+  Search highlights for the `current_location`, providing snippets of the matching text.
+  """
+  current_location: [String!]!
+
+  """
+  Search highlights for the `id`, providing snippets of the matching text.
+  """
+  id: [String!]!
+
+  """
+  Search highlights for the `partner_name`, providing snippets of the matching text.
+  """
+  partner_name: [String!]!
+
+  """
+  Search highlights for the `platform`, providing snippets of the matching text.
+  """
+  platform: [String!]!
+
+  """
+  Search highlights for the `url`, providing snippets of the matching text.
+  """
+  url: [String!]!
+
+  """
+  Search highlights for the `vehicle_type`, providing snippets of the matching text.
+  """
+  vehicle_type: [String!]!
+}
+
+"""
+Enumerates the ways `DistributionChannel`s can be sorted.
+"""
+enum DistributionChannelSortOrderInput {
+  """
+  Sorts ascending by the `address` field.
+  """
+  address_ASC
+
+  """
+  Sorts descending by the `address` field.
+  """
+  address_DESC
+
+  """
+  Sorts ascending by the `contract_terms` field.
+  """
+  contract_terms_ASC
+
+  """
+  Sorts descending by the `contract_terms` field.
+  """
+  contract_terms_DESC
+
+  """
+  Sorts ascending by the `current_location` field.
+  """
+  current_location_ASC
+
+  """
+  Sorts descending by the `current_location` field.
+  """
+  current_location_DESC
+
+  """
+  Sorts ascending by the `established_on` field.
+  """
+  established_on_ASC
+
+  """
+  Sorts descending by the `established_on` field.
+  """
+  established_on_DESC
+
+  """
+  Sorts ascending by the `id` field.
+  """
+  id_ASC
+
+  """
+  Sorts descending by the `id` field.
+  """
+  id_DESC
+
+  """
+  Sorts ascending by the `partner_name` field.
+  """
+  partner_name_ASC
+
+  """
+  Sorts descending by the `partner_name` field.
+  """
+  partner_name_DESC
+
+  """
+  Sorts ascending by the `platform` field.
+  """
+  platform_ASC
+
+  """
+  Sorts descending by the `platform` field.
+  """
+  platform_DESC
+
+  """
+  Sorts ascending by the `square_footage` field.
+  """
+  square_footage_ASC
+
+  """
+  Sorts descending by the `square_footage` field.
+  """
+  square_footage_DESC
+
+  """
+  Sorts ascending by the `url` field.
+  """
+  url_ASC
+
+  """
+  Sorts descending by the `url` field.
+  """
+  url_DESC
+
+  """
+  Sorts ascending by the `vehicle_type` field.
+  """
+  vehicle_type_ASC
+
+  """
+  Sorts descending by the `vehicle_type` field.
+  """
+  vehicle_type_DESC
 }
 
 type ElectricalPart implements NamedEntity @key(fields: "id") {
@@ -5958,6 +6212,15 @@ enum MechanicalPartSortOrderInput {
   name_DESC
 }
 
+type MobileStore implements DistributionChannel & Retail & Store @key(fields: "id") {
+  active: Boolean
+  current_location: String
+  customer_facing: Boolean
+  established_on: Date
+  id: ID!
+  vehicle_type: String!
+}
+
 type Money {
   amount_cents: Int
   currency: String!
@@ -8053,6 +8316,15 @@ type NonNumericAggregatedValues @shareable {
   approximate_distinct_value_count: JsonSafeLong
 }
 
+type OnlineStore implements DistributionChannel & Retail & Store @key(fields: "id") {
+  active: Boolean
+  customer_facing: Boolean
+  established_on: Date
+  id: ID!
+  platform: String
+  url: String!
+}
+
 """
 Provides information about the specific fetched page. This implements the `PageInfo`
 specification from the [Relay GraphQL Cursor Connections
@@ -8433,127 +8705,6 @@ type PersonAggregatedValues {
 }
 
 """
-Return type representing a bucket of `Person` documents for an aggregations query.
-"""
-type PersonAggregation {
-  """
-  Provides computed aggregated values over all `Person` documents in an aggregation bucket.
-  """
-  aggregated_values: PersonAggregatedValues
-
-  """
-  The count of `Person` documents in an aggregation bucket.
-  """
-  count: JsonSafeLong!
-
-  """
-  Used to specify the `Person` fields to group by. The returned values identify each aggregation bucket.
-  """
-  grouped_by: PersonGroupedBy
-}
-
-"""
-Represents a paginated collection of `PersonAggregation` results.
-
-See the [Relay GraphQL Cursor Connections
-Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
-"""
-type PersonAggregationConnection {
-  """
-  Wraps a specific `PersonAggregation` to pair it with its pagination cursor.
-  """
-  edges: [PersonAggregationEdge!]!
-
-  """
-  The list of `PersonAggregation` results.
-  """
-  nodes: [PersonAggregation!]!
-
-  """
-  Provides pagination-related information.
-  """
-  page_info: PageInfo!
-}
-
-"""
-Represents a specific `PersonAggregation` in the context of a `PersonAggregationConnection`,
-providing access to both the `PersonAggregation` and query-specific information such as the pagination `Cursor`.
-
-See the [Relay GraphQL Cursor Connections
-Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
-"""
-type PersonAggregationEdge {
-  """
-  The `Cursor` of this `PersonAggregation`. This can be passed in the next query as
-  a `before` or `after` argument to continue paginating from this `PersonAggregation`.
-  """
-  cursor: Cursor
-
-  """
-  The `PersonAggregation` of this edge.
-  """
-  node: PersonAggregation
-}
-
-"""
-Represents a paginated collection of `Person` results.
-
-See the [Relay GraphQL Cursor Connections
-Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
-"""
-type PersonConnection {
-  """
-  Wraps a specific `Person` to pair it with its pagination cursor.
-  """
-  edges: [PersonEdge!]!
-
-  """
-  The list of `Person` results.
-  """
-  nodes: [Person!]!
-
-  """
-  Provides pagination-related information.
-  """
-  page_info: PageInfo!
-
-  """
-  The total number of edges available in this connection to paginate over.
-  """
-  total_edge_count: JsonSafeLong!
-}
-
-"""
-Represents a specific `Person` in the context of a `PersonConnection`,
-providing access to both the `Person` and query-specific information such as the pagination `Cursor`.
-
-See the [Relay GraphQL Cursor Connections
-Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
-"""
-type PersonEdge {
-  """
-  All search highlights for this `Person`, indicating where in the indexed document the query matched.
-  """
-  all_highlights: [SearchHighlight!]!
-
-  """
-  The `Cursor` of this `Person`. This can be passed in the next query as
-  a `before` or `after` argument to continue paginating from this `Person`.
-  """
-  cursor: Cursor
-
-  """
-  Specific search highlights for this `Person`, providing matching snippets for the requested fields.
-  """
-  highlights: PersonHighlights
-
-  """
-  The `Person` of this edge.
-  """
-  node: Person
-}
-
-"""
 Input type used to specify filters on `Person` fields.
 
 Will match all documents if passed as an empty object (or as `null`).
@@ -8645,10 +8796,318 @@ type PersonHighlights {
   nationality: [String!]!
 }
 
+type PhysicalStore implements DistributionChannel & Retail & Store @key(fields: "id") {
+  active: Boolean
+  address: String!
+  customer_facing: Boolean
+  established_on: Date
+  id: ID!
+  square_footage: Int
+}
+
 """
-Enumerates the ways `Person`s can be sorted.
+Type used to perform aggregation computations on `PhysicalStore` fields.
 """
-enum PersonSortOrderInput {
+type PhysicalStoreAggregatedValues {
+  """
+  Computed aggregate values for the `active` field.
+  """
+  active: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `address` field.
+  """
+  address: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `customer_facing` field.
+  """
+  customer_facing: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `established_on` field.
+  """
+  established_on: DateAggregatedValues
+
+  """
+  Computed aggregate values for the `id` field.
+  """
+  id: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `square_footage` field.
+  """
+  square_footage: IntAggregatedValues
+}
+
+"""
+Return type representing a bucket of `PhysicalStore` documents for an aggregations query.
+"""
+type PhysicalStoreAggregation {
+  """
+  Provides computed aggregated values over all `PhysicalStore` documents in an aggregation bucket.
+  """
+  aggregated_values: PhysicalStoreAggregatedValues
+
+  """
+  The count of `PhysicalStore` documents in an aggregation bucket.
+  """
+  count: JsonSafeLong!
+
+  """
+  Used to specify the `PhysicalStore` fields to group by. The returned values identify each aggregation bucket.
+  """
+  grouped_by: PhysicalStoreGroupedBy
+}
+
+"""
+Represents a paginated collection of `PhysicalStoreAggregation` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type PhysicalStoreAggregationConnection {
+  """
+  Wraps a specific `PhysicalStoreAggregation` to pair it with its pagination cursor.
+  """
+  edges: [PhysicalStoreAggregationEdge!]!
+
+  """
+  The list of `PhysicalStoreAggregation` results.
+  """
+  nodes: [PhysicalStoreAggregation!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+}
+
+"""
+Represents a specific `PhysicalStoreAggregation` in the context of a `PhysicalStoreAggregationConnection`,
+providing access to both the `PhysicalStoreAggregation` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type PhysicalStoreAggregationEdge {
+  """
+  The `Cursor` of this `PhysicalStoreAggregation`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `PhysicalStoreAggregation`.
+  """
+  cursor: Cursor
+
+  """
+  The `PhysicalStoreAggregation` of this edge.
+  """
+  node: PhysicalStoreAggregation
+}
+
+"""
+Represents a paginated collection of `PhysicalStore` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type PhysicalStoreConnection {
+  """
+  Wraps a specific `PhysicalStore` to pair it with its pagination cursor.
+  """
+  edges: [PhysicalStoreEdge!]!
+
+  """
+  The list of `PhysicalStore` results.
+  """
+  nodes: [PhysicalStore!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+
+  """
+  The total number of edges available in this connection to paginate over.
+  """
+  total_edge_count: JsonSafeLong!
+}
+
+"""
+Represents a specific `PhysicalStore` in the context of a `PhysicalStoreConnection`,
+providing access to both the `PhysicalStore` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type PhysicalStoreEdge {
+  """
+  All search highlights for this `PhysicalStore`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
+  The `Cursor` of this `PhysicalStore`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `PhysicalStore`.
+  """
+  cursor: Cursor
+
+  """
+  Specific search highlights for this `PhysicalStore`, providing matching snippets for the requested fields.
+  """
+  highlights: PhysicalStoreHighlights
+
+  """
+  The `PhysicalStore` of this edge.
+  """
+  node: PhysicalStore
+}
+
+"""
+Input type used to specify filters on `PhysicalStore` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input PhysicalStoreFilterInput {
+  """
+  Used to filter on the `active` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  active: BooleanFilterInput
+
+  """
+  Used to filter on the `address` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  address: StringFilterInput
+
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `PhysicalStoreFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [PhysicalStoreFilterInput!]
+
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [PhysicalStoreFilterInput!]
+
+  """
+  Used to filter on the `customer_facing` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  customer_facing: BooleanFilterInput
+
+  """
+  Used to filter on the `established_on` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  established_on: DateFilterInput
+
+  """
+  Used to filter on the `id` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  id: IDFilterInput
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: PhysicalStoreFilterInput
+
+  """
+  Used to filter on the `square_footage` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  square_footage: IntFilterInput
+}
+
+"""
+Type used to specify the `PhysicalStore` fields to group by for aggregations.
+"""
+type PhysicalStoreGroupedBy {
+  """
+  The `active` field value for this group.
+  """
+  active: Boolean
+
+  """
+  The `address` field value for this group.
+  """
+  address: String
+
+  """
+  The `customer_facing` field value for this group.
+  """
+  customer_facing: Boolean
+
+  """
+  Offers the different grouping options for the `established_on` value within this group.
+  """
+  established_on: DateGroupedBy
+
+  """
+  The `square_footage` field value for this group.
+  """
+  square_footage: Int
+}
+
+"""
+Type used to request desired `PhysicalStore` search highlight fields.
+"""
+type PhysicalStoreHighlights {
+  """
+  Search highlights for the `address`, providing snippets of the matching text.
+  """
+  address: [String!]!
+
+  """
+  Search highlights for the `id`, providing snippets of the matching text.
+  """
+  id: [String!]!
+}
+
+"""
+Enumerates the ways `PhysicalStore`s can be sorted.
+"""
+enum PhysicalStoreSortOrderInput {
+  """
+  Sorts ascending by the `address` field.
+  """
+  address_ASC
+
+  """
+  Sorts descending by the `address` field.
+  """
+  address_DESC
+
+  """
+  Sorts ascending by the `established_on` field.
+  """
+  established_on_ASC
+
+  """
+  Sorts descending by the `established_on` field.
+  """
+  established_on_DESC
+
   """
   Sorts ascending by the `id` field.
   """
@@ -8660,24 +9119,14 @@ enum PersonSortOrderInput {
   id_DESC
 
   """
-  Sorts ascending by the `name` field.
+  Sorts ascending by the `square_footage` field.
   """
-  name_ASC
+  square_footage_ASC
 
   """
-  Sorts descending by the `name` field.
+  Sorts descending by the `square_footage` field.
   """
-  name_DESC
-
-  """
-  Sorts ascending by the `nationality` field.
-  """
-  nationality_ASC
-
-  """
-  Sorts descending by the `nationality` field.
-  """
-  nationality_DESC
+  square_footage_DESC
 }
 
 type Player {
@@ -9467,109 +9916,6 @@ type Query {
   ): AddressConnection
 
   """
-  Fetches `Company`s based on the provided arguments.
-  """
-  companies(
-    """
-    Used to forward-paginate through the `companies`. When provided, the next page after the
-    provided cursor will be returned.
-
-    See the [Relay GraphQL Cursor Connections
-    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
-    """
-    after: Cursor
-
-    """
-    Used to backward-paginate through the `companies`. When provided, the previous page before the
-    provided cursor will be returned.
-
-    See the [Relay GraphQL Cursor Connections
-    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
-    """
-    before: Cursor
-
-    """
-    Used to filter the returned `companies` based on the provided criteria.
-    """
-    filter: CompanyFilterInput
-
-    """
-    Used in conjunction with the `after` argument to forward-paginate through the `companies`.
-    When provided, limits the number of returned results to the first `n` after the provided
-    `after` cursor (or from the start of the `companies`, if no `after` cursor is provided).
-
-    See the [Relay GraphQL Cursor Connections
-    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
-    """
-    first: Int
-
-    """
-    Used in conjunction with the `before` argument to backward-paginate through the `companies`.
-    When provided, limits the number of returned results to the last `n` before the provided
-    `before` cursor (or from the end of the `companies`, if no `before` cursor is provided).
-
-    See the [Relay GraphQL Cursor Connections
-    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
-    """
-    last: Int
-
-    """
-    Used to specify how the returned `companies` should be sorted.
-    """
-    order_by: [CompanySortOrderInput!]
-  ): CompanyConnection
-
-  """
-  Aggregations over the `companies` data:
-
-  > Fetches `Company`s based on the provided arguments.
-  """
-  company_aggregations(
-    """
-    Used to forward-paginate through the `company_aggregations`. When provided, the next page after the
-    provided cursor will be returned.
-
-    See the [Relay GraphQL Cursor Connections
-    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
-    """
-    after: Cursor
-
-    """
-    Used to backward-paginate through the `company_aggregations`. When provided, the previous page before the
-    provided cursor will be returned.
-
-    See the [Relay GraphQL Cursor Connections
-    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
-    """
-    before: Cursor
-
-    """
-    Used to filter the `Company` documents that get aggregated over based on the provided criteria.
-    """
-    filter: CompanyFilterInput
-
-    """
-    Used in conjunction with the `after` argument to forward-paginate through the `company_aggregations`.
-    When provided, limits the number of returned results to the first `n` after the provided
-    `after` cursor (or from the start of the `company_aggregations`, if no `after` cursor is provided).
-
-    See the [Relay GraphQL Cursor Connections
-    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
-    """
-    first: Int
-
-    """
-    Used in conjunction with the `before` argument to backward-paginate through the `company_aggregations`.
-    When provided, limits the number of returned results to the last `n` before the provided
-    `before` cursor (or from the end of the `company_aggregations`, if no `before` cursor is provided).
-
-    See the [Relay GraphQL Cursor Connections
-    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
-    """
-    last: Int
-  ): CompanyAggregationConnection
-
-  """
   Aggregations over the `components` data:
 
   > Fetches `Component`s based on the provided arguments.
@@ -9671,6 +10017,109 @@ type Query {
     """
     order_by: [ComponentSortOrderInput!]
   ): ComponentConnection
+
+  """
+  Aggregations over the `distribution_channels` data:
+
+  > Fetches `DistributionChannel`s based on the provided arguments.
+  """
+  distribution_channel_aggregations(
+    """
+    Used to forward-paginate through the `distribution_channel_aggregations`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `distribution_channel_aggregations`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the `DistributionChannel` documents that get aggregated over based on the provided criteria.
+    """
+    filter: DistributionChannelFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `distribution_channel_aggregations`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `distribution_channel_aggregations`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `distribution_channel_aggregations`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `distribution_channel_aggregations`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+  ): DistributionChannelAggregationConnection
+
+  """
+  Fetches `DistributionChannel`s based on the provided arguments.
+  """
+  distribution_channels(
+    """
+    Used to forward-paginate through the `distribution_channels`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `distribution_channels`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the returned `distribution_channels` based on the provided criteria.
+    """
+    filter: DistributionChannelFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `distribution_channels`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `distribution_channels`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `distribution_channels`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `distribution_channels`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+
+    """
+    Used to specify how the returned `distribution_channels` should be sorted.
+    """
+    order_by: [DistributionChannelSortOrderInput!]
+  ): DistributionChannelConnection
 
   """
   Aggregations over the `electrical_parts` data:
@@ -10394,11 +10843,13 @@ type Query {
   ): PartConnection
 
   """
-  Fetches `Person`s based on the provided arguments.
+  Aggregations over the `physical_stores` data:
+
+  > Fetches `PhysicalStore`s based on the provided arguments.
   """
-  people(
+  physical_store_aggregations(
     """
-    Used to forward-paginate through the `people`. When provided, the next page after the
+    Used to forward-paginate through the `physical_store_aggregations`. When provided, the next page after the
     provided cursor will be returned.
 
     See the [Relay GraphQL Cursor Connections
@@ -10407,7 +10858,7 @@ type Query {
     after: Cursor
 
     """
-    Used to backward-paginate through the `people`. When provided, the previous page before the
+    Used to backward-paginate through the `physical_store_aggregations`. When provided, the previous page before the
     provided cursor will be returned.
 
     See the [Relay GraphQL Cursor Connections
@@ -10416,14 +10867,14 @@ type Query {
     before: Cursor
 
     """
-    Used to filter the returned `people` based on the provided criteria.
+    Used to filter the `PhysicalStore` documents that get aggregated over based on the provided criteria.
     """
-    filter: PersonFilterInput
+    filter: PhysicalStoreFilterInput
 
     """
-    Used in conjunction with the `after` argument to forward-paginate through the `people`.
+    Used in conjunction with the `after` argument to forward-paginate through the `physical_store_aggregations`.
     When provided, limits the number of returned results to the first `n` after the provided
-    `after` cursor (or from the start of the `people`, if no `after` cursor is provided).
+    `after` cursor (or from the start of the `physical_store_aggregations`, if no `after` cursor is provided).
 
     See the [Relay GraphQL Cursor Connections
     Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
@@ -10431,29 +10882,22 @@ type Query {
     first: Int
 
     """
-    Used in conjunction with the `before` argument to backward-paginate through the `people`.
+    Used in conjunction with the `before` argument to backward-paginate through the `physical_store_aggregations`.
     When provided, limits the number of returned results to the last `n` before the provided
-    `before` cursor (or from the end of the `people`, if no `before` cursor is provided).
+    `before` cursor (or from the end of the `physical_store_aggregations`, if no `before` cursor is provided).
 
     See the [Relay GraphQL Cursor Connections
     Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
     """
     last: Int
-
-    """
-    Used to specify how the returned `people` should be sorted.
-    """
-    order_by: [PersonSortOrderInput!]
-  ): PersonConnection
+  ): PhysicalStoreAggregationConnection
 
   """
-  Aggregations over the `people` data:
-
-  > Fetches `Person`s based on the provided arguments.
+  Fetches `PhysicalStore`s based on the provided arguments.
   """
-  person_aggregations(
+  physical_stores(
     """
-    Used to forward-paginate through the `person_aggregations`. When provided, the next page after the
+    Used to forward-paginate through the `physical_stores`. When provided, the next page after the
     provided cursor will be returned.
 
     See the [Relay GraphQL Cursor Connections
@@ -10462,7 +10906,7 @@ type Query {
     after: Cursor
 
     """
-    Used to backward-paginate through the `person_aggregations`. When provided, the previous page before the
+    Used to backward-paginate through the `physical_stores`. When provided, the previous page before the
     provided cursor will be returned.
 
     See the [Relay GraphQL Cursor Connections
@@ -10471,14 +10915,14 @@ type Query {
     before: Cursor
 
     """
-    Used to filter the `Person` documents that get aggregated over based on the provided criteria.
+    Used to filter the returned `physical_stores` based on the provided criteria.
     """
-    filter: PersonFilterInput
+    filter: PhysicalStoreFilterInput
 
     """
-    Used in conjunction with the `after` argument to forward-paginate through the `person_aggregations`.
+    Used in conjunction with the `after` argument to forward-paginate through the `physical_stores`.
     When provided, limits the number of returned results to the first `n` after the provided
-    `after` cursor (or from the start of the `person_aggregations`, if no `after` cursor is provided).
+    `after` cursor (or from the start of the `physical_stores`, if no `after` cursor is provided).
 
     See the [Relay GraphQL Cursor Connections
     Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
@@ -10486,15 +10930,123 @@ type Query {
     first: Int
 
     """
-    Used in conjunction with the `before` argument to backward-paginate through the `person_aggregations`.
+    Used in conjunction with the `before` argument to backward-paginate through the `physical_stores`.
     When provided, limits the number of returned results to the last `n` before the provided
-    `before` cursor (or from the end of the `person_aggregations`, if no `before` cursor is provided).
+    `before` cursor (or from the end of the `physical_stores`, if no `before` cursor is provided).
 
     See the [Relay GraphQL Cursor Connections
     Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
     """
     last: Int
-  ): PersonAggregationConnection
+
+    """
+    Used to specify how the returned `physical_stores` should be sorted.
+    """
+    order_by: [PhysicalStoreSortOrderInput!]
+  ): PhysicalStoreConnection
+
+  """
+  Aggregations over the `retailers` data:
+
+  > Fetches `Retail`s based on the provided arguments.
+  """
+  retail_aggregations(
+    """
+    Used to forward-paginate through the `retail_aggregations`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `retail_aggregations`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the `Retail` documents that get aggregated over based on the provided criteria.
+    """
+    filter: RetailFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `retail_aggregations`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `retail_aggregations`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `retail_aggregations`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `retail_aggregations`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+  ): RetailAggregationConnection
+
+  """
+  Fetches `Retail`s based on the provided arguments.
+  """
+  retailers(
+    """
+    Used to forward-paginate through the `retailers`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `retailers`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the returned `retailers` based on the provided criteria.
+    """
+    filter: RetailFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `retailers`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `retailers`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `retailers`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `retailers`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+
+    """
+    Used to specify how the returned `retailers` should be sorted.
+    """
+    order_by: [RetailSortOrderInput!]
+  ): RetailConnection
 
   """
   Aggregations over the `sponsors` data:
@@ -10598,6 +11150,109 @@ type Query {
     """
     order_by: [SponsorSortOrderInput!]
   ): SponsorConnection
+
+  """
+  Aggregations over the `stores` data:
+
+  > Fetches `Store`s based on the provided arguments.
+  """
+  store_aggregations(
+    """
+    Used to forward-paginate through the `store_aggregations`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `store_aggregations`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the `Store` documents that get aggregated over based on the provided criteria.
+    """
+    filter: StoreFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `store_aggregations`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `store_aggregations`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `store_aggregations`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `store_aggregations`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+  ): StoreAggregationConnection
+
+  """
+  Fetches `Store`s based on the provided arguments.
+  """
+  stores(
+    """
+    Used to forward-paginate through the `stores`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `stores`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the returned `stores` based on the provided criteria.
+    """
+    filter: StoreFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `stores`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `stores`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `stores`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `stores`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+
+    """
+    Used to specify how the returned `stores` should be sorted.
+    """
+    order_by: [StoreSortOrderInput!]
+  ): StoreConnection
 
   """
   Aggregations over the `teams` data:
@@ -11118,6 +11773,464 @@ type Query {
     """
     order_by: [WidgetOrAddressSortOrderInput!]
   ): WidgetOrAddressConnection
+}
+
+interface Retail implements DistributionChannel {
+  active: Boolean
+  established_on: Date
+  id: ID!
+}
+
+"""
+Type used to perform aggregation computations on `Retail` fields.
+"""
+type RetailAggregatedValues {
+  """
+  Computed aggregate values for the `active` field.
+  """
+  active: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `address` field.
+  """
+  address: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `current_location` field.
+  """
+  current_location: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `customer_facing` field.
+  """
+  customer_facing: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `established_on` field.
+  """
+  established_on: DateAggregatedValues
+
+  """
+  Computed aggregate values for the `id` field.
+  """
+  id: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `platform` field.
+  """
+  platform: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `square_footage` field.
+  """
+  square_footage: IntAggregatedValues
+
+  """
+  Computed aggregate values for the `url` field.
+  """
+  url: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `vehicle_type` field.
+  """
+  vehicle_type: NonNumericAggregatedValues
+}
+
+"""
+Return type representing a bucket of `Retail` documents for an aggregations query.
+"""
+type RetailAggregation {
+  """
+  Provides computed aggregated values over all `Retail` documents in an aggregation bucket.
+  """
+  aggregated_values: RetailAggregatedValues
+
+  """
+  The count of `Retail` documents in an aggregation bucket.
+  """
+  count: JsonSafeLong!
+
+  """
+  Used to specify the `Retail` fields to group by. The returned values identify each aggregation bucket.
+  """
+  grouped_by: RetailGroupedBy
+}
+
+"""
+Represents a paginated collection of `RetailAggregation` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type RetailAggregationConnection {
+  """
+  Wraps a specific `RetailAggregation` to pair it with its pagination cursor.
+  """
+  edges: [RetailAggregationEdge!]!
+
+  """
+  The list of `RetailAggregation` results.
+  """
+  nodes: [RetailAggregation!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+}
+
+"""
+Represents a specific `RetailAggregation` in the context of a `RetailAggregationConnection`,
+providing access to both the `RetailAggregation` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type RetailAggregationEdge {
+  """
+  The `Cursor` of this `RetailAggregation`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `RetailAggregation`.
+  """
+  cursor: Cursor
+
+  """
+  The `RetailAggregation` of this edge.
+  """
+  node: RetailAggregation
+}
+
+"""
+Represents a paginated collection of `Retail` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type RetailConnection {
+  """
+  Wraps a specific `Retail` to pair it with its pagination cursor.
+  """
+  edges: [RetailEdge!]!
+
+  """
+  The list of `Retail` results.
+  """
+  nodes: [Retail!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+
+  """
+  The total number of edges available in this connection to paginate over.
+  """
+  total_edge_count: JsonSafeLong!
+}
+
+"""
+Represents a specific `Retail` in the context of a `RetailConnection`,
+providing access to both the `Retail` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type RetailEdge {
+  """
+  All search highlights for this `Retail`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
+  The `Cursor` of this `Retail`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `Retail`.
+  """
+  cursor: Cursor
+
+  """
+  Specific search highlights for this `Retail`, providing matching snippets for the requested fields.
+  """
+  highlights: RetailHighlights
+
+  """
+  The `Retail` of this edge.
+  """
+  node: Retail
+}
+
+"""
+Input type used to specify filters on `Retail` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input RetailFilterInput {
+  """
+  Used to filter on the `active` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  active: BooleanFilterInput
+
+  """
+  Used to filter on the `address` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  address: StringFilterInput
+
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `RetailFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [RetailFilterInput!]
+
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [RetailFilterInput!]
+
+  """
+  Used to filter on the `current_location` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  current_location: StringFilterInput
+
+  """
+  Used to filter on the `customer_facing` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  customer_facing: BooleanFilterInput
+
+  """
+  Used to filter on the `established_on` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  established_on: DateFilterInput
+
+  """
+  Used to filter on the `id` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  id: IDFilterInput
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: RetailFilterInput
+
+  """
+  Used to filter on the `platform` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  platform: StringFilterInput
+
+  """
+  Used to filter on the `square_footage` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  square_footage: IntFilterInput
+
+  """
+  Used to filter on the `url` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  url: StringFilterInput
+
+  """
+  Used to filter on the `vehicle_type` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  vehicle_type: StringFilterInput
+}
+
+"""
+Type used to specify the `Retail` fields to group by for aggregations.
+"""
+type RetailGroupedBy {
+  """
+  The `active` field value for this group.
+  """
+  active: Boolean
+
+  """
+  The `address` field value for this group.
+  """
+  address: String
+
+  """
+  The `current_location` field value for this group.
+  """
+  current_location: String
+
+  """
+  The `customer_facing` field value for this group.
+  """
+  customer_facing: Boolean
+
+  """
+  Offers the different grouping options for the `established_on` value within this group.
+  """
+  established_on: DateGroupedBy
+
+  """
+  The `platform` field value for this group.
+  """
+  platform: String
+
+  """
+  The `square_footage` field value for this group.
+  """
+  square_footage: Int
+
+  """
+  The `url` field value for this group.
+  """
+  url: String
+
+  """
+  The `vehicle_type` field value for this group.
+  """
+  vehicle_type: String
+}
+
+"""
+Type used to request desired `Retail` search highlight fields.
+"""
+type RetailHighlights {
+  """
+  Search highlights for the `address`, providing snippets of the matching text.
+  """
+  address: [String!]!
+
+  """
+  Search highlights for the `current_location`, providing snippets of the matching text.
+  """
+  current_location: [String!]!
+
+  """
+  Search highlights for the `id`, providing snippets of the matching text.
+  """
+  id: [String!]!
+
+  """
+  Search highlights for the `platform`, providing snippets of the matching text.
+  """
+  platform: [String!]!
+
+  """
+  Search highlights for the `url`, providing snippets of the matching text.
+  """
+  url: [String!]!
+
+  """
+  Search highlights for the `vehicle_type`, providing snippets of the matching text.
+  """
+  vehicle_type: [String!]!
+}
+
+"""
+Enumerates the ways `Retail`s can be sorted.
+"""
+enum RetailSortOrderInput {
+  """
+  Sorts ascending by the `address` field.
+  """
+  address_ASC
+
+  """
+  Sorts descending by the `address` field.
+  """
+  address_DESC
+
+  """
+  Sorts ascending by the `current_location` field.
+  """
+  current_location_ASC
+
+  """
+  Sorts descending by the `current_location` field.
+  """
+  current_location_DESC
+
+  """
+  Sorts ascending by the `established_on` field.
+  """
+  established_on_ASC
+
+  """
+  Sorts descending by the `established_on` field.
+  """
+  established_on_DESC
+
+  """
+  Sorts ascending by the `id` field.
+  """
+  id_ASC
+
+  """
+  Sorts descending by the `id` field.
+  """
+  id_DESC
+
+  """
+  Sorts ascending by the `platform` field.
+  """
+  platform_ASC
+
+  """
+  Sorts descending by the `platform` field.
+  """
+  platform_DESC
+
+  """
+  Sorts ascending by the `square_footage` field.
+  """
+  square_footage_ASC
+
+  """
+  Sorts descending by the `square_footage` field.
+  """
+  square_footage_DESC
+
+  """
+  Sorts ascending by the `url` field.
+  """
+  url_ASC
+
+  """
+  Sorts descending by the `url` field.
+  """
+  url_DESC
+
+  """
+  Sorts ascending by the `vehicle_type` field.
+  """
+  vehicle_type_ASC
+
+  """
+  Sorts descending by the `vehicle_type` field.
+  """
+  vehicle_type_DESC
 }
 
 """
@@ -11929,6 +13042,465 @@ input SponsorshipListFilterInput {
   When `null` or an empty object is passed, matches no documents.
   """
   not: SponsorshipListFilterInput
+}
+
+interface Store implements DistributionChannel & Retail {
+  active: Boolean
+  customer_facing: Boolean
+  established_on: Date
+  id: ID!
+}
+
+"""
+Type used to perform aggregation computations on `Store` fields.
+"""
+type StoreAggregatedValues {
+  """
+  Computed aggregate values for the `active` field.
+  """
+  active: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `address` field.
+  """
+  address: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `current_location` field.
+  """
+  current_location: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `customer_facing` field.
+  """
+  customer_facing: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `established_on` field.
+  """
+  established_on: DateAggregatedValues
+
+  """
+  Computed aggregate values for the `id` field.
+  """
+  id: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `platform` field.
+  """
+  platform: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `square_footage` field.
+  """
+  square_footage: IntAggregatedValues
+
+  """
+  Computed aggregate values for the `url` field.
+  """
+  url: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `vehicle_type` field.
+  """
+  vehicle_type: NonNumericAggregatedValues
+}
+
+"""
+Return type representing a bucket of `Store` documents for an aggregations query.
+"""
+type StoreAggregation {
+  """
+  Provides computed aggregated values over all `Store` documents in an aggregation bucket.
+  """
+  aggregated_values: StoreAggregatedValues
+
+  """
+  The count of `Store` documents in an aggregation bucket.
+  """
+  count: JsonSafeLong!
+
+  """
+  Used to specify the `Store` fields to group by. The returned values identify each aggregation bucket.
+  """
+  grouped_by: StoreGroupedBy
+}
+
+"""
+Represents a paginated collection of `StoreAggregation` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type StoreAggregationConnection {
+  """
+  Wraps a specific `StoreAggregation` to pair it with its pagination cursor.
+  """
+  edges: [StoreAggregationEdge!]!
+
+  """
+  The list of `StoreAggregation` results.
+  """
+  nodes: [StoreAggregation!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+}
+
+"""
+Represents a specific `StoreAggregation` in the context of a `StoreAggregationConnection`,
+providing access to both the `StoreAggregation` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type StoreAggregationEdge {
+  """
+  The `Cursor` of this `StoreAggregation`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `StoreAggregation`.
+  """
+  cursor: Cursor
+
+  """
+  The `StoreAggregation` of this edge.
+  """
+  node: StoreAggregation
+}
+
+"""
+Represents a paginated collection of `Store` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type StoreConnection {
+  """
+  Wraps a specific `Store` to pair it with its pagination cursor.
+  """
+  edges: [StoreEdge!]!
+
+  """
+  The list of `Store` results.
+  """
+  nodes: [Store!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+
+  """
+  The total number of edges available in this connection to paginate over.
+  """
+  total_edge_count: JsonSafeLong!
+}
+
+"""
+Represents a specific `Store` in the context of a `StoreConnection`,
+providing access to both the `Store` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type StoreEdge {
+  """
+  All search highlights for this `Store`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
+  The `Cursor` of this `Store`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `Store`.
+  """
+  cursor: Cursor
+
+  """
+  Specific search highlights for this `Store`, providing matching snippets for the requested fields.
+  """
+  highlights: StoreHighlights
+
+  """
+  The `Store` of this edge.
+  """
+  node: Store
+}
+
+"""
+Input type used to specify filters on `Store` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input StoreFilterInput {
+  """
+  Used to filter on the `active` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  active: BooleanFilterInput
+
+  """
+  Used to filter on the `address` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  address: StringFilterInput
+
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `StoreFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [StoreFilterInput!]
+
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [StoreFilterInput!]
+
+  """
+  Used to filter on the `current_location` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  current_location: StringFilterInput
+
+  """
+  Used to filter on the `customer_facing` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  customer_facing: BooleanFilterInput
+
+  """
+  Used to filter on the `established_on` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  established_on: DateFilterInput
+
+  """
+  Used to filter on the `id` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  id: IDFilterInput
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: StoreFilterInput
+
+  """
+  Used to filter on the `platform` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  platform: StringFilterInput
+
+  """
+  Used to filter on the `square_footage` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  square_footage: IntFilterInput
+
+  """
+  Used to filter on the `url` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  url: StringFilterInput
+
+  """
+  Used to filter on the `vehicle_type` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  vehicle_type: StringFilterInput
+}
+
+"""
+Type used to specify the `Store` fields to group by for aggregations.
+"""
+type StoreGroupedBy {
+  """
+  The `active` field value for this group.
+  """
+  active: Boolean
+
+  """
+  The `address` field value for this group.
+  """
+  address: String
+
+  """
+  The `current_location` field value for this group.
+  """
+  current_location: String
+
+  """
+  The `customer_facing` field value for this group.
+  """
+  customer_facing: Boolean
+
+  """
+  Offers the different grouping options for the `established_on` value within this group.
+  """
+  established_on: DateGroupedBy
+
+  """
+  The `platform` field value for this group.
+  """
+  platform: String
+
+  """
+  The `square_footage` field value for this group.
+  """
+  square_footage: Int
+
+  """
+  The `url` field value for this group.
+  """
+  url: String
+
+  """
+  The `vehicle_type` field value for this group.
+  """
+  vehicle_type: String
+}
+
+"""
+Type used to request desired `Store` search highlight fields.
+"""
+type StoreHighlights {
+  """
+  Search highlights for the `address`, providing snippets of the matching text.
+  """
+  address: [String!]!
+
+  """
+  Search highlights for the `current_location`, providing snippets of the matching text.
+  """
+  current_location: [String!]!
+
+  """
+  Search highlights for the `id`, providing snippets of the matching text.
+  """
+  id: [String!]!
+
+  """
+  Search highlights for the `platform`, providing snippets of the matching text.
+  """
+  platform: [String!]!
+
+  """
+  Search highlights for the `url`, providing snippets of the matching text.
+  """
+  url: [String!]!
+
+  """
+  Search highlights for the `vehicle_type`, providing snippets of the matching text.
+  """
+  vehicle_type: [String!]!
+}
+
+"""
+Enumerates the ways `Store`s can be sorted.
+"""
+enum StoreSortOrderInput {
+  """
+  Sorts ascending by the `address` field.
+  """
+  address_ASC
+
+  """
+  Sorts descending by the `address` field.
+  """
+  address_DESC
+
+  """
+  Sorts ascending by the `current_location` field.
+  """
+  current_location_ASC
+
+  """
+  Sorts descending by the `current_location` field.
+  """
+  current_location_DESC
+
+  """
+  Sorts ascending by the `established_on` field.
+  """
+  established_on_ASC
+
+  """
+  Sorts descending by the `established_on` field.
+  """
+  established_on_DESC
+
+  """
+  Sorts ascending by the `id` field.
+  """
+  id_ASC
+
+  """
+  Sorts descending by the `id` field.
+  """
+  id_DESC
+
+  """
+  Sorts ascending by the `platform` field.
+  """
+  platform_ASC
+
+  """
+  Sorts descending by the `platform` field.
+  """
+  platform_DESC
+
+  """
+  Sorts ascending by the `square_footage` field.
+  """
+  square_footage_ASC
+
+  """
+  Sorts descending by the `square_footage` field.
+  """
+  square_footage_DESC
+
+  """
+  Sorts ascending by the `url` field.
+  """
+  url_ASC
+
+  """
+  Sorts descending by the `url` field.
+  """
+  url_DESC
+
+  """
+  Sorts ascending by the `vehicle_type` field.
+  """
+  vehicle_type_ASC
+
+  """
+  Sorts descending by the `vehicle_type` field.
+  """
+  vehicle_type_DESC
 }
 
 """
@@ -14481,6 +16053,13 @@ input TextFilterInput {
   When `null` or an empty object is passed, matches no documents.
   """
   not: TextFilterInput
+}
+
+type ThirdPartyWholesale implements DistributionChannel @key(fields: "id") {
+  active: Boolean
+  contract_terms: String
+  id: ID!
+  partner_name: String
 }
 
 """
@@ -18624,7 +20203,7 @@ In an ElasticGraph schema, this is a union of all indexed types.
 
 Not intended for use by clients other than Apollo.
 """
-union _Entity = Company | Component | Country | ElectricalPart | Manufacturer | MechanicalPart | Person | Sponsor | Team | Widget | WidgetCurrency | WidgetWorkspace
+union _Entity = Company | Component | Country | ElectricalPart | Manufacturer | MechanicalPart | MobileStore | OnlineStore | Person | PhysicalStore | Sponsor | Team | ThirdPartyWholesale | Widget | WidgetCurrency | WidgetWorkspace
 
 """
 An object type required by the [Apollo Federation subgraph

--- a/config/schema/artifacts_with_apollo/schema.graphql
+++ b/config/schema/artifacts_with_apollo/schema.graphql
@@ -2808,26 +2808,6 @@ type DistributionChannelAggregatedValues {
   active: NonNumericAggregatedValues
 
   """
-  Computed aggregate values for the `address` field.
-  """
-  address: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `contract_terms` field.
-  """
-  contract_terms: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `current_location` field.
-  """
-  current_location: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `customer_facing` field.
-  """
-  customer_facing: NonNumericAggregatedValues
-
-  """
   Computed aggregate values for the `established_on` field.
   """
   established_on: DateAggregatedValues
@@ -2836,31 +2816,6 @@ type DistributionChannelAggregatedValues {
   Computed aggregate values for the `id` field.
   """
   id: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `partner_name` field.
-  """
-  partner_name: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `platform` field.
-  """
-  platform: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `square_footage` field.
-  """
-  square_footage: IntAggregatedValues
-
-  """
-  Computed aggregate values for the `url` field.
-  """
-  url: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `vehicle_type` field.
-  """
-  vehicle_type: NonNumericAggregatedValues
 }
 
 """
@@ -2999,13 +2954,6 @@ input DistributionChannelFilterInput {
   active: BooleanFilterInput
 
   """
-  Used to filter on the `address` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  address: StringFilterInput
-
-  """
   Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
@@ -3025,27 +2973,6 @@ input DistributionChannelFilterInput {
   When an empty list is passed, this part of the filter matches no documents.
   """
   any_of: [DistributionChannelFilterInput!]
-
-  """
-  Used to filter on the `contract_terms` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  contract_terms: StringFilterInput
-
-  """
-  Used to filter on the `current_location` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  current_location: StringFilterInput
-
-  """
-  Used to filter on the `customer_facing` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  customer_facing: BooleanFilterInput
 
   """
   Used to filter on the `established_on` field.
@@ -3068,41 +2995,6 @@ input DistributionChannelFilterInput {
   When `null` or an empty object is passed, matches no documents.
   """
   not: DistributionChannelFilterInput
-
-  """
-  Used to filter on the `partner_name` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  partner_name: StringFilterInput
-
-  """
-  Used to filter on the `platform` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  platform: StringFilterInput
-
-  """
-  Used to filter on the `square_footage` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  square_footage: IntFilterInput
-
-  """
-  Used to filter on the `url` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  url: StringFilterInput
-
-  """
-  Used to filter on the `vehicle_type` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  vehicle_type: StringFilterInput
 }
 
 """
@@ -3115,54 +3007,9 @@ type DistributionChannelGroupedBy {
   active: Boolean
 
   """
-  The `address` field value for this group.
-  """
-  address: String
-
-  """
-  The `contract_terms` field value for this group.
-  """
-  contract_terms: String
-
-  """
-  The `current_location` field value for this group.
-  """
-  current_location: String
-
-  """
-  The `customer_facing` field value for this group.
-  """
-  customer_facing: Boolean
-
-  """
   Offers the different grouping options for the `established_on` value within this group.
   """
   established_on: DateGroupedBy
-
-  """
-  The `partner_name` field value for this group.
-  """
-  partner_name: String
-
-  """
-  The `platform` field value for this group.
-  """
-  platform: String
-
-  """
-  The `square_footage` field value for this group.
-  """
-  square_footage: Int
-
-  """
-  The `url` field value for this group.
-  """
-  url: String
-
-  """
-  The `vehicle_type` field value for this group.
-  """
-  vehicle_type: String
 }
 
 """
@@ -3170,80 +3017,15 @@ Type used to request desired `DistributionChannel` search highlight fields.
 """
 type DistributionChannelHighlights {
   """
-  Search highlights for the `address`, providing snippets of the matching text.
-  """
-  address: [String!]!
-
-  """
-  Search highlights for the `contract_terms`, providing snippets of the matching text.
-  """
-  contract_terms: [String!]!
-
-  """
-  Search highlights for the `current_location`, providing snippets of the matching text.
-  """
-  current_location: [String!]!
-
-  """
   Search highlights for the `id`, providing snippets of the matching text.
   """
   id: [String!]!
-
-  """
-  Search highlights for the `partner_name`, providing snippets of the matching text.
-  """
-  partner_name: [String!]!
-
-  """
-  Search highlights for the `platform`, providing snippets of the matching text.
-  """
-  platform: [String!]!
-
-  """
-  Search highlights for the `url`, providing snippets of the matching text.
-  """
-  url: [String!]!
-
-  """
-  Search highlights for the `vehicle_type`, providing snippets of the matching text.
-  """
-  vehicle_type: [String!]!
 }
 
 """
 Enumerates the ways `DistributionChannel`s can be sorted.
 """
 enum DistributionChannelSortOrderInput {
-  """
-  Sorts ascending by the `address` field.
-  """
-  address_ASC
-
-  """
-  Sorts descending by the `address` field.
-  """
-  address_DESC
-
-  """
-  Sorts ascending by the `contract_terms` field.
-  """
-  contract_terms_ASC
-
-  """
-  Sorts descending by the `contract_terms` field.
-  """
-  contract_terms_DESC
-
-  """
-  Sorts ascending by the `current_location` field.
-  """
-  current_location_ASC
-
-  """
-  Sorts descending by the `current_location` field.
-  """
-  current_location_DESC
-
   """
   Sorts ascending by the `established_on` field.
   """
@@ -3263,56 +3045,6 @@ enum DistributionChannelSortOrderInput {
   Sorts descending by the `id` field.
   """
   id_DESC
-
-  """
-  Sorts ascending by the `partner_name` field.
-  """
-  partner_name_ASC
-
-  """
-  Sorts descending by the `partner_name` field.
-  """
-  partner_name_DESC
-
-  """
-  Sorts ascending by the `platform` field.
-  """
-  platform_ASC
-
-  """
-  Sorts descending by the `platform` field.
-  """
-  platform_DESC
-
-  """
-  Sorts ascending by the `square_footage` field.
-  """
-  square_footage_ASC
-
-  """
-  Sorts descending by the `square_footage` field.
-  """
-  square_footage_DESC
-
-  """
-  Sorts ascending by the `url` field.
-  """
-  url_ASC
-
-  """
-  Sorts descending by the `url` field.
-  """
-  url_DESC
-
-  """
-  Sorts ascending by the `vehicle_type` field.
-  """
-  vehicle_type_ASC
-
-  """
-  Sorts descending by the `vehicle_type` field.
-  """
-  vehicle_type_DESC
 }
 
 type ElectricalPart implements NamedEntity @key(fields: "id") {
@@ -6212,15 +5944,6 @@ enum MechanicalPartSortOrderInput {
   name_DESC
 }
 
-type MobileStore implements DistributionChannel & Retail & Store @key(fields: "id") {
-  active: Boolean
-  current_location: String
-  customer_facing: Boolean
-  established_on: Date
-  id: ID!
-  vehicle_type: String!
-}
-
 type Money {
   amount_cents: Int
   currency: String!
@@ -8318,11 +8041,8 @@ type NonNumericAggregatedValues @shareable {
 
 type OnlineStore implements DistributionChannel & Retail & Store @key(fields: "id") {
   active: Boolean
-  customer_facing: Boolean
   established_on: Date
   id: ID!
-  platform: String
-  url: String!
 }
 
 """
@@ -8798,11 +8518,8 @@ type PersonHighlights {
 
 type PhysicalStore implements DistributionChannel & Retail & Store @key(fields: "id") {
   active: Boolean
-  address: String!
-  customer_facing: Boolean
   established_on: Date
   id: ID!
-  square_footage: Int
 }
 
 """
@@ -8815,16 +8532,6 @@ type PhysicalStoreAggregatedValues {
   active: NonNumericAggregatedValues
 
   """
-  Computed aggregate values for the `address` field.
-  """
-  address: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `customer_facing` field.
-  """
-  customer_facing: NonNumericAggregatedValues
-
-  """
   Computed aggregate values for the `established_on` field.
   """
   established_on: DateAggregatedValues
@@ -8833,11 +8540,6 @@ type PhysicalStoreAggregatedValues {
   Computed aggregate values for the `id` field.
   """
   id: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `square_footage` field.
-  """
-  square_footage: IntAggregatedValues
 }
 
 """
@@ -8975,13 +8677,6 @@ input PhysicalStoreFilterInput {
   active: BooleanFilterInput
 
   """
-  Used to filter on the `address` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  address: StringFilterInput
-
-  """
   Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
@@ -9001,13 +8696,6 @@ input PhysicalStoreFilterInput {
   When an empty list is passed, this part of the filter matches no documents.
   """
   any_of: [PhysicalStoreFilterInput!]
-
-  """
-  Used to filter on the `customer_facing` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  customer_facing: BooleanFilterInput
 
   """
   Used to filter on the `established_on` field.
@@ -9030,13 +8718,6 @@ input PhysicalStoreFilterInput {
   When `null` or an empty object is passed, matches no documents.
   """
   not: PhysicalStoreFilterInput
-
-  """
-  Used to filter on the `square_footage` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  square_footage: IntFilterInput
 }
 
 """
@@ -9049,35 +8730,15 @@ type PhysicalStoreGroupedBy {
   active: Boolean
 
   """
-  The `address` field value for this group.
-  """
-  address: String
-
-  """
-  The `customer_facing` field value for this group.
-  """
-  customer_facing: Boolean
-
-  """
   Offers the different grouping options for the `established_on` value within this group.
   """
   established_on: DateGroupedBy
-
-  """
-  The `square_footage` field value for this group.
-  """
-  square_footage: Int
 }
 
 """
 Type used to request desired `PhysicalStore` search highlight fields.
 """
 type PhysicalStoreHighlights {
-  """
-  Search highlights for the `address`, providing snippets of the matching text.
-  """
-  address: [String!]!
-
   """
   Search highlights for the `id`, providing snippets of the matching text.
   """
@@ -9088,16 +8749,6 @@ type PhysicalStoreHighlights {
 Enumerates the ways `PhysicalStore`s can be sorted.
 """
 enum PhysicalStoreSortOrderInput {
-  """
-  Sorts ascending by the `address` field.
-  """
-  address_ASC
-
-  """
-  Sorts descending by the `address` field.
-  """
-  address_DESC
-
   """
   Sorts ascending by the `established_on` field.
   """
@@ -9117,16 +8768,6 @@ enum PhysicalStoreSortOrderInput {
   Sorts descending by the `id` field.
   """
   id_DESC
-
-  """
-  Sorts ascending by the `square_footage` field.
-  """
-  square_footage_ASC
-
-  """
-  Sorts descending by the `square_footage` field.
-  """
-  square_footage_DESC
 }
 
 type Player {
@@ -11791,21 +11432,6 @@ type RetailAggregatedValues {
   active: NonNumericAggregatedValues
 
   """
-  Computed aggregate values for the `address` field.
-  """
-  address: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `current_location` field.
-  """
-  current_location: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `customer_facing` field.
-  """
-  customer_facing: NonNumericAggregatedValues
-
-  """
   Computed aggregate values for the `established_on` field.
   """
   established_on: DateAggregatedValues
@@ -11814,26 +11440,6 @@ type RetailAggregatedValues {
   Computed aggregate values for the `id` field.
   """
   id: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `platform` field.
-  """
-  platform: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `square_footage` field.
-  """
-  square_footage: IntAggregatedValues
-
-  """
-  Computed aggregate values for the `url` field.
-  """
-  url: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `vehicle_type` field.
-  """
-  vehicle_type: NonNumericAggregatedValues
 }
 
 """
@@ -11971,13 +11577,6 @@ input RetailFilterInput {
   active: BooleanFilterInput
 
   """
-  Used to filter on the `address` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  address: StringFilterInput
-
-  """
   Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
@@ -11997,20 +11596,6 @@ input RetailFilterInput {
   When an empty list is passed, this part of the filter matches no documents.
   """
   any_of: [RetailFilterInput!]
-
-  """
-  Used to filter on the `current_location` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  current_location: StringFilterInput
-
-  """
-  Used to filter on the `customer_facing` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  customer_facing: BooleanFilterInput
 
   """
   Used to filter on the `established_on` field.
@@ -12033,34 +11618,6 @@ input RetailFilterInput {
   When `null` or an empty object is passed, matches no documents.
   """
   not: RetailFilterInput
-
-  """
-  Used to filter on the `platform` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  platform: StringFilterInput
-
-  """
-  Used to filter on the `square_footage` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  square_footage: IntFilterInput
-
-  """
-  Used to filter on the `url` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  url: StringFilterInput
-
-  """
-  Used to filter on the `vehicle_type` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  vehicle_type: StringFilterInput
 }
 
 """
@@ -12073,44 +11630,9 @@ type RetailGroupedBy {
   active: Boolean
 
   """
-  The `address` field value for this group.
-  """
-  address: String
-
-  """
-  The `current_location` field value for this group.
-  """
-  current_location: String
-
-  """
-  The `customer_facing` field value for this group.
-  """
-  customer_facing: Boolean
-
-  """
   Offers the different grouping options for the `established_on` value within this group.
   """
   established_on: DateGroupedBy
-
-  """
-  The `platform` field value for this group.
-  """
-  platform: String
-
-  """
-  The `square_footage` field value for this group.
-  """
-  square_footage: Int
-
-  """
-  The `url` field value for this group.
-  """
-  url: String
-
-  """
-  The `vehicle_type` field value for this group.
-  """
-  vehicle_type: String
 }
 
 """
@@ -12118,60 +11640,15 @@ Type used to request desired `Retail` search highlight fields.
 """
 type RetailHighlights {
   """
-  Search highlights for the `address`, providing snippets of the matching text.
-  """
-  address: [String!]!
-
-  """
-  Search highlights for the `current_location`, providing snippets of the matching text.
-  """
-  current_location: [String!]!
-
-  """
   Search highlights for the `id`, providing snippets of the matching text.
   """
   id: [String!]!
-
-  """
-  Search highlights for the `platform`, providing snippets of the matching text.
-  """
-  platform: [String!]!
-
-  """
-  Search highlights for the `url`, providing snippets of the matching text.
-  """
-  url: [String!]!
-
-  """
-  Search highlights for the `vehicle_type`, providing snippets of the matching text.
-  """
-  vehicle_type: [String!]!
 }
 
 """
 Enumerates the ways `Retail`s can be sorted.
 """
 enum RetailSortOrderInput {
-  """
-  Sorts ascending by the `address` field.
-  """
-  address_ASC
-
-  """
-  Sorts descending by the `address` field.
-  """
-  address_DESC
-
-  """
-  Sorts ascending by the `current_location` field.
-  """
-  current_location_ASC
-
-  """
-  Sorts descending by the `current_location` field.
-  """
-  current_location_DESC
-
   """
   Sorts ascending by the `established_on` field.
   """
@@ -12191,46 +11668,6 @@ enum RetailSortOrderInput {
   Sorts descending by the `id` field.
   """
   id_DESC
-
-  """
-  Sorts ascending by the `platform` field.
-  """
-  platform_ASC
-
-  """
-  Sorts descending by the `platform` field.
-  """
-  platform_DESC
-
-  """
-  Sorts ascending by the `square_footage` field.
-  """
-  square_footage_ASC
-
-  """
-  Sorts descending by the `square_footage` field.
-  """
-  square_footage_DESC
-
-  """
-  Sorts ascending by the `url` field.
-  """
-  url_ASC
-
-  """
-  Sorts descending by the `url` field.
-  """
-  url_DESC
-
-  """
-  Sorts ascending by the `vehicle_type` field.
-  """
-  vehicle_type_ASC
-
-  """
-  Sorts descending by the `vehicle_type` field.
-  """
-  vehicle_type_DESC
 }
 
 """
@@ -13046,7 +12483,6 @@ input SponsorshipListFilterInput {
 
 interface Store implements DistributionChannel & Retail {
   active: Boolean
-  customer_facing: Boolean
   established_on: Date
   id: ID!
 }
@@ -13061,21 +12497,6 @@ type StoreAggregatedValues {
   active: NonNumericAggregatedValues
 
   """
-  Computed aggregate values for the `address` field.
-  """
-  address: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `current_location` field.
-  """
-  current_location: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `customer_facing` field.
-  """
-  customer_facing: NonNumericAggregatedValues
-
-  """
   Computed aggregate values for the `established_on` field.
   """
   established_on: DateAggregatedValues
@@ -13084,26 +12505,6 @@ type StoreAggregatedValues {
   Computed aggregate values for the `id` field.
   """
   id: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `platform` field.
-  """
-  platform: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `square_footage` field.
-  """
-  square_footage: IntAggregatedValues
-
-  """
-  Computed aggregate values for the `url` field.
-  """
-  url: NonNumericAggregatedValues
-
-  """
-  Computed aggregate values for the `vehicle_type` field.
-  """
-  vehicle_type: NonNumericAggregatedValues
 }
 
 """
@@ -13241,13 +12642,6 @@ input StoreFilterInput {
   active: BooleanFilterInput
 
   """
-  Used to filter on the `address` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  address: StringFilterInput
-
-  """
   Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
 
   Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
@@ -13267,20 +12661,6 @@ input StoreFilterInput {
   When an empty list is passed, this part of the filter matches no documents.
   """
   any_of: [StoreFilterInput!]
-
-  """
-  Used to filter on the `current_location` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  current_location: StringFilterInput
-
-  """
-  Used to filter on the `customer_facing` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  customer_facing: BooleanFilterInput
 
   """
   Used to filter on the `established_on` field.
@@ -13303,34 +12683,6 @@ input StoreFilterInput {
   When `null` or an empty object is passed, matches no documents.
   """
   not: StoreFilterInput
-
-  """
-  Used to filter on the `platform` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  platform: StringFilterInput
-
-  """
-  Used to filter on the `square_footage` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  square_footage: IntFilterInput
-
-  """
-  Used to filter on the `url` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  url: StringFilterInput
-
-  """
-  Used to filter on the `vehicle_type` field.
-
-  When `null` or an empty object is passed, matches all documents.
-  """
-  vehicle_type: StringFilterInput
 }
 
 """
@@ -13343,44 +12695,9 @@ type StoreGroupedBy {
   active: Boolean
 
   """
-  The `address` field value for this group.
-  """
-  address: String
-
-  """
-  The `current_location` field value for this group.
-  """
-  current_location: String
-
-  """
-  The `customer_facing` field value for this group.
-  """
-  customer_facing: Boolean
-
-  """
   Offers the different grouping options for the `established_on` value within this group.
   """
   established_on: DateGroupedBy
-
-  """
-  The `platform` field value for this group.
-  """
-  platform: String
-
-  """
-  The `square_footage` field value for this group.
-  """
-  square_footage: Int
-
-  """
-  The `url` field value for this group.
-  """
-  url: String
-
-  """
-  The `vehicle_type` field value for this group.
-  """
-  vehicle_type: String
 }
 
 """
@@ -13388,60 +12705,15 @@ Type used to request desired `Store` search highlight fields.
 """
 type StoreHighlights {
   """
-  Search highlights for the `address`, providing snippets of the matching text.
-  """
-  address: [String!]!
-
-  """
-  Search highlights for the `current_location`, providing snippets of the matching text.
-  """
-  current_location: [String!]!
-
-  """
   Search highlights for the `id`, providing snippets of the matching text.
   """
   id: [String!]!
-
-  """
-  Search highlights for the `platform`, providing snippets of the matching text.
-  """
-  platform: [String!]!
-
-  """
-  Search highlights for the `url`, providing snippets of the matching text.
-  """
-  url: [String!]!
-
-  """
-  Search highlights for the `vehicle_type`, providing snippets of the matching text.
-  """
-  vehicle_type: [String!]!
 }
 
 """
 Enumerates the ways `Store`s can be sorted.
 """
 enum StoreSortOrderInput {
-  """
-  Sorts ascending by the `address` field.
-  """
-  address_ASC
-
-  """
-  Sorts descending by the `address` field.
-  """
-  address_DESC
-
-  """
-  Sorts ascending by the `current_location` field.
-  """
-  current_location_ASC
-
-  """
-  Sorts descending by the `current_location` field.
-  """
-  current_location_DESC
-
   """
   Sorts ascending by the `established_on` field.
   """
@@ -13461,46 +12733,6 @@ enum StoreSortOrderInput {
   Sorts descending by the `id` field.
   """
   id_DESC
-
-  """
-  Sorts ascending by the `platform` field.
-  """
-  platform_ASC
-
-  """
-  Sorts descending by the `platform` field.
-  """
-  platform_DESC
-
-  """
-  Sorts ascending by the `square_footage` field.
-  """
-  square_footage_ASC
-
-  """
-  Sorts descending by the `square_footage` field.
-  """
-  square_footage_DESC
-
-  """
-  Sorts ascending by the `url` field.
-  """
-  url_ASC
-
-  """
-  Sorts descending by the `url` field.
-  """
-  url_DESC
-
-  """
-  Sorts ascending by the `vehicle_type` field.
-  """
-  vehicle_type_ASC
-
-  """
-  Sorts descending by the `vehicle_type` field.
-  """
-  vehicle_type_DESC
 }
 
 """
@@ -16057,9 +15289,7 @@ input TextFilterInput {
 
 type ThirdPartyWholesale implements DistributionChannel @key(fields: "id") {
   active: Boolean
-  contract_terms: String
   id: ID!
-  partner_name: String
 }
 
 """
@@ -20203,7 +19433,7 @@ In an ElasticGraph schema, this is a union of all indexed types.
 
 Not intended for use by clients other than Apollo.
 """
-union _Entity = Company | Component | Country | ElectricalPart | Manufacturer | MechanicalPart | MobileStore | OnlineStore | Person | PhysicalStore | Sponsor | Team | ThirdPartyWholesale | Widget | WidgetCurrency | WidgetWorkspace
+union _Entity = Company | Component | Country | ElectricalPart | Manufacturer | MechanicalPart | OnlineStore | Person | PhysicalStore | Sponsor | Team | ThirdPartyWholesale | Widget | WidgetCurrency | WidgetWorkspace
 
 """
 An object type required by the [Apollo Federation subgraph

--- a/config/schema/widgets.rb
+++ b/config/schema/widgets.rb
@@ -35,20 +35,16 @@ ElasticGraph.define_schema do |schema|
 
   schema.object_type "Person" do |t|
     t.implements "NamedInventor"
-    t.root_query_fields plural: "people"
     t.field "id", "ID!"
     t.field "name", "String"
     t.field "nationality", "String"
-    t.index "people"
   end
 
   schema.object_type "Company" do |t|
     t.implements "NamedInventor"
-    t.root_query_fields plural: "companies"
     t.field "id", "ID!"
     t.field "name", "String"
     t.field "stock_ticker", "String"
-    t.index "companies"
   end
 
   schema.union_type "Inventor" do |t|
@@ -59,6 +55,7 @@ ElasticGraph.define_schema do |schema|
   schema.interface_type "NamedInventor" do |t|
     t.field "id", "ID!"
     t.field "name", "String"
+    t.index "named_inventors"
   end
 
   # Indexed interfae type.
@@ -341,6 +338,70 @@ ElasticGraph.define_schema do |schema|
 
   schema.union_type "Part" do |t|
     t.subtypes "MechanicalPart", "ElectricalPart"
+  end
+
+  schema.interface_type "DistributionChannel" do |t|
+    t.field "id", "ID!"
+    t.field "active", "Boolean"
+    t.index "distribution_channels"
+  end
+
+  # Retail branch - multi-level interface inheritance
+  schema.interface_type "Retail" do |t|
+    t.implements "DistributionChannel"
+    t.root_query_fields plural: "retailers"
+    t.field "id", "ID!"
+    t.field "active", "Boolean"
+    t.field "established_on", "Date"
+  end
+
+  schema.interface_type "Store" do |t|
+    t.implements "Retail"
+    t.field "id", "ID!"
+    t.field "active", "Boolean"
+    t.field "established_on", "Date"
+    t.field "customer_facing", "Boolean"
+  end
+
+  # ThirdPartyWholesale - concrete type in parallel to Retail branch
+  schema.object_type "ThirdPartyWholesale" do |t|
+    t.implements "DistributionChannel"
+    t.field "id", "ID!"
+    t.field "active", "Boolean"
+    t.field "partner_name", "String"
+    t.field "contract_terms", "String"
+  end
+
+  schema.object_type "OnlineStore" do |t|
+    t.implements "Store"
+    t.field "id", "ID!"
+    t.field "url", "String!"
+    t.field "platform", "String"  # e.g., "Shopify", "WooCommerce"
+    t.field "established_on", "Date"
+    t.field "active", "Boolean"
+    t.field "customer_facing", "Boolean"
+  end
+
+  schema.object_type "PhysicalStore" do |t|
+    t.implements "Store"
+    t.field "id", "ID!"
+    t.field "address", "String!"
+    t.field "square_footage", "Int"
+    t.field "established_on", "Date"
+    t.field "active", "Boolean"
+    t.field "customer_facing", "Boolean"
+
+    t.index "physical_stores"
+  end
+
+  schema.object_type "MobileStore" do |t|
+    t.implements "Store"
+    t.field "id", "ID!"
+    t.field "vehicle_type", "String!"  # e.g., "food truck", "pop-up cart"
+    t.field "current_location", "String"
+    t.field "established_on", "Date"
+    t.field "active", "Boolean"
+    t.field "customer_facing", "Boolean"
   end
 
   # Note: `Manufacturer` is used in our tests as an example of an indexed type that has no list fields, so we should

--- a/config/schema/widgets.rb
+++ b/config/schema/widgets.rb
@@ -51,14 +51,15 @@ ElasticGraph.define_schema do |schema|
     t.subtypes "Person", "Company"
   end
 
-  # Interface type used both as an embedded field and as a root document type.
+  # Indexed interface type. Person and Company inherit the `named_inventors` index via
+  # index inheritance rather than declaring it themselves.
   schema.interface_type "NamedInventor" do |t|
     t.field "id", "ID!"
     t.field "name", "String"
     t.index "named_inventors"
   end
 
-  # Indexed interfae type.
+  # Indexed interface type.
   schema.interface_type "NamedEntity" do |t|
     t.root_query_fields plural: "named_entities"
     t.field "id", "ID!"
@@ -346,7 +347,9 @@ ElasticGraph.define_schema do |schema|
     t.index "distribution_channels"
   end
 
-  # Retail branch - multi-level interface inheritance
+  # Retail and Store form a two-level interface chain under DistributionChannel. This depth is
+  # intentional: it exercises that __typename filtering works correctly when querying at any
+  # level of a multi-level hierarchy, not just one level from the root.
   schema.interface_type "Retail" do |t|
     t.implements "DistributionChannel"
     t.root_query_fields plural: "retailers"
@@ -360,7 +363,6 @@ ElasticGraph.define_schema do |schema|
     t.field "id", "ID!"
     t.field "active", "Boolean"
     t.field "established_on", "Date"
-    t.field "customer_facing", "Boolean"
   end
 
   # ThirdPartyWholesale - concrete type in parallel to Retail branch
@@ -368,40 +370,22 @@ ElasticGraph.define_schema do |schema|
     t.implements "DistributionChannel"
     t.field "id", "ID!"
     t.field "active", "Boolean"
-    t.field "partner_name", "String"
-    t.field "contract_terms", "String"
   end
 
   schema.object_type "OnlineStore" do |t|
     t.implements "Store"
     t.field "id", "ID!"
-    t.field "url", "String!"
-    t.field "platform", "String"  # e.g., "Shopify", "WooCommerce"
     t.field "established_on", "Date"
     t.field "active", "Boolean"
-    t.field "customer_facing", "Boolean"
   end
 
   schema.object_type "PhysicalStore" do |t|
     t.implements "Store"
     t.field "id", "ID!"
-    t.field "address", "String!"
-    t.field "square_footage", "Int"
     t.field "established_on", "Date"
     t.field "active", "Boolean"
-    t.field "customer_facing", "Boolean"
 
     t.index "physical_stores"
-  end
-
-  schema.object_type "MobileStore" do |t|
-    t.implements "Store"
-    t.field "id", "ID!"
-    t.field "vehicle_type", "String!"  # e.g., "food truck", "pop-up cart"
-    t.field "current_location", "String"
-    t.field "established_on", "Date"
-    t.field "active", "Boolean"
-    t.field "customer_facing", "Boolean"
   end
 
   # Note: `Manufacturer` is used in our tests as an example of an indexed type that has no list fields, so we should

--- a/config/settings/development.yaml
+++ b/config/settings/development.yaml
@@ -18,8 +18,7 @@ datastore:
       setting_overrides_by_timestamp: {}
     components: *main_index_settings
     electrical_parts: *main_index_settings
-    companies: *main_index_settings
-    people: *main_index_settings
+    named_inventors: *main_index_settings
     manufacturers: *main_index_settings
     mechanical_parts: *main_index_settings
     teams: *main_index_settings
@@ -27,6 +26,8 @@ datastore:
     widgets: *main_index_settings
     widget_workspaces: *main_index_settings
     sponsors: *main_index_settings
+    distribution_channels: *main_index_settings
+    physical_stores: *main_index_settings
   max_client_retries: 3
 graphql:
   default_page_size: 50

--- a/config/settings/development_with_apollo.yaml
+++ b/config/settings/development_with_apollo.yaml
@@ -26,7 +26,6 @@ datastore:
     widgets: *main_index_settings
     widget_workspaces: *main_index_settings
     sponsors: *main_index_settings
-    stores: *main_index_settings
     physical_stores: *main_index_settings
     distribution_channels: *main_index_settings
   max_client_retries: 3

--- a/config/settings/development_with_apollo.yaml
+++ b/config/settings/development_with_apollo.yaml
@@ -18,8 +18,7 @@ datastore:
       setting_overrides_by_timestamp: {}
     components: *main_index_settings
     electrical_parts: *main_index_settings
-    companies: *main_index_settings
-    people: *main_index_settings
+    named_inventors: *main_index_settings
     manufacturers: *main_index_settings
     mechanical_parts: *main_index_settings
     teams: *main_index_settings
@@ -27,6 +26,9 @@ datastore:
     widgets: *main_index_settings
     widget_workspaces: *main_index_settings
     sponsors: *main_index_settings
+    stores: *main_index_settings
+    physical_stores: *main_index_settings
+    distribution_channels: *main_index_settings
   max_client_retries: 3
 graphql:
   default_page_size: 50

--- a/config/settings/test.yaml.template
+++ b/config/settings/test.yaml.template
@@ -74,7 +74,6 @@ datastore:
         "2021-01-01T00:00:00Z": {}
     widget_workspaces: *main_index_settings
     sponsors: *main_index_settings
-    stores: *main_index_settings
     physical_stores: *main_index_settings
     distribution_channels: *main_index_settings
   max_client_retries: 3

--- a/config/settings/test.yaml.template
+++ b/config/settings/test.yaml.template
@@ -36,8 +36,7 @@ datastore:
       setting_overrides_by_timestamp: {}
     components: *main_index_settings
     electrical_parts: *main_index_settings
-    companies: *main_index_settings
-    people: *main_index_settings
+    named_inventors: *main_index_settings
     manufacturers: *main_index_settings
     mechanical_parts: *main_index_settings
     teams: *main_index_settings
@@ -75,6 +74,9 @@ datastore:
         "2021-01-01T00:00:00Z": {}
     widget_workspaces: *main_index_settings
     sponsors: *main_index_settings
+    stores: *main_index_settings
+    physical_stores: *main_index_settings
+    distribution_channels: *main_index_settings
   max_client_retries: 3
 graphql:
   # default_page_size of 50 is duplicated in `elasticgraph/spec/support/aggregations_helpers.rb`.

--- a/elasticgraph-graphql/lib/elastic_graph/graphql.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql.rb
@@ -192,6 +192,7 @@ module ElasticGraph
     def datastore_query_adapters
       @datastore_query_adapters ||= begin
         require "elastic_graph/graphql/aggregation/query_adapter"
+        require "elastic_graph/graphql/query_adapter/abstract_type_filter"
         require "elastic_graph/graphql/query_adapter/filters"
         require "elastic_graph/graphql/query_adapter/pagination"
         require "elastic_graph/graphql/query_adapter/sort"
@@ -200,6 +201,7 @@ module ElasticGraph
         schema_element_names = runtime_metadata.schema_element_names
 
         [
+          GraphQL::QueryAdapter::AbstractTypeFilter.new,
           GraphQL::QueryAdapter::Pagination.new(schema_element_names: schema_element_names),
           GraphQL::QueryAdapter::Filters.new(
             schema_element_names: schema_element_names,

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/abstract_type_filter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/abstract_type_filter.rb
@@ -1,0 +1,39 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+module ElasticGraph
+  class GraphQL
+    class QueryAdapter
+      # Query adapter that injects a `__typename` filter when querying an abstract type (interface
+      # or union) that shares an index with types that fall outside the set of its subtypes. Without
+      # this filter, documents belonging to those other types would incorrectly appear in results.
+      #
+      # For example, if `Store` and `ThirdPartyWholesale` both share the `distribution_channels`
+      # index, a query for `stores` must filter to only return documents whose `__typename` is one
+      # of `Store`'s concrete subtypes.
+      #
+      # Subtypes with a dedicated index will not have `__typename` in their documents — the index
+      # itself identifies the type — so `nil` is included to allow those documents through.
+      class AbstractTypeFilter
+        def call(field:, query:, args:, lookahead:, context:)
+          type = field.type.unwrap_fully
+          return query unless type.abstract?
+
+          # Note: subtypes returns all concrete subtypes at any depth — intermediate abstract
+          # types in the hierarchy are not included, even though they may share the same index.
+          subtypes = type.subtypes
+          return query unless type.other_types_in_index.any? { |t| !subtypes.include?(t) }
+
+          query.merge_with(internal_filters: [{
+            "__typename" => {query.schema_element_names.equal_to_any_of => [nil] + subtypes.map(&:name)}
+          }])
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/abstract_type_filter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/abstract_type_filter.rb
@@ -22,11 +22,15 @@ module ElasticGraph
       class AbstractTypeFilter
         def call(field:, query:, args:, lookahead:, context:)
           type = field.type.unwrap_fully
-          return query unless type.abstract?
 
-          return query unless type.non_subtypes_in_shared_index.any?
+          # For indexed aggregation fields, resolve the underlying document type so we can
+          # apply the same __typename scoping as we do for document queries.
+          doc_type = type.indexed_aggregation? ? type.aggregation_source_type : type
 
-          subtypes = type.subtypes # Note: subtypes returns all concrete subtypes at any depth
+          return query unless doc_type.abstract?
+          return query unless doc_type.non_subtypes_in_shared_index.any?
+
+          subtypes = doc_type.subtypes # Note: subtypes returns all concrete subtypes at any depth
           query.merge_with(internal_filters: [{
             "__typename" => {query.schema_element_names.equal_to_any_of => [nil] + subtypes.map(&:name)}
           }])

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/abstract_type_filter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/abstract_type_filter.rb
@@ -24,11 +24,9 @@ module ElasticGraph
           type = field.type.unwrap_fully
           return query unless type.abstract?
 
-          # Note: subtypes returns all concrete subtypes at any depth — intermediate abstract
-          # types in the hierarchy are not included, even though they may share the same index.
-          subtypes = type.subtypes
-          return query unless type.other_types_in_index.any? { |t| !subtypes.include?(t) }
+          return query unless type.non_subtypes_in_shared_index.any?
 
+          subtypes = type.subtypes # Note: subtypes returns all concrete subtypes at any depth
           query.merge_with(internal_filters: [{
             "__typename" => {query.schema_element_names.equal_to_any_of => [nil] + subtypes.map(&:name)}
           }])

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/requested_fields.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/requested_fields.rb
@@ -88,7 +88,7 @@ module ElasticGraph
 
           # For abstract types (unions/interfaces), we need __typename to resolve the concrete type.
           # We must fully unwrap the type to check the innermost type, since the field type could be
-          # wrapped in non-null or list wrappers (e.g., `[NamedInventor!]!`).
+          # wrapped in non-null or list wrappers (e.g., `[NamedInventor!]!` on a `nodes` relay connection field).
           fields << "#{path_prefix}__typename" if field_for(node.field)&.type&.unwrap_fully&.abstract?
           fields
         end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/requested_fields.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/requested_fields.rb
@@ -86,7 +86,10 @@ module ElasticGraph
             requested_fields_for(child, index_field_paths, path_prefix: path_prefix)
           end
 
-          fields << "#{path_prefix}__typename" if field_for(node.field)&.type&.abstract?
+          # For abstract types (unions/interfaces), we need __typename to resolve the concrete type.
+          # We must fully unwrap the type to check the innermost type, since the field type could be
+          # wrapped in non-null or list wrappers (e.g., `[NamedInventor!]!`).
+          fields << "#{path_prefix}__typename" if field_for(node.field)&.type&.unwrap_fully&.abstract?
           fields
         end
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter_builder.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter_builder.rb
@@ -110,8 +110,10 @@ module ElasticGraph
         # In order to support unions and interfaces, we must implement `resolve_type`.
         def resolve_type(supertype, object, context)
           schema = context.fetch(:elastic_graph_schema)
-          # If `__typename` is available, use that to resolve. It should be available on any embedded abstract types...
-          # (See `Inventor` in `config/schema.graphql` for an example of this kind of type union.)
+          # If `__typename` is available, use that to resolve. It will be present on embedded abstract
+          # types, and also on root documents indexed in a shared interface/union index (e.g. `NamedInventor`).
+          # (See `Inventor` in `config/schema/widgets.rb` for an example of an embedded abstract type,
+          # and `NamedInventor` for an example of a shared interface index.)
           if (typename = object["__typename"])
             schema
               .graphql_schema

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/query_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/query_adapter.rb
@@ -68,50 +68,8 @@ module ElasticGraph
             monotonic_clock_deadline: monotonic_clock_deadline
           )
 
-          # When querying an abstract type (interface/union) that shares an index with sibling types,
-          # we must filter by __typename to only return documents of the queried type's subtypes.
-          # Example: Store interface and ThirdPartyWholesale both implement DistributionChannel
-          # and share the distribution_channels index. When querying `stores`, we must filter to
-          # only include PhysicalStore, OnlineStore, and MobileStore documents.
-          initial_query = add_typename_filter_if_needed(initial_query, unwrapped_type, context)
-
           @datastore_query_adapters.reduce(initial_query) do |query, adapter|
             adapter.call(query: query, field: field, args: args, lookahead: lookahead, context: context)
-          end
-        end
-
-        def add_typename_filter_if_needed(query, type, context)
-          return query unless type.abstract?
-
-          subtypes = type.subtypes
-
-          # Check if any of the indexes being searched contain documents from non-subtypes
-          # (i.e., sibling types that share the same index but shouldn't be returned).
-          # Only apply __typename filtering if needed to disambiguate.
-          return query unless query.search_index_definitions.any? do |index_def|
-            index_has_sibling_types?(context.fetch(:elastic_graph_schema), index_def, type, subtypes)
-          end
-
-          # Allow documents without __typename to pass through (they'll be resolved by index name).
-          query.merge_with(internal_filters: [{
-            query.schema_element_names.any_of => [
-              {"__typename" => {query.schema_element_names.equal_to_any_of => subtypes.map(&:name)}},
-              {"__typename" => {query.schema_element_names.equal_to_any_of => [nil]}}
-            ]
-          }])
-        end
-
-        # Checks if the given index contains documents from types that are NOT subtypes of the queried type.
-        # This indicates we need __typename filtering to exclude those sibling types.
-        def index_has_sibling_types?(schema, index_def, queried_type, queried_subtypes)
-          # Get all types that use this index
-          types_in_index = schema.indexed_document_types.select do |type|
-            type.index_definitions.any? { |idx| idx.name == index_def.name }
-          end
-
-          # Check if any of those types are NOT subtypes of the queried type
-          types_in_index.any? do |type|
-            !queried_subtypes.include?(type) && type != queried_type
           end
         end
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/query_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/query_adapter.rb
@@ -68,8 +68,50 @@ module ElasticGraph
             monotonic_clock_deadline: monotonic_clock_deadline
           )
 
+          # When querying an abstract type (interface/union) that shares an index with sibling types,
+          # we must filter by __typename to only return documents of the queried type's subtypes.
+          # Example: Store interface and ThirdPartyWholesale both implement DistributionChannel
+          # and share the distribution_channels index. When querying `stores`, we must filter to
+          # only include PhysicalStore, OnlineStore, and MobileStore documents.
+          initial_query = add_typename_filter_if_needed(initial_query, unwrapped_type, context)
+
           @datastore_query_adapters.reduce(initial_query) do |query, adapter|
             adapter.call(query: query, field: field, args: args, lookahead: lookahead, context: context)
+          end
+        end
+
+        def add_typename_filter_if_needed(query, type, context)
+          return query unless type.abstract?
+
+          subtypes = type.subtypes
+
+          # Check if any of the indexes being searched contain documents from non-subtypes
+          # (i.e., sibling types that share the same index but shouldn't be returned).
+          # Only apply __typename filtering if needed to disambiguate.
+          return query unless query.search_index_definitions.any? do |index_def|
+            index_has_sibling_types?(context.fetch(:elastic_graph_schema), index_def, type, subtypes)
+          end
+
+          # Allow documents without __typename to pass through (they'll be resolved by index name).
+          query.merge_with(internal_filters: [{
+            query.schema_element_names.any_of => [
+              {"__typename" => {query.schema_element_names.equal_to_any_of => subtypes.map(&:name)}},
+              {"__typename" => {query.schema_element_names.equal_to_any_of => [nil]}}
+            ]
+          }])
+        end
+
+        # Checks if the given index contains documents from types that are NOT subtypes of the queried type.
+        # This indicates we need __typename filtering to exclude those sibling types.
+        def index_has_sibling_types?(schema, index_def, queried_type, queried_subtypes)
+          # Get all types that use this index
+          types_in_index = schema.indexed_document_types.select do |type|
+            type.index_definitions.any? { |idx| idx.name == index_def.name }
+          end
+
+          # Check if any of those types are NOT subtypes of the queried type
+          types_in_index.any? do |type|
+            !queried_subtypes.include?(type) && type != queried_type
           end
         end
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
@@ -127,7 +127,7 @@ module ElasticGraph
           else
             raise Errors::NotFoundError, "The index definition `#{index_definition_name}` does not appear to exist. Is it misspelled?"
           end
-        end
+        end.first
       end
 
       def field_named(type_name, field_name)
@@ -151,6 +151,17 @@ module ElasticGraph
         "#<#{self.class.name} 0x#{__id__.to_s(16)} indexed_document_types=[#{indexed_document_types.map(&:name).sort.join(", ")}]>"
       end
       alias_method :inspect, :to_s
+
+      # Returns a hash mapping each index definition name to all indexed document types that use that index.
+      # Multiple types may map to the same index when abstract types share an index with their concrete subtypes
+      # via index inheritance.
+      def indexed_document_types_by_index_definition_name
+        @indexed_document_types_by_index_definition_name ||= indexed_document_types.each_with_object({}) do |type, hash|
+          type.index_definitions.each do |index_def|
+            (hash[index_def.name] ||= []) << type
+          end
+        end.freeze
+      end
 
       private
 
@@ -188,14 +199,6 @@ module ElasticGraph
         graphql_schema.types(visibility_profile: :boot).transform_values do |graphql_type|
           @types_by_graphql_type[graphql_type]
         end
-      end
-
-      def indexed_document_types_by_index_definition_name
-        @indexed_document_types_by_index_definition_name ||= indexed_document_types.each_with_object({}) do |type, hash|
-          type.index_definitions.each do |index_def|
-            hash[index_def.name] ||= type
-          end
-        end.freeze
       end
 
       def log_hidden_types

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/type.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/type.rb
@@ -126,13 +126,16 @@ module ElasticGraph
             .map { |t| @schema.type_from(t) } - [self]
         end
 
-        # Returns the set of other indexed document types that share any of this type's search indexes.
-        # Used to determine whether `__typename` filtering is needed when querying an abstract type
-        # that shares an index with types that fall outside the set of this type's subtypes.
-        def other_types_in_index
-          @other_types_in_index ||= search_index_definitions.flat_map do |index_def|
-            @schema.indexed_document_types_by_index_definition_name.fetch(index_def.name, [])
-          end.reject { |t| t == self }.to_set
+        # Returns the set of indexed document types that share any of this type's search indexes
+        # but are not subtypes of this type. Used to determine whether a `__typename` filter is
+        # needed when querying an abstract type.
+        def non_subtypes_in_shared_index
+          @non_subtypes_in_shared_index ||= begin
+            all_subtypes = subtypes.to_set # all concrete subtypes at any depth
+            search_index_definitions.flat_map do |index_def|
+              @schema.indexed_document_types_by_index_definition_name.fetch(index_def.name, [])
+            end.reject { |t| t == self || all_subtypes.include?(t) }.to_set
+          end
         end
 
         def field_named(field_name)

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/type.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/type.rb
@@ -126,6 +126,11 @@ module ElasticGraph
             .map { |t| @schema.type_from(t) } - [self]
         end
 
+        # For indexed aggregation types, returns the underlying source document type.
+        def aggregation_source_type
+          @schema.type_named(@object_runtime_metadata.source_type)
+        end
+
         # Returns the set of indexed document types that share any of this type's search indexes
         # but are not subtypes of this type. Used to determine whether a `__typename` filter is
         # needed when querying an abstract type.

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema/type.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema/type.rb
@@ -117,13 +117,22 @@ module ElasticGraph
           end
         end
 
-        # Returns the subtypes of this type, if it has any. This is like `#possible_types` provided by the
+        # Returns all concrete subtypes, at any depth. This is like `#possible_types` provided by the
         # GraphQL gem, but that includes a type itself when you ask for the possible types of a non-abstract type.
         def subtypes
           @subtypes ||= @schema
             .graphql_schema
             .possible_types(graphql_type, visibility_profile: :boot)
             .map { |t| @schema.type_from(t) } - [self]
+        end
+
+        # Returns the set of other indexed document types that share any of this type's search indexes.
+        # Used to determine whether `__typename` filtering is needed when querying an abstract type
+        # that shares an index with types that fall outside the set of this type's subtypes.
+        def other_types_in_index
+          @other_types_in_index ||= search_index_definitions.flat_map do |index_def|
+            @schema.indexed_document_types_by_index_definition_name.fetch(index_def.name, [])
+          end.reject { |t| t == self }.to_set
         end
 
         def field_named(field_name)

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/schema.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/schema.rbs
@@ -32,6 +32,7 @@ module ElasticGraph
       def document_type_stored_in: (::String) -> Type
       def field_named: (::String, ::String) -> Field
       def indexed_document_types: () -> ::Array[Type]
+      def indexed_document_types_by_index_definition_name: () -> ::Hash[::String, ::Array[Type]]
       def log_hidden_types: (Logger) -> void
     end
   end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/schema/type.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/schema/type.rbs
@@ -9,6 +9,7 @@ module ElasticGraph
         attr_reader graphql_type: ::GraphQL::Schema::_Type
         attr_reader grouping_missing_value_placeholder: ::String? | ::Numeric?
         def search_index_definitions: () -> ::Array[DatastoreCore::_IndexDefinition]
+        def aggregation_source_type: () -> Type
         def non_subtypes_in_shared_index: () -> ::Set[Type]
         def unwrap_fully: () -> Type
         def field_named: (::String) -> Field

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/schema/type.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/schema/type.rbs
@@ -9,7 +9,7 @@ module ElasticGraph
         attr_reader graphql_type: ::GraphQL::Schema::_Type
         attr_reader grouping_missing_value_placeholder: ::String? | ::Numeric?
         def search_index_definitions: () -> ::Array[DatastoreCore::_IndexDefinition]
-        def other_types_in_index: () -> ::Set[Type]
+        def non_subtypes_in_shared_index: () -> ::Set[Type]
         def unwrap_fully: () -> Type
         def field_named: (::String) -> Field
         def fields_by_name_in_index: () -> ::Hash[::String, ::Array[Field]]

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/schema/type.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/schema/type.rbs
@@ -9,6 +9,7 @@ module ElasticGraph
         attr_reader graphql_type: ::GraphQL::Schema::_Type
         attr_reader grouping_missing_value_placeholder: ::String? | ::Numeric?
         def search_index_definitions: () -> ::Array[DatastoreCore::_IndexDefinition]
+        def other_types_in_index: () -> ::Set[Type]
         def unwrap_fully: () -> Type
         def field_named: (::String) -> Field
         def fields_by_name_in_index: () -> ::Hash[::String, ::Array[Field]]

--- a/elasticgraph-graphql/spec/acceptance/hidden_types_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/hidden_types_spec.rb
@@ -119,7 +119,7 @@ module ElasticGraph
             %w[
               FloatAggregatedValues IntAggregatedValues JsonSafeLongAggregatedValues LongStringAggregatedValues NonNumericAggregatedValues
               DateAggregatedValues DateTimeAggregatedValues LocalTimeAggregatedValues
-              Company Cursor PageInfo Query TextFilterInput GeoLocation MobileStore OnlineStore ThirdPartyWholesale
+              Company Cursor PageInfo Query TextFilterInput GeoLocation OnlineStore ThirdPartyWholesale
               DateTimeGroupingOffsetInput DateTimeUnitInput DateTimeTimeOfDayFilterInput
               DateGroupedBy DateGroupingOffsetInput DateGroupingTruncationUnitInput DateUnitInput
               DateTimeGroupedBy DateTimeGroupingTruncationUnitInput TimeZone

--- a/elasticgraph-graphql/spec/acceptance/hidden_types_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/hidden_types_spec.rb
@@ -78,10 +78,12 @@ module ElasticGraph
             all_types_related_to("WidgetCurrency") +
             all_types_related_to("Team") +
             all_types_related_to("Sponsor") +
-            all_types_related_to("Person") +
-            all_types_related_to("Company") +
             all_types_related_to("Inventor") +
             all_types_related_to("NamedInventor") +
+            all_types_related_to("Store") +
+            all_types_related_to("DistributionChannel") +
+            all_types_related_to("Retail") +
+            all_types_related_to("PhysicalStore") +
             relay_types_related_to("String", include_list_filter: true) - ["StringSortOrderInput"] +
             type_and_filters_for("Boolean", include_list: true) +
             type_and_filters_for("Color", include_list: true, as_input_enum: true) +
@@ -96,6 +98,7 @@ module ElasticGraph
             type_and_filters_for("TeamNestedFields") + ["TeamNestedFieldsHighlights"] +
             type_and_filters_for("Affiliations") +
             type_and_filters_for("ID", include_list: true) +
+            type_filter_and_non_indexed_aggregation_types_for("Person") +
             type_filter_and_non_indexed_aggregation_types_for("TeamDetails") +
             type_filter_and_non_indexed_aggregation_types_for("AddressTimestamps", include_highlights: false) - ["AddressTimestamps"] +
             type_filter_and_non_indexed_aggregation_types_for("Affiliations", include_fields_list_filter: true) +
@@ -116,7 +119,7 @@ module ElasticGraph
             %w[
               FloatAggregatedValues IntAggregatedValues JsonSafeLongAggregatedValues LongStringAggregatedValues NonNumericAggregatedValues
               DateAggregatedValues DateTimeAggregatedValues LocalTimeAggregatedValues
-              Cursor PageInfo Query TextFilterInput GeoLocation
+              Company Cursor PageInfo Query TextFilterInput GeoLocation MobileStore OnlineStore ThirdPartyWholesale
               DateTimeGroupingOffsetInput DateTimeUnitInput DateTimeTimeOfDayFilterInput
               DateGroupedBy DateGroupingOffsetInput DateGroupingTruncationUnitInput DateUnitInput
               DateTimeGroupedBy DateTimeGroupingTruncationUnitInput TimeZone

--- a/elasticgraph-graphql/spec/acceptance/search_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/search_spec.rb
@@ -708,32 +708,28 @@ module ElasticGraph
         #   └── Retail               (interface, inherits distribution_channels)
         #       └── Store            (interface, inherits distribution_channels)
         #           ├── OnlineStore  (concrete, distribution_channels index)
-        #           ├── MobileStore  (concrete, distribution_channels index)
         #           └── PhysicalStore (concrete, physical_stores index)
         #
         # The key invariant: querying at a sub-interface level (e.g. retailers, stores) must
         # filter OUT sibling types in the shared index (e.g. ThirdPartyWholesale when querying stores).
         index_records(
-          physical_store1 = build(:physical_store, address: "123 Main St, Anytown USA", square_footage: 5000, established_on: "2019-03-10", active: true),
-          physical_store2 = build(:physical_store, address: "456 Oak Ave, Other City", square_footage: 10000, established_on: "2022-08-05", active: true),
-          mobile_store1 = build(:mobile_store, vehicle_type: "food truck", current_location: "789 Park Ave, Big City", established_on: "2020-06-15", active: true),
-          mobile_store2 = build(:mobile_store, vehicle_type: "pop-up cart", current_location: "321 Beach Blvd, Coast Town", established_on: "2021-11-20", active: true),
-          online_store1 = build(:online_store, url: "https://shop1.example.com", platform: "Shopify", established_on: "2020-01-15", active: true),
-          online_store2 = build(:online_store, url: "https://shop2.example.com", platform: "WooCommerce", established_on: "2021-06-20", active: true),
-          build(:third_party_wholesale, partner_name: "Acme Corp", contract_terms: "Net 30", active: true),
-          wholesale2 = build(:third_party_wholesale, partner_name: "Global Dist", contract_terms: "Net 60", active: false)
+          physical_store1 = build(:physical_store, established_on: "2019-03-10", active: true),
+          physical_store2 = build(:physical_store, established_on: "2022-08-05", active: true),
+          online_store1 = build(:online_store, established_on: "2020-01-15", active: true),
+          online_store2 = build(:online_store, established_on: "2021-06-20", active: true),
+          build(:third_party_wholesale, active: true),
+          wholesale2 = build(:third_party_wholesale, active: false)
         )
 
         store_fragments = [
           "...on PhysicalStore { id __typename established_on }",
-          "...on MobileStore { id __typename established_on }",
           "...on OnlineStore { id __typename established_on }"
         ]
         all_channel_fragments = store_fragments + ["...on ThirdPartyWholesale { id __typename active }"]
 
-        store_typenames = %w[PhysicalStore PhysicalStore MobileStore MobileStore OnlineStore OnlineStore]
+        store_typenames = %w[PhysicalStore PhysicalStore OnlineStore OnlineStore]
 
-        # Querying at the top-level DistributionChannel interface returns all 4 concrete types,
+        # Querying at the top-level DistributionChannel interface returns all 3 concrete types,
         # including ThirdPartyWholesale.
         channels = list_distribution_channels_with(*all_channel_fragments)
         expect(channels.map { |c| c["__typename"] }).to contain_exactly(
@@ -758,7 +754,6 @@ module ElasticGraph
         # At retailers: established_on filter applies, and ThirdPartyWholesale is still excluded.
         retailers_after_2020 = list_retailers_with(*store_fragments, filter: {established_on: {gte: "2020-01-01"}})
         expect(retailers_after_2020.map { |r| r["id"] }).to contain_exactly(
-          mobile_store1.fetch(:id), mobile_store2.fetch(:id),
           online_store1.fetch(:id), online_store2.fetch(:id),
           physical_store2.fetch(:id)
         )
@@ -768,9 +763,7 @@ module ElasticGraph
         expect(stores_sorted.map { |s| s["id"] }).to eq([
           physical_store1.fetch(:id),
           online_store1.fetch(:id),
-          mobile_store1.fetch(:id),
           online_store2.fetch(:id),
-          mobile_store2.fetch(:id),
           physical_store2.fetch(:id)
         ])
 
@@ -786,10 +779,9 @@ module ElasticGraph
         # Filter by ID spans indices and respects the __typename scope at each query level.
         stores_by_id = list_stores_with(
           *store_fragments,
-          filter: {id: {equal_to_any_of: [mobile_store1.fetch(:id), physical_store1.fetch(:id), online_store1.fetch(:id)]}}
+          filter: {id: {equal_to_any_of: [physical_store1.fetch(:id), online_store1.fetch(:id)]}}
         )
         expect(stores_by_id.map { |s| [s["id"], s["__typename"]] }).to contain_exactly(
-          [mobile_store1.fetch(:id), "MobileStore"],
           [physical_store1.fetch(:id), "PhysicalStore"],
           [online_store1.fetch(:id), "OnlineStore"]
         )

--- a/elasticgraph-graphql/spec/acceptance/search_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/search_spec.rb
@@ -698,6 +698,103 @@ module ElasticGraph
         test_widget_search_highlighting(widget1, widget2, widget3)
       end
 
+      it "correctly scopes results to the queried interface level across a multi-level type hierarchy", :expect_search_routing do
+        established_on_asc = :"#{case_correctly("established_on")}_ASC"
+        id_desc = :"#{case_correctly("id")}_DESC"
+
+        # The DistributionChannel hierarchy has two branches:
+        #   DistributionChannel (index: distribution_channels)
+        #   ├── ThirdPartyWholesale   (concrete, distribution_channels index)
+        #   └── Retail               (interface, inherits distribution_channels)
+        #       └── Store            (interface, inherits distribution_channels)
+        #           ├── OnlineStore  (concrete, distribution_channels index)
+        #           ├── MobileStore  (concrete, distribution_channels index)
+        #           └── PhysicalStore (concrete, physical_stores index)
+        #
+        # The key invariant: querying at a sub-interface level (e.g. retailers, stores) must
+        # filter OUT sibling types in the shared index (e.g. ThirdPartyWholesale when querying stores).
+        index_records(
+          physical_store1 = build(:physical_store, address: "123 Main St, Anytown USA", square_footage: 5000, established_on: "2019-03-10", active: true),
+          physical_store2 = build(:physical_store, address: "456 Oak Ave, Other City", square_footage: 10000, established_on: "2022-08-05", active: true),
+          mobile_store1 = build(:mobile_store, vehicle_type: "food truck", current_location: "789 Park Ave, Big City", established_on: "2020-06-15", active: true),
+          mobile_store2 = build(:mobile_store, vehicle_type: "pop-up cart", current_location: "321 Beach Blvd, Coast Town", established_on: "2021-11-20", active: true),
+          online_store1 = build(:online_store, url: "https://shop1.example.com", platform: "Shopify", established_on: "2020-01-15", active: true),
+          online_store2 = build(:online_store, url: "https://shop2.example.com", platform: "WooCommerce", established_on: "2021-06-20", active: true),
+          build(:third_party_wholesale, partner_name: "Acme Corp", contract_terms: "Net 30", active: true),
+          wholesale2 = build(:third_party_wholesale, partner_name: "Global Dist", contract_terms: "Net 60", active: false)
+        )
+
+        store_fragments = [
+          "...on PhysicalStore { id __typename established_on }",
+          "...on MobileStore { id __typename established_on }",
+          "...on OnlineStore { id __typename established_on }"
+        ]
+        all_channel_fragments = store_fragments + ["...on ThirdPartyWholesale { id __typename active }"]
+
+        store_typenames = %w[PhysicalStore PhysicalStore MobileStore MobileStore OnlineStore OnlineStore]
+
+        # Querying at the top-level DistributionChannel interface returns all 4 concrete types,
+        # including ThirdPartyWholesale.
+        channels = list_distribution_channels_with(*all_channel_fragments)
+        expect(channels.map { |c| c["__typename"] }).to contain_exactly(
+          *store_typenames, "ThirdPartyWholesale", "ThirdPartyWholesale"
+        )
+
+        # Querying at the Retail interface excludes ThirdPartyWholesale, even though it lives in
+        # the same distribution_channels index. The __typename filter handles this.
+        retailers = list_retailers_with(*store_fragments)
+        expect(retailers.map { |r| r["__typename"] }).to contain_exactly(*store_typenames)
+
+        # Querying at the Store interface likewise excludes ThirdPartyWholesale.
+        stores = list_stores_with(*store_fragments)
+        expect(stores.map { |s| s["__typename"] }).to contain_exactly(*store_typenames)
+
+        # Filters apply within the correct scope at each level.
+        # At distribution_channels: active=false matches only wholesale2.
+        inactive = list_distribution_channels_with(*all_channel_fragments, filter: {active: {equal_to_any_of: [false]}})
+        expect(inactive.map { |c| c["__typename"] }).to contain_exactly("ThirdPartyWholesale")
+        expect(inactive.map { |c| c["id"] }).to contain_exactly(wholesale2.fetch(:id))
+
+        # At retailers: established_on filter applies, and ThirdPartyWholesale is still excluded.
+        retailers_after_2020 = list_retailers_with(*store_fragments, filter: {established_on: {gte: "2020-01-01"}})
+        expect(retailers_after_2020.map { |r| r["id"] }).to contain_exactly(
+          mobile_store1.fetch(:id), mobile_store2.fetch(:id),
+          online_store1.fetch(:id), online_store2.fetch(:id),
+          physical_store2.fetch(:id)
+        )
+
+        # Sort by established_on at the stores level spans both indices correctly.
+        stores_sorted = list_stores_with(*store_fragments, order_by: [established_on_asc])
+        expect(stores_sorted.map { |s| s["id"] }).to eq([
+          physical_store1.fetch(:id),
+          online_store1.fetch(:id),
+          mobile_store1.fetch(:id),
+          online_store2.fetch(:id),
+          mobile_store2.fetch(:id),
+          physical_store2.fetch(:id)
+        ])
+
+        # Pagination at the distribution_channels level covers all types.
+        channels_page, page_info = list_distribution_channels_and_page_info_with(
+          *all_channel_fragments,
+          first: 4,
+          order_by: [id_desc]
+        )
+        expect(channels_page.size).to eq(4)
+        expect(page_info).to include(case_correctly("has_next_page") => true)
+
+        # Filter by ID spans indices and respects the __typename scope at each query level.
+        stores_by_id = list_stores_with(
+          *store_fragments,
+          filter: {id: {equal_to_any_of: [mobile_store1.fetch(:id), physical_store1.fetch(:id), online_store1.fetch(:id)]}}
+        )
+        expect(stores_by_id.map { |s| [s["id"], s["__typename"]] }).to contain_exactly(
+          [mobile_store1.fetch(:id), "MobileStore"],
+          [physical_store1.fetch(:id), "PhysicalStore"],
+          [online_store1.fetch(:id), "OnlineStore"]
+        )
+      end
+
       it "supports fetching interface fields" do
         index_into(
           graphql,
@@ -1483,6 +1580,45 @@ module ElasticGraph
                   ...on Widget {
                     id
                   }
+                }
+              }
+            }
+          }
+        QUERY
+      end
+
+      def list_distribution_channels_with(*fragments, **query_args)
+        field = case_correctly("distribution_channels")
+        query_abstract_type_with(field, *fragments, **query_args).dig("data", field, "edges").map { |e| e.fetch("node") }
+      end
+
+      def list_distribution_channels_and_page_info_with(*fragments, **query_args)
+        field = case_correctly("distribution_channels")
+        response = query_abstract_type_with(field, *fragments, **query_args).dig("data", field)
+        [response.fetch("edges").map { |e| e.fetch("node") }, response.fetch(case_correctly("page_info"))]
+      end
+
+      def list_retailers_with(*fragments, **query_args)
+        query_abstract_type_with("retailers", *fragments, **query_args).dig("data", "retailers", "edges").map { |e| e.fetch("node") }
+      end
+
+      def list_stores_with(*fragments, **query_args)
+        query_abstract_type_with("stores", *fragments, **query_args).dig("data", "stores", "edges").map { |e| e.fetch("node") }
+      end
+
+      def query_abstract_type_with(field, *fragments, allow_errors: false, **query_args)
+        fragment_string = fragments.join("\n")
+        call_graphql_query(<<~QUERY, allow_errors: allow_errors)
+          query {
+            #{field}#{graphql_args(query_args)} {
+              #{case_correctly("page_info")} {
+                #{case_correctly("end_cursor")}
+                #{case_correctly("has_next_page")}
+                #{case_correctly("has_previous_page")}
+              }
+              edges {
+                node {
+                  #{fragment_string}
                 }
               }
             }

--- a/elasticgraph-graphql/spec/acceptance/search_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/search_spec.rb
@@ -785,6 +785,11 @@ module ElasticGraph
           [physical_store1.fetch(:id), "PhysicalStore"],
           [online_store1.fetch(:id), "OnlineStore"]
         )
+
+        # Aggregations respect the same __typename scoping as document queries.
+        store_agg_count = call_graphql_query("query { #{case_correctly("store_aggregations")} { nodes { #{case_correctly("count")} } } }")
+          .dig("data", case_correctly("store_aggregations"), "nodes", 0, case_correctly("count"))
+        expect(store_agg_count).to eq(store_typenames.size)
       end
 
       it "supports fetching interface fields" do

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/abstract_type_filter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/abstract_type_filter_spec.rb
@@ -98,6 +98,7 @@ module ElasticGraph
             QUERY
 
             typename_filter = query.internal_filters.find { |f| f.key?("__typename") }
+            expect(typename_filter).not_to be_nil
             expect(typename_filter.dig("__typename", "equal_to_any_of")).to contain_exactly(nil, "OnlineStore", "PhysicalStore")
           end
 
@@ -107,6 +108,16 @@ module ElasticGraph
             QUERY
 
             expect(query.internal_filters).not_to be_empty
+          end
+
+          it "applies a __typename filter on aggregations of the abstract type" do
+            query = datastore_query_for(:Query, :store_aggregations, <<~QUERY)
+              query { store_aggregations { nodes { count } } }
+            QUERY
+
+            typename_filter = query.internal_filters.find { |f| f.key?("__typename") }
+            expect(typename_filter).not_to be_nil
+            expect(typename_filter.dig("__typename", "equal_to_any_of")).to contain_exactly(nil, "OnlineStore", "PhysicalStore")
           end
         end
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/abstract_type_filter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/abstract_type_filter_spec.rb
@@ -110,12 +110,16 @@ module ElasticGraph
           end
         end
 
-        context "when calling other_types_in_index on a concrete type" do
-          it "excludes the type itself from the result" do
+        context "when calling non_subtypes_in_shared_index" do
+          it "excludes the type itself and its subtypes from the result" do
             schema = build_graphql(schema_artifacts: schema_artifacts).schema
-            physical_store = schema.type_named("PhysicalStore")
+            store = schema.type_named("Store")
 
-            expect(physical_store.other_types_in_index).not_to include(physical_store)
+            result = store.non_subtypes_in_shared_index
+            expect(result).not_to include(store)
+            expect(result).not_to include(schema.type_named("OnlineStore"))
+            expect(result).not_to include(schema.type_named("PhysicalStore"))
+            expect(result).to include(schema.type_named("Wholesaler"))
           end
         end
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/abstract_type_filter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/abstract_type_filter_spec.rb
@@ -1,0 +1,139 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/graphql/query_adapter/abstract_type_filter"
+
+module ElasticGraph
+  class GraphQL
+    class QueryAdapter
+      RSpec.describe AbstractTypeFilter, :query_adapter do
+        attr_accessor :schema_artifacts
+
+        before(:context) do
+          self.schema_artifacts = generate_schema_artifacts do |schema|
+            # A concrete type with its own dedicated index.
+            schema.object_type "Widget" do |t|
+              t.field "id", "ID!"
+              t.root_query_fields plural: "widgets"
+              t.index "widgets"
+            end
+
+            # A union whose subtypes all share one index — no __typename filter needed.
+            schema.object_type "Person" do |t|
+              t.field "id", "ID!"
+            end
+
+            schema.object_type "Company" do |t|
+              t.field "id", "ID!"
+            end
+
+            schema.union_type "Inventor" do |t|
+              t.subtypes "Person", "Company"
+              t.root_query_fields plural: "inventors"
+              t.index "inventors"
+            end
+
+            # An interface hierarchy where `Store` shares the `channels` index with `Wholesaler`,
+            # requiring a __typename filter when querying stores.
+            # `PhysicalStore` has its own dedicated index, so its documents will not have __typename.
+            schema.interface_type "Channel" do |t|
+              t.field "id", "ID!"
+              t.root_query_fields plural: "channels"
+              t.index "channels"
+            end
+
+            schema.object_type "Wholesaler" do |t|
+              t.implements "Channel"
+              t.field "id", "ID!"
+            end
+
+            schema.interface_type "Store" do |t|
+              t.implements "Channel"
+              t.field "id", "ID!"
+              t.root_query_fields plural: "stores"
+            end
+
+            schema.object_type "OnlineStore" do |t|
+              t.implements "Store"
+              t.field "id", "ID!"
+            end
+
+            schema.object_type "PhysicalStore" do |t|
+              t.implements "Store"
+              t.field "id", "ID!"
+              t.index "physical_stores"
+            end
+          end
+        end
+
+        context "when querying a concrete type" do
+          it "does not apply a __typename filter" do
+            query = datastore_query_for(:Query, :widgets, <<~QUERY)
+              query { widgets { edges { node { id } } } }
+            QUERY
+
+            expect(query.internal_filters).to be_empty
+          end
+        end
+
+        context "when querying an abstract type whose subtypes all share one index" do
+          it "does not apply a __typename filter" do
+            query = datastore_query_for(:Query, :inventors, <<~QUERY)
+              query { inventors { edges { node { ... on Person { id } ... on Company { id } } } } }
+            QUERY
+
+            expect(query.internal_filters).to be_empty
+          end
+        end
+
+        context "when querying an abstract type that shares an index with a sibling type" do
+          it "applies a __typename filter scoped to the queried type's concrete subtypes, including nil for subtypes with dedicated indexes" do
+            query = datastore_query_for(:Query, :stores, <<~QUERY)
+              query { stores { edges { node { id } } } }
+            QUERY
+
+            typename_filter = query.internal_filters.find { |f| f.key?("__typename") }
+            expect(typename_filter.dig("__typename", "equal_to_any_of")).to contain_exactly(nil, "OnlineStore", "PhysicalStore")
+          end
+
+          it "applies a __typename filter when querying the root abstract type" do
+            query = datastore_query_for(:Query, :channels, <<~QUERY)
+              query { channels { edges { node { id } } } }
+            QUERY
+
+            expect(query.internal_filters).not_to be_empty
+          end
+        end
+
+        context "when calling other_types_in_index on a concrete type" do
+          it "excludes the type itself from the result" do
+            schema = build_graphql(schema_artifacts: schema_artifacts).schema
+            physical_store = schema.type_named("PhysicalStore")
+
+            expect(physical_store.other_types_in_index).not_to include(physical_store)
+          end
+        end
+
+        private
+
+        def graphql_and_datastore_queries_by_field_for(graphql_query, **graphql_opts)
+          super(graphql_query, schema_artifacts: schema_artifacts, **graphql_opts)
+        end
+
+        def datastore_query_for(type, field, graphql_query)
+          super(
+            schema_artifacts: schema_artifacts,
+            graphql_query: graphql_query,
+            type: type,
+            field: field
+          )
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/requested_fields_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/requested_fields_spec.rb
@@ -43,6 +43,29 @@ module ElasticGraph
               t.field "name", "String"
             end
 
+            # Indexed interface type used solely as a root document type (not embedded anywhere).
+            # Author and Scientist inherit the `creators` index via index inheritance rather than
+            # declaring it themselves.
+            schema.interface_type "Creator" do |t|
+              t.field "id", "ID!"
+              t.field "name", "String"
+              t.index "creators"
+            end
+
+            schema.object_type "Author" do |t|
+              t.implements "Creator"
+              t.field "id", "ID!"
+              t.field "name", "String"
+              t.field "genre", "String"
+            end
+
+            schema.object_type "Scientist" do |t|
+              t.implements "Creator"
+              t.field "id", "ID!"
+              t.field "name", "String"
+              t.field "field_of_study", "String"
+            end
+
             # Indexed interface type.
             schema.interface_type "NamedEntity" do |t|
               t.root_query_fields plural: "named_entities"
@@ -370,12 +393,12 @@ module ElasticGraph
         end
 
         it "requests __typename when using `nodes` on an abstract indexed type" do
-          query = datastore_query_for(:Query, :named_entities, <<~QUERY)
+          query = datastore_query_for(:Query, :creators, <<~QUERY)
             query {
-              named_entities {
+              creators {
                 nodes {
-                  id
-                  name
+                  ... on Author { genre }
+                  ... on Scientist { field_of_study }
                 }
               }
             }

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/requested_fields_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/requested_fields_spec.rb
@@ -43,7 +43,7 @@ module ElasticGraph
               t.field "name", "String"
             end
 
-            # Indexed interfae type.
+            # Indexed interface type.
             schema.interface_type "NamedEntity" do |t|
               t.root_query_fields plural: "named_entities"
               t.field "id", "ID"
@@ -367,6 +367,21 @@ module ElasticGraph
           expect(query.total_document_count_needed).to be false
           expect(query.requested_highlights).to be_empty
           expect(query.request_all_highlights).to be false
+        end
+
+        it "requests __typename when using `nodes` on an abstract indexed type" do
+          query = datastore_query_for(:Query, :named_entities, <<~QUERY)
+            query {
+              named_entities {
+                nodes {
+                  id
+                  name
+                }
+              }
+            }
+          QUERY
+
+          expect(query.requested_fields).to include("__typename")
         end
 
         it "ignores relay connection sub-fields that are not directly under `edges.node` (e.g. `page_info`)" do

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
@@ -139,6 +139,10 @@ module ElasticGraph
       # one or more fields that concrete implementations of the interface must also define. Each implementation can be an
       # {SchemaElements::ObjectType} or {SchemaElements::InterfaceType}.
       #
+      # @note An interface type can declare an index with {Mixins::HasIndices#index}. All concrete types that implement
+      #   the interface will automatically share that index unless they declare their own. This is the primary way to define a
+      #   _mixed-type index_ where multiple concrete types coexist in a single datastore index.
+      #
       # @param name [String] name of the interface
       # @yield [SchemaElements::InterfaceType] interface type object
       # @return [void]
@@ -159,6 +163,35 @@ module ElasticGraph
       #
       #     schema.object_type "BasketballPlayer" do |t|
       #       t.implements "Athlete"
+      #       t.field "name", "String"
+      #       t.field "team", "String"
+      #       t.field "pointsPerGame", "Float"
+      #     end
+      #   end
+      #
+      # @example Define an indexed interface so subtypes share a single index
+      #   ElasticGraph.define_schema do |schema|
+      #     schema.interface_type "Athlete" do |t|
+      #       t.field "id", "ID!"
+      #       t.field "name", "String"
+      #       t.field "team", "String"
+      #       t.root_query_fields plural: "athletes"
+      #       t.index "athletes"
+      #     end
+      #
+      #     # Inherits the `athletes` index automatically.
+      #     schema.object_type "BaseballPlayer" do |t|
+      #       t.implements "Athlete"
+      #       t.field "id", "ID!"
+      #       t.field "name", "String"
+      #       t.field "team", "String"
+      #       t.field "battingAvg", "Float"
+      #     end
+      #
+      #     # Also inherits the `athletes` index.
+      #     schema.object_type "BasketballPlayer" do |t|
+      #       t.implements "Athlete"
+      #       t.field "id", "ID!"
       #       t.field "name", "String"
       #       t.field "team", "String"
       #       t.field "pointsPerGame", "Float"

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
@@ -29,12 +29,19 @@ module ElasticGraph
           initialize_has_indices { yield self }
         end
 
-        # Converts the current type from being an _embedded_ type (that is, a type that is embedded within another indexed type) to an
-        # _indexed_ type that resides in the named index definition. Indexed types are directly indexed into the datastore, and will be
-        # queryable from the root `Query` type.
+        # Declares a datastore index for the current type. The behavior depends on whether this is called
+        # on a concrete type or an abstract type:
+        #
+        # - On a concrete `object_type`: converts it from an _embedded_ type to an _indexed_ type that is
+        #   directly queryable from the root `Query` type.
+        # - On an abstract `interface_type` or `union_type`: declares a _shared index_ that all concrete
+        #   subtypes automatically inherit. Subtypes that inherit an index do not need to call `t.index`
+        #   themselves — they share the same physical index. A concrete subtype can still call `t.index`
+        #   with a different name to opt out of inheritance and get a dedicated index instead.
         #
         # @note Use {#root_query_fields} on indexed types to name the field that will be exposed on `Query`.
         # @note Indexed types must also define an `id` field, which ElasticGraph will use as the primary key.
+        #   When an abstract type declares the index, each concrete subtype must also define `id`.
         # @note Datastore index settings can also be defined (or overridden) in an environment-specific settings YAML file. Index settings
         #   that you want to configure differently for different environments (such as `index.number_of_shards`—-production and staging
         #   will probably need different numbers!) should be configured in the per-environment YAML configuration files rather than here.
@@ -46,7 +53,7 @@ module ElasticGraph
         # @yield [Indexing::Index] the index, so it can be customized further
         # @return [void]
         #
-        # @example Define a `campaigns` index
+        # @example Define a `campaigns` index on a concrete type
         #   ElasticGraph.define_schema do |schema|
         #     schema.object_type "Campaign" do |t|
         #       t.field "id", "ID"
@@ -60,6 +67,34 @@ module ElasticGraph
         #       ) do |i|
         #         # The index can be customized further here.
         #       end
+        #     end
+        #   end
+        #
+        # @example Declare a shared index on an interface so subtypes inherit it
+        #   ElasticGraph.define_schema do |schema|
+        #     schema.interface_type "Vehicle" do |t|
+        #       t.field "id", "ID"
+        #       t.field "make", "String"
+        #       t.root_query_fields plural: "vehicles"
+        #       # Car and Motorcycle will share this index automatically.
+        #       t.index "vehicles"
+        #     end
+        #
+        #     # Inherits the `vehicles` index — no need to call `t.index`.
+        #     schema.object_type "Car" do |t|
+        #       t.implements "Vehicle"
+        #       t.field "id", "ID"
+        #       t.field "make", "String"
+        #       t.field "numDoors", "Int"
+        #     end
+        #
+        #     # Opts out of the shared index and gets its own dedicated index instead.
+        #     schema.object_type "Motorcycle" do |t|
+        #       t.implements "Vehicle"
+        #       t.field "id", "ID"
+        #       t.field "make", "String"
+        #       t.field "engineCC", "Int"
+        #       t.index "motorcycles"
         #     end
         #   end
         def index(name, **settings, &block)
@@ -133,6 +168,9 @@ module ElasticGraph
         end
 
         # @return [Boolean] true if this type is directly queryable via a type-specific field on the root `Query` type.
+        # @note A concrete subtype that inherits an index from an abstract parent is NOT directly queryable on its own —
+        #   only the abstract type that declared the index is. Use {#root_document_type?} to check whether a type
+        #   participates in any index (own or inherited).
         def directly_queryable?
           has_own_index_def?
         end

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/implements_interfaces.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/implements_interfaces.rb
@@ -16,6 +16,11 @@ module ElasticGraph
         # Declares that the current type implements the specified interface, making the current type a subtype of the interface. The
         # current type must define all of the fields of the named interface, with the exact same field types.
         #
+        # @note If the named interface has declared an index (via {Mixins::HasIndices#index}), calling `implements`
+        #   causes this type to automatically inherit that index — it will be stored in the same datastore index as all other
+        #   implementers. To override this and use a dedicated index, call {Mixins::HasIndices#index} on this type
+        #   after `implements`.
+        #
         # @param interface_names [Array<String>] names of interface types implemented by this type
         # @return [void]
         #

--- a/spec_support/lib/elastic_graph/spec_support/factories/widgets.rb
+++ b/spec_support/lib/elastic_graph/spec_support/factories/widgets.rb
@@ -215,35 +215,18 @@ FactoryBot.define do
 
   factory :online_store, parent: :indexed_type do
     __typename { "OnlineStore" }
-    url { "https://#{Faker::Internet.domain_name}" }
-    platform { Faker::Base.sample(["Shopify", "WooCommerce", "Magento", "Custom"]) }
     established_on { Faker::Date.between(from: recent_date - 365, to: recent_date).iso8601 }
     active { true }
-    customer_facing { true }
   end
 
   factory :physical_store, parent: :indexed_type do
     __typename { "PhysicalStore" }
-    address { Faker::Address.full_address }
-    square_footage { Faker::Number.between(from: 500, to: 50000) }
     established_on { Faker::Date.between(from: recent_date - 365, to: recent_date).iso8601 }
     active { true }
-    customer_facing { true }
-  end
-
-  factory :mobile_store, parent: :indexed_type do
-    __typename { "MobileStore" }
-    vehicle_type { Faker::Base.sample(["food truck", "pop-up cart", "mobile kiosk", "trailer"]) }
-    current_location { Faker::Address.full_address }
-    established_on { Faker::Date.between(from: recent_date - 365, to: recent_date).iso8601 }
-    active { true }
-    customer_facing { true }
   end
 
   factory :third_party_wholesale, parent: :indexed_type do
     __typename { "ThirdPartyWholesale" }
-    partner_name { Faker::Company.name }
-    contract_terms { Faker::Base.sample(["Net 30", "Net 60", "Net 90", "COD"]) }
     active { true }
   end
 end

--- a/spec_support/lib/elastic_graph/spec_support/factories/widgets.rb
+++ b/spec_support/lib/elastic_graph/spec_support/factories/widgets.rb
@@ -47,12 +47,14 @@ FactoryBot.define do
 
   factory :person, parent: :indexed_type do
     __typename { "Person" }
+    id { Faker::Alphanumeric.alpha(number: 20) }
     name { Faker::Name.name }
     nationality { Faker::Nation.nationality }
   end
 
   factory :company, parent: :indexed_type do
     __typename { "Company" }
+    id { Faker::Alphanumeric.alpha(number: 20) }
     name { Faker::Company.name }
     stock_ticker { name[0..3].upcase }
   end
@@ -209,5 +211,39 @@ FactoryBot.define do
     transient do
       parts { [] }
     end
+  end
+
+  factory :online_store, parent: :indexed_type do
+    __typename { "OnlineStore" }
+    url { "https://#{Faker::Internet.domain_name}" }
+    platform { Faker::Base.sample(["Shopify", "WooCommerce", "Magento", "Custom"]) }
+    established_on { Faker::Date.between(from: recent_date - 365, to: recent_date).iso8601 }
+    active { true }
+    customer_facing { true }
+  end
+
+  factory :physical_store, parent: :indexed_type do
+    __typename { "PhysicalStore" }
+    address { Faker::Address.full_address }
+    square_footage { Faker::Number.between(from: 500, to: 50000) }
+    established_on { Faker::Date.between(from: recent_date - 365, to: recent_date).iso8601 }
+    active { true }
+    customer_facing { true }
+  end
+
+  factory :mobile_store, parent: :indexed_type do
+    __typename { "MobileStore" }
+    vehicle_type { Faker::Base.sample(["food truck", "pop-up cart", "mobile kiosk", "trailer"]) }
+    current_location { Faker::Address.full_address }
+    established_on { Faker::Date.between(from: recent_date - 365, to: recent_date).iso8601 }
+    active { true }
+    customer_facing { true }
+  end
+
+  factory :third_party_wholesale, parent: :indexed_type do
+    __typename { "ThirdPartyWholesale" }
+    partner_name { Faker::Company.name }
+    contract_terms { Faker::Base.sample(["Net 30", "Net 60", "Net 90", "COD"]) }
+    active { true }
   end
 end


### PR DESCRIPTION
Updates the graphql gem to handle abstract types whose subtypes share an inherited index: when querying an abstract type, a new `AbstractTypeFilter` query adapter injects a `__typename` filter to exclude sibling types that share the same index. The filter correctly handles mixed hierarchies where some subtypes use a shared inherited index while others have their own dedicated index.

Also fixes `RequestedFields#requested_fields_under` to use `unwrap_fully` when checking whether a type is abstract, so that `__typename` is correctly added to `requested_fields` when the abstract type is wrapped in a list (e.g. the `nodes` field in a relay connection returns `[NamedInventor!]!`). Without this fix, querying `named_inventors { nodes { ... on Person { name } } }` would return empty results.

Adds end-to-end acceptance tests covering the full interface index inheritance flow, and extends the test schema with the `DistributionChannel`/`Retail`/`Store` interface hierarchy and concrete types (`PhysicalStore`, `OnlineStore`, `ThirdPartyWholesale`) to exercise multi-level inheritance and mixed shared/dedicated index scenarios.

Improves YARD documentation on `HasIndices#index`, `API#interface_type`, `ImplementsInterfaces#implements`, and `HasIndices#directly_queryable?` to document index inheritance behavior, shared-index examples, and the dedicated-index override pattern.

Adds a blurb about index inheritance to ai-memory/README.md for use by agents.

Fixes #1029