### PR TITLE
Rename document_type_stored_in → document_types_stored_in returning Set

### DIFF
--- a/config/schema/artifacts/data_warehouse.yaml
+++ b/config/schema/artifacts/data_warehouse.yaml
@@ -38,6 +38,15 @@ tables:
         owner_ids ARRAY<STRING>,
         owner_id STRING
       )
+  distribution_channels:
+    table_schema: |-
+      CREATE TABLE IF NOT EXISTS distribution_channels (
+        id STRING,
+        established_on DATE,
+        active BOOLEAN,
+        name STRING,
+        __typename STRING
+      )
   electrical_parts:
     table_schema: |-
       CREATE TABLE IF NOT EXISTS electrical_parts (
@@ -70,6 +79,13 @@ tables:
         id STRING,
         name STRING,
         nationality STRING
+      )
+  physical_stores:
+    table_schema: |-
+      CREATE TABLE IF NOT EXISTS physical_stores (
+        id STRING,
+        established_on DATE,
+        active BOOLEAN
       )
   sponsors:
     table_schema: |-

--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -1618,6 +1618,35 @@ indices:
       index.number_of_replicas: 1
       index.number_of_shards: 1
       index.max_result_window: 10000
+  distribution_channels:
+    aliases: {}
+    mappings:
+      dynamic: strict
+      properties:
+        id:
+          type: keyword
+        established_on:
+          type: date
+          format: strict_date
+        active:
+          type: boolean
+        name:
+          type: keyword
+        __typename:
+          type: keyword
+        __sources:
+          type: keyword
+        __versions:
+          type: object
+          dynamic: 'false'
+      _size:
+        enabled: true
+    settings:
+      index.mapping.ignore_malformed: false
+      index.mapping.coerce: false
+      index.number_of_replicas: 1
+      index.number_of_shards: 1
+      index.max_result_window: 10000
   electrical_parts:
     aliases: {}
     mappings:
@@ -1720,6 +1749,31 @@ indices:
           type: keyword
         nationality:
           type: keyword
+        __sources:
+          type: keyword
+        __versions:
+          type: object
+          dynamic: 'false'
+      _size:
+        enabled: true
+    settings:
+      index.mapping.ignore_malformed: false
+      index.mapping.coerce: false
+      index.number_of_replicas: 1
+      index.number_of_shards: 1
+      index.max_result_window: 10000
+  physical_stores:
+    aliases: {}
+    mappings:
+      dynamic: strict
+      properties:
+        id:
+          type: keyword
+        established_on:
+          type: date
+          format: strict_date
+        active:
+          type: boolean
         __sources:
           type: keyword
         __versions:

--- a/config/schema/artifacts/json_schemas.yaml
+++ b/config/schema/artifacts/json_schemas.yaml
@@ -28,9 +28,12 @@ json_schema_version: 1
         - ElectricalPart
         - Manufacturer
         - MechanicalPart
+        - OnlineStore
         - Person
+        - PhysicalStore
         - Sponsor
         - Team
+        - ThirdPartyWholesale
         - Widget
         - WidgetWorkspace
       id:
@@ -445,6 +448,36 @@ json_schema_version: 1
     oneOf:
     - "$ref": "#/$defs/Person"
     - "$ref": "#/$defs/Company"
+  OnlineStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      name:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+      __typename:
+        type: string
+        const: OnlineStore
+        default: OnlineStore
+    required:
+    - id
+    - established_on
+    - active
+    - name
   Person:
     type: object
     properties:
@@ -472,6 +505,29 @@ json_schema_version: 1
     - id
     - name
     - nationality
+  PhysicalStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      __typename:
+        type: string
+        const: PhysicalStore
+        default: PhysicalStore
+    required:
+    - id
+    - established_on
+    - active
   Player:
     type: object
     properties:
@@ -819,6 +875,24 @@ json_schema_version: 1
     - was_shortened
     - players_nested
     - players_object
+  ThirdPartyWholesale:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      __typename:
+        type: string
+        const: ThirdPartyWholesale
+        default: ThirdPartyWholesale
+    required:
+    - id
+    - active
   Untyped:
     type:
     - array

--- a/config/schema/artifacts/json_schemas_by_version/v1.yaml
+++ b/config/schema/artifacts/json_schemas_by_version/v1.yaml
@@ -28,9 +28,12 @@ json_schema_version: 1
         - ElectricalPart
         - Manufacturer
         - MechanicalPart
+        - OnlineStore
         - Person
+        - PhysicalStore
         - Sponsor
         - Team
+        - ThirdPartyWholesale
         - Widget
         - WidgetWorkspace
       id:
@@ -565,6 +568,48 @@ json_schema_version: 1
     oneOf:
     - "$ref": "#/$defs/Person"
     - "$ref": "#/$defs/Company"
+  OnlineStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+        ElasticGraph:
+          type: ID!
+          nameInIndex: id
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+        ElasticGraph:
+          type: Date
+          nameInIndex: established_on
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: active
+      name:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+        ElasticGraph:
+          type: String
+          nameInIndex: name
+      __typename:
+        type: string
+        const: OnlineStore
+        default: OnlineStore
+    required:
+    - id
+    - established_on
+    - active
+    - name
   Person:
     type: object
     properties:
@@ -601,6 +646,38 @@ json_schema_version: 1
     - id
     - name
     - nationality
+  PhysicalStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+        ElasticGraph:
+          type: ID!
+          nameInIndex: id
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+        ElasticGraph:
+          type: Date
+          nameInIndex: established_on
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: active
+      __typename:
+        type: string
+        const: PhysicalStore
+        default: PhysicalStore
+    required:
+    - id
+    - established_on
+    - active
   Player:
     type: object
     properties:
@@ -1098,6 +1175,30 @@ json_schema_version: 1
     - was_shortened
     - players_nested
     - players_object
+  ThirdPartyWholesale:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+        ElasticGraph:
+          type: ID!
+          nameInIndex: id
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: active
+      __typename:
+        type: string
+        const: ThirdPartyWholesale
+        default: ThirdPartyWholesale
+    required:
+    - id
+    - active
   Untyped:
     type:
     - array

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -201,6 +201,32 @@ enum_types_by_name:
         datastore_abbreviation: nmi
       YARD:
         datastore_abbreviation: yd
+  DistributionChannelSortOrderInput:
+    values_by_name:
+      established_on_ASC:
+        sort_field:
+          direction: asc
+          field_path: established_on
+      established_on_DESC:
+        sort_field:
+          direction: desc
+          field_path: established_on
+      id_ASC:
+        sort_field:
+          direction: asc
+          field_path: id
+      id_DESC:
+        sort_field:
+          direction: desc
+          field_path: id
+      name_ASC:
+        sort_field:
+          direction: asc
+          field_path: name
+      name_DESC:
+        sort_field:
+          direction: desc
+          field_path: name
   ElectricalPartSortOrderInput:
     values_by_name:
       created_at_ASC:
@@ -897,8 +923,78 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: nationality
+  PhysicalStoreSortOrderInput:
+    values_by_name:
+      established_on_ASC:
+        sort_field:
+          direction: asc
+          field_path: established_on
+      established_on_DESC:
+        sort_field:
+          direction: desc
+          field_path: established_on
+      id_ASC:
+        sort_field:
+          direction: asc
+          field_path: id
+      id_DESC:
+        sort_field:
+          direction: desc
+          field_path: id
+  RetailSortOrderInput:
+    values_by_name:
+      established_on_ASC:
+        sort_field:
+          direction: asc
+          field_path: established_on
+      established_on_DESC:
+        sort_field:
+          direction: desc
+          field_path: established_on
+      id_ASC:
+        sort_field:
+          direction: asc
+          field_path: id
+      id_DESC:
+        sort_field:
+          direction: desc
+          field_path: id
+      name_ASC:
+        sort_field:
+          direction: asc
+          field_path: name
+      name_DESC:
+        sort_field:
+          direction: desc
+          field_path: name
   SponsorSortOrderInput:
     values_by_name:
+      id_ASC:
+        sort_field:
+          direction: asc
+          field_path: id
+      id_DESC:
+        sort_field:
+          direction: desc
+          field_path: id
+      name_ASC:
+        sort_field:
+          direction: asc
+          field_path: name
+      name_DESC:
+        sort_field:
+          direction: desc
+          field_path: name
+  StoreSortOrderInput:
+    values_by_name:
+      established_on_ASC:
+        sort_field:
+          direction: asc
+          field_path: established_on
+      established_on_DESC:
+        sort_field:
+          direction: desc
+          field_path: established_on
       id_ASC:
         sort_field:
           direction: asc
@@ -1833,6 +1929,19 @@ index_definitions_by_name:
         source: widget
     has_had_multiple_sources: true
     route_with: id
+  distribution_channels:
+    current_sources:
+    - __self
+    fields_by_path:
+      active:
+        source: __self
+      established_on:
+        source: __self
+      id:
+        source: __self
+      name:
+        source: __self
+    route_with: id
   electrical_parts:
     current_sources:
     - __self
@@ -1898,6 +2007,17 @@ index_definitions_by_name:
       name:
         source: __self
       nationality:
+        source: __self
+    route_with: id
+  physical_stores:
+    current_sources:
+    - __self
+    fields_by_path:
+      active:
+        source: __self
+      established_on:
+        source: __self
+      id:
         source: __self
     route_with: id
   sponsors:
@@ -3685,6 +3805,119 @@ object_types_by_name:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  DistributionChannel:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      name:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+  DistributionChannelAggregatedValues:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      id:
+        resolver:
+          name: object_with_lookahead
+      name:
+        resolver:
+          name: object_with_lookahead
+  DistributionChannelAggregation:
+    elasticgraph_category: indexed_aggregation
+    graphql_fields_by_name:
+      aggregated_values:
+        resolver:
+          name: object_without_lookahead
+      count:
+        resolver:
+          name: object_without_lookahead
+      grouped_by:
+        resolver:
+          name: object_without_lookahead
+    source_type: DistributionChannel
+  DistributionChannelAggregationConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+  DistributionChannelAggregationEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  DistributionChannelConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+      total_edge_count:
+        resolver:
+          name: object_without_lookahead
+  DistributionChannelEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      all_highlights:
+        resolver:
+          name: object_without_lookahead
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      highlights:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  DistributionChannelGroupedBy:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      name:
+        resolver:
+          name: object_with_lookahead
+  DistributionChannelHighlights:
+    graphql_fields_by_name:
+      id:
+        resolver:
+          name: get_record_field_value
+      name:
+        resolver:
+          name: get_record_field_value
   ElectricalPart:
     graphql_fields_by_name:
       component_aggregations:
@@ -5301,6 +5534,48 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
     graphql_only_return_type: true
+  OnlineStore:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      name:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+    update_targets:
+    - data_params:
+        __typename:
+          cardinality: one
+        active:
+          cardinality: one
+        established_on:
+          cardinality: one
+        name:
+          cardinality: one
+      id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      routing_value_source: id
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      type: OnlineStore
   PageInfo:
     graphql_fields_by_name:
       end_cursor:
@@ -5586,6 +5861,129 @@ object_types_by_name:
       nationality:
         resolver:
           name: get_record_field_value
+  PhysicalStore:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - physical_stores
+    update_targets:
+    - data_params:
+        active:
+          cardinality: one
+        established_on:
+          cardinality: one
+      id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      routing_value_source: id
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      type: PhysicalStore
+  PhysicalStoreAggregatedValues:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      id:
+        resolver:
+          name: object_with_lookahead
+  PhysicalStoreAggregation:
+    elasticgraph_category: indexed_aggregation
+    graphql_fields_by_name:
+      aggregated_values:
+        resolver:
+          name: object_without_lookahead
+      count:
+        resolver:
+          name: object_without_lookahead
+      grouped_by:
+        resolver:
+          name: object_without_lookahead
+    source_type: PhysicalStore
+  PhysicalStoreAggregationConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+  PhysicalStoreAggregationEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  PhysicalStoreConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+      total_edge_count:
+        resolver:
+          name: object_without_lookahead
+  PhysicalStoreEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      all_highlights:
+        resolver:
+          name: object_without_lookahead
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      highlights:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  PhysicalStoreGroupedBy:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+  PhysicalStoreHighlights:
+    graphql_fields_by_name:
+      id:
+        resolver:
+          name: get_record_field_value
   Player:
     graphql_fields_by_name:
       affiliations:
@@ -5740,6 +6138,12 @@ object_types_by_name:
       components:
         resolver:
           name: list_records
+      distribution_channel_aggregations:
+        resolver:
+          name: list_records
+      distribution_channels:
+        resolver:
+          name: list_records
       electrical_part_aggregations:
         resolver:
           name: list_records
@@ -5788,10 +6192,28 @@ object_types_by_name:
       person_aggregations:
         resolver:
           name: list_records
+      physical_store_aggregations:
+        resolver:
+          name: list_records
+      physical_stores:
+        resolver:
+          name: list_records
+      retail_aggregations:
+        resolver:
+          name: list_records
+      retailers:
+        resolver:
+          name: list_records
       sponsor_aggregations:
         resolver:
           name: list_records
       sponsors:
+        resolver:
+          name: list_records
+      store_aggregations:
+        resolver:
+          name: list_records
+      stores:
         resolver:
           name: list_records
       team_aggregations:
@@ -5824,6 +6246,119 @@ object_types_by_name:
       widgets_or_addresses:
         resolver:
           name: list_records
