### PR TITLE
Allow callers to skip JSON.generate on the response body

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb
@@ -42,10 +42,17 @@ module ElasticGraph
       # `max_timeout_in_ms` is not a property of the HTTP request (the
       # calling application will determine it instead!) so it is a separate argument.
       #
+      # When a block is given, it is invoked with the GraphQL result hash and must return
+      # the response body to assign to the {HTTPResponse}. The body may be any value the
+      # calling adapter accepts, such as a `String` or any object responding to
+      # `each` per the Rack body spec. This lets a host avoid allocating a large JSON
+      # `String` by streaming the result hash directly into the response output stream.
+      # Without a block, the body is built via `JSON.generate(result.to_h)` as before.
+      #
       # Note that this method does _not_ convert exceptions to 500 responses. It's up to
       # the calling application to do that if it wants to (and to determine how much of the
       # exception to return in the HTTP response...).
-      def process(request, max_timeout_in_ms: nil, start_time_in_ms: @monotonic_clock.now_in_ms)
+      def process(request, max_timeout_in_ms: nil, start_time_in_ms: @monotonic_clock.now_in_ms, &body_serializer)
         client_or_response = @client_resolver.resolve(request)
         return client_or_response if client_or_response.is_a?(HTTPResponse)
 
@@ -60,7 +67,11 @@ module ElasticGraph
             start_time_in_ms: start_time_in_ms
           )
 
-          HTTPResponse.json(200, result.to_h)
+          if body_serializer
+            HTTPResponse.new(200, {"Content-Type" => APPLICATION_JSON}, body_serializer.call(result.to_h))
+          else
+            HTTPResponse.json(200, result.to_h)
+          end
         end
       rescue Errors::RequestExceededDeadlineError
         HTTPResponse.error(504, "Search exceeded requested timeout.")
@@ -209,7 +220,9 @@ module ElasticGraph
     #
     # - status_code: an integer like 200.
     # - headers: a hash with string keys and values containing HTTP response headers.
-    # - body: a string containing the response body.
+    # - body: the response body. The {.json} and {.error} factories produce a `String` body;
+    #   custom callers may supply any value the calling adapter accepts (for example, a Rack
+    #   body responding to `each`).
     HTTPResponse = Data.define(:status_code, :headers, :body) do
       # @implements HTTPResponse
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/http_endpoint.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/http_endpoint.rbs
@@ -14,7 +14,7 @@ module ElasticGraph
         HTTPRequest,
         ?max_timeout_in_ms: ::Integer?,
         ?start_time_in_ms: ::Integer
-      ) -> HTTPResponse
+      ) ?{ (::Hash[::String, untyped]) -> untyped } -> HTTPResponse
 
       private
 
@@ -93,21 +93,21 @@ module ElasticGraph
     class HTTPResponse
       attr_reader status_code: ::Integer
       attr_reader headers: ::Hash[::String, ::String]
-      attr_reader body: ::String
+      attr_reader body: untyped
 
       def initialize: (
         status_code: ::Integer,
         headers: ::Hash[::String, ::String],
-        body: ::String) -> void
+        body: untyped) -> void
 
       def self.new:
-        (status_code: ::Integer, headers: ::Hash[::String, ::String], body: ::String) -> instance
-      | (::Integer, ::Hash[::String, ::String], ::String) -> instance
+        (status_code: ::Integer, headers: ::Hash[::String, ::String], body: untyped) -> instance
+      | (::Integer, ::Hash[::String, ::String], untyped) -> instance
 
       def with: (
         ?status_code: ::Integer,
         ?headers: ::Hash[::String, ::String],
-        ?body: ::String) -> HTTPResponse
+        ?body: untyped) -> HTTPResponse
 
       def self.json: (::Integer, ::Hash[::String, untyped]) -> HTTPResponse
       def self.error: (::Integer, ::String) -> HTTPResponse

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/http_endpoint_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/http_endpoint_spec.rb
@@ -328,6 +328,41 @@ module ElasticGraph
         expect(response).to eq error_with("No query string was present")
       end
 
