### PR TITLE
Add __typename as constant_keyword to single-type index mappings

### DIFF
--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -1241,6 +1241,9 @@ index_templates:
           __versions:
             type: object
             dynamic: 'false'
+          __typename:
+            type: constant_keyword
+            value: Team
         _routing:
           required: true
         _size:
@@ -1312,6 +1315,9 @@ index_templates:
           __versions:
             type: object
             dynamic: 'false'
+          __typename:
+            type: constant_keyword
+            value: WidgetCurrency
         _routing:
           required: true
         _size:
@@ -1475,6 +1481,9 @@ index_templates:
           __versions:
             type: object
             dynamic: 'false'
+          __typename:
+            type: constant_keyword
+            value: Widget
         _routing:
           required: true
         _size:
@@ -1523,6 +1532,9 @@ indices:
         __versions:
           type: object
           dynamic: 'false'
+        __typename:
+          type: constant_keyword
+          value: Address
       _size:
         enabled: true
     settings:
@@ -1586,6 +1598,9 @@ indices:
         __versions:
           type: object
           dynamic: 'false'
+        __typename:
+          type: constant_keyword
+          value: Component
       _size:
         enabled: true
     settings:
@@ -1644,6 +1659,9 @@ indices:
         __versions:
           type: object
           dynamic: 'false'
+        __typename:
+          type: constant_keyword
+          value: ElectricalPart
       _size:
         enabled: true
     settings:
@@ -1677,6 +1695,9 @@ indices:
         __versions:
           type: object
           dynamic: 'false'
+        __typename:
+          type: constant_keyword
+          value: Manufacturer
       _size:
         enabled: true
     settings:
@@ -1706,6 +1727,9 @@ indices:
         __versions:
           type: object
           dynamic: 'false'
+        __typename:
+          type: constant_keyword
+          value: MechanicalPart
       _size:
         enabled: true
     settings:
@@ -1759,6 +1783,9 @@ indices:
         __versions:
           type: object
           dynamic: 'false'
+        __typename:
+          type: constant_keyword
+          value: PhysicalStore
       _size:
         enabled: true
     settings:
@@ -1781,6 +1808,9 @@ indices:
         __versions:
           type: object
           dynamic: 'false'
+        __typename:
+          type: constant_keyword
+          value: Sponsor
       _size:
         enabled: true
     settings:
@@ -1810,6 +1840,9 @@ indices:
         __versions:
           type: object
           dynamic: 'false'
+        __typename:
+          type: constant_keyword
+          value: WidgetWorkspace
       _size:
         enabled: true
     settings:

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -1241,6 +1241,9 @@ index_templates:
           __versions:
             type: object
             dynamic: 'false'
+          __typename:
+            type: constant_keyword
+            value: Team
         _routing:
           required: true
         _size:
@@ -1312,6 +1315,9 @@ index_templates:
           __versions:
             type: object
             dynamic: 'false'
+          __typename:
+            type: constant_keyword
+            value: WidgetCurrency
         _routing:
           required: true
         _size:
@@ -1475,6 +1481,9 @@ index_templates:
           __versions:
             type: object
             dynamic: 'false'
+          __typename:
+            type: constant_keyword
+            value: Widget
         _routing:
           required: true
         _size:
@@ -1523,6 +1532,9 @@ indices:
         __versions:
           type: object
           dynamic: 'false'
+        __typename:
+          type: constant_keyword
+          value: Address
       _size:
         enabled: true
     settings:
@@ -1586,6 +1598,9 @@ indices:
         __versions:
           type: object
           dynamic: 'false'
+        __typename:
+          type: constant_keyword
+          value: Component
       _size:
         enabled: true
     settings:
@@ -1644,6 +1659,9 @@ indices:
         __versions:
           type: object
           dynamic: 'false'
+        __typename:
+          type: constant_keyword
+          value: ElectricalPart
       _size:
         enabled: true
     settings:
@@ -1677,6 +1695,9 @@ indices:
         __versions:
           type: object
           dynamic: 'false'
+        __typename:
+          type: constant_keyword
+          value: Manufacturer
       _size:
         enabled: true
     settings:
@@ -1706,6 +1727,9 @@ indices:
         __versions:
           type: object
           dynamic: 'false'
+        __typename:
+          type: constant_keyword
+          value: MechanicalPart
       _size:
         enabled: true
     settings:
@@ -1759,6 +1783,9 @@ indices:
         __versions:
           type: object
           dynamic: 'false'
+        __typename:
+          type: constant_keyword
+          value: PhysicalStore
       _size:
         enabled: true
     settings:
