### PR TITLE
Rename ListRecords resolver class to IndexedTypeRootFieldsResolver

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -34,7 +34,7 @@ target :elasticgraph_gems do
     elasticgraph-graphql/lib/elastic_graph/graphql/datastore_response/search_response.rb
     elasticgraph-graphql/lib/elastic_graph/graphql/datastore_search_router.rb
     elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/get_record_field_value.rb
-    elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/list_records.rb
+    elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/indexed_type_root_fields_resolver.rb
     elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships.rb
     elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
     elasticgraph-graphql/lib/elastic_graph/graphql/schema/field.rb

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -1829,7 +1829,7 @@ graphql_resolvers_by_name:
     resolver_ref:
       name: ElasticGraph::GraphQL::Resolvers::GetRecordFieldValue
       require_path: elastic_graph/graphql/resolvers/get_record_field_value
-  list_records:
+  indexed_type_root_fields:
     needs_lookahead: true
     resolver_ref:
       name: ElasticGraph::GraphQL::Resolvers::IndexedTypeRootFieldsResolver
@@ -6196,136 +6196,136 @@ object_types_by_name:
     graphql_fields_by_name:
       address_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       addresses:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       companies:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       company_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       component_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       components:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       distribution_channel_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       distribution_channels:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       electrical_part_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       electrical_parts:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       inventor_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       inventors:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       manufacturer_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       manufacturers:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       mechanical_part_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       mechanical_parts:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       named_entities:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       named_entity_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       named_inventor_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       named_inventors:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       part_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       parts:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       people:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       person_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       physical_store_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       physical_stores:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       retail_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       retailers:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       sponsor_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       sponsors:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       store_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       stores:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       team_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       teams:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       wholesale_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       wholesalers:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       widget_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       widget_currencies:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       widget_currency_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       widget_or_address_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       widget_workspace_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       widget_workspaces:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       widgets:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       widgets_or_addresses:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
   Retail:
     graphql_fields_by_name:
       active:

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -1832,8 +1832,8 @@ graphql_resolvers_by_name:
   list_records:
     needs_lookahead: true
     resolver_ref:
-      name: ElasticGraph::GraphQL::Resolvers::ListRecords
-      require_path: elastic_graph/graphql/resolvers/list_records
+      name: ElasticGraph::GraphQL::Resolvers::IndexedTypeRootFieldsResolver
+      require_path: elastic_graph/graphql/resolvers/indexed_type_root_fields_resolver
   nested_relationships:
     needs_lookahead: true
     resolver_ref:

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -1861,8 +1861,8 @@ graphql_resolvers_by_name:
   list_records:
     needs_lookahead: true
     resolver_ref:
-      name: ElasticGraph::GraphQL::Resolvers::ListRecords
-      require_path: elastic_graph/graphql/resolvers/list_records
+      name: ElasticGraph::GraphQL::Resolvers::IndexedTypeRootFieldsResolver
+      require_path: elastic_graph/graphql/resolvers/indexed_type_root_fields_resolver
   nested_relationships:
     needs_lookahead: true
     resolver_ref:

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -1858,7 +1858,7 @@ graphql_resolvers_by_name:
     resolver_ref:
       name: ElasticGraph::GraphQL::Resolvers::GetRecordFieldValue
       require_path: elastic_graph/graphql/resolvers/get_record_field_value
-  list_records:
+  indexed_type_root_fields:
     needs_lookahead: true
     resolver_ref:
       name: ElasticGraph::GraphQL::Resolvers::IndexedTypeRootFieldsResolver
@@ -6325,136 +6325,136 @@ object_types_by_name:
           name: apollo_service
       address_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       addresses:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       companies:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       company_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       component_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       components:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       distribution_channel_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       distribution_channels:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       electrical_part_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       electrical_parts:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       inventor_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       inventors:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       manufacturer_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       manufacturers:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       mechanical_part_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       mechanical_parts:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       named_entities:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       named_entity_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       named_inventor_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       named_inventors:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       part_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       parts:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       people:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       person_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       physical_store_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       physical_stores:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       retail_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       retailers:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       sponsor_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       sponsors:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       store_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       stores:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       team_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       teams:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       wholesale_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       wholesalers:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       widget_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       widget_currencies:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       widget_currency_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       widget_or_address_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       widget_workspace_aggregations:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       widget_workspaces:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       widgets:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
       widgets_or_addresses:
         resolver:
-          name: list_records
+          name: indexed_type_root_fields
   Retail:
     graphql_fields_by_name:
       active:

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/indexed_type_root_fields_resolver.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/indexed_type_root_fields_resolver.rb
@@ -12,8 +12,8 @@ require "elastic_graph/graphql/resolvers/relay_connection"
 module ElasticGraph
   class GraphQL
     module Resolvers
-      # Responsible for fetching a a list of records of a particular type
-      class ListRecords
+      # Responsible for resolving the list and aggregation root fields generated for each indexed type.
+      class IndexedTypeRootFieldsResolver
         def initialize(elasticgraph_graphql:, config:)
           # Nothing to initialize, but needs to be defined to satisfy the resolver interface.
         end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/indexed_type_root_fields_resolver.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/indexed_type_root_fields_resolver.rbs
