### PR TITLE
Add index inheritance notes to YARD API docs and AI memory

### DIFF
--- a/ai-memory/README.md
+++ b/ai-memory/README.md
@@ -301,6 +301,16 @@ The project is a monorepo composed of many gems. Each gem typically resides in i
     -   **Dependencies**: `elasticgraph-graphql`, `elasticgraph-indexer`, `elasticgraph-schema_artifacts`, `elasticgraph-support`, `graphql`, `graphql-c_parser`, `rake`.
     -   **Provides**: The schema definition framework and artifact generation capabilities.
 
+### Index Inheritance
+
+Abstract types (interfaces and unions) may declare an index that their concrete subtypes inherit, rather than each subtype declaring its own. Multiple concrete types then share a single datastore index. A subtype may still declare its own dedicated index, which overrides the inherited one — those documents are stored in a separate index and do not have `__typename` stored in them.
+
+**`__typename` injection (indexer)**: When a record is indexed into a shared (inherited) index, the indexer automatically injects `__typename` into the document so the datastore can distinguish between concrete types at query time.
+
+**Query-time scoping**: When an abstract type shares an index with types outside its subtype hierarchy, `QueryAdapter::AbstractTypeFilter` automatically injects an internal `__typename` filter scoped to the queried type's concrete subtypes.
+
+**Key files**: `schema_definition/indexing/index.rb`, `schema_definition/mixins/has_indices.rb`, `schema_definition/schema_elements/type_with_subfields.rb`, `indexer/record_preparer.rb`, `graphql/query_adapter/abstract_type_filter.rb`, `graphql/schema/type.rb`.
+
 ## Other Key Information
 
 This section highlights other important aspects of the ElasticGraph project:

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/search_response_adapter_builder.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/search_response_adapter_builder.rb
@@ -53,7 +53,8 @@ module ElasticGraph
                   # that identifies the concrete type; use it to resolve the concrete type directly.
                   schema.type_named(typename)
                 else
-                  # For individually-indexed types the set always contains exactly one type.
+                  # Index inheritance always injects `__typename` into any shared index mapping,
+                  # so a missing `__typename` means no sharing — the set contains exactly one type.
                   schema.document_types_stored_in(node.index_definition_name).first # : Schema::Type
                 end
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
@@ -139,6 +139,10 @@ module ElasticGraph
       # one or more fields that concrete implementations of the interface must also define. Each implementation can be an
       # {SchemaElements::ObjectType} or {SchemaElements::InterfaceType}.
       #
+      # @note An interface type can declare an index with {Mixins::HasIndices#index}. This creates a _mixed-type index_ in
+      #   the datastore where concrete types that implement the interface coexist. A subtype may opt out of this shared
+      #   index inheritance and use a dedicated index by declaring its own with {Mixins::HasIndices#index}.
+      #
       # @param name [String] name of the interface
       # @yield [SchemaElements::InterfaceType] interface type object
       # @return [void]
@@ -202,6 +206,10 @@ module ElasticGraph
 
       # Defines a [GraphQL union type](https://graphql.org/learn/schema/#union-types). Use it to define an abstract supertype with one or
       # more concrete subtypes. Each subtype must be an {SchemaElements::ObjectType}, but they do not have to share any fields in common.
+      #
+      # @note A union type can declare an index with {Mixins::HasIndices#index}. This creates a _mixed-type index_ in
+      #   the datastore where the union members coexist. A subtype may opt out of this shared index inheritance and use
+      #   a dedicated index by declaring its own with {Mixins::HasIndices#index}.
       #
       # @param name [String] name of the union type
       # @yield [SchemaElements::UnionType] union type object

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
@@ -164,7 +164,7 @@ module ElasticGraph
         # @return [Boolean] true if this type is directly queryable via a type-specific field on the root `Query` type.
         # @note A concrete subtype that inherits an index from an abstract parent is NOT directly queryable on its own —
         #   only the abstract type that declared the index is. Use {#root_document_type?} to check whether a type
-        #   participates in any index (own or inherited).
+        #   is stored at the root of any index (own or inherited).
         def directly_queryable?
           has_own_index_def?
         end

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
@@ -29,12 +29,15 @@ module ElasticGraph
           initialize_has_indices { yield self }
         end
 