@@ -1781,6 +1808,9 @@ indices:
         __versions:
           type: object
           dynamic: 'false'
+        __typename:
+          type: constant_keyword
+          value: Sponsor
       _size:
         enabled: true
     settings:
@@ -1810,6 +1840,9 @@ indices:
         __versions:
           type: object
           dynamic: 'false'
+        __typename:
+          type: constant_keyword
+          value: WidgetWorkspace
       _size:
         enabled: true
     settings:

--- a/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/shared_examples.rb
+++ b/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/shared_examples.rb
@@ -42,7 +42,7 @@ module ElasticGraph
         let(:output_io) { StringIO.new }
         let(:clock) { class_double(::Time, now: ::Time.utc(2024, 3, 20, 12, 0, 0)) }
         let(:mapping_removal_note_snippet) { "extra fields listed here will not actually get removed" }
-        let(:index_meta_fields) { ["__sources", "__versions"] }
+        let(:index_meta_fields) { ["__sources", "__typename", "__versions"] }
 
         it "idempotently creates an index or index template, avoiding unneeded datastore write calls" do
           expect {

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/abstract_type_filter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/abstract_type_filter.rb
@@ -29,11 +29,10 @@ module ElasticGraph
       # `BrokerWholesaler` documents from `distribution_channels` would appear in results.
       # So we inject:
       #
-      #   __typename: { equal_to_any_of: [nil, "OnlineStore", "PhysicalStore"] }
+      #   __typename: { equal_to_any_of: ["OnlineStore", "PhysicalStore"] }
       #
-      # `nil` is included because `PhysicalStore` has a dedicated index where documents lack
-      # `__typename` — the index itself identifies the type. We only include `nil` when at least
-      # one of the queried indexes stores only a single type (and thus lacks `__typename`).
+      # `PhysicalStore` has a dedicated index with `__typename` stored as a `constant_keyword`,
+      # so it matches the `equal_to_any_of` filter just like documents in the shared index.
       class AbstractTypeFilter
         def initialize(schema_element_names)
           @equal_to_any_of = schema_element_names.equal_to_any_of
@@ -48,15 +47,8 @@ module ElasticGraph
 
           return query unless doc_type.shares_index_with_non_subtypes?
 
-          schema = context.fetch(:elastic_graph_schema)
           subtypes = doc_type.subtypes # Note: subtypes returns all concrete subtypes at any depth
           typename_values = subtypes.map(&:name)
-          # Only include nil when at least one queried index stores only a single type — those
-          # documents lack __typename (the index itself identifies the type), so nil is needed to
-          # allow them through.
-          if doc_type.search_index_definitions.any? { |idx| schema.document_types_stored_in(idx.name).size == 1 }
-            typename_values += [nil]
-          end
           query.merge_with(internal_filters: [{
             "__typename" => {@equal_to_any_of => typename_values}
           }])

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/abstract_type_filter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_adapter/abstract_type_filter_spec.rb
@@ -29,22 +29,16 @@ module ElasticGraph
         end
 
         context "when querying an abstract type that shares a search index with a non-subtype" do
-          it "applies a __typename filter scoped to the queried type's concrete subtypes, including nil for subtypes with dedicated indexes" do
+          it "applies a __typename filter scoped to the queried type's concrete subtypes" do
             query = datastore_query_for(:Query, :retailers, "query { retailers { edges { node { id } } } }")
 
-            expect(typename_filter_from(query)).to contain_exactly(nil, "OnlineStore", "PhysicalStore")
+            expect(typename_filter_from(query)).to contain_exactly("OnlineStore", "PhysicalStore")
           end
 
           it "applies a __typename filter on aggregations of this kind of abstract type" do
             query = datastore_query_for(:Query, :retail_aggregations, "query { retail_aggregations { nodes { count } } }")
 
-            expect(typename_filter_from(query)).to contain_exactly(nil, "OnlineStore", "PhysicalStore")
-          end
-
-          it "omits nil from the __typename filter when all queried indexes store multiple types" do
-            query = datastore_query_for(:Query, :wholesalers, "query { wholesalers { edges { node { id } } } }")
-
-            expect(typename_filter_from(query)).to contain_exactly("DirectWholesaler", "BrokerWholesaler")
+            expect(typename_filter_from(query)).to contain_exactly("OnlineStore", "PhysicalStore")
           end
         end
 

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/record_preparer.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/record_preparer.rb
@@ -118,13 +118,16 @@ module ElasticGraph
           # what the concrete subtype is. `__typename` is required on abstract types and indicates that.
           eg_meta_by_field_name = @eg_meta_by_field_name_by_concrete_type.fetch(value["__typename"] || type_name)
 
-          # Determine whether __typename belongs at this position by checking the index mapping.
-          typename_in_mapping = mapping_properties&.key?("__typename")
+          # We only want to consider __typename if it's in the per-record mapping in order to determine
+          # whether __typename is required on records. When it's a constant_keyword it exists at the index
+          # level and therefore should be ignored for this purpose.
+          typename_type = mapping_properties&.dig("__typename", "type")
+          typename_in_record_mapping = typename_type && typename_type != "constant_keyword"
 
           prepared_fields = value.filter_map do |field_name, field_value|
             if field_name == "__typename"
               # Only include __typename if the index mapping has it at this position.
-              [field_name, field_value] if typename_in_mapping
+              [field_name, field_value] if typename_in_record_mapping
             elsif (eg_meta = eg_meta_by_field_name[field_name])
               name_in_index = eg_meta.fetch("nameInIndex")
               nested_mapping_properties = mapping_properties&.dig(name_in_index, "properties")
@@ -134,7 +137,7 @@ module ElasticGraph
 
           # Inject __typename if the mapping requires it but it's absent from the record
           # (e.g. for a concrete type indexed in a mixed-type index).
-          if typename_in_mapping && !value.key?("__typename")
+          if typename_in_record_mapping && !value.key?("__typename")
             prepared_fields["__typename"] = type_name
           end
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/index.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/index.rb
@@ -297,7 +297,7 @@ module ElasticGraph
             .except("type") # `type` is invalid at the mapping root because it always has to be an object.
             .then { |mapping| ListCountsMapping.merged_into(mapping, for_type: indexed_type) }
             .then do |fm|
-              Support::HashUtil.deep_merge(fm, {"properties" => {
+              internal_fields = {
                 "__sources" => {"type" => "keyword"},
                 "__versions" => {
                   "type" => "object",
@@ -317,7 +317,17 @@ module ElasticGraph
                   # a boolean.
                   "dynamic" => "false"
                 }
-              }})
+              }
+
+              # We add __typename for concrete types so they can be matched by __typename filters, which are
+              # applied when querying abstract types that span multiple indices. Since every document in a
+              # concrete type's index has the same value, we use constant_keyword here. It stores __typename
+              # once at the index level with zero per-document overhead.
+              unless indexed_type.abstract?
+                internal_fields["__typename"] = {"type" => "constant_keyword", "value" => indexed_type.name}
+              end
+
+              Support::HashUtil.deep_merge(fm, {"properties" => internal_fields})
             end
 
           {"dynamic" => "strict"}.merge(field_mappings).tap do |hash|

--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
@@ -1025,7 +1025,7 @@ module ElasticGraph
             expect(error.message.lines.first(8).join).to eq(<<~EOS)
               6 schema artifact(s) are out of date. Run `bundle exec rake schema_artifacts:dump` to update the following artifact(s):
 
-              1. config/schema/artifacts/datastore_config.yaml (see [1] below for the diff)
+              1. config/schema/artifacts/datastore_config.yaml (see [1] below for the first 50 lines of the diff)
               2. config/schema/artifacts/json_schemas.yaml (see [2] below for the first 50 lines of the diff)
               3. config/schema/artifacts/json_schemas_by_version/v1.yaml (see [3] below for the diff)
               4. config/schema/artifacts/json_schemas_by_version/v2.yaml (file does not exist)

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/abstract_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/abstract_types_spec.rb
@@ -249,6 +249,40 @@ module ElasticGraph
         end
       end
 
+      context "for a concrete type with its own index" do
+        it "includes __typename as a constant_keyword with the type name as the value" do
+          mapping = index_mapping_for "widgets" do |s|
+            s.object_type "Widget" do |t|
+              t.field "id", "ID!"
+              t.field "name", "String"
+              t.index "widgets"
+            end
+          end
+
+          expect(mapping.dig("properties", "__typename")).to eq({"type" => "constant_keyword", "value" => "Widget"})
+        end
+
+        it "does not include __typename as constant_keyword for an abstract type's shared index" do
+          mapping = index_mapping_for "things" do |s|
+            s.object_type "Widget" do |t|
+              t.field "id", "ID!"
+              t.implements "Thing"
+            end
+
+            s.object_type "Component" do |t|
+              t.field "id", "ID!"
+              t.implements "Thing"
+            end
+
+            s.interface_type "Thing" do |t|
+              t.index "things"
+            end
+          end
+
+          expect(mapping.dig("properties", "__typename")).to eq({"type" => "keyword"})
+        end
+      end
+
       context "on a type union" do
         include_examples "a type with subtypes", :union_type do
           def link_subtype_to_supertype(object_type, supertype_name)

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/abstract_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/abstract_types_spec.rb
@@ -261,26 +261,6 @@ module ElasticGraph
 
           expect(mapping.dig("properties", "__typename")).to eq({"type" => "constant_keyword", "value" => "Widget"})
         end
-
-        it "does not include __typename as constant_keyword for an abstract type's shared index" do
-          mapping = index_mapping_for "things" do |s|
-            s.object_type "Widget" do |t|
-              t.field "id", "ID!"
-              t.implements "Thing"
-            end
-
-            s.object_type "Component" do |t|
-              t.field "id", "ID!"
-              t.implements "Thing"
-            end
-
-            s.interface_type "Thing" do |t|
-              t.index "things"
-            end
-          end
-
-          expect(mapping.dig("properties", "__typename")).to eq({"type" => "keyword"})
-        end
       end
 
       context "on a type union" do

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/miscellaneous_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/miscellaneous_spec.rb
@@ -347,7 +347,7 @@ module ElasticGraph
         mapping = generate_mapping.call(graphql_only: true)
 
         # Verify that it does not have a property for `size` or `options.size`
-        expect(mapping.fetch("properties").keys).to contain_exactly("id", "options", "__sources", "__versions")
+        expect(mapping.fetch("properties").keys).to contain_exactly("id", "options", "__sources", "__versions", "__typename")
         expect(mapping.fetch("properties")).to include({
           "id" => {"type" => "keyword"},
           "options" => {


### PR DESCRIPTION

## What is changing?

Single-type indices previously omitted `__typename` from their mappings entirely. This adds `__typename` as a [`constant_keyword`](https://www.elastic.co/guide/en/elasticsearch/reference/current/keyword.html#constant-keyword-field-type) to the root mapping of every single-type index, using the type name as the value. `constant_keyword` stores the value once at the index level with zero per-document overhead and supports filtering — so `AbstractTypeFilter` can now include dedicated-index subtypes in `__typename` filter values without the `nil` sentinel workaround that was previously needed.

## Why are we making this change?

Besides the `nil` sentinel cleanup in `AbstractTypeFilter` mentioned above, this is a prerequisite for `_typename` filtering (#1169) to match concrete subtypes stored in single-type indices. When querying an abstract type whose subtypes span both shared and dedicated indices, a `_typename` filter must be able to match documents in both. Without `__typename` in their mappings, documents in single-type indices have no field to match against — they would always be excluded from results when a `_typename` filter is applied. Storing `__typename` as a `constant_keyword` gives those documents a value to match without any per-document storage cost.

For example, querying `retailers` with `_typename: { equal_to_any_of: ["OnlineStore", "PhysicalStore"] }` would target two indices: `distribution_channels` (where `OnlineStore` documents live) and `physical_stores` (where `PhysicalStore` documents live). The filter is applied against both indexes, but before this change `physical_stores` had no `__typename` field — so none of its documents would match:

| | `distribution_channels` | `physical_stores` |
|---|---|---|
| **Before** | `OnlineStore` matches ✓ | no `__typename` field — no match ✗ |
| **After** | `OnlineStore` matches ✓ | `PhysicalStore` matches ✓ |

The "After" works because `physical_stores` now has `__typename` mapped as a `constant_keyword` with value `PhysicalStore`.

## Why only root types?

This adds `__typename` only to the root mapping of each single-type index, not to nested concrete object types (e.g. Manufacturer.ceo: Person).

I considered going further and adding `constant_keyword` `__typename` to every concrete nested object type for consistency. However, the known spots that conditionally use `__typename` — `resolve_type` and `all_highlights` — both fall back to `document_types_stored_in` only for root documents from single-type indices. Suppose we do a follow-on optimization to eliminate those fallbacks. We could do that by adding `"fields": ["__typename"]` to search requests so the datastore returns the `constant_keyword` `__typename` value alongside each hit, thereby eliminating the need for `document_types_stored_in`. But the fields API returns `constant_keyword` values only for root-level fields, not for nested object properties — so nested concrete types can't contribute to that goal even if they had `constant_keyword`.

Since I can't identify an immediate use for `constant_keyword` `__typename` on nested concrete types — even as a stepping stone toward eliminating `document_types_stored_in` — I've decided not to include them speculatively. Do you agree we should limit this to root types only, or do you want me to add it to all concrete object types in case a use case emerges in the future?