+      describe "with a custom body serializer block" do
+        it "passes the result hash to the block and uses its return value as the response body" do
+          captured = nil
+          custom_body = ::Object.new
+
+          response = process(
+            http_method: :post,
+            headers: {"Content-Type" => "application/json"},
+            body: ::JSON.generate("query" => "query { widgets { __typename } }")
+          ) do |result_hash|
+            captured = result_hash
+            custom_body
+          end
+
+          expect(response.status_code).to eq(200)
+          expect(response.headers).to include("Content-Type" => "application/json")
+          expect(response.body).to be(custom_body)
+          expect(captured).to eq("data" => {"widgets" => {"__typename" => "WidgetConnection"}})
+        end
+
+        it "does not invoke the block when the request fails before query execution" do
+          body_serializer = ::Kernel.method(:raise)
+
+          response = process(
+            http_method: :post,
+            headers: {"Content-Type" => "application/json"},
+            body: "not json",
+            &body_serializer
+          )
+
+          expect(response.status_code).to eq(400)
+          expect(::JSON.parse(response.body)).to eq error_with("Request body is invalid JSON.")
+        end
+      end
+
       def process_expecting(status_code, ...)
         response = process(...)
 
@@ -337,9 +372,9 @@ module ElasticGraph
         ::JSON.parse(response.body)
       end
 
-      def process(http_method:, url: "http://foo.test/bar", body: nil, headers: {}, extra_headers: {}, **options)
+      def process(http_method:, url: "http://foo.test/bar", body: nil, headers: {}, extra_headers: {}, **options, &block)
         request = HTTPRequest.new(url: url, http_method: http_method, body: body, headers: headers.merge(extra_headers))
-        graphql.graphql_http_endpoint.process(request, **options)
+        graphql.graphql_http_endpoint.process(request, **options, &block)
       end
 
       def error_with(message)

--- a/elasticgraph-rack/lib/elastic_graph/rack/graphql_endpoint.rb
+++ b/elasticgraph-rack/lib/elastic_graph/rack/graphql_endpoint.rb
@@ -23,15 +23,22 @@ module ElasticGraph
     #   run ElasticGraph::Rack::GraphQLEndpoint.new(graphql)
     class GraphQLEndpoint
       # @param graphql [ElasticGraph::GraphQL] ElasticGraph GraphQL instance
-      def initialize(graphql)
+      # @param body_serializer [#call, nil] optional callable invoked with the GraphQL result
+      #   hash; its return value is used as the response body. The body may be a `String` or
+      #   any object responding to `each` per the Rack body spec. Use this to bypass the
+      #   default `JSON.generate(result.to_h)` allocation by streaming the
+      #   result hash directly into the response output stream via a JSON encoder of your
+      #   choice. Errors and non-200 responses still produce a `String` body.
+      def initialize(graphql, body_serializer: nil)
         @logger = graphql.logger
         @graphql_http_endpoint = graphql.graphql_http_endpoint
+        @body_serializer = body_serializer
       end
 
       # Responds to a Rack request.
       #
       # @param env [Hash<String, Object>] Rack env
-      # @return [Array(Integer, Hash<String, String>, Array<String>)]
+      # @return [Array(Integer, Hash<String, String>, #each)]
       def call(env)
         rack_request = ::Rack::Request.new(env)
 
@@ -50,9 +57,17 @@ module ElasticGraph
           body: rack_request.body&.read
         )
 
-        response = @graphql_http_endpoint.process(request)
+        response =
+          if (body_serializer = @body_serializer)
+            @graphql_http_endpoint.process(request, &body_serializer)
+          else
+            @graphql_http_endpoint.process(request)
+          end
 
-        [response.status_code, response.headers.transform_keys(&:downcase), [response.body]]
+        body = response.body
+        rack_body = body.is_a?(::String) ? [body] : body
+
+        [response.status_code, response.headers.transform_keys(&:downcase), rack_body]
       rescue => e
         raise if ENV["RACK_ENV"] == "test"
 

--- a/elasticgraph-rack/sig/elastic_graph/rack/graphql_endpoint.rbs
+++ b/elasticgraph-rack/sig/elastic_graph/rack/graphql_endpoint.rbs
@@ -2,9 +2,10 @@ module ElasticGraph
   module Rack
     class GraphQLEndpoint
       include ::Rack::_Application
-      def initialize: (GraphQL) -> void
+      def initialize: (GraphQL, ?body_serializer: ^(::Hash[::String, untyped]) -> untyped | nil) -> void
       @logger: ::Logger
       @graphql_http_endpoint: GraphQL::HTTPEndpoint
+      @body_serializer: ^(::Hash[::String, untyped]) -> untyped | nil
     end
   end
 end