-        # Converts the current type from being an _embedded_ type (that is, a type that is embedded within another indexed type) to an
-        # _indexed_ type that resides in the named index definition. Indexed types are directly indexed into the datastore, and will be
-        # queryable from the root `Query` type.
+        # Declares a datastore index for the current type, converting it from an _embedded_ type to an _indexed_ type
+        # that is directly queryable from the root `Query` type. When called on an abstract `interface_type` or
+        # `union_type`, concrete subtypes inherit the index by default — they share the same datastore index without
+        # needing to call `t.index` themselves. A subtype can opt out of this shared index inheritance by calling
+        # `t.index` with a different name to use a dedicated index instead.
         #
         # @note Use {#root_query_fields} on indexed types to name the field that will be exposed on `Query`.
         # @note Indexed types must also define an `id` field, which ElasticGraph will use as the primary key.
+        #   When an abstract type declares the index, each concrete subtype must also define `id`.
         # @note Datastore index settings can also be defined (or overridden) in an environment-specific settings YAML file. Index settings
         #   that you want to configure differently for different environments (such as `index.number_of_shards`—-production and staging
         #   will probably need different numbers!) should be configured in the per-environment YAML configuration files rather than here.
@@ -46,7 +49,7 @@ module ElasticGraph
         # @yield [Indexing::Index] the index, so it can be customized further
         # @return [void]
         #
-        # @example Define a `campaigns` index
+        # @example Define a `campaigns` index on a concrete type
         #   ElasticGraph.define_schema do |schema|
         #     schema.object_type "Campaign" do |t|
         #       t.field "id", "ID"
@@ -60,6 +63,32 @@ module ElasticGraph
         #       ) do |i|
         #         # The index can be customized further here.
         #       end
+        #     end
+        #   end
+        #
+        # @example Declare a shared index on an interface
+        #   ElasticGraph.define_schema do |schema|
+        #     schema.interface_type "Vehicle" do |t|
+        #       t.field "id", "ID"
+        #       t.field "make", "String"
+        #       t.index "vehicles"
+        #     end
+        #
+        #     schema.object_type "Car" do |t|
+        #       t.implements "Vehicle"
+        #       t.field "id", "ID"
+        #       t.field "make", "String"
+        #       t.field "numDoors", "Int"
+        #       # Inherits the `vehicles` index — no need to call `t.index`.
+        #     end
+        #
+        #     schema.object_type "Motorcycle" do |t|
+        #       t.implements "Vehicle"
+        #       t.field "id", "ID"
+        #       t.field "make", "String"
+        #       t.field "engineCC", "Int"
+        #       # Opts out of the shared index and gets its own dedicated index instead.
+        #       t.index "motorcycles"
         #     end
         #   end
         def index(name, **settings, &block)
@@ -133,6 +162,9 @@ module ElasticGraph
         end
 
         # @return [Boolean] true if this type is directly queryable via a type-specific field on the root `Query` type.
+        # @note A concrete subtype that inherits an index from an abstract parent is NOT directly queryable on its own —
+        #   only the abstract type that declared the index is. Use {#root_document_type?} to check whether a type
+        #   participates in any index (own or inherited).
         def directly_queryable?
           has_own_index_def?
         end

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/implements_interfaces.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/implements_interfaces.rb
@@ -16,6 +16,10 @@ module ElasticGraph
         # Declares that the current type implements the specified interface, making the current type a subtype of the interface. The
         # current type must define all of the fields of the named interface, with the exact same field types.
         #
+        # @note If the named interface has declared an index (via {Mixins::HasIndices#index}), calling `implements`
+        #   causes this type to automatically inherit that index — it will be stored in the same datastore index as all other
+        #   implementations of the named interface. To use a dedicated index instead, call {Mixins::HasIndices#index} on this type.
+        #
         # @param interface_names [Array<String>] names of interface types implemented by this type
         # @return [void]
         #


### PR DESCRIPTION
Augments existing `index`, `interface_type`, and `union_type` YARD docs with notes explaining shared index inheritance and the opt-out pattern. Adds a new index inheritance section to `ai-memory/README.md` to help contributor agents understand the feature.

This is the last planned PR for index inheritance. It should pave the way for working on typename filtering (#1024).

Closes #1029