+  Retail:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      name:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+  RetailAggregatedValues:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      id:
+        resolver:
+          name: object_with_lookahead
+      name:
+        resolver:
+          name: object_with_lookahead
+  RetailAggregation:
+    elasticgraph_category: indexed_aggregation
+    graphql_fields_by_name:
+      aggregated_values:
+        resolver:
+          name: object_without_lookahead
+      count:
+        resolver:
+          name: object_without_lookahead
+      grouped_by:
+        resolver:
+          name: object_without_lookahead
+    source_type: Retail
+  RetailAggregationConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+  RetailAggregationEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  RetailConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+      total_edge_count:
+        resolver:
+          name: object_without_lookahead
+  RetailEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      all_highlights:
+        resolver:
+          name: object_without_lookahead
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      highlights:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  RetailGroupedBy:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      name:
+        resolver:
+          name: object_with_lookahead
+  RetailHighlights:
+    graphql_fields_by_name:
+      id:
+        resolver:
+          name: get_record_field_value
+      name:
+        resolver:
+          name: get_record_field_value
   SearchHighlight:
     graphql_fields_by_name:
       path:
@@ -6022,6 +6557,119 @@ object_types_by_name:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  Store:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      name:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+  StoreAggregatedValues:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      id:
+        resolver:
+          name: object_with_lookahead
+      name:
+        resolver:
+          name: object_with_lookahead
+  StoreAggregation:
+    elasticgraph_category: indexed_aggregation
+    graphql_fields_by_name:
+      aggregated_values:
+        resolver:
+          name: object_without_lookahead
+      count:
+        resolver:
+          name: object_without_lookahead
+      grouped_by:
+        resolver:
+          name: object_without_lookahead
+    source_type: Store
+  StoreAggregationConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+  StoreAggregationEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  StoreConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+      total_edge_count:
+        resolver:
+          name: object_without_lookahead
+  StoreEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      all_highlights:
+        resolver:
+          name: object_without_lookahead
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      highlights:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  StoreGroupedBy:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      name:
+        resolver:
+          name: object_with_lookahead
+  StoreHighlights:
+    graphql_fields_by_name:
+      id:
+        resolver:
+          name: get_record_field_value
+      name:
+        resolver:
+          name: get_record_field_value
   StringConnection:
     elasticgraph_category: relay_connection
     graphql_fields_by_name:
@@ -6955,6 +7603,38 @@ object_types_by_name:
       players_object:
         resolver:
           name: object_with_lookahead
+  ThirdPartyWholesale:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+    update_targets:
+    - data_params:
+        __typename:
+          cardinality: one
+        active:
+          cardinality: one
+      id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      routing_value_source: id
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      type: ThirdPartyWholesale
   Widget:
     graphql_fields_by_name:
       amount_cents:

--- a/config/schema/artifacts/schema.graphql
+++ b/config/schema/artifacts/schema.graphql
@@ -2794,6 +2794,292 @@ enum DistanceUnitInput {
   YARD
 }
 
+interface DistributionChannel {
+  active: Boolean
+  id: ID!
+}
+
+"""
+Type used to perform aggregation computations on `DistributionChannel` fields.
+"""
+type DistributionChannelAggregatedValues {
+  """
+  Computed aggregate values for the `active` field.
+  """
+  active: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `established_on` field.
+  """
+  established_on: DateAggregatedValues
+
+  """
+  Computed aggregate values for the `id` field.
+  """
+  id: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `name` field.
+  """
+  name: NonNumericAggregatedValues
+}
+
+"""
+Return type representing a bucket of `DistributionChannel` documents for an aggregations query.
+"""
+type DistributionChannelAggregation {
+  """
+  Provides computed aggregated values over all `DistributionChannel` documents in an aggregation bucket.
+  """
+  aggregated_values: DistributionChannelAggregatedValues
+
+  """
+  The count of `DistributionChannel` documents in an aggregation bucket.
+  """
+  count: JsonSafeLong!
+
+  """
+  Used to specify the `DistributionChannel` fields to group by. The returned values identify each aggregation bucket.
+  """
+  grouped_by: DistributionChannelGroupedBy
+}
+
+"""
+Represents a paginated collection of `DistributionChannelAggregation` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type DistributionChannelAggregationConnection {
+  """
+  Wraps a specific `DistributionChannelAggregation` to pair it with its pagination cursor.
+  """
+  edges: [DistributionChannelAggregationEdge!]!
+
+  """
+  The list of `DistributionChannelAggregation` results.
+  """
+  nodes: [DistributionChannelAggregation!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+}
+
+"""
+Represents a specific `DistributionChannelAggregation` in the context of a `DistributionChannelAggregationConnection`,
+providing access to both the `DistributionChannelAggregation` and query-specific
+information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type DistributionChannelAggregationEdge {
+  """
+  The `Cursor` of this `DistributionChannelAggregation`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `DistributionChannelAggregation`.
+  """
+  cursor: Cursor
+
+  """
+  The `DistributionChannelAggregation` of this edge.
+  """
+  node: DistributionChannelAggregation
+}
+
+"""
+Represents a paginated collection of `DistributionChannel` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type DistributionChannelConnection {
+  """
+  Wraps a specific `DistributionChannel` to pair it with its pagination cursor.
+  """
+  edges: [DistributionChannelEdge!]!
+
+  """
+  The list of `DistributionChannel` results.
+  """
+  nodes: [DistributionChannel!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+
+  """
+  The total number of edges available in this connection to paginate over.
+  """
+  total_edge_count: JsonSafeLong!
+}
+
+"""
+Represents a specific `DistributionChannel` in the context of a `DistributionChannelConnection`,
+providing access to both the `DistributionChannel` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type DistributionChannelEdge {
+  """
+  All search highlights for this `DistributionChannel`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
+  The `Cursor` of this `DistributionChannel`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `DistributionChannel`.
+  """
+  cursor: Cursor
+
+  """
+  Specific search highlights for this `DistributionChannel`, providing matching snippets for the requested fields.
+  """
+  highlights: DistributionChannelHighlights
+
+  """
+  The `DistributionChannel` of this edge.
+  """
+  node: DistributionChannel
+}
+
+"""
+Input type used to specify filters on `DistributionChannel` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input DistributionChannelFilterInput {
+  """
+  Used to filter on the `active` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  active: BooleanFilterInput
+
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `DistributionChannelFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [DistributionChannelFilterInput!]
+
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [DistributionChannelFilterInput!]
+
+  """
+  Used to filter on the `established_on` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  established_on: DateFilterInput
+
+  """
+  Used to filter on the `id` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  id: IDFilterInput
+
+  """
+  Used to filter on the `name` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  name: StringFilterInput
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: DistributionChannelFilterInput
+}
+
+"""
+Type used to specify the `DistributionChannel` fields to group by for aggregations.
+"""
+type DistributionChannelGroupedBy {
+  """
+  The `active` field value for this group.
+  """
+  active: Boolean
+
+  """
+  Offers the different grouping options for the `established_on` value within this group.
+  """
+  established_on: DateGroupedBy
+
+  """
+  The `name` field value for this group.
+  """
+  name: String
+}
+
+"""
+Type used to request desired `DistributionChannel` search highlight fields.
+"""
+type DistributionChannelHighlights {
+  """
+  Search highlights for the `id`, providing snippets of the matching text.
+  """
+  id: [String!]!
+
+  """
+  Search highlights for the `name`, providing snippets of the matching text.
+  """
+  name: [String!]!
+}
+
+"""
+Enumerates the ways `DistributionChannel`s can be sorted.
+"""
+enum DistributionChannelSortOrderInput {
+  """
+  Sorts ascending by the `established_on` field.
+  """
+  established_on_ASC
+
+  """
+  Sorts descending by the `established_on` field.
+  """
+  established_on_DESC
+
+  """
+  Sorts ascending by the `id` field.
+  """
+  id_ASC
+
+  """
+  Sorts descending by the `id` field.
+  """
+  id_DESC
+
+  """
+  Sorts ascending by the `name` field.
+  """
+  name_ASC
+
+  """
+  Sorts descending by the `name` field.
+  """
+  name_DESC
+}
+
 type ElectricalPart implements NamedEntity {
   """
   Aggregations over the `components` data.
@@ -7771,6 +8057,13 @@ type NonNumericAggregatedValues {
   approximate_distinct_value_count: JsonSafeLong
 }
 
+type OnlineStore implements DistributionChannel & Retail & Store {
+  active: Boolean
+  established_on: Date
+  id: ID!
+  name: String
+}
+
 """
 Provides information about the specific fetched page. This implements the `PageInfo`
 specification from the [Relay GraphQL Cursor Connections
@@ -8396,6 +8689,260 @@ enum PersonSortOrderInput {
   Sorts descending by the `nationality` field.
   """
   nationality_DESC
+}
+
+type PhysicalStore implements DistributionChannel & Retail & Store {
+  active: Boolean
+  established_on: Date
+  id: ID!
+}
+
+"""
+Type used to perform aggregation computations on `PhysicalStore` fields.
+"""
+type PhysicalStoreAggregatedValues {
+  """
+  Computed aggregate values for the `active` field.
+  """
+  active: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `established_on` field.
+  """
+  established_on: DateAggregatedValues
+
+  """
+  Computed aggregate values for the `id` field.
+  """
+  id: NonNumericAggregatedValues
+}
+
+"""
+Return type representing a bucket of `PhysicalStore` documents for an aggregations query.
+"""
+type PhysicalStoreAggregation {
+  """
+  Provides computed aggregated values over all `PhysicalStore` documents in an aggregation bucket.
+  """
+  aggregated_values: PhysicalStoreAggregatedValues
+
+  """
+  The count of `PhysicalStore` documents in an aggregation bucket.
+  """
+  count: JsonSafeLong!
+
+  """
+  Used to specify the `PhysicalStore` fields to group by. The returned values identify each aggregation bucket.
+  """
+  grouped_by: PhysicalStoreGroupedBy
+}
+
+"""
+Represents a paginated collection of `PhysicalStoreAggregation` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type PhysicalStoreAggregationConnection {
+  """
+  Wraps a specific `PhysicalStoreAggregation` to pair it with its pagination cursor.
+  """
+  edges: [PhysicalStoreAggregationEdge!]!
+
+  """
+  The list of `PhysicalStoreAggregation` results.
+  """
+  nodes: [PhysicalStoreAggregation!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+}
+
+"""
+Represents a specific `PhysicalStoreAggregation` in the context of a `PhysicalStoreAggregationConnection`,
+providing access to both the `PhysicalStoreAggregation` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type PhysicalStoreAggregationEdge {
+  """
+  The `Cursor` of this `PhysicalStoreAggregation`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `PhysicalStoreAggregation`.
+  """
+  cursor: Cursor
+
+  """
+  The `PhysicalStoreAggregation` of this edge.
+  """
+  node: PhysicalStoreAggregation
+}
+
+"""
+Represents a paginated collection of `PhysicalStore` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type PhysicalStoreConnection {
+  """
+  Wraps a specific `PhysicalStore` to pair it with its pagination cursor.
+  """
+  edges: [PhysicalStoreEdge!]!
+
+  """
+  The list of `PhysicalStore` results.
+  """
+  nodes: [PhysicalStore!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+
+  """
+  The total number of edges available in this connection to paginate over.
+  """
+  total_edge_count: JsonSafeLong!
+}
+
+"""
+Represents a specific `PhysicalStore` in the context of a `PhysicalStoreConnection`,
+providing access to both the `PhysicalStore` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type PhysicalStoreEdge {
+  """
+  All search highlights for this `PhysicalStore`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
+  The `Cursor` of this `PhysicalStore`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `PhysicalStore`.
+  """
+  cursor: Cursor
+
+  """
+  Specific search highlights for this `PhysicalStore`, providing matching snippets for the requested fields.
+  """
+  highlights: PhysicalStoreHighlights
+
+  """
+  The `PhysicalStore` of this edge.
+  """
+  node: PhysicalStore
+}
+
+"""
+Input type used to specify filters on `PhysicalStore` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input PhysicalStoreFilterInput {
+  """
+  Used to filter on the `active` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  active: BooleanFilterInput
+
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `PhysicalStoreFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [PhysicalStoreFilterInput!]
+
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [PhysicalStoreFilterInput!]
+
+  """
+  Used to filter on the `established_on` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  established_on: DateFilterInput
+
+  """
+  Used to filter on the `id` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  id: IDFilterInput
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: PhysicalStoreFilterInput
+}
+
+"""
+Type used to specify the `PhysicalStore` fields to group by for aggregations.
+"""
+type PhysicalStoreGroupedBy {
+  """
+  The `active` field value for this group.
+  """
+  active: Boolean
+
+  """
+  Offers the different grouping options for the `established_on` value within this group.
+  """
+  established_on: DateGroupedBy
+}
+
+"""
+Type used to request desired `PhysicalStore` search highlight fields.
+"""
+type PhysicalStoreHighlights {
+  """
+  Search highlights for the `id`, providing snippets of the matching text.
+  """
+  id: [String!]!
+}
+
+"""
+Enumerates the ways `PhysicalStore`s can be sorted.
+"""
+enum PhysicalStoreSortOrderInput {
+  """
+  Sorts ascending by the `established_on` field.
+  """
+  established_on_ASC
+
+  """
+  Sorts descending by the `established_on` field.
+  """
+  established_on_DESC
+
+  """
+  Sorts ascending by the `id` field.
+  """
+  id_ASC
+
+  """
+  Sorts descending by the `id` field.
+  """
+  id_DESC
 }
 
 type Player {
@@ -9350,6 +9897,109 @@ type Query {
   ): ComponentConnection
 
   """
+  Aggregations over the `distribution_channels` data:
+
+  > Fetches `DistributionChannel`s based on the provided arguments.
+  """
+  distribution_channel_aggregations(
+    """
+    Used to forward-paginate through the `distribution_channel_aggregations`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `distribution_channel_aggregations`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the `DistributionChannel` documents that get aggregated over based on the provided criteria.
+    """
+    filter: DistributionChannelFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `distribution_channel_aggregations`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `distribution_channel_aggregations`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `distribution_channel_aggregations`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `distribution_channel_aggregations`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+  ): DistributionChannelAggregationConnection
+
+  """
+  Fetches `DistributionChannel`s based on the provided arguments.
+  """
+  distribution_channels(
+    """
+    Used to forward-paginate through the `distribution_channels`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `distribution_channels`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the returned `distribution_channels` based on the provided criteria.
+    """
+    filter: DistributionChannelFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `distribution_channels`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `distribution_channels`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `distribution_channels`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `distribution_channels`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+
+    """
+    Used to specify how the returned `distribution_channels` should be sorted.
+    """
+    order_by: [DistributionChannelSortOrderInput!]
+  ): DistributionChannelConnection
+
+  """
   Aggregations over the `electrical_parts` data:
 
   > Fetches `ElectricalPart`s based on the provided arguments.
@@ -10174,6 +10824,212 @@ type Query {
   ): PersonAggregationConnection
 
   """
+  Aggregations over the `physical_stores` data:
+
+  > Fetches `PhysicalStore`s based on the provided arguments.
+  """
+  physical_store_aggregations(
+    """
+    Used to forward-paginate through the `physical_store_aggregations`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `physical_store_aggregations`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the `PhysicalStore` documents that get aggregated over based on the provided criteria.
+    """
+    filter: PhysicalStoreFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `physical_store_aggregations`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `physical_store_aggregations`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `physical_store_aggregations`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `physical_store_aggregations`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+  ): PhysicalStoreAggregationConnection
+
+  """
+  Fetches `PhysicalStore`s based on the provided arguments.
+  """
+  physical_stores(
+    """
+    Used to forward-paginate through the `physical_stores`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `physical_stores`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the returned `physical_stores` based on the provided criteria.
+    """
+    filter: PhysicalStoreFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `physical_stores`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `physical_stores`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `physical_stores`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `physical_stores`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+
+    """
+    Used to specify how the returned `physical_stores` should be sorted.
+    """
+    order_by: [PhysicalStoreSortOrderInput!]
+  ): PhysicalStoreConnection
+
+  """
+  Aggregations over the `retailers` data:
+
+  > Fetches `Retail`s based on the provided arguments.
+  """
+  retail_aggregations(
+    """
+    Used to forward-paginate through the `retail_aggregations`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `retail_aggregations`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the `Retail` documents that get aggregated over based on the provided criteria.
+    """
+    filter: RetailFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `retail_aggregations`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `retail_aggregations`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `retail_aggregations`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `retail_aggregations`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+  ): RetailAggregationConnection
+
+  """
+  Fetches `Retail`s based on the provided arguments.
+  """
+  retailers(
+    """
+    Used to forward-paginate through the `retailers`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `retailers`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the returned `retailers` based on the provided criteria.
+    """
+    filter: RetailFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `retailers`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `retailers`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `retailers`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `retailers`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+
+    """
+    Used to specify how the returned `retailers` should be sorted.
+    """
+    order_by: [RetailSortOrderInput!]
+  ): RetailConnection
+
+  """
   Aggregations over the `sponsors` data:
 
   > Fetches `Sponsor`s based on the provided arguments.
@@ -10275,6 +11131,109 @@ type Query {
     """
     order_by: [SponsorSortOrderInput!]
   ): SponsorConnection
+
+  """
+  Aggregations over the `stores` data:
+
+  > Fetches `Store`s based on the provided arguments.
+  """
+  store_aggregations(
+    """
+    Used to forward-paginate through the `store_aggregations`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `store_aggregations`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the `Store` documents that get aggregated over based on the provided criteria.
+    """
+    filter: StoreFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `store_aggregations`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `store_aggregations`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `store_aggregations`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `store_aggregations`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+  ): StoreAggregationConnection
+
+  """
+  Fetches `Store`s based on the provided arguments.
+  """
+  stores(
+    """
+    Used to forward-paginate through the `stores`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `stores`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the returned `stores` based on the provided criteria.
+    """
+    filter: StoreFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `stores`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `stores`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `stores`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `stores`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+
+    """
+    Used to specify how the returned `stores` should be sorted.
+    """
+    order_by: [StoreSortOrderInput!]
+  ): StoreConnection
 
   """
   Aggregations over the `teams` data:
@@ -10795,6 +11754,292 @@ type Query {
     """
     order_by: [WidgetOrAddressSortOrderInput!]
   ): WidgetOrAddressConnection
+}
+
+interface Retail implements DistributionChannel {
+  active: Boolean
+  established_on: Date
+  id: ID!
+}
+
+"""
+Type used to perform aggregation computations on `Retail` fields.
+"""
+type RetailAggregatedValues {
+  """
+  Computed aggregate values for the `active` field.
+  """
+  active: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `established_on` field.
+  """
+  established_on: DateAggregatedValues
+
+  """
+  Computed aggregate values for the `id` field.
+  """
+  id: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `name` field.
+  """
+  name: NonNumericAggregatedValues
+}
+
+"""
+Return type representing a bucket of `Retail` documents for an aggregations query.
+"""
+type RetailAggregation {
+  """
+  Provides computed aggregated values over all `Retail` documents in an aggregation bucket.
+  """
+  aggregated_values: RetailAggregatedValues
+
+  """
+  The count of `Retail` documents in an aggregation bucket.
+  """
+  count: JsonSafeLong!
+
+  """
+  Used to specify the `Retail` fields to group by. The returned values identify each aggregation bucket.
+  """
+  grouped_by: RetailGroupedBy
+}
+
+"""
+Represents a paginated collection of `RetailAggregation` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type RetailAggregationConnection {
+  """
+  Wraps a specific `RetailAggregation` to pair it with its pagination cursor.
+  """
+  edges: [RetailAggregationEdge!]!
+
+  """
+  The list of `RetailAggregation` results.
+  """
+  nodes: [RetailAggregation!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+}
+
+"""
+Represents a specific `RetailAggregation` in the context of a `RetailAggregationConnection`,
+providing access to both the `RetailAggregation` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type RetailAggregationEdge {
+  """
+  The `Cursor` of this `RetailAggregation`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `RetailAggregation`.
+  """
+  cursor: Cursor
+
+  """
+  The `RetailAggregation` of this edge.
+  """
+  node: RetailAggregation
+}
+
+"""
+Represents a paginated collection of `Retail` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type RetailConnection {
+  """
+  Wraps a specific `Retail` to pair it with its pagination cursor.
+  """
+  edges: [RetailEdge!]!
+
+  """
+  The list of `Retail` results.
+  """
+  nodes: [Retail!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+
+  """
+  The total number of edges available in this connection to paginate over.
+  """
+  total_edge_count: JsonSafeLong!
+}
+
+"""
+Represents a specific `Retail` in the context of a `RetailConnection`,
+providing access to both the `Retail` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type RetailEdge {
+  """
+  All search highlights for this `Retail`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
+  The `Cursor` of this `Retail`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `Retail`.
+  """
+  cursor: Cursor
+
+  """
+  Specific search highlights for this `Retail`, providing matching snippets for the requested fields.
+  """
+  highlights: RetailHighlights
+
+  """
+  The `Retail` of this edge.
+  """
+  node: Retail
+}
+
+"""
+Input type used to specify filters on `Retail` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input RetailFilterInput {
+  """
+  Used to filter on the `active` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  active: BooleanFilterInput
+
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `RetailFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [RetailFilterInput!]
+
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [RetailFilterInput!]
+
+  """
+  Used to filter on the `established_on` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  established_on: DateFilterInput
+
+  """
+  Used to filter on the `id` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  id: IDFilterInput
+
+  """
+  Used to filter on the `name` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  name: StringFilterInput
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: RetailFilterInput
+}
+
+"""
+Type used to specify the `Retail` fields to group by for aggregations.
+"""
+type RetailGroupedBy {
+  """
+  The `active` field value for this group.
+  """
+  active: Boolean
+
+  """
+  Offers the different grouping options for the `established_on` value within this group.
+  """
+  established_on: DateGroupedBy
+
+  """
+  The `name` field value for this group.
+  """
+  name: String
+}
+
+"""
+Type used to request desired `Retail` search highlight fields.
+"""
+type RetailHighlights {
+  """
+  Search highlights for the `id`, providing snippets of the matching text.
+  """
+  id: [String!]!
+
+  """
+  Search highlights for the `name`, providing snippets of the matching text.
+  """
+  name: [String!]!
+}
+
+"""
+Enumerates the ways `Retail`s can be sorted.
+"""
+enum RetailSortOrderInput {
+  """
+  Sorts ascending by the `established_on` field.
+  """
+  established_on_ASC
+
+  """
+  Sorts descending by the `established_on` field.
+  """
+  established_on_DESC
+
+  """
+  Sorts ascending by the `id` field.
+  """
+  id_ASC
+
+  """
+  Sorts descending by the `id` field.
+  """
+  id_DESC
+
+  """
+  Sorts ascending by the `name` field.
+  """
+  name_ASC
+
+  """
+  Sorts descending by the `name` field.
+  """
+  name_DESC
 }
 
 """
@@ -11606,6 +12851,292 @@ input SponsorshipListFilterInput {
   When `null` or an empty object is passed, matches no documents.
   """
   not: SponsorshipListFilterInput
+}
+
+interface Store implements DistributionChannel & Retail {
+  active: Boolean
+  established_on: Date
+  id: ID!
+}
+
+"""
+Type used to perform aggregation computations on `Store` fields.
+"""
+type StoreAggregatedValues {
+  """
+  Computed aggregate values for the `active` field.
+  """
+  active: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `established_on` field.
+  """
+  established_on: DateAggregatedValues
+
+  """
+  Computed aggregate values for the `id` field.
+  """
+  id: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `name` field.
+  """
+  name: NonNumericAggregatedValues
+}
+
+"""
+Return type representing a bucket of `Store` documents for an aggregations query.
+"""
+type StoreAggregation {
+  """
+  Provides computed aggregated values over all `Store` documents in an aggregation bucket.
+  """
+  aggregated_values: StoreAggregatedValues
+
+  """
+  The count of `Store` documents in an aggregation bucket.
+  """
+  count: JsonSafeLong!
+
+  """
+  Used to specify the `Store` fields to group by. The returned values identify each aggregation bucket.
+  """
+  grouped_by: StoreGroupedBy
+}
+
+"""
+Represents a paginated collection of `StoreAggregation` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type StoreAggregationConnection {
+  """
+  Wraps a specific `StoreAggregation` to pair it with its pagination cursor.
+  """
+  edges: [StoreAggregationEdge!]!
+
+  """
+  The list of `StoreAggregation` results.
+  """
+  nodes: [StoreAggregation!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+}
+
+"""
+Represents a specific `StoreAggregation` in the context of a `StoreAggregationConnection`,
+providing access to both the `StoreAggregation` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type StoreAggregationEdge {
+  """
+  The `Cursor` of this `StoreAggregation`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `StoreAggregation`.
+  """
+  cursor: Cursor
+
+  """
+  The `StoreAggregation` of this edge.
+  """
+  node: StoreAggregation
+}
+
+"""
+Represents a paginated collection of `Store` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type StoreConnection {
+  """
+  Wraps a specific `Store` to pair it with its pagination cursor.
+  """
+  edges: [StoreEdge!]!
+
+  """
+  The list of `Store` results.
+  """
+  nodes: [Store!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+
+  """
+  The total number of edges available in this connection to paginate over.
+  """
+  total_edge_count: JsonSafeLong!
+}
+
+"""
+Represents a specific `Store` in the context of a `StoreConnection`,
+providing access to both the `Store` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type StoreEdge {
+  """
+  All search highlights for this `Store`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
+  The `Cursor` of this `Store`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `Store`.
+  """
+  cursor: Cursor
+
+  """
+  Specific search highlights for this `Store`, providing matching snippets for the requested fields.
+  """
+  highlights: StoreHighlights
+
+  """
+  The `Store` of this edge.
+  """
+  node: Store
+}
+
+"""
+Input type used to specify filters on `Store` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input StoreFilterInput {
+  """
+  Used to filter on the `active` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  active: BooleanFilterInput
+
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `StoreFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [StoreFilterInput!]
+
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [StoreFilterInput!]
+
+  """
+  Used to filter on the `established_on` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  established_on: DateFilterInput
+
+  """
+  Used to filter on the `id` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  id: IDFilterInput
+
+  """
+  Used to filter on the `name` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  name: StringFilterInput
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: StoreFilterInput
+}
+
+"""
+Type used to specify the `Store` fields to group by for aggregations.
+"""
+type StoreGroupedBy {
+  """
+  The `active` field value for this group.
+  """
+  active: Boolean
+
+  """
+  Offers the different grouping options for the `established_on` value within this group.
+  """
+  established_on: DateGroupedBy
+
+  """
+  The `name` field value for this group.
+  """
+  name: String
+}
+
+"""
+Type used to request desired `Store` search highlight fields.
+"""
+type StoreHighlights {
+  """
+  Search highlights for the `id`, providing snippets of the matching text.
+  """
+  id: [String!]!
+
+  """
+  Search highlights for the `name`, providing snippets of the matching text.
+  """
+  name: [String!]!
+}
+
+"""
+Enumerates the ways `Store`s can be sorted.
+"""
+enum StoreSortOrderInput {
+  """
+  Sorts ascending by the `established_on` field.
+  """
+  established_on_ASC
+
+  """
+  Sorts descending by the `established_on` field.
+  """
+  established_on_DESC
+
+  """
+  Sorts ascending by the `id` field.
+  """
+  id_ASC
+
+  """
+  Sorts descending by the `id` field.
+  """
+  id_DESC
+
+  """
+  Sorts ascending by the `name` field.
+  """
+  name_ASC
+
+  """
+  Sorts descending by the `name` field.
+  """
+  name_DESC
 }
 
 """
@@ -14158,6 +15689,11 @@ input TextFilterInput {
   When `null` or an empty object is passed, matches no documents.
   """
   not: TextFilterInput
+}
+
+type ThirdPartyWholesale implements DistributionChannel {
+  active: Boolean
+  id: ID!
 }
 
 """

--- a/config/schema/artifacts_with_apollo/data_warehouse.yaml
+++ b/config/schema/artifacts_with_apollo/data_warehouse.yaml
@@ -38,6 +38,15 @@ tables:
         owner_ids ARRAY<STRING>,
         owner_id STRING
       )
+  distribution_channels:
+    table_schema: |-
+      CREATE TABLE IF NOT EXISTS distribution_channels (
+        id STRING,
+        established_on DATE,
+        active BOOLEAN,
+        name STRING,
+        __typename STRING
+      )
   electrical_parts:
     table_schema: |-
       CREATE TABLE IF NOT EXISTS electrical_parts (
@@ -70,6 +79,13 @@ tables:
         id STRING,
         name STRING,
         nationality STRING
+      )
+  physical_stores:
+    table_schema: |-
+      CREATE TABLE IF NOT EXISTS physical_stores (
+        id STRING,
+        established_on DATE,
+        active BOOLEAN
       )
   sponsors:
     table_schema: |-

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -1618,6 +1618,35 @@ indices:
       index.number_of_replicas: 1
       index.number_of_shards: 1
       index.max_result_window: 10000
+  distribution_channels:
+    aliases: {}
+    mappings:
+      dynamic: strict
+      properties:
+        id:
+          type: keyword
+        established_on:
+          type: date
+          format: strict_date
+        active:
+          type: boolean
+        name:
+          type: keyword
+        __typename:
+          type: keyword
+        __sources:
+          type: keyword
+        __versions:
+          type: object
+          dynamic: 'false'
+      _size:
+        enabled: true
+    settings:
+      index.mapping.ignore_malformed: false
+      index.mapping.coerce: false
+      index.number_of_replicas: 1
+      index.number_of_shards: 1
+      index.max_result_window: 10000
   electrical_parts:
     aliases: {}
     mappings:
@@ -1720,6 +1749,31 @@ indices:
           type: keyword
         nationality:
           type: keyword
+        __sources:
+          type: keyword
+        __versions:
+          type: object
+          dynamic: 'false'
+      _size:
+        enabled: true
+    settings:
+      index.mapping.ignore_malformed: false
+      index.mapping.coerce: false
+      index.number_of_replicas: 1
+      index.number_of_shards: 1
+      index.max_result_window: 10000
+  physical_stores:
+    aliases: {}
+    mappings:
+      dynamic: strict
+      properties:
+        id:
+          type: keyword
+        established_on:
+          type: date
+          format: strict_date
+        active:
+          type: boolean
         __sources:
           type: keyword
         __versions:

--- a/config/schema/artifacts_with_apollo/json_schemas.yaml
+++ b/config/schema/artifacts_with_apollo/json_schemas.yaml
@@ -28,9 +28,12 @@ json_schema_version: 1
         - ElectricalPart
         - Manufacturer
         - MechanicalPart
+        - OnlineStore
         - Person
+        - PhysicalStore
         - Sponsor
         - Team
+        - ThirdPartyWholesale
         - Widget
         - WidgetWorkspace
       id:
@@ -445,6 +448,36 @@ json_schema_version: 1
     oneOf:
     - "$ref": "#/$defs/Person"
     - "$ref": "#/$defs/Company"
+  OnlineStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      name:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+      __typename:
+        type: string
+        const: OnlineStore
+        default: OnlineStore
+    required:
+    - id
+    - established_on
+    - active
+    - name
   Person:
     type: object
     properties:
@@ -472,6 +505,29 @@ json_schema_version: 1
     - id
     - name
     - nationality
+  PhysicalStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      __typename:
+        type: string
+        const: PhysicalStore
+        default: PhysicalStore
+    required:
+    - id
+    - established_on
+    - active
   Player:
     type: object
     properties:
@@ -819,6 +875,24 @@ json_schema_version: 1
     - was_shortened
     - players_nested
     - players_object
+  ThirdPartyWholesale:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+      __typename:
+        type: string
+        const: ThirdPartyWholesale
+        default: ThirdPartyWholesale
+    required:
+    - id
+    - active
   Untyped:
     type:
     - array

--- a/config/schema/artifacts_with_apollo/json_schemas_by_version/v1.yaml
+++ b/config/schema/artifacts_with_apollo/json_schemas_by_version/v1.yaml
@@ -28,9 +28,12 @@ json_schema_version: 1
         - ElectricalPart
         - Manufacturer
         - MechanicalPart
+        - OnlineStore
         - Person
+        - PhysicalStore
         - Sponsor
         - Team
+        - ThirdPartyWholesale
         - Widget
         - WidgetWorkspace
       id:
@@ -565,6 +568,48 @@ json_schema_version: 1
     oneOf:
     - "$ref": "#/$defs/Person"
     - "$ref": "#/$defs/Company"
+  OnlineStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+        ElasticGraph:
+          type: ID!
+          nameInIndex: id
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+        ElasticGraph:
+          type: Date
+          nameInIndex: established_on
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: active
+      name:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+        ElasticGraph:
+          type: String
+          nameInIndex: name
+      __typename:
+        type: string
+        const: OnlineStore
+        default: OnlineStore
+    required:
+    - id
+    - established_on
+    - active
+    - name
   Person:
     type: object
     properties:
@@ -601,6 +646,38 @@ json_schema_version: 1
     - id
     - name
     - nationality
+  PhysicalStore:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+        ElasticGraph:
+          type: ID!
+          nameInIndex: id
+      established_on:
+        anyOf:
+        - "$ref": "#/$defs/Date"
+        - type: 'null'
+        ElasticGraph:
+          type: Date
+          nameInIndex: established_on
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: active
+      __typename:
+        type: string
+        const: PhysicalStore
+        default: PhysicalStore
+    required:
+    - id
+    - established_on
+    - active
   Player:
     type: object
     properties:
@@ -1098,6 +1175,30 @@ json_schema_version: 1
     - was_shortened
     - players_nested
     - players_object
+  ThirdPartyWholesale:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+        ElasticGraph:
+          type: ID!
+          nameInIndex: id
+      active:
+        anyOf:
+        - "$ref": "#/$defs/Boolean"
+        - type: 'null'
+        ElasticGraph:
+          type: Boolean
+          nameInIndex: active
+      __typename:
+        type: string
+        const: ThirdPartyWholesale
+        default: ThirdPartyWholesale
+    required:
+    - id
+    - active
   Untyped:
     type:
     - array

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -201,6 +201,32 @@ enum_types_by_name:
         datastore_abbreviation: nmi
       YARD:
         datastore_abbreviation: yd
+  DistributionChannelSortOrderInput:
+    values_by_name:
+      established_on_ASC:
+        sort_field:
+          direction: asc
+          field_path: established_on
+      established_on_DESC:
+        sort_field:
+          direction: desc
+          field_path: established_on
+      id_ASC:
+        sort_field:
+          direction: asc
+          field_path: id
+      id_DESC:
+        sort_field:
+          direction: desc
+          field_path: id
+      name_ASC:
+        sort_field:
+          direction: asc
+          field_path: name
+      name_DESC:
+        sort_field:
+          direction: desc
+          field_path: name
   ElectricalPartSortOrderInput:
     values_by_name:
       created_at_ASC:
@@ -897,8 +923,78 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: nationality
+  PhysicalStoreSortOrderInput:
+    values_by_name:
+      established_on_ASC:
+        sort_field:
+          direction: asc
+          field_path: established_on
+      established_on_DESC:
+        sort_field:
+          direction: desc
+          field_path: established_on
+      id_ASC:
+        sort_field:
+          direction: asc
+          field_path: id
+      id_DESC:
+        sort_field:
+          direction: desc
+          field_path: id
+  RetailSortOrderInput:
+    values_by_name:
+      established_on_ASC:
+        sort_field:
+          direction: asc
+          field_path: established_on
+      established_on_DESC:
+        sort_field:
+          direction: desc
+          field_path: established_on
+      id_ASC:
+        sort_field:
+          direction: asc
+          field_path: id
+      id_DESC:
+        sort_field:
+          direction: desc
+          field_path: id
+      name_ASC:
+        sort_field:
+          direction: asc
+          field_path: name
+      name_DESC:
+        sort_field:
+          direction: desc
+          field_path: name
   SponsorSortOrderInput:
     values_by_name:
+      id_ASC:
+        sort_field:
+          direction: asc
+          field_path: id
+      id_DESC:
+        sort_field:
+          direction: desc
+          field_path: id
+      name_ASC:
+        sort_field:
+          direction: asc
+          field_path: name
+      name_DESC:
+        sort_field:
+          direction: desc
+          field_path: name
+  StoreSortOrderInput:
+    values_by_name:
+      established_on_ASC:
+        sort_field:
+          direction: asc
+          field_path: established_on
+      established_on_DESC:
+        sort_field:
+          direction: desc
+          field_path: established_on
       id_ASC:
         sort_field:
           direction: asc
@@ -1862,6 +1958,19 @@ index_definitions_by_name:
         source: widget
     has_had_multiple_sources: true
     route_with: id
+  distribution_channels:
+    current_sources:
+    - __self
+    fields_by_path:
+      active:
+        source: __self
+      established_on:
+        source: __self
+      id:
+        source: __self
+      name:
+        source: __self
+    route_with: id
   electrical_parts:
     current_sources:
     - __self
@@ -1927,6 +2036,17 @@ index_definitions_by_name:
       name:
         source: __self
       nationality:
+        source: __self
+    route_with: id
+  physical_stores:
+    current_sources:
+    - __self
+    fields_by_path:
+      active:
+        source: __self
+      established_on:
+        source: __self
+      id:
         source: __self
     route_with: id
   sponsors:
@@ -3787,6 +3907,119 @@ object_types_by_name:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  DistributionChannel:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      name:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+  DistributionChannelAggregatedValues:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      id:
+        resolver:
+          name: object_with_lookahead
+      name:
+        resolver:
+          name: object_with_lookahead
+  DistributionChannelAggregation:
+    elasticgraph_category: indexed_aggregation
+    graphql_fields_by_name:
+      aggregated_values:
+        resolver:
+          name: object_without_lookahead
+      count:
+        resolver:
+          name: object_without_lookahead
+      grouped_by:
+        resolver:
+          name: object_without_lookahead
+    source_type: DistributionChannel
+  DistributionChannelAggregationConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+  DistributionChannelAggregationEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  DistributionChannelConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+      total_edge_count:
+        resolver:
+          name: object_without_lookahead
+  DistributionChannelEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      all_highlights:
+        resolver:
+          name: object_without_lookahead
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      highlights:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  DistributionChannelGroupedBy:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      name:
+        resolver:
+          name: object_with_lookahead
+  DistributionChannelHighlights:
+    graphql_fields_by_name:
+      id:
+        resolver:
+          name: get_record_field_value
+      name:
+        resolver:
+          name: get_record_field_value
   ElectricalPart:
     graphql_fields_by_name:
       component_aggregations:
@@ -5424,6 +5657,48 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
     graphql_only_return_type: true
+  OnlineStore:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      name:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+    update_targets:
+    - data_params:
+        __typename:
+          cardinality: one
+        active:
+          cardinality: one
+        established_on:
+          cardinality: one
+        name:
+          cardinality: one
+      id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      routing_value_source: id
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      type: OnlineStore
   PageInfo:
     graphql_fields_by_name:
       end_cursor:
@@ -5709,6 +5984,129 @@ object_types_by_name:
       nationality:
         resolver:
           name: get_record_field_value
+  PhysicalStore:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - physical_stores
+    update_targets:
+    - data_params:
+        active:
+          cardinality: one
+        established_on:
+          cardinality: one
+      id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      routing_value_source: id
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      type: PhysicalStore
+  PhysicalStoreAggregatedValues:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      id:
+        resolver:
+          name: object_with_lookahead
+  PhysicalStoreAggregation:
+    elasticgraph_category: indexed_aggregation
+    graphql_fields_by_name:
+      aggregated_values:
+        resolver:
+          name: object_without_lookahead
+      count:
+        resolver:
+          name: object_without_lookahead
+      grouped_by:
+        resolver:
+          name: object_without_lookahead
+    source_type: PhysicalStore
+  PhysicalStoreAggregationConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+  PhysicalStoreAggregationEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  PhysicalStoreConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+      total_edge_count:
+        resolver:
+          name: object_without_lookahead
+  PhysicalStoreEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      all_highlights:
+        resolver:
+          name: object_without_lookahead
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      highlights:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  PhysicalStoreGroupedBy:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+  PhysicalStoreHighlights:
+    graphql_fields_by_name:
+      id:
+        resolver:
+          name: get_record_field_value
   Player:
     graphql_fields_by_name:
       affiliations:
@@ -5869,6 +6267,12 @@ object_types_by_name:
       components:
         resolver:
           name: list_records
+      distribution_channel_aggregations:
+        resolver:
+          name: list_records
+      distribution_channels:
+        resolver:
+          name: list_records
       electrical_part_aggregations:
         resolver:
           name: list_records
@@ -5917,10 +6321,28 @@ object_types_by_name:
       person_aggregations:
         resolver:
           name: list_records
+      physical_store_aggregations:
+        resolver:
+          name: list_records
+      physical_stores:
+        resolver:
+          name: list_records
+      retail_aggregations:
+        resolver:
+          name: list_records
+      retailers:
+        resolver:
+          name: list_records
       sponsor_aggregations:
         resolver:
           name: list_records
       sponsors:
+        resolver:
+          name: list_records
+      store_aggregations:
+        resolver:
+          name: list_records
+      stores:
         resolver:
           name: list_records
       team_aggregations:
@@ -5953,6 +6375,119 @@ object_types_by_name:
       widgets_or_addresses:
         resolver:
           name: list_records
+  Retail:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      name:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+  RetailAggregatedValues:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      id:
+        resolver:
+          name: object_with_lookahead
+      name:
+        resolver:
+          name: object_with_lookahead
+  RetailAggregation:
+    elasticgraph_category: indexed_aggregation
+    graphql_fields_by_name:
+      aggregated_values:
+        resolver:
+          name: object_without_lookahead
+      count:
+        resolver:
+          name: object_without_lookahead
+      grouped_by:
+        resolver:
+          name: object_without_lookahead
+    source_type: Retail
+  RetailAggregationConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+  RetailAggregationEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  RetailConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+      total_edge_count:
+        resolver:
+          name: object_without_lookahead
+  RetailEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      all_highlights:
+        resolver:
+          name: object_without_lookahead
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      highlights:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  RetailGroupedBy:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      name:
+        resolver:
+          name: object_with_lookahead
+  RetailHighlights:
+    graphql_fields_by_name:
+      id:
+        resolver:
+          name: get_record_field_value
+      name:
+        resolver:
+          name: get_record_field_value
   SearchHighlight:
     graphql_fields_by_name:
       path:
@@ -6151,6 +6686,119 @@ object_types_by_name:
     graphql_fields_by_name:
       count:
         name_in_index: __counts
+  Store:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      established_on:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+      name:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+  StoreAggregatedValues:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      id:
+        resolver:
+          name: object_with_lookahead
+      name:
+        resolver:
+          name: object_with_lookahead
+  StoreAggregation:
+    elasticgraph_category: indexed_aggregation
+    graphql_fields_by_name:
+      aggregated_values:
+        resolver:
+          name: object_without_lookahead
+      count:
+        resolver:
+          name: object_without_lookahead
+      grouped_by:
+        resolver:
+          name: object_without_lookahead
+    source_type: Store
+  StoreAggregationConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+  StoreAggregationEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  StoreConnection:
+    elasticgraph_category: relay_connection
+    graphql_fields_by_name:
+      edges:
+        resolver:
+          name: object_without_lookahead
+      nodes:
+        resolver:
+          name: object_without_lookahead
+      page_info:
+        resolver:
+          name: object_without_lookahead
+      total_edge_count:
+        resolver:
+          name: object_without_lookahead
+  StoreEdge:
+    elasticgraph_category: relay_edge
+    graphql_fields_by_name:
+      all_highlights:
+        resolver:
+          name: object_without_lookahead
+      cursor:
+        resolver:
+          name: object_without_lookahead
+      highlights:
+        resolver:
+          name: object_without_lookahead
+      node:
+        resolver:
+          name: object_without_lookahead
+  StoreGroupedBy:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: object_with_lookahead
+      established_on:
+        resolver:
+          name: object_with_lookahead
+      name:
+        resolver:
+          name: object_with_lookahead
+  StoreHighlights:
+    graphql_fields_by_name:
+      id:
+        resolver:
+          name: get_record_field_value
+      name:
+        resolver:
+          name: get_record_field_value
   StringConnection:
     elasticgraph_category: relay_connection
     graphql_fields_by_name:
@@ -7084,6 +7732,38 @@ object_types_by_name:
       players_object:
         resolver:
           name: object_with_lookahead
+  ThirdPartyWholesale:
+    graphql_fields_by_name:
+      active:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+    index_definition_names:
+    - distribution_channels
+    update_targets:
+    - data_params:
+        __typename:
+          cardinality: one
+        active:
+          cardinality: one
+      id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      routing_value_source: id
+      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      type: ThirdPartyWholesale
   Widget:
     graphql_fields_by_name:
       amount_cents:

--- a/config/schema/artifacts_with_apollo/schema.graphql
+++ b/config/schema/artifacts_with_apollo/schema.graphql
@@ -3061,6 +3061,292 @@ enum DistanceUnitInput {
   YARD
 }
 
+interface DistributionChannel {
+  active: Boolean
+  id: ID!
+}
+
+"""
+Type used to perform aggregation computations on `DistributionChannel` fields.
+"""
+type DistributionChannelAggregatedValues {
+  """
+  Computed aggregate values for the `active` field.
+  """
+  active: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `established_on` field.
+  """
+  established_on: DateAggregatedValues
+
+  """
+  Computed aggregate values for the `id` field.
+  """
+  id: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `name` field.
+  """
+  name: NonNumericAggregatedValues
+}
+
+"""
+Return type representing a bucket of `DistributionChannel` documents for an aggregations query.
+"""
+type DistributionChannelAggregation {
+  """
+  Provides computed aggregated values over all `DistributionChannel` documents in an aggregation bucket.
+  """
+  aggregated_values: DistributionChannelAggregatedValues
+
+  """
+  The count of `DistributionChannel` documents in an aggregation bucket.
+  """
+  count: JsonSafeLong!
+
+  """
+  Used to specify the `DistributionChannel` fields to group by. The returned values identify each aggregation bucket.
+  """
+  grouped_by: DistributionChannelGroupedBy
+}
+
+"""
+Represents a paginated collection of `DistributionChannelAggregation` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type DistributionChannelAggregationConnection {
+  """
+  Wraps a specific `DistributionChannelAggregation` to pair it with its pagination cursor.
+  """
+  edges: [DistributionChannelAggregationEdge!]!
+
+  """
+  The list of `DistributionChannelAggregation` results.
+  """
+  nodes: [DistributionChannelAggregation!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+}
+
+"""
+Represents a specific `DistributionChannelAggregation` in the context of a `DistributionChannelAggregationConnection`,
+providing access to both the `DistributionChannelAggregation` and query-specific
+information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type DistributionChannelAggregationEdge {
+  """
+  The `Cursor` of this `DistributionChannelAggregation`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `DistributionChannelAggregation`.
+  """
+  cursor: Cursor
+
+  """
+  The `DistributionChannelAggregation` of this edge.
+  """
+  node: DistributionChannelAggregation
+}
+
+"""
+Represents a paginated collection of `DistributionChannel` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type DistributionChannelConnection {
+  """
+  Wraps a specific `DistributionChannel` to pair it with its pagination cursor.
+  """
+  edges: [DistributionChannelEdge!]!
+
+  """
+  The list of `DistributionChannel` results.
+  """
+  nodes: [DistributionChannel!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+
+  """
+  The total number of edges available in this connection to paginate over.
+  """
+  total_edge_count: JsonSafeLong!
+}
+
+"""
+Represents a specific `DistributionChannel` in the context of a `DistributionChannelConnection`,
+providing access to both the `DistributionChannel` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type DistributionChannelEdge {
+  """
+  All search highlights for this `DistributionChannel`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
+  The `Cursor` of this `DistributionChannel`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `DistributionChannel`.
+  """
+  cursor: Cursor
+
+  """
+  Specific search highlights for this `DistributionChannel`, providing matching snippets for the requested fields.
+  """
+  highlights: DistributionChannelHighlights
+
+  """
+  The `DistributionChannel` of this edge.
+  """
+  node: DistributionChannel
+}
+
+"""
+Input type used to specify filters on `DistributionChannel` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input DistributionChannelFilterInput {
+  """
+  Used to filter on the `active` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  active: BooleanFilterInput
+
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `DistributionChannelFilterInput` input because of
+  collisions between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [DistributionChannelFilterInput!]
+
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [DistributionChannelFilterInput!]
+
+  """
+  Used to filter on the `established_on` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  established_on: DateFilterInput
+
+  """
+  Used to filter on the `id` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  id: IDFilterInput
+
+  """
+  Used to filter on the `name` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  name: StringFilterInput
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: DistributionChannelFilterInput
+}
+
+"""
+Type used to specify the `DistributionChannel` fields to group by for aggregations.
+"""
+type DistributionChannelGroupedBy {
+  """
+  The `active` field value for this group.
+  """
+  active: Boolean
+
+  """
+  Offers the different grouping options for the `established_on` value within this group.
+  """
+  established_on: DateGroupedBy
+
+  """
+  The `name` field value for this group.
+  """
+  name: String
+}
+
+"""
+Type used to request desired `DistributionChannel` search highlight fields.
+"""
+type DistributionChannelHighlights {
+  """
+  Search highlights for the `id`, providing snippets of the matching text.
+  """
+  id: [String!]!
+
+  """
+  Search highlights for the `name`, providing snippets of the matching text.
+  """
+  name: [String!]!
+}
+
+"""
+Enumerates the ways `DistributionChannel`s can be sorted.
+"""
+enum DistributionChannelSortOrderInput {
+  """
+  Sorts ascending by the `established_on` field.
+  """
+  established_on_ASC
+
+  """
+  Sorts descending by the `established_on` field.
+  """
+  established_on_DESC
+
+  """
+  Sorts ascending by the `id` field.
+  """
+  id_ASC
+
+  """
+  Sorts descending by the `id` field.
+  """
+  id_DESC
+
+  """
+  Sorts ascending by the `name` field.
+  """
+  name_ASC
+
+  """
+  Sorts descending by the `name` field.
+  """
+  name_DESC
+}
+
 type ElectricalPart implements NamedEntity @key(fields: "id") {
   """
   Aggregations over the `components` data.
@@ -8053,6 +8339,13 @@ type NonNumericAggregatedValues @shareable {
   approximate_distinct_value_count: JsonSafeLong
 }
 
+type OnlineStore implements DistributionChannel & Retail & Store @key(fields: "id") {
+  active: Boolean
+  established_on: Date
+  id: ID!
+  name: String
+}
+
 """
 Provides information about the specific fetched page. This implements the `PageInfo`
 specification from the [Relay GraphQL Cursor Connections
@@ -8678,6 +8971,260 @@ enum PersonSortOrderInput {
   Sorts descending by the `nationality` field.
   """
   nationality_DESC
+}
+
+type PhysicalStore implements DistributionChannel & Retail & Store @key(fields: "id") {
+  active: Boolean
+  established_on: Date
+  id: ID!
+}
+
+"""
+Type used to perform aggregation computations on `PhysicalStore` fields.
+"""
+type PhysicalStoreAggregatedValues {
+  """
+  Computed aggregate values for the `active` field.
+  """
+  active: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `established_on` field.
+  """
+  established_on: DateAggregatedValues
+
+  """
+  Computed aggregate values for the `id` field.
+  """
+  id: NonNumericAggregatedValues
+}
+
+"""
+Return type representing a bucket of `PhysicalStore` documents for an aggregations query.
+"""
+type PhysicalStoreAggregation {
+  """
+  Provides computed aggregated values over all `PhysicalStore` documents in an aggregation bucket.
+  """
+  aggregated_values: PhysicalStoreAggregatedValues
+
+  """
+  The count of `PhysicalStore` documents in an aggregation bucket.
+  """
+  count: JsonSafeLong!
+
+  """
+  Used to specify the `PhysicalStore` fields to group by. The returned values identify each aggregation bucket.
+  """
+  grouped_by: PhysicalStoreGroupedBy
+}
+
+"""
+Represents a paginated collection of `PhysicalStoreAggregation` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type PhysicalStoreAggregationConnection {
+  """
+  Wraps a specific `PhysicalStoreAggregation` to pair it with its pagination cursor.
+  """
+  edges: [PhysicalStoreAggregationEdge!]!
+
+  """
+  The list of `PhysicalStoreAggregation` results.
+  """
+  nodes: [PhysicalStoreAggregation!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+}
+
+"""
+Represents a specific `PhysicalStoreAggregation` in the context of a `PhysicalStoreAggregationConnection`,
+providing access to both the `PhysicalStoreAggregation` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type PhysicalStoreAggregationEdge {
+  """
+  The `Cursor` of this `PhysicalStoreAggregation`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `PhysicalStoreAggregation`.
+  """
+  cursor: Cursor
+
+  """
+  The `PhysicalStoreAggregation` of this edge.
+  """
+  node: PhysicalStoreAggregation
+}
+
+"""
+Represents a paginated collection of `PhysicalStore` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type PhysicalStoreConnection {
+  """
+  Wraps a specific `PhysicalStore` to pair it with its pagination cursor.
+  """
+  edges: [PhysicalStoreEdge!]!
+
+  """
+  The list of `PhysicalStore` results.
+  """
+  nodes: [PhysicalStore!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+
+  """
+  The total number of edges available in this connection to paginate over.
+  """
+  total_edge_count: JsonSafeLong!
+}
+
+"""
+Represents a specific `PhysicalStore` in the context of a `PhysicalStoreConnection`,
+providing access to both the `PhysicalStore` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type PhysicalStoreEdge {
+  """
+  All search highlights for this `PhysicalStore`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
+  The `Cursor` of this `PhysicalStore`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `PhysicalStore`.
+  """
+  cursor: Cursor
+
+  """
+  Specific search highlights for this `PhysicalStore`, providing matching snippets for the requested fields.
+  """
+  highlights: PhysicalStoreHighlights
+
+  """
+  The `PhysicalStore` of this edge.
+  """
+  node: PhysicalStore
+}
+
+"""
+Input type used to specify filters on `PhysicalStore` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input PhysicalStoreFilterInput {
+  """
+  Used to filter on the `active` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  active: BooleanFilterInput
+
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `PhysicalStoreFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [PhysicalStoreFilterInput!]
+
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [PhysicalStoreFilterInput!]
+
+  """
+  Used to filter on the `established_on` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  established_on: DateFilterInput
+
+  """
+  Used to filter on the `id` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  id: IDFilterInput
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: PhysicalStoreFilterInput
+}
+
+"""
+Type used to specify the `PhysicalStore` fields to group by for aggregations.
+"""
+type PhysicalStoreGroupedBy {
+  """
+  The `active` field value for this group.
+  """
+  active: Boolean
+
+  """
+  Offers the different grouping options for the `established_on` value within this group.
+  """
+  established_on: DateGroupedBy
+}
+
+"""
+Type used to request desired `PhysicalStore` search highlight fields.
+"""
+type PhysicalStoreHighlights {
+  """
+  Search highlights for the `id`, providing snippets of the matching text.
+  """
+  id: [String!]!
+}
+
+"""
+Enumerates the ways `PhysicalStore`s can be sorted.
+"""
+enum PhysicalStoreSortOrderInput {
+  """
+  Sorts ascending by the `established_on` field.
+  """
+  established_on_ASC
+
+  """
+  Sorts descending by the `established_on` field.
+  """
+  established_on_DESC
+
+  """
+  Sorts ascending by the `id` field.
+  """
+  id_ASC
+
+  """
+  Sorts descending by the `id` field.
+  """
+  id_DESC
 }
 
 type Player {
@@ -9673,6 +10220,109 @@ type Query {
   ): ComponentConnection
 
   """
+  Aggregations over the `distribution_channels` data:
+
+  > Fetches `DistributionChannel`s based on the provided arguments.
+  """
+  distribution_channel_aggregations(
+    """
+    Used to forward-paginate through the `distribution_channel_aggregations`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `distribution_channel_aggregations`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the `DistributionChannel` documents that get aggregated over based on the provided criteria.
+    """
+    filter: DistributionChannelFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `distribution_channel_aggregations`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `distribution_channel_aggregations`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `distribution_channel_aggregations`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `distribution_channel_aggregations`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+  ): DistributionChannelAggregationConnection
+
+  """
+  Fetches `DistributionChannel`s based on the provided arguments.
+  """
+  distribution_channels(
+    """
+    Used to forward-paginate through the `distribution_channels`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `distribution_channels`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the returned `distribution_channels` based on the provided criteria.
+    """
+    filter: DistributionChannelFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `distribution_channels`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `distribution_channels`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `distribution_channels`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `distribution_channels`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+
+    """
+    Used to specify how the returned `distribution_channels` should be sorted.
+    """
+    order_by: [DistributionChannelSortOrderInput!]
+  ): DistributionChannelConnection
+
+  """
   Aggregations over the `electrical_parts` data:
 
   > Fetches `ElectricalPart`s based on the provided arguments.
@@ -10497,6 +11147,212 @@ type Query {
   ): PersonAggregationConnection
 
   """
+  Aggregations over the `physical_stores` data:
+
+  > Fetches `PhysicalStore`s based on the provided arguments.
+  """
+  physical_store_aggregations(
+    """
+    Used to forward-paginate through the `physical_store_aggregations`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `physical_store_aggregations`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the `PhysicalStore` documents that get aggregated over based on the provided criteria.
+    """
+    filter: PhysicalStoreFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `physical_store_aggregations`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `physical_store_aggregations`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `physical_store_aggregations`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `physical_store_aggregations`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+  ): PhysicalStoreAggregationConnection
+
+  """
+  Fetches `PhysicalStore`s based on the provided arguments.
+  """
+  physical_stores(
+    """
+    Used to forward-paginate through the `physical_stores`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `physical_stores`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the returned `physical_stores` based on the provided criteria.
+    """
+    filter: PhysicalStoreFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `physical_stores`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `physical_stores`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `physical_stores`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `physical_stores`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+
+    """
+    Used to specify how the returned `physical_stores` should be sorted.
+    """
+    order_by: [PhysicalStoreSortOrderInput!]
+  ): PhysicalStoreConnection
+
+  """
+  Aggregations over the `retailers` data:
+
+  > Fetches `Retail`s based on the provided arguments.
+  """
+  retail_aggregations(
+    """
+    Used to forward-paginate through the `retail_aggregations`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `retail_aggregations`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the `Retail` documents that get aggregated over based on the provided criteria.
+    """
+    filter: RetailFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `retail_aggregations`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `retail_aggregations`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `retail_aggregations`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `retail_aggregations`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+  ): RetailAggregationConnection
+
+  """
+  Fetches `Retail`s based on the provided arguments.
+  """
+  retailers(
+    """
+    Used to forward-paginate through the `retailers`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `retailers`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the returned `retailers` based on the provided criteria.
+    """
+    filter: RetailFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `retailers`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `retailers`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `retailers`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `retailers`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+
+    """
+    Used to specify how the returned `retailers` should be sorted.
+    """
+    order_by: [RetailSortOrderInput!]
+  ): RetailConnection
+
+  """
   Aggregations over the `sponsors` data:
 
   > Fetches `Sponsor`s based on the provided arguments.
@@ -10598,6 +11454,109 @@ type Query {
     """
     order_by: [SponsorSortOrderInput!]
   ): SponsorConnection
+
+  """
+  Aggregations over the `stores` data:
+
+  > Fetches `Store`s based on the provided arguments.
+  """
+  store_aggregations(
+    """
+    Used to forward-paginate through the `store_aggregations`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `store_aggregations`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the `Store` documents that get aggregated over based on the provided criteria.
+    """
+    filter: StoreFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `store_aggregations`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `store_aggregations`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `store_aggregations`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `store_aggregations`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+  ): StoreAggregationConnection
+
+  """
+  Fetches `Store`s based on the provided arguments.
+  """
+  stores(
+    """
+    Used to forward-paginate through the `stores`. When provided, the next page after the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    after: Cursor
+
+    """
+    Used to backward-paginate through the `stores`. When provided, the previous page before the
+    provided cursor will be returned.
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    before: Cursor
+
+    """
+    Used to filter the returned `stores` based on the provided criteria.
+    """
+    filter: StoreFilterInput
+
+    """
+    Used in conjunction with the `after` argument to forward-paginate through the `stores`.
+    When provided, limits the number of returned results to the first `n` after the provided
+    `after` cursor (or from the start of the `stores`, if no `after` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    first: Int
+
+    """
+    Used in conjunction with the `before` argument to backward-paginate through the `stores`.
+    When provided, limits the number of returned results to the last `n` before the provided
+    `before` cursor (or from the end of the `stores`, if no `before` cursor is provided).
+
+    See the [Relay GraphQL Cursor Connections
+    Specification](https://relay.dev/graphql/connections.htm#sec-Arguments) for more info.
+    """
+    last: Int
+
+    """
+    Used to specify how the returned `stores` should be sorted.
+    """
+    order_by: [StoreSortOrderInput!]
+  ): StoreConnection
 
   """
   Aggregations over the `teams` data:
@@ -11118,6 +12077,292 @@ type Query {
     """
     order_by: [WidgetOrAddressSortOrderInput!]
   ): WidgetOrAddressConnection
+}
+
+interface Retail implements DistributionChannel {
+  active: Boolean
+  established_on: Date
+  id: ID!
+}
+
+"""
+Type used to perform aggregation computations on `Retail` fields.
+"""
+type RetailAggregatedValues {
+  """
+  Computed aggregate values for the `active` field.
+  """
+  active: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `established_on` field.
+  """
+  established_on: DateAggregatedValues
+
+  """
+  Computed aggregate values for the `id` field.
+  """
+  id: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `name` field.
+  """
+  name: NonNumericAggregatedValues
+}
+
+"""
+Return type representing a bucket of `Retail` documents for an aggregations query.
+"""
+type RetailAggregation {
+  """
+  Provides computed aggregated values over all `Retail` documents in an aggregation bucket.
+  """
+  aggregated_values: RetailAggregatedValues
+
+  """
+  The count of `Retail` documents in an aggregation bucket.
+  """
+  count: JsonSafeLong!
+
+  """
+  Used to specify the `Retail` fields to group by. The returned values identify each aggregation bucket.
+  """
+  grouped_by: RetailGroupedBy
+}
+
+"""
+Represents a paginated collection of `RetailAggregation` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type RetailAggregationConnection {
+  """
+  Wraps a specific `RetailAggregation` to pair it with its pagination cursor.
+  """
+  edges: [RetailAggregationEdge!]!
+
+  """
+  The list of `RetailAggregation` results.
+  """
+  nodes: [RetailAggregation!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+}
+
+"""
+Represents a specific `RetailAggregation` in the context of a `RetailAggregationConnection`,
+providing access to both the `RetailAggregation` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type RetailAggregationEdge {
+  """
+  The `Cursor` of this `RetailAggregation`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `RetailAggregation`.
+  """
+  cursor: Cursor
+
+  """
+  The `RetailAggregation` of this edge.
+  """
+  node: RetailAggregation
+}
+
+"""
+Represents a paginated collection of `Retail` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type RetailConnection {
+  """
+  Wraps a specific `Retail` to pair it with its pagination cursor.
+  """
+  edges: [RetailEdge!]!
+
+  """
+  The list of `Retail` results.
+  """
+  nodes: [Retail!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+
+  """
+  The total number of edges available in this connection to paginate over.
+  """
+  total_edge_count: JsonSafeLong!
+}
+
+"""
+Represents a specific `Retail` in the context of a `RetailConnection`,
+providing access to both the `Retail` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type RetailEdge {
+  """
+  All search highlights for this `Retail`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
+  The `Cursor` of this `Retail`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `Retail`.
+  """
+  cursor: Cursor
+
+  """
+  Specific search highlights for this `Retail`, providing matching snippets for the requested fields.
+  """
+  highlights: RetailHighlights
+
+  """
+  The `Retail` of this edge.
+  """
+  node: Retail
+}
+
+"""
+Input type used to specify filters on `Retail` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input RetailFilterInput {
+  """
+  Used to filter on the `active` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  active: BooleanFilterInput
+
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `RetailFilterInput` input because of collisions
+  between key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [RetailFilterInput!]
+
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [RetailFilterInput!]
+
+  """
+  Used to filter on the `established_on` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  established_on: DateFilterInput
+
+  """
+  Used to filter on the `id` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  id: IDFilterInput
+
+  """
+  Used to filter on the `name` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  name: StringFilterInput
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: RetailFilterInput
+}
+
+"""
+Type used to specify the `Retail` fields to group by for aggregations.
+"""
+type RetailGroupedBy {
+  """
+  The `active` field value for this group.
+  """
+  active: Boolean
+
+  """
+  Offers the different grouping options for the `established_on` value within this group.
+  """
+  established_on: DateGroupedBy
+
+  """
+  The `name` field value for this group.
+  """
+  name: String
+}
+
+"""
+Type used to request desired `Retail` search highlight fields.
+"""
+type RetailHighlights {
+  """
+  Search highlights for the `id`, providing snippets of the matching text.
+  """
+  id: [String!]!
+
+  """
+  Search highlights for the `name`, providing snippets of the matching text.
+  """
+  name: [String!]!
+}
+
+"""
+Enumerates the ways `Retail`s can be sorted.
+"""
+enum RetailSortOrderInput {
+  """
+  Sorts ascending by the `established_on` field.
+  """
+  established_on_ASC
+
+  """
+  Sorts descending by the `established_on` field.
+  """
+  established_on_DESC
+
+  """
+  Sorts ascending by the `id` field.
+  """
+  id_ASC
+
+  """
+  Sorts descending by the `id` field.
+  """
+  id_DESC
+
+  """
+  Sorts ascending by the `name` field.
+  """
+  name_ASC
+
+  """
+  Sorts descending by the `name` field.
+  """
+  name_DESC
 }
 
 """
@@ -11929,6 +13174,292 @@ input SponsorshipListFilterInput {
   When `null` or an empty object is passed, matches no documents.
   """
   not: SponsorshipListFilterInput
+}
+
+interface Store implements DistributionChannel & Retail {
+  active: Boolean
+  established_on: Date
+  id: ID!
+}
+
+"""
+Type used to perform aggregation computations on `Store` fields.
+"""
+type StoreAggregatedValues {
+  """
+  Computed aggregate values for the `active` field.
+  """
+  active: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `established_on` field.
+  """
+  established_on: DateAggregatedValues
+
+  """
+  Computed aggregate values for the `id` field.
+  """
+  id: NonNumericAggregatedValues
+
+  """
+  Computed aggregate values for the `name` field.
+  """
+  name: NonNumericAggregatedValues
+}
+
+"""
+Return type representing a bucket of `Store` documents for an aggregations query.
+"""
+type StoreAggregation {
+  """
+  Provides computed aggregated values over all `Store` documents in an aggregation bucket.
+  """
+  aggregated_values: StoreAggregatedValues
+
+  """
+  The count of `Store` documents in an aggregation bucket.
+  """
+  count: JsonSafeLong!
+
+  """
+  Used to specify the `Store` fields to group by. The returned values identify each aggregation bucket.
+  """
+  grouped_by: StoreGroupedBy
+}
+
+"""
+Represents a paginated collection of `StoreAggregation` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type StoreAggregationConnection {
+  """
+  Wraps a specific `StoreAggregation` to pair it with its pagination cursor.
+  """
+  edges: [StoreAggregationEdge!]!
+
+  """
+  The list of `StoreAggregation` results.
+  """
+  nodes: [StoreAggregation!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+}
+
+"""
+Represents a specific `StoreAggregation` in the context of a `StoreAggregationConnection`,
+providing access to both the `StoreAggregation` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type StoreAggregationEdge {
+  """
+  The `Cursor` of this `StoreAggregation`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `StoreAggregation`.
+  """
+  cursor: Cursor
+
+  """
+  The `StoreAggregation` of this edge.
+  """
+  node: StoreAggregation
+}
+
+"""
+Represents a paginated collection of `Store` results.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Connection-Types) for more info.
+"""
+type StoreConnection {
+  """
+  Wraps a specific `Store` to pair it with its pagination cursor.
+  """
+  edges: [StoreEdge!]!
+
+  """
+  The list of `Store` results.
+  """
+  nodes: [Store!]!
+
+  """
+  Provides pagination-related information.
+  """
+  page_info: PageInfo!
+
+  """
+  The total number of edges available in this connection to paginate over.
+  """
+  total_edge_count: JsonSafeLong!
+}
+
+"""
+Represents a specific `Store` in the context of a `StoreConnection`,
+providing access to both the `Store` and query-specific information such as the pagination `Cursor`.
+
+See the [Relay GraphQL Cursor Connections
+Specification](https://relay.dev/graphql/connections.htm#sec-Edge-Types) for more info.
+"""
+type StoreEdge {
+  """
+  All search highlights for this `Store`, indicating where in the indexed document the query matched.
+  """
+  all_highlights: [SearchHighlight!]!
+
+  """
+  The `Cursor` of this `Store`. This can be passed in the next query as
+  a `before` or `after` argument to continue paginating from this `Store`.
+  """
+  cursor: Cursor
+
+  """
+  Specific search highlights for this `Store`, providing matching snippets for the requested fields.
+  """
+  highlights: StoreHighlights
+
+  """
+  The `Store` of this edge.
+  """
+  node: Store
+}
+
+"""
+Input type used to specify filters on `Store` fields.
+
+Will match all documents if passed as an empty object (or as `null`).
+"""
+input StoreFilterInput {
+  """
+  Used to filter on the `active` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  active: BooleanFilterInput
+
+  """
+  Matches records where all of the provided sub-filters evaluate to true. This works just like an AND operator in SQL.
+
+  Note: multiple filters are automatically ANDed together. This is only needed when you have multiple filters that can't
+  be provided on a single `StoreFilterInput` input because of collisions between
+  key names. For example, if you want to AND multiple
+  OR'd sub-filters (the equivalent of (A OR B) AND (C OR D)), you could do all_of: [{any_of: [...]}, {any_of: [...]}].
+
+  When `null` or an empty list is passed, matches all documents.
+  """
+  all_of: [StoreFilterInput!]
+
+  """
+  Matches records where any of the provided sub-filters evaluate to true.
+  This works just like an OR operator in SQL.
+
+  When `null` is passed, matches all documents.
+  When an empty list is passed, this part of the filter matches no documents.
+  """
+  any_of: [StoreFilterInput!]
+
+  """
+  Used to filter on the `established_on` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  established_on: DateFilterInput
+
+  """
+  Used to filter on the `id` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  id: IDFilterInput
+
+  """
+  Used to filter on the `name` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  name: StringFilterInput
+
+  """
+  Matches records where the provided sub-filter evaluates to false.
+  This works just like a NOT operator in SQL.
+
+  When `null` or an empty object is passed, matches no documents.
+  """
+  not: StoreFilterInput
+}
+
+"""
+Type used to specify the `Store` fields to group by for aggregations.
+"""
+type StoreGroupedBy {
+  """
+  The `active` field value for this group.
+  """
+  active: Boolean
+
+  """
+  Offers the different grouping options for the `established_on` value within this group.
+  """
+  established_on: DateGroupedBy
+
+  """
+  The `name` field value for this group.
+  """
+  name: String
+}
+
+"""
+Type used to request desired `Store` search highlight fields.
+"""
+type StoreHighlights {
+  """
+  Search highlights for the `id`, providing snippets of the matching text.
+  """
+  id: [String!]!
+
+  """
+  Search highlights for the `name`, providing snippets of the matching text.
+  """
+  name: [String!]!
+}
+
+"""
+Enumerates the ways `Store`s can be sorted.
+"""
+enum StoreSortOrderInput {
+  """
+  Sorts ascending by the `established_on` field.
+  """
+  established_on_ASC
+
+  """
+  Sorts descending by the `established_on` field.
+  """
+  established_on_DESC
+
+  """
+  Sorts ascending by the `id` field.
+  """
+  id_ASC
+
+  """
+  Sorts descending by the `id` field.
+  """
+  id_DESC
+
+  """
+  Sorts ascending by the `name` field.
+  """
+  name_ASC
+
+  """
+  Sorts descending by the `name` field.
+  """
+  name_DESC
 }
 
 """
@@ -14481,6 +16012,11 @@ input TextFilterInput {
   When `null` or an empty object is passed, matches no documents.
   """
   not: TextFilterInput
+}
+
+type ThirdPartyWholesale implements DistributionChannel @key(fields: "id") {
+  active: Boolean
+  id: ID!
 }
 
 """
@@ -18624,7 +20160,7 @@ In an ElasticGraph schema, this is a union of all indexed types.
 
 Not intended for use by clients other than Apollo.
 """
-union _Entity = Company | Component | Country | ElectricalPart | Manufacturer | MechanicalPart | Person | Sponsor | Team | Widget | WidgetCurrency | WidgetWorkspace
+union _Entity = Company | Component | Country | ElectricalPart | Manufacturer | MechanicalPart | OnlineStore | Person | PhysicalStore | Sponsor | Team | ThirdPartyWholesale | Widget | WidgetCurrency | WidgetWorkspace
 
 """
 An object type required by the [Apollo Federation subgraph

--- a/config/schema/widgets.rb
+++ b/config/schema/widgets.rb
@@ -343,6 +343,54 @@ ElasticGraph.define_schema do |schema|
     t.subtypes "MechanicalPart", "ElectricalPart"
   end
 
+  schema.interface_type "DistributionChannel" do |t|
+    t.field "id", "ID!"
+    t.field "active", "Boolean"
+    t.index "distribution_channels"
+  end
+
+  # Retail and Store form a two-level interface chain under DistributionChannel. This depth is
+  # intentional: it exercises that __typename filtering works correctly when querying at any
+  # level of a multi-level hierarchy, not just one level from the root.
+  schema.interface_type "Retail" do |t|
+    t.implements "DistributionChannel"
+    t.root_query_fields plural: "retailers"
+    t.field "id", "ID!"
+    t.field "active", "Boolean"
+    t.field "established_on", "Date"
+  end
+
+  schema.interface_type "Store" do |t|
+    t.implements "Retail"
+    t.field "id", "ID!"
+    t.field "active", "Boolean"
+    t.field "established_on", "Date"
+  end
+
+  # ThirdPartyWholesale - concrete type in parallel to Retail branch
+  schema.object_type "ThirdPartyWholesale" do |t|
+    t.implements "DistributionChannel"
+    t.field "id", "ID!"
+    t.field "active", "Boolean"
+  end
+
+  schema.object_type "OnlineStore" do |t|
+    t.implements "Store"
+    t.field "id", "ID!"
+    t.field "established_on", "Date"
+    t.field "active", "Boolean"
+    t.field "name", "String"
+  end
+
+  schema.object_type "PhysicalStore" do |t|
+    t.implements "Store"
+    t.field "id", "ID!"
+    t.field "established_on", "Date"
+    t.field "active", "Boolean"
+
+    t.index "physical_stores"
+  end
+
   # Note: `Manufacturer` is used in our tests as an example of an indexed type that has no list fields, so we should
   # not add any list fields to this type in the future.
   schema.object_type "Manufacturer" do |t|

--- a/config/settings/development.yaml
+++ b/config/settings/development.yaml
@@ -27,6 +27,8 @@ datastore:
     widgets: *main_index_settings
     widget_workspaces: *main_index_settings
     sponsors: *main_index_settings
+    distribution_channels: *main_index_settings
+    physical_stores: *main_index_settings
   max_client_retries: 3
 graphql:
   default_page_size: 50

--- a/config/settings/development_with_apollo.yaml
+++ b/config/settings/development_with_apollo.yaml
@@ -27,6 +27,8 @@ datastore:
     widgets: *main_index_settings
     widget_workspaces: *main_index_settings
     sponsors: *main_index_settings
+    distribution_channels: *main_index_settings
+    physical_stores: *main_index_settings
   max_client_retries: 3
 graphql:
   default_page_size: 50

--- a/config/settings/test.yaml.template
+++ b/config/settings/test.yaml.template
@@ -75,6 +75,8 @@ datastore:
         "2021-01-01T00:00:00Z": {}
     widget_workspaces: *main_index_settings
     sponsors: *main_index_settings
+    distribution_channels: *main_index_settings
+    physical_stores: *main_index_settings
   max_client_retries: 3
 graphql:
   # default_page_size of 50 is duplicated in `elasticgraph/spec/support/aggregations_helpers.rb`.

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter_builder.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter_builder.rb
@@ -121,7 +121,9 @@ module ElasticGraph
             # ...otherwise infer the type based on what index the object came from. This is the case
             # with unions/interfaces of individually indexed types.
             # (See `Part` in `config/schema/widgets.rb` for an example of this kind of type union.)
-            schema.document_type_stored_in(object.index_definition_name).graphql_type
+            # This branch is only reached for individually-indexed types (no `__typename`
+            # in the document), so the set always contains exactly one type.
+            schema.document_types_stored_in(object.index_definition_name).first.graphql_type
           end
         end
       end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/search_response_adapter_builder.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/search_response_adapter_builder.rb
@@ -47,7 +47,15 @@ module ElasticGraph
 
           def all_highlights
             @all_highlights ||= begin
-              document_type = schema.document_type_stored_in(node.index_definition_name)
+              document_type =
+                if (typename = node["__typename"])
+                  # When multiple types share an index, documents carry a `__typename` field
+                  # that identifies the concrete type; use it to resolve the concrete type directly.
+                  schema.type_named(typename)
+                else
+                  # For individually-indexed types the set always contains exactly one type.
+                  schema.document_types_stored_in(node.index_definition_name).first # : Schema::Type
+                end
 
               node.highlights.filter_map do |path_string, snippets|
                 if (path = path_from(path_string, document_type))

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
@@ -120,7 +120,7 @@ module ElasticGraph
         raise Errors::NotFoundError, msg
       end
 
-      def document_type_stored_in(index_definition_name)
+      def document_types_stored_in(index_definition_name)
         indexed_document_types_by_index_definition_name.fetch(index_definition_name) do
           if index_definition_name.include?(ROLLOVER_INDEX_INFIX_MARKER)
             raise ArgumentError, "`#{index_definition_name}` is the name of a rollover index; pass the name of the parent index definition instead."
@@ -193,7 +193,7 @@ module ElasticGraph
       def indexed_document_types_by_index_definition_name
         @indexed_document_types_by_index_definition_name ||= indexed_document_types.each_with_object({}) do |type, hash|
           type.index_definitions.each do |index_def|
-            hash[index_def.name] ||= type
+            (hash[index_def.name] ||= Set.new) << type
           end
         end.freeze
       end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
@@ -121,7 +121,8 @@ module ElasticGraph
       end
 
       # Returns all indexed document types stored in the named index definition.
-      # The returned set is never empty: if no types are found, an error is raised instead.
+      # Multiple types may be returned when abstract types share an index with their concrete subtypes
+      # via index inheritance. The returned set is never empty: if no types are found, an error is raised instead.
       def document_types_stored_in(index_definition_name)
         indexed_document_types_by_index_definition_name.fetch(index_definition_name) do
           if index_definition_name.include?(ROLLOVER_INDEX_INFIX_MARKER)
@@ -155,18 +156,6 @@ module ElasticGraph
       alias_method :inspect, :to_s
 
       private
-
-      # Returns a hash mapping each index definition name to all indexed document types that use that index.
-      # Multiple types may map to the same index when abstract types share an index with their concrete subtypes
-      # via index inheritance. Intentionally private: public callers should use `document_types_stored_in` instead.
-      def indexed_document_types_by_index_definition_name
-        @indexed_document_types_by_index_definition_name ||=
-          indexed_document_types.each_with_object(::Hash.new { |h, k| h[k] = ::Set.new }) do |type, hash|
-            type.index_definitions.each do |index_def|
-              hash[index_def.name] << type
-            end
-          end.freeze
-      end
 
       def build_base_object_class
         schema = self
@@ -202,6 +191,16 @@ module ElasticGraph
         graphql_schema.types(visibility_profile: :boot).transform_values do |graphql_type|
           @types_by_graphql_type[graphql_type]
         end
+      end
+
+      # Intentionally private: public callers should use `document_types_stored_in` instead.
+      def indexed_document_types_by_index_definition_name
+        @indexed_document_types_by_index_definition_name ||=
+          indexed_document_types.each_with_object(::Hash.new { |h, k| h[k] = ::Set.new }) do |type, hash|
+            type.index_definitions.each do |index_def|
+              hash[index_def.name] << type
+            end
+          end.freeze
       end
 
       def log_hidden_types

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
@@ -152,6 +152,17 @@ module ElasticGraph
       end
       alias_method :inspect, :to_s
 
+      # Returns a hash mapping each index definition name to all indexed document types that use that index.
+      # Multiple types may map to the same index when abstract types share an index with their concrete subtypes
+      # via index inheritance.
+      def indexed_document_types_by_index_definition_name
+        @indexed_document_types_by_index_definition_name ||= indexed_document_types.each_with_object({}) do |type, hash|
+          type.index_definitions.each do |index_def|
+            (hash[index_def.name] ||= Set.new) << type
+          end
+        end.freeze
+      end
+
       private
 
       def build_base_object_class
@@ -188,14 +199,6 @@ module ElasticGraph
         graphql_schema.types(visibility_profile: :boot).transform_values do |graphql_type|
           @types_by_graphql_type[graphql_type]
         end
-      end
-
-      def indexed_document_types_by_index_definition_name
-        @indexed_document_types_by_index_definition_name ||= indexed_document_types.each_with_object({}) do |type, hash|
-          type.index_definitions.each do |index_def|
-            (hash[index_def.name] ||= Set.new) << type
-          end
-        end.freeze
       end
 
       def log_hidden_types

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
@@ -120,6 +120,8 @@ module ElasticGraph
         raise Errors::NotFoundError, msg
       end
 
+      # Returns all indexed document types stored in the named index definition.
+      # The returned set is never empty: if no types are found, an error is raised instead.
       def document_types_stored_in(index_definition_name)
         indexed_document_types_by_index_definition_name.fetch(index_definition_name) do
           if index_definition_name.include?(ROLLOVER_INDEX_INFIX_MARKER)
@@ -152,18 +154,19 @@ module ElasticGraph
       end
       alias_method :inspect, :to_s
 
+      private
+
       # Returns a hash mapping each index definition name to all indexed document types that use that index.
       # Multiple types may map to the same index when abstract types share an index with their concrete subtypes
-      # via index inheritance.
+      # via index inheritance. Intentionally private: public callers should use `document_types_stored_in` instead.
       def indexed_document_types_by_index_definition_name
-        @indexed_document_types_by_index_definition_name ||= indexed_document_types.each_with_object({}) do |type, hash|
-          type.index_definitions.each do |index_def|
-            (hash[index_def.name] ||= Set.new) << type
-          end
-        end.freeze
+        @indexed_document_types_by_index_definition_name ||=
+          indexed_document_types.each_with_object(::Hash.new { |h, k| h[k] = ::Set.new }) do |type, hash|
+            type.index_definitions.each do |index_def|
+              hash[index_def.name] << type
+            end
+          end.freeze
       end
-
-      private
 
       def build_base_object_class
         schema = self

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
@@ -121,8 +121,10 @@ module ElasticGraph
       end
 
       # Returns all indexed document types stored in the named index definition.
-      # Multiple types may be returned when abstract types share an index with their concrete subtypes
-      # via index inheritance. The returned set is never empty: if no types are found, an error is raised instead.
+      # The returned set includes both abstract and concrete types. Multiple types may be returned
+      # when abstract types share an index with their concrete subtypes via index inheritance.
+      # @raise [Errors::NotFoundError] if the index definition name is not recognized
+      # @raise [ArgumentError] if given the name of a rollover index instead of the parent index definition name
       def document_types_stored_in(index_definition_name)
         indexed_document_types_by_index_definition_name.fetch(index_definition_name) do
           if index_definition_name.include?(ROLLOVER_INDEX_INFIX_MARKER)

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/schema.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/schema.rbs
@@ -30,7 +30,6 @@ module ElasticGraph
       def type_from: (::GraphQL::Schema::_Type) -> Type
       def type_named: (::String) -> Type
       def document_types_stored_in: (::String) -> ::Set[Type]
-      def indexed_document_types_by_index_definition_name: () -> ::Hash[::String, ::Set[Type]]
       def field_named: (::String, ::String) -> Field
       def indexed_document_types: () -> ::Array[Type]
       def log_hidden_types: (Logger) -> void

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/schema.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/schema.rbs
@@ -29,7 +29,8 @@ module ElasticGraph
       def graphql_query_context: () -> ::GraphQL::Query::Context
       def type_from: (::GraphQL::Schema::_Type) -> Type
       def type_named: (::String) -> Type
-      def document_type_stored_in: (::String) -> Type
+      def document_types_stored_in: (::String) -> ::Set[Type]
+      def indexed_document_types_by_index_definition_name: () -> ::Hash[::String, ::Set[Type]]
       def field_named: (::String, ::String) -> Field
       def indexed_document_types: () -> ::Array[Type]
       def log_hidden_types: (Logger) -> void

--- a/elasticgraph-graphql/spec/acceptance/hidden_types_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/hidden_types_spec.rb
@@ -82,6 +82,10 @@ module ElasticGraph
             all_types_related_to("Company") +
             all_types_related_to("Inventor") +
             all_types_related_to("NamedInventor") +
+            all_types_related_to("DistributionChannel") +
+            all_types_related_to("Retail") +
+            all_types_related_to("Store") +
+            all_types_related_to("PhysicalStore") +
             relay_types_related_to("String", include_list_filter: true) - ["StringSortOrderInput"] +
             type_and_filters_for("Boolean", include_list: true) +
             type_and_filters_for("Color", include_list: true, as_input_enum: true) +
@@ -116,6 +120,7 @@ module ElasticGraph
             %w[
               FloatAggregatedValues IntAggregatedValues JsonSafeLongAggregatedValues LongStringAggregatedValues NonNumericAggregatedValues
               DateAggregatedValues DateTimeAggregatedValues LocalTimeAggregatedValues
+              OnlineStore ThirdPartyWholesale
               Cursor PageInfo Query TextFilterInput GeoLocation
               DateTimeGroupingOffsetInput DateTimeUnitInput DateTimeTimeOfDayFilterInput
               DateGroupedBy DateGroupingOffsetInput DateGroupingTruncationUnitInput DateUnitInput

--- a/elasticgraph-graphql/spec/acceptance/search_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/search_spec.rb
@@ -698,6 +698,28 @@ module ElasticGraph
         test_widget_search_highlighting(widget1, widget2, widget3)
       end
 
+      it "resolves all_highlights against the concrete type for documents in a shared-index hierarchy" do
+        # OnlineStore.name is a field specific to OnlineStore — absent from DistributionChannel.
+        # Without __typename-aware type resolution in all_highlights, the highlight response from
+        # the datastore would be resolved against the wrong type (e.g. DistributionChannel), causing
+        # the name highlight to be silently dropped.
+        index_records(
+          online_store = build(:online_store, name: "Example Marketplace"),
+          build(:online_store, name: "Other Store"),
+          build(:third_party_wholesale)
+        )
+
+        highlights_by_id = query_all_highlights("retailers", filter: {
+          "name" => {"contains" => {"any_substring_of" => ["Marketplace"]}}
+        })
+
+        expect(highlights_by_id).to eq({
+          online_store.fetch(:id) => [
+            {"path" => ["name"], "snippets" => ["<em>Example Marketplace</em>"]}
+          ]
+        })
+      end
+
       it "supports fetching interface fields" do
         index_into(
           graphql,

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection/search_response_adapter_builder_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection/search_response_adapter_builder_spec.rb
@@ -51,6 +51,27 @@ module ElasticGraph
                   i.default_sort "amount_cents", :asc
                 end
               end
+
+              # Used to test __typename-based type resolution for shared-index types.
+              schema.interface_type "Retailer" do |t|
+                t.field "id", "ID!"
+                t.field "name", "String"
+                t.index "retailers"
+              end
+
+              schema.object_type "OnlineStore" do |t|
+                t.implements "Retailer"
+                t.field "id", "ID!"
+                t.field "name", "String"
+                t.field "url", "String"
+              end
+
+              schema.object_type "PhysicalStore" do |t|
+                t.implements "Retailer"
+                t.field "id", "ID!"
+                t.field "name", "String"
+                t.field "address", "String"
+              end
             end
           end
 
@@ -490,6 +511,33 @@ module ElasticGraph
                     ]
                   }
                 }
+              )
+            end
+
+            it "uses `__typename` from the document to resolve the concrete type when looking up highlight paths" do
+              hit = {
+                "_index" => "retailers",
+                "_id" => "r1",
+                "_source" => {"id" => "r1", "__typename" => "OnlineStore"},
+                "sort" => ["r1"],
+                "highlight" => {"url" => ["https://example.com"]}
+              }
+
+              results = execute_query(query: <<~QUERY, hits: [hit])
+                query {
+                  retailers {
+                    edges {
+                      all_highlights {
+                        path
+                        snippets
+                      }
+                    }
+                  }
+                }
+              QUERY
+
+              expect(results.dig("data", "retailers", "edges")).to contain_exactly(
+                {"all_highlights" => [{"path" => ["url"], "snippets" => ["https://example.com"]}]}
               )
             end
           end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
@@ -123,6 +123,31 @@ module ElasticGraph
           expect(schema.document_types_stored_in("widgets")).to contain_exactly(schema.type_named("Widget"))
         end
 
+        it "returns multiple types when an abstract type shares an index with its concrete subtypes via index inheritance" do
+          schema = define_schema do |s|
+            s.interface_type "Animal" do |t|
+              t.field "id", "ID!"
+              t.index "animals"
+            end
+
+            s.object_type "Dog" do |t|
+              t.implements "Animal"
+              t.field "id", "ID!"
+            end
+
+            s.object_type "Cat" do |t|
+              t.implements "Animal"
+              t.field "id", "ID!"
+            end
+          end
+
+          expect(schema.document_types_stored_in("animals")).to contain_exactly(
+            schema.type_named("Animal"),
+            schema.type_named("Dog"),
+            schema.type_named("Cat")
+          )
+        end
+
         it "raises an exception if given an unrecognizd index name" do
           schema = schema_with_indices("Person" => "people", "Widget" => "widgets")
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema_spec.rb
@@ -115,19 +115,19 @@ module ElasticGraph
         end
       end
 
-      describe "#document_type_stored_in" do
-        it "returns the type stored in the named index" do
+      describe "#document_types_stored_in" do
+        it "returns the types stored in the named index" do
           schema = schema_with_indices("Person" => "people", "Widget" => "widgets")
 
-          expect(schema.document_type_stored_in("people")).to eq(schema.type_named("Person"))
-          expect(schema.document_type_stored_in("widgets")).to eq(schema.type_named("Widget"))
+          expect(schema.document_types_stored_in("people")).to contain_exactly(schema.type_named("Person"))
+          expect(schema.document_types_stored_in("widgets")).to contain_exactly(schema.type_named("Widget"))
         end
 
         it "raises an exception if given an unrecognizd index name" do
           schema = schema_with_indices("Person" => "people", "Widget" => "widgets")
 
           expect {
-            schema.document_type_stored_in("foobars")
+            schema.document_types_stored_in("foobars")
           }.to raise_error(Errors::NotFoundError, a_string_including("foobars"))
         end
 
@@ -135,7 +135,7 @@ module ElasticGraph
           schema = schema_with_indices("Person" => "people", "Widget" => "widgets")
 
           expect {
-            schema.document_type_stored_in("widgets#{ROLLOVER_INDEX_INFIX_MARKER}2021-02")
+            schema.document_types_stored_in("widgets#{ROLLOVER_INDEX_INFIX_MARKER}2021-02")
           }.to raise_error(ArgumentError, a_string_including("widgets#{ROLLOVER_INDEX_INFIX_MARKER}2021-02", "name of a rollover index"))
         end
 

--- a/spec_support/lib/elastic_graph/spec_support/factories/widgets.rb
+++ b/spec_support/lib/elastic_graph/spec_support/factories/widgets.rb
@@ -210,4 +210,22 @@ FactoryBot.define do
       parts { [] }
     end
   end
+
+  factory :online_store, parent: :indexed_type do
+    __typename { "OnlineStore" }
+    established_on { Faker::Date.between(from: recent_date - 365, to: recent_date).iso8601 }
+    active { true }
+    name { Faker::Company.name }
+  end
+
+  factory :physical_store, parent: :indexed_type do
+    __typename { "PhysicalStore" }
+    established_on { Faker::Date.between(from: recent_date - 365, to: recent_date).iso8601 }
+    active { true }
+  end
+
+  factory :third_party_wholesale, parent: :indexed_type do
+    __typename { "ThirdPartyWholesale" }
+    active { true }
+  end
 end


### PR DESCRIPTION
This PR was created as a companion to #1150 (an initial step). It paves the way for the `non_subtypes_in_shared_index`  method by ensuring the GraphQL schema correctly tracks all document types per index, rather than only the first one seen.

### `indexed_document_types_by_index_definition_name` now returns `Set` per index

Previously, the hash stored only the *first* type seen for a given index name (via `||=`). With index inheritance, multiple concrete types can share the same index — so the old approach would non-deterministically drop all but one.

Changed to accumulate *all* indexed document types per index into a `Set`. This is required for `non_subtypes_in_shared_index` to work correctly: that method uses this hash to enumerate all types sharing an index when deciding whether a `__typename` filter is needed on abstract type queries. With the old approach, other types sharing the same index could be silently omitted, leading to incorrect or missing `__typename` filters.

### `document_type_stored_in` → `document_types_stored_in`

Renamed to reflect that the method now returns a `Set[Type]` rather than a single `Type`. Updated the two callers:

- **`graphql_adapter_builder`** (`resolve_type`): uses `.first` — safe here because this branch is only reached for individually-indexed types (no `__typename` in the document means no shared index), so the set always contains exactly one type.
- **`search_response_adapter_builder`** (`all_highlights`): now prefers `__typename` from the document source when present. Documents stored in a shared index carry `__typename` to identify their concrete type; using it directly ensures highlight field paths are resolved against the right type rather than whichever abstract or sibling type `.first` might return. Falls back to `.first` for individually-indexed types.

## Test plan

- New unit test in `search_response_adapter_builder_spec.rb` verifies that `all_highlights` uses `__typename` to resolve the concrete type: a hit from the `retailers` index with `__typename: "OnlineStore"` correctly resolves a highlight on `url` (an `OnlineStore`-specific field absent from the `Retailer` interface — without the fix, the wrong type would be used and the highlight would be silently dropped)
- In #1150, I plan to add an `all_highlights` acceptance test to `search_spec.rb` for shared-index types that would fail without the `search_response_adapter_builder` change made here. That acceptance test requires additions to the stock schema types and remaining index inheritance support that I didn't want to cloud this more focused PR step.