--- a/elasticgraph-rack/spec/acceptance/graphql_endpoint_spec.rb
+++ b/elasticgraph-rack/spec/acceptance/graphql_endpoint_spec.rb
@@ -11,6 +11,19 @@ require "elastic_graph/rack/graphql_endpoint"
 require "elastic_graph/constants"
 
 module ElasticGraph::Rack
+  # Minimal stand-in for a streaming JSON body. Real callers would write directly
+  # into a response output stream via their preferred encoder; this verifies only
+  # that the Rack adapter passes a non-String, `each`-responding body through.
+  class ChunkedJSONBody
+    def initialize(hash)
+      @hash = hash
+    end
+
+    def each
+      yield ::JSON.generate(@hash)
+    end
+  end
+
   RSpec.describe GraphQLEndpoint, :rack_app, :uses_datastore do
     let(:graphql) { build_graphql }
     let(:app_to_test) { GraphQLEndpoint.new(graphql) }
@@ -32,6 +45,30 @@ module ElasticGraph::Rack
       response = call_graphql_query(introspection_query)
 
       expect(response.dig("data", "__schema", "types").count).to be > 5
+    end
+
+    context "when configured with a custom body_serializer" do
+      let(:app_to_test) do
+        GraphQLEndpoint.new(graphql, body_serializer: lambda do |result_hash|
+          # Return a Rack-compatible streaming body (responds to `each` yielding String chunks)
+          # built without round-tripping the result through a single large `JSON.generate` String.
+          ChunkedJSONBody.new(result_hash)
+        end)
+      end
+
+      it "uses the custom body and passes its `each`-yielded chunks straight through to Rack" do
+        response = call_graphql_query(introspection_query)
+
+        expect(response.dig("data", "__schema", "types").count).to be > 5
+      end
+
+      it "still produces a String body for error responses" do
+        post_json "/", "not json"
+
+        expect(last_response.status).to eq 400
+        expect(last_response.body).to be_a(::String)
+        expect_json_error_including("invalid JSON")
+      end
     end
 
     it "supports executing queries submitted as a GET" do


### PR DESCRIPTION
## Summary

Adds an optional `body_serializer` callable to `HTTPEndpoint#process` and `Rack::GraphQLEndpoint`. When provided, it receives the GraphQL `result.to_h` hash and returns the response body — a `String`, or any object responding to `each` per the Rack body spec — so a host can write the result hash directly into the response output stream rather than going through the default `JSON.generate(result.to_h)` allocation.

## Motivation

For 200 responses today, `HTTPEndpoint#process` always builds the response body via:

```ruby
HTTPResponse.json(200, result.to_h)
# => HTTPResponse.new(..., ..., ::JSON.generate(result.to_h))
```

That allocates one large JSON `String` per request. Hosts that have a streaming JSON encoder and a writable response output stream available (for example, a Rack 3 host backed by a server that supports chunked writes) can skip that allocation entirely and emit the result hash straight onto the wire. This change exposes a single hook to do that, without changing any default behavior.

## Approach

- `HTTPEndpoint#process` now accepts an optional block. If given, the block is called with `result.to_h` and its return value becomes `HTTPResponse#body`. Without a block, behavior is identical to before — `JSON.generate(result.to_h)` String body.
- `Rack::GraphQLEndpoint.new(graphql, body_serializer: ...)` accepts the same callable and threads it through. The Rack adapter wraps a `String` body in the canonical one-element array (today's behavior) and passes any `each`-responding body straight through to Rack.
- `HTTPResponse#body` is documented to accept any value the calling adapter accepts. The `.json` and `.error` factories still always produce `String` bodies, so error paths and Lambda integrations are unaffected.

## What's intentionally left out

- No streaming-from-the-datastore. graphql-ruby's interpreter still builds the full `result.to_h` hash before the body callable runs; this PR only changes how that hash is turned into bytes on the wire.
- `@defer` / `@stream` (truly incremental responses) is a separate change.
- No new dependencies. Picking a streaming JSON encoder is left to the host.

## Test plan

- [ ] `script/run_gem_specs elasticgraph-graphql` (covers the new `HTTPEndpoint` block path)
- [ ] `script/run_gem_specs elasticgraph-rack` (covers the Rack adapter passing a non-String, `each`-responding body straight through)
- [ ] `script/lint`
- [ ] `script/type_check`

Lint and type-check pass locally; the spec runs require a booted test datastore which I'll verify in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)