@@ -1,7 +1,7 @@
 module ElasticGraph
   class GraphQL
     module Resolvers
-      class ListRecords
+      class IndexedTypeRootFieldsResolver
         include _GraphQLResolverWithLookahead
       end
     end

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/indexed_type_root_fields_resolver_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/indexed_type_root_fields_resolver_spec.rb
@@ -6,12 +6,12 @@
 #
 # frozen_string_literal: true
 
-require "elastic_graph/graphql/resolvers/list_records"
+require "elastic_graph/graphql/resolvers/indexed_type_root_fields_resolver"
 
 module ElasticGraph
   class GraphQL
     module Resolvers
-      RSpec.describe ListRecords, :factories, :uses_datastore, :resolver do
+      RSpec.describe IndexedTypeRootFieldsResolver, :factories, :uses_datastore, :resolver do
         context "when the field being resolved is a relay connection field" do
           let(:graphql) { build_graphql }
 

--- a/elasticgraph-graphql/spec/support/query_adapter.rb
+++ b/elasticgraph-graphql/spec/support/query_adapter.rb
@@ -70,7 +70,7 @@ module QueryAdapterSpecSupport
 
     def resolved_with_resolver_that_builds_datastore_query?(schema_field, object)
       # Only 2 resolvers yield to `Resolvers::GraphQLAdapter` to get a query built.
-      [:list_records, :nested_relationships].include?(schema_field.resolver.name)
+      [:indexed_type_root_fields, :nested_relationships].include?(schema_field.resolver.name)
     end
 
     def coerce_input(type, value, ctx)

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_executor_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_executor_spec.rb
@@ -46,11 +46,11 @@ module ElasticGraph
               if type.name == "Query"
                 type.field "colors", "[Color!]!" do |f|
                   f.argument "args", "ColorArgs"
-                  f.resolve_with :list_records
+                  f.resolve_with :indexed_type_root_fields
                 end
                 type.field "colors2", "[Color2!]!" do |f|
                   f.argument "args", "ColorArgs"
-                  f.resolve_with :list_records
+                  f.resolve_with :indexed_type_root_fields
                 end
               end
             end
@@ -187,7 +187,7 @@ module ElasticGraph
             schema.on_root_query_type do |t|
               t.resolve_fields_with nil
               t.field "foo", "Int" do |f|
-                f.resolve_with :list_records
+                f.resolve_with :indexed_type_root_fields
               end
             end
           end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection_spec.rb
@@ -31,7 +31,7 @@ module ElasticGraph
               schema.on_root_query_type do |t|
                 # One test relies on `widgets_non_relay`, which isn't defined by default on `Query` so we define it here.
                 t.field "widgets_non_relay", "[Widget!]!" do |f|
-                  f.resolve_with :list_records
+                  f.resolve_with :indexed_type_root_fields
                 end
               end
             end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/resolvable_value_spec.rb
@@ -44,7 +44,7 @@ module ElasticGraph
 
               schema.on_root_query_type do |t|
                 t.field "person", "Person" do |f|
-                  f.resolve_with :list_records
+                  f.resolve_with :indexed_type_root_fields
                 end
               end
             end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/field_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/field_spec.rb
@@ -170,7 +170,7 @@ module ElasticGraph
               s.on_root_query_type do |f|
                 f.field "photos", "[Photo!]!" do |f|
                   f.argument "order_by", "[PhotoSort!]"
-                  f.resolve_with :list_records
+                  f.resolve_with :indexed_type_root_fields
                 end
               end
             end
@@ -295,7 +295,7 @@ module ElasticGraph
                   f.argument "camelCaseField", "Int"
                   f.argument "maybe_set_to_null", "String"
                   f.argument "nested", "Nested1FilterInput"
-                  f.resolve_with :list_records
+                  f.resolve_with :indexed_type_root_fields
                 end
               end
             end.field_named("Query", "foo")

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
@@ -131,7 +131,7 @@ module ElasticGraph
               singular: root_doc_type.singular_root_query_field_name
             ) do |f|
               f.documentation "Fetches `#{root_doc_type.name}`s based on the provided arguments."
-              f.resolve_with :list_records
+              f.resolve_with :indexed_type_root_fields
               f.hide_relationship_runtime_metadata = true
               root_doc_type.root_query_fields_customizations&.call(f)
             end

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
@@ -1428,9 +1428,9 @@ module ElasticGraph
             defined_at: require_path,
             built_in: true
 
-          require(require_path = "elastic_graph/graphql/resolvers/list_records")
+          require(require_path = "elastic_graph/graphql/resolvers/indexed_type_root_fields_resolver")
           schema_def_api.register_graphql_resolver :list_records,
-            GraphQL::Resolvers::ListRecords,
+            GraphQL::Resolvers::IndexedTypeRootFieldsResolver,
             defined_at: require_path,
             built_in: true
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
@@ -1429,7 +1429,7 @@ module ElasticGraph
             built_in: true
 
           require(require_path = "elastic_graph/graphql/resolvers/indexed_type_root_fields_resolver")
