### PR TITLE
Refactor Query to be registered as a namespace_type

### DIFF
--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -6118,6 +6118,7 @@ object_types_by_name:
       widgets_or_addresses:
         resolver:
           name: indexed_type_root_fields
+    graphql_only_return_type: true
   Retail:
     graphql_fields_by_name:
       active:

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -6247,6 +6247,7 @@ object_types_by_name:
       widgets_or_addresses:
         resolver:
           name: indexed_type_root_fields
+    graphql_only_return_type: true
   Retail:
     graphql_fields_by_name:
       active:

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/factory_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/factory_extension.rb
@@ -75,6 +75,15 @@ module ElasticGraph
           end
         end
 
+        def new_namespace_type(name, &block)
+          super(name) do |raw_type|
+            raw_type.extend ObjectTypeExtension
+            type = raw_type # : ElasticGraph::SchemaDefinition::SchemaElements::NamespaceType & ObjectTypeExtension
+
+            yield type if block_given?
+          end
+        end
+
         def new_scalar_type(name)
           super(name) do |type|
             type.extend ScalarTypeExtension

--- a/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
+++ b/elasticgraph-apollo/spec/unit/elastic_graph/apollo/schema_definition_spec.rb
@@ -607,6 +607,18 @@ module ElasticGraph
           expect(result).to_not include("@tag")
         end
 
+        it "supports namespace types declared without a block" do
+          schema_string = graphql_schema_string do |schema|
+            define_some_types_on(schema)
+            schema.namespace_type "OlapQuery"
+            schema.on_root_query_type do |t|
+              t.field "olap", "OlapQuery!"
+            end
+          end
+
+          expect(type_def_from(schema_string, "OlapQuery")).to start_with("type OlapQuery")
+        end
+
         it "adds its extension methods in a way that does not leak into a schema definition that lacks the apollo extension" do
           schema_extensions = [:tag_built_in_types_with]
           field_extensions = [:tag_with]

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
@@ -111,64 +111,6 @@ module ElasticGraph
         # Record that we are now generating results so that caching can kick in.
         state.user_definition_complete = true
         state.user_definition_complete_callbacks.each(&:call)
-        define_root_graphql_type
-      end
-
-      def define_root_graphql_type
-        state.api.object_type "Query" do |query_type|
-          query_type.documentation "The query entry point for the entire schema."
-          query_type.resolve_fields_with nil
-
-          state.object_types_by_name.values.select(&:directly_queryable?).sort_by(&:name).each do |type|
-            # @type var root_doc_type: Mixins::HasIndices & _Type
-            root_doc_type = _ = type
-
-            query_type.relates_to_many(
-              root_doc_type.plural_root_query_field_name,
-              root_doc_type.name,
-              via: "ignore",
-              dir: :in,
-              singular: root_doc_type.singular_root_query_field_name
-            ) do |f|
-              f.documentation "Fetches `#{root_doc_type.name}`s based on the provided arguments."
-              f.resolve_with :indexed_type_root_fields
-              f.hide_relationship_runtime_metadata = true
-              root_doc_type.root_query_fields_customizations&.call(f)
-            end
-
-            # Add additional efficiency hints to the aggregation field documentation if we have any such hints.
-            # This needs to be outside the `relates_to_many` block because `relates_to_many` adds its own "suffix" to
-            # the field documentation, and here we add another one.
-            if (agg_efficiency_hint = aggregation_efficiency_hints_for(root_doc_type.derived_indexed_types))
-              agg_name = state.schema_elements.normalize_case("#{root_doc_type.singular_root_query_field_name}_aggregations")
-              agg_field = query_type.graphql_fields_by_name.fetch(agg_name)
-              agg_field.documentation "#{agg_field.doc_comment}\n\n#{agg_efficiency_hint}"
-            end
-          end
-
-          state.built_in_types_customization_blocks.each do |customization_block|
-            customization_block.call(query_type)
-          end
-        end
-      end
-
-      def aggregation_efficiency_hints_for(derived_indexed_types)
-        return nil if derived_indexed_types.empty?
-
-        hints = derived_indexed_types.map do |type|
-          derived_indexing_type = state.types_by_name.fetch(type.destination_type_ref.name)
-          alternate_field_name = (_ = derived_indexing_type).plural_root_query_field_name
-          grouping_field = type.id_source
-
-          "  - The root `#{alternate_field_name}` field groups by `#{grouping_field}`"
-        end
-
-        <<~EOS
-          Note: aggregation queries are relatively expensive, and some fields have been pre-aggregated to allow
-          more efficient queries for some common aggregation cases:
-
-          #{hints.join("\n")}
-        EOS
       end
 
       def json_schema_with_metadata_merger
@@ -463,13 +405,7 @@ module ElasticGraph
 
       def all_types
         @all_types ||= state.types_by_name.values.flat_map do |registered_type|
-          related_types =
-            if registered_type.name == "Query"
-              [registered_type]
-            else
-              [registered_type] + registered_type.derived_graphql_types
-            end
-
+          related_types = [registered_type] + registered_type.derived_graphql_types
           apply_customizations_to(related_types, registered_type)
           related_types
         end

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
@@ -179,6 +179,7 @@ module ElasticGraph
           register_date_and_time_grouped_by_types
           register_standard_elastic_graph_types
           register_standard_graphql_resolvers
+          register_root_query_type
         end
 
         private
@@ -1455,6 +1456,66 @@ module ElasticGraph
             GraphQL::Resolvers::Object::WithoutLookahead,
             defined_at: require_path,
             built_in: true
+        end
+
+        def register_root_query_type
+          schema_def_api.namespace_type "Query" do |t|
+            t.documentation "The query entry point for the entire schema."
+          end
+
+          schema_def_state.after_user_definition_complete do
+            populate_root_query_fields
+          end
+        end
+
+        def populate_root_query_fields
+          query_type = schema_def_state.object_types_by_name.fetch("Query")
+
+          schema_def_state.object_types_by_name.values.select(&:directly_queryable?).sort_by(&:name).each do |type|
+            # @type var root_doc_type: Mixins::HasIndices & _Type
+            root_doc_type = _ = type
+
+            query_type.relates_to_many(
+              root_doc_type.plural_root_query_field_name,
+              root_doc_type.name,
+              via: "ignore",
+              dir: :in,
+              singular: root_doc_type.singular_root_query_field_name
+            ) do |f|
+              f.documentation "Fetches `#{root_doc_type.name}`s based on the provided arguments."
+              f.resolve_with :indexed_type_root_fields
+              f.hide_relationship_runtime_metadata = true
+              root_doc_type.root_query_fields_customizations&.call(f)
+            end
+
+            # Add additional efficiency hints to the aggregation field documentation if we have any such hints.
+            # This needs to be outside the `relates_to_many` block because `relates_to_many` adds its own "suffix" to
+            # the field documentation, and here we add another one.
+            if (agg_efficiency_hint = aggregation_efficiency_hints_for(root_doc_type.derived_indexed_types))
+              agg_name = schema_def_state.schema_elements.normalize_case("#{root_doc_type.singular_root_query_field_name}_aggregations")
+              agg_field = query_type.graphql_fields_by_name.fetch(agg_name)
+              agg_field.documentation "#{agg_field.doc_comment}\n\n#{agg_efficiency_hint}"
+            end
+          end
+        end
+
+        def aggregation_efficiency_hints_for(derived_indexed_types)
+          return nil if derived_indexed_types.empty?
+
+          hints = derived_indexed_types.map do |type|
+            derived_indexing_type = schema_def_state.types_by_name.fetch(type.destination_type_ref.name)
+            alternate_field_name = (_ = derived_indexing_type).plural_root_query_field_name
+            grouping_field = type.id_source
+
+            "  - The root `#{alternate_field_name}` field groups by `#{grouping_field}`"
+          end
+
+          <<~EOS
+            Note: aggregation queries are relatively expensive, and some fields have been pre-aggregated to allow
+            more efficient queries for some common aggregation cases:
+
+            #{hints.join("\n")}
+          EOS
         end
 
         def define_date_grouping_arguments(grouping_field, omit_timezone: false)

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/results.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/results.rbs
@@ -35,8 +35,6 @@ module ElasticGraph
 
       private
 
-      def define_root_graphql_type: () -> void
-      def aggregation_efficiency_hints_for: (::Array[Indexing::DerivedIndexedType]) -> ::String?
       def json_schema_with_metadata_merger: () -> Indexing::JSONSchemaWithMetadata::Merger
       def generate_datastore_config: () -> ::Hash[::String, untyped]
       def build_dynamic_scripts: () -> ::Array[Scripting::Script]


### PR DESCRIPTION
Part 3 of the stacked PR series implementing query namespacing (https://github.com/block/elasticgraph/discussions/1130).

## Summary                                      
                                                                                                                                                                                                                                   
Removes the one remaining Query-specific code path in Results by registering Query itself as a regular namespace type during built-in type registration. Field population moves to a normal after_user_definition_complete callback colocated with the registration.                                                                                                                                                                                        
                                                                                                                                                                                           
## Why
                 
namespace_type (introduced in #1176) exists precisely so that a type can host root-like fields without being indexed. Query was the motivating use case; it's now also the first consumer.
                                                                                   
Before this PR, Query had a bespoke finalization path (Results#define_root_graphql_type) that built the Query type from scratch at SDL generation time. Collapsing it into the generic namespace-type path:
  - Removes ~60 lines of Query-specific special casing                                                                                                                           
  - Makes follow-up PRs' behavior (e.g. on: "Query", cycle/reachability validation over the whole namespace graph) fall out naturally as Query becomes just another namespace type
                                                                                                                                 
## Changes                                                                                                                                                                                                                          
  - built_in_types.rb: Query is registered via schema_def_api.namespace_type "Query"; field population runs in an after_user_definition_complete callback colocated with the registration.                                         
  - results.rb: removes define_root_graphql_type, aggregation_efficiency_hints_for, and the Query-name branch in all_types.                                                               
  - elasticgraph-apollo: FactoryExtension now applies ObjectTypeExtension to namespace types so tag_built_in_types_with keeps working for Query.                                                                                   
  - Runtime metadata artifacts: Query now carries graphql_only_return_type: true (inherited from NamespaceType's graphql_only flag). No behavioral impact.