### PR TITLE
Improve release notes skill based on v1.2.0 authoring feedback

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -36,33 +36,63 @@ You are generating release notes for ElasticGraph. Follow this workflow:
    gh pr view <number> --json title,body
    ```
 
-### Step 3: Review Release Note Format
+### Step 3: Comprehensive PR Discovery
+
+**IMPORTANT**: Multiple discovery methods are needed because:
+- Some PRs are squash-merged without the PR number in the commit message
+- Some PRs are merged into stacked branches (not directly into main) but their changes are included via a parent PR
+- The `gh pr list` date-based search may include PRs that were merged before the base tag was cut (same day, earlier timestamp)
+
+Perform these cross-checks:
+1. Extract PR numbers from `git log v<base>..HEAD --oneline` (grep for `#\d+`)
+2. Get PR numbers from `gh pr list --state merged --base main --search "merged:>=<date>"` 
+3. Combine both lists; any PR in the `gh` list but not in `git log` needs investigation:
+   - Check `gh pr view <number> --json baseRefName` — if merged to a non-main branch, it was a stacked PR whose changes came in via a parent. Include its PR number in the parent feature's bullet.
+   - Check merge timestamp vs tag timestamp — PRs merged before the tag are already in the previous release.
+4. **Gap audit**: enumerate all numbers between the lowest and highest PR number in the range. For each gap, run `gh pr view` and `gh issue view` to determine if it's a closed/unmerged PR, an issue, or a merged PR we missed. Only merged-to-main PRs need coverage. Stacked PRs merged to intermediate branches should be listed with their parent feature's PR numbers.
+
+### Step 4: Review Release Note Format
 1. Read `MAINTAINERS_RUNBOOK.md` for release note structure guidelines
 2. Fetch 1-2 recent release notes for format reference:
    ```bash
    gh release view <recent-version> --json body
    ```
 
-### Step 4: Categorize PRs
+### Step 5: Categorize PRs
 Group PRs into these categories:
 - **New Features**: New functionality, new gems, new APIs
 - **Performance Optimizations**: Speed improvements, resource efficiency
-- **Bug Fixes**: Corrections to existing behavior
+- **Bug Fixes**: Corrections to existing behavior (single section — never split into two)
 - **Other Improvements**: Documentation, tooling, refactoring, cleanup
 - **Dependency Upgrades**: Grouped by type (Ruby gems, GitHub Actions, NPM, Python)
 
 Guidelines:
 - Multiple PRs implementing one feature should be combined into one bullet
-- Internal-only changes (CI fixes, codebase cleanup) go under "Other Improvements"
+- Internal-only changes (CI fixes, codebase cleanup, test fixes, typo fixes) go under "Other Improvements" as a single "Various codebase maintenance" line with all PR numbers listed
 - Dependabot PRs are grouped under "Dependency Upgrades" with all PR numbers listed
+- **Dependency upgrade consolidation**: ALL PRs that update, pin, exclude, or otherwise modify a dependency belong in the dependency upgrade bullet for that dependency — not in separate bug fix or other improvement sections. For example, a PR that excludes a buggy gem version, a PR that upgrades to a fixed version, and a Dependabot PR that bumps the version all belong together in one dependency line.
+- There should be exactly ONE "Bug Fixes" section under "What's Changed". Do not create a separate top-level Bug Fixes section.
 
-### Step 5: Identify New Contributors
+### Step 6: Identify New Contributors
 1. Get all contributors since base version
 2. Get all contributors before base version
 3. New contributors = those in first list but not second
 4. List them with their first PR
 
-### Step 6: Draft Release Notes
+### Step 7: Draft Release Notes
+
+#### Writing style for feature descriptions
+
+- **Lead with user value, not implementation details.** For example, `returnable: false` saves storage — don't bury that under implementation details about `_source.excludes`.
+- **Use ElasticGraph terminology.** Say "abstract supertypes" not "parent abstract types". Check existing docs and schema definition DSL for canonical terms.
+- **Use camelCase in GraphQL examples** to match how most ElasticGraph schemas are configured. Use `query { ... }` wrappers and multi-line filter expressions for readability.
+- **Be precise about scope.** If a feature only applies when using a specific gem (e.g., `elasticgraph-query_registry`), say so.
+- **Distinguish "new" from "fixed".** If something was supposed to work but was broken by a later change (regression), it's a bug fix, not a new feature. For example, config validation rejecting a previously-valid value is a regression fix.
+- **Don't overclaim performance wins.** Report what changed and why it matters; avoid micro-benchmark multipliers that don't reflect real-world impact (e.g., "146x faster" on a path where the overhead was never dominant). Focus on what the optimization removes or avoids.
+- **For first-time support of something** (e.g., JRuby), say "for the first time" — don't version-qualify it (e.g., don't say "JRuby 10.0 support" when it's the first JRuby support ever).
+- **Reference MRI as "MRI (C Ruby)"** on first mention, then just "MRI" subsequently.
+- **Link to external documentation** when referencing datastore-specific features (e.g., `X-Opaque-Id` headers).
+
 Structure:
 ```
 ElasticGraph v<VERSION> has been released! <1-2 sentence summary>
@@ -71,8 +101,12 @@ ElasticGraph v<VERSION> has been released! <1-2 sentence summary>
 ### <Feature Name>
 Description of major features with their own subsections.
 
-## Upgrade notes
+## Upgrade Notes
 Any breaking changes or required migration steps.
+
+## Performance Optimizations
+### <Optimization Name>
+Description of performance improvements.
 
 ## What's Changed
 
@@ -87,6 +121,7 @@ Any breaking changes or required migration steps.
 
 ### Other Improvements
 * Description by @author in [#PR](url)...
+* Various codebase maintenance by @author in [#PR](url), [#PR](url)...
 
 ### Dependency Upgrades
 The datastore versions we build against have been upgraded:
@@ -114,17 +149,17 @@ The following Python packages have been upgraded:
 **Full Changelog**: https://github.com/block/elasticgraph/compare/v<base>...v<VERSION>
 ```
 
-### Step 7: Audit Coverage
+### Step 8: Audit Coverage
 1. Count total PRs since base version (exclude release PRs like "Release vX.Y.Z")
 2. Count PRs mentioned in release notes
 3. Identify any missing PRs and add them to appropriate sections
 4. Ensure 100% coverage
 
-### Step 8: Present for Review
+### Step 9: Present for Review
 Output the complete release notes and ask if any adjustments are needed.
 
 ## Notes
-- The audience is ElasticGraph users - focus on user-facing changes
+- The audience is ElasticGraph users — focus on user-facing changes
 - Internal improvements can be grouped (e.g., "Various codebase maintenance")
 - For pre-releases (rc1, rc2), use GitHub's autogenerated notes instead
 - Check versioning policy if unsure whether version should be major/minor/patch


### PR DESCRIPTION
## Summary

Improvements to the Claude Code release notes skill based on feedback from authoring the v1.2.0 release notes.

* Add comprehensive PR discovery step: cross-check git log vs gh search, handle stacked PRs merged to intermediate branches, gap audit of PR numbers
* Add writing style guidelines: lead with user value, use ElasticGraph terminology, camelCase in GraphQL examples, distinguish new features from regression fixes, don't overclaim performance wins, link external docs
* Consolidate all dependency-related PRs (upgrades, pins, exclusions) into single bullets per dependency
* Group internal-only changes as "Various codebase maintenance"
* Enforce single Bug Fixes section (previously generated two)
* Add Performance Optimizations to the release notes structure template

## Test plan

- [ ] Invoke `/release-notes` on next release and verify improved output quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)