-          schema_def_api.register_graphql_resolver :list_records,
+          schema_def_api.register_graphql_resolver :indexed_type_root_fields,
             GraphQL::Resolvers::IndexedTypeRootFieldsResolver,
             defined_at: require_path,
             built_in: true

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/filters_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/filters_spec.rb
@@ -691,7 +691,7 @@ module ElasticGraph
           define_schema do |api|
             api.object_type "Widget" do |t|
               t.field "id", "ID!" do |f|
-                f.resolve_with :list_records
+                f.resolve_with :indexed_type_root_fields
 
                 f.customize_filter_field do |ff|
                   results << ff.resolver

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/graphql_resolvers_by_name_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/graphql_resolvers_by_name_spec.rb
@@ -20,7 +20,7 @@ module ElasticGraph
 
         expect(result.keys).to contain_exactly(
           :get_record_field_value,
-          :list_records,
+          :indexed_type_root_fields,
           :nested_relationships,
           :object_with_lookahead,
           :object_without_lookahead
@@ -119,7 +119,7 @@ module ElasticGraph
             or update the fields listed above to use one of the other registered resolvers:
 
               - :get_record_field_value
-              - :list_records
+              - :indexed_type_root_fields
               - :nested_relationships
               - :object_with_lookahead
               - :object_without_lookahead

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/graphql_fields_by_name_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/graphql_fields_by_name_spec.rb
@@ -16,7 +16,7 @@ module ElasticGraph
       it "defaults the `resolver` of each individual field to the parent type's `default_graphql_resolver`" do
         metadata = object_type_metadata_for "Widget" do |s|
           s.object_type "Widget" do |t|
-            t.resolve_fields_with :list_records
+            t.resolve_fields_with :indexed_type_root_fields
 
             t.field "id", "ID"
             t.field "description", "String"
@@ -32,8 +32,8 @@ module ElasticGraph
         end
 
         expect(metadata.graphql_fields_by_name).to eq({
-          "id" => graphql_field_with(name_in_index: "id", resolver: configured_graphql_resolver(:list_records)),
-          "description" => graphql_field_with(name_in_index: "description", resolver: configured_graphql_resolver(:list_records)),
+          "id" => graphql_field_with(name_in_index: "id", resolver: configured_graphql_resolver(:indexed_type_root_fields)),
+          "description" => graphql_field_with(name_in_index: "description", resolver: configured_graphql_resolver(:indexed_type_root_fields)),
           "name" => graphql_field_with(name_in_index: "name", resolver: configured_graphql_resolver(:get_record_field_value)),
           "title" => graphql_field_with(name_in_index: "title", resolver: configured_graphql_resolver(:object_without_lookahead))
         })
@@ -42,12 +42,12 @@ module ElasticGraph
       it "records resolver arguments as `config`" do
         metadata = object_type_metadata_for "Widget" do |s|
           s.object_type "Widget" do |t|
-            t.resolve_fields_with :list_records, limit: 17
+            t.resolve_fields_with :indexed_type_root_fields, limit: 17
 
             t.field "id", "ID"
 
             t.field "description", "String" do |f|
-              f.resolve_with :list_records, limit: 4
+              f.resolve_with :indexed_type_root_fields, limit: 4
             end
 
             t.field "name", "String" do |f|
@@ -61,8 +61,8 @@ module ElasticGraph
         end
 
         expect(metadata.graphql_fields_by_name).to eq({
-          "id" => graphql_field_with(name_in_index: "id", resolver: configured_graphql_resolver(:list_records, limit: 17)),
-          "description" => graphql_field_with(name_in_index: "description", resolver: configured_graphql_resolver(:list_records, limit: 4)),
+          "id" => graphql_field_with(name_in_index: "id", resolver: configured_graphql_resolver(:indexed_type_root_fields, limit: 17)),
+          "description" => graphql_field_with(name_in_index: "description", resolver: configured_graphql_resolver(:indexed_type_root_fields, limit: 4)),
           "name" => graphql_field_with(name_in_index: "name", resolver: configured_graphql_resolver(:get_record_field_value, max: 12)),
           "title" => graphql_field_with(name_in_index: "title", resolver: configured_graphql_resolver(:object_without_lookahead, size: 3))
         })


### PR DESCRIPTION
This is the first in a series of PR's to to implement the feature detailed in this feature request: https://github.com/block/elasticgraph/discussions/1130

**Summary**                                                                                                                                                                                                                                                                                                                                           
  - Rename the ListRecords resolver class to IndexedTypeRootFieldsResolver to reflect that it resolves both list and aggregation root fields for indexed types — not just list fields.                     
  - Rename the corresponding .rb, .rbs, and integration spec files; update Steepfile and built_in_types.rb registration accordingly.                                                                       
  - Regenerate schema artifacts (non-Apollo, Apollo, music examples) — the name: field in runtime_metadata.yaml reflects the new class name.                                                               
  - Preserve the :list_records resolver symbol to avoid a breaking artifact change for downstream users. The rename is class-only; the registered symbol is unchanged.   