### PR TITLE
Followups from #1176: improve tests a bit.

### DIFF
--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_definition_spec_support.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_definition_spec_support.rb
@@ -13,22 +13,30 @@ module ElasticGraph
     ::RSpec.shared_context "IndexDefinitionSpecSupport" do
       include_context "SchemaDefinitionHelpers"
 
-      def index_configs_for(*index_names, index_document_sizes: false, schema_element_name_form: "snake_case", &schema_definition)
-        config = define_schema(
+      def build_datastore_config(index_document_sizes: false, schema_element_name_form: "snake_case", &schema_definition)
+        define_schema(
           index_document_sizes: index_document_sizes,
           schema_element_name_form: schema_element_name_form,
           &schema_definition
         ).datastore_config
+      end
+
+      def index_configs_for(*index_names, index_document_sizes: false, schema_element_name_form: "snake_case", &schema_definition)
+        config = build_datastore_config(
+          index_document_sizes: index_document_sizes,
+          schema_element_name_form: schema_element_name_form,
+          &schema_definition
+        )
 
         index_names.map { |i| config.fetch("indices").fetch(i) }
       end
 
       def index_template_configs_for(*index_names, index_document_sizes: false, schema_element_name_form: "snake_case", &schema_definition)
-        config = define_schema(
+        config = build_datastore_config(
           index_document_sizes: index_document_sizes,
           schema_element_name_form: schema_element_name_form,
           &schema_definition
-        ).datastore_config
+        )
 
         index_names.map { |i| config.fetch("index_templates").fetch(i) }
       end

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/namespace_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/namespace_type_spec.rb
@@ -14,7 +14,7 @@ module ElasticGraph
       include_context "IndexMappingsSpecSupport"
 
       it "does not generate an index mapping for a namespace type since it has no backing data to index" do
-        index_configs = index_configs_for "widgets" do |s|
+        datastore_config = build_datastore_config do |s|
           s.object_type "Widget" do |t|
             t.field "id", "ID!"
             t.index "widgets"
@@ -23,9 +23,8 @@ module ElasticGraph
           s.namespace_type "OlapQuery"
         end
 
-        # Only the `widgets` index mapping is generated (no namespace type mapping).
-        widget_mapping = index_configs.first.fetch("mappings")
-        expect(widget_mapping.dig("properties")).to include("id" => {"type" => "keyword"})
+        expect(datastore_config.fetch("indices").keys).to contain_exactly("widgets")
+        expect(datastore_config.fetch("index_templates").keys).to be_empty
       end
 
       it "omits fields that reference a namespace type from the index mapping of an indexed type" do

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/namespace_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/namespace_type_spec.rb
@@ -101,6 +101,8 @@ module ElasticGraph
 
           # But it doesn't appear on any derived type of `Widget`.
           widget_derived_types = types_defined_in(result).grep(/\AWidget/) - ["Widget"]
+          expect(widget_derived_types.size).to be >= 5
+
           widget_derived_types.each do |derived_type_name|
             derived_type_sdl = type_def_from(result, derived_type_name)
             expect(derived_type_sdl).not_to include("olap"),


### PR DESCRIPTION
- Refocus a mapping test at the indices named in the mappings instead of just the `widgets` index mapping.
- Rename `namespace_spec.rb` -> `namespace_type_spec.rb` for consistency.
- Verify `widget_derived_types` has multiple entries as expected.