### PR TITLE
Add on: parameter to root_query_fields

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
@@ -154,7 +154,7 @@ module ElasticGraph
       # @yield [SchemaElements::NamespaceType] namespace type object, for further customization
       # @return [void]
       #
-      # @example Define an `OlapQuery` namespace type and hang it off `Query`
+      # @example Group an indexed type's root query fields under an `OlapQuery` namespace
       #   ElasticGraph.define_schema do |schema|
       #     schema.namespace_type "OlapQuery" do |t|
       #       t.documentation "Namespace for OLAP query fields."
@@ -162,6 +162,14 @@ module ElasticGraph
       #
       #     schema.on_root_query_type do |t|
       #       t.field "olap", "OlapQuery!"
+      #     end
+      #
+      #     schema.object_type "Widget" do |t|
+      #       t.field "id", "ID"
+      #       # Routes `widgets` and `widgetAggregations` onto `OlapQuery` instead of `Query`,
+      #       # exposing them as `Query.olap.widgets` and `Query.olap.widgetAggregations`.
+      #       t.root_query_fields plural: "widgets", on: "OlapQuery"
+      #       t.index "widgets"
       #     end
       #   end
       def namespace_type(name, &block)

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
@@ -268,14 +268,17 @@ module ElasticGraph
           ).with(**runtime_metadata_overrides)
         end
 
-        # Determines what the root `Query` fields will be to query this indexed type. In addition, this method accepts a block, which you
+        # Determines what the root query fields will be to query this indexed type. In addition, this method accepts a block, which you
         # can use to customize the root query field (such as adding a GraphQL directive to it).
         #
-        # @param plural [String] the plural name of the entity; used for the root `Query` field that queries documents of this indexed type
-        # @param singular [String, nil] the singular name of the entity; used for the root `Query` field (with an `Aggregations` suffix) that
+        # @param plural [String] the plural name of the entity; used for the root query field that queries documents of this indexed type
+        # @param singular [String, nil] the singular name of the entity; used for the root query field (with an `Aggregations` suffix) that
         #   queries aggregations of this indexed type. If not provided, will derive it from the type name (e.g. converting it to `camelCase`
         #   or `snake_case`, depending on configuration).
-        # @yield [SchemaElements::Field] field on the root `Query` type used to query this indexed type, to support customization
+        # @param on [String] name of the object type on which the root fields should be defined. Defaults to `"Query"`. To route the
+        #   fields to a {API#namespace_type namespace type} instead, pass its name (e.g. `"OlapQuery"`). The target type must have been
+        #   declared via `namespace_type`; otherwise an error is raised at schema-definition time.
+        # @yield [SchemaElements::Field] field on the target type used to query this indexed type, to support customization
         # @return [void]
         #
         # @example Set `plural` and `singular` names
@@ -303,9 +306,26 @@ module ElasticGraph
         #       t.index "people"
         #     end
         #   end
-        def root_query_fields(plural:, singular: nil, &customization_block)
+        #
+        # @example Route root fields to a namespace type
+        #   ElasticGraph.define_schema do |schema|
+        #     schema.namespace_type "OlapQuery"
+        #
+        #     schema.on_root_query_type do |t|
+        #       t.field "olap", "OlapQuery"
+        #     end
+        #
+        #     schema.object_type "Widget" do |t|
+        #       # Results in `OlapQuery.widgets` and `OlapQuery.widgetAggregations`.
+        #       t.root_query_fields plural: "widgets", on: "OlapQuery"
+        #       t.field "id", "ID"
+        #       t.index "widgets"
+        #     end
+        #   end
+        def root_query_fields(plural:, singular: nil, on: "Query", &customization_block)
           @plural_root_query_field_name = plural
           @singular_root_query_field_name = singular
+          @root_query_fields_target_namespace = on
           @root_query_fields_customizations = customization_block
         end
 
@@ -324,6 +344,42 @@ module ElasticGraph
         # @private
         def root_query_fields_customizations
           @root_query_fields_customizations
+        end
+
+        # @return [String] name of the object type on which the root fields for this indexed type should be defined.
+        #   Defaults to `"Query"`; can be overridden via the `on:` parameter of {#root_query_fields}.
+        def root_query_fields_target_namespace
+          @root_query_fields_target_namespace || "Query"
+        end
+
+        # Registers the root query fields for this indexed type on its target namespace type. Called during
+        # schema finalization, after all user type definitions have been evaluated.
+        #
+        # @private
+        def register_root_query_fields
+          target_type = resolve_root_query_fields_target
+
+          target_type.relates_to_many(
+            plural_root_query_field_name,
+            name,
+            via: "ignore",
+            dir: :in,
+            singular: singular_root_query_field_name
+          ) do |f|
+            f.documentation "Fetches `#{name}`s based on the provided arguments."
+            f.resolve_with :indexed_type_root_fields
+            f.hide_relationship_runtime_metadata = true
+            root_query_fields_customizations&.call(f)
+          end
+
+          # Add additional efficiency hints to the aggregation field documentation if we have any such hints.
+          # This needs to be outside the `relates_to_many` block because `relates_to_many` adds its own "suffix" to
+          # the field documentation, and here we add another one.
+          if (agg_efficiency_hint = aggregation_efficiency_hint)
+            agg_name = schema_def_state.schema_elements.normalize_case("#{singular_root_query_field_name}_aggregations")
+            agg_field = target_type.graphql_fields_by_name.fetch(agg_name)
+            agg_field.documentation "#{agg_field.doc_comment}\n\n#{agg_efficiency_hint}"
+          end
         end
 
         # @private
@@ -428,6 +484,44 @@ module ElasticGraph
               field_metadata
             end
           end
+        end
+
+        def resolve_root_query_fields_target
+          target_name = root_query_fields_target_namespace
+          target_type = schema_def_state.object_types_by_name[target_name]
+
+          if target_type.nil?
+            raise Errors::SchemaError,
+              "`#{name}` uses `root_query_fields on: #{target_name.inspect}`, but no type named `#{target_name}` is defined. " \
+              "Declare it with `schema.namespace_type #{target_name.inspect}` or correct the `on:` value."
+          end
+
+          unless schema_def_state.namespace_types_by_name.key?(target_name)
+            raise Errors::SchemaError,
+              "`#{name}` uses `root_query_fields on: #{target_name.inspect}`, but `#{target_name}` is not a namespace type. " \
+              "`on:` must reference a type declared with `schema.namespace_type`."
+          end
+
+          target_type
+        end
+
+        def aggregation_efficiency_hint
+          return nil if derived_indexed_types.empty?
+
+          hints = derived_indexed_types.map do |type|
+            derived_indexing_type = schema_def_state.types_by_name.fetch(type.destination_type_ref.name)
+            alternate_field_name = (_ = derived_indexing_type).plural_root_query_field_name
+            grouping_field = type.id_source
+
+            "  - The root `#{alternate_field_name}` field groups by `#{grouping_field}`"
+          end
+
+          <<~EOS
+            Note: aggregation queries are relatively expensive, and some fields have been pre-aggregated to allow
+            more efficient queries for some common aggregation cases:
+
+            #{hints.join("\n")}
+          EOS
         end
 
         # Provides a "best effort" conversion of a type name to the plural form.

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
@@ -322,7 +322,7 @@ module ElasticGraph
         #       t.index "widgets"
         #     end
         #   end
-        def root_query_fields(plural:, singular: nil, on: "Query", &customization_block)
+        def root_query_fields(plural:, singular: nil, on: root_query_fields_target_namespace, &customization_block)
           @plural_root_query_field_name = plural
           @singular_root_query_field_name = singular
           @root_query_fields_target_namespace = on

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
@@ -186,7 +186,7 @@ module ElasticGraph
         sourced_field_errors = [] # : ::Array[::String]
         relationship_errors = [] # : ::Array[::String]
 
-        state.object_types_by_name.except("Query").values.each_with_object(
+        state.object_types_by_name.reject { |name, _| state.namespace_types_by_name.key?(name) }.values.each_with_object(
           ::Hash.new { |h, k| h[k] = [] } # : ::Hash[untyped, ::Array[SchemaArtifacts::RuntimeMetadata::UpdateTarget]]
         ) do |object_type, accum|
           fields_with_sources_by_relationship_name =

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
@@ -186,7 +186,7 @@ module ElasticGraph
         sourced_field_errors = [] # : ::Array[::String]
         relationship_errors = [] # : ::Array[::String]
 
-        state.object_types_by_name.reject { |name, _| state.namespace_types_by_name.key?(name) }.values.each_with_object(
+        state.object_types_by_name.except(*state.namespace_types_by_name.keys).values.each_with_object(
           ::Hash.new { |h, k| h[k] = [] } # : ::Hash[untyped, ::Array[SchemaArtifacts::RuntimeMetadata::UpdateTarget]]
         ) do |object_type, accum|
           fields_with_sources_by_relationship_name =

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
@@ -1464,58 +1464,10 @@ module ElasticGraph
           end
 
           schema_def_state.after_user_definition_complete do
-            populate_root_query_fields
-          end
-        end
-
-        def populate_root_query_fields
-          query_type = schema_def_state.object_types_by_name.fetch("Query")
-
-          schema_def_state.object_types_by_name.values.select(&:directly_queryable?).sort_by(&:name).each do |type|
-            # @type var root_doc_type: Mixins::HasIndices & _Type
-            root_doc_type = _ = type
-
-            query_type.relates_to_many(
-              root_doc_type.plural_root_query_field_name,
-              root_doc_type.name,
-              via: "ignore",
-              dir: :in,
-              singular: root_doc_type.singular_root_query_field_name
-            ) do |f|
-              f.documentation "Fetches `#{root_doc_type.name}`s based on the provided arguments."
-              f.resolve_with :indexed_type_root_fields
-              f.hide_relationship_runtime_metadata = true
-              root_doc_type.root_query_fields_customizations&.call(f)
-            end
-
-            # Add additional efficiency hints to the aggregation field documentation if we have any such hints.
-            # This needs to be outside the `relates_to_many` block because `relates_to_many` adds its own "suffix" to
-            # the field documentation, and here we add another one.
-            if (agg_efficiency_hint = aggregation_efficiency_hints_for(root_doc_type.derived_indexed_types))
-              agg_name = schema_def_state.schema_elements.normalize_case("#{root_doc_type.singular_root_query_field_name}_aggregations")
-              agg_field = query_type.graphql_fields_by_name.fetch(agg_name)
-              agg_field.documentation "#{agg_field.doc_comment}\n\n#{agg_efficiency_hint}"
+            schema_def_state.object_types_by_name.values.select(&:directly_queryable?).sort_by(&:name).each do |type|
+              (_ = type).register_root_query_fields
             end
           end
-        end
-
-        def aggregation_efficiency_hints_for(derived_indexed_types)
-          return nil if derived_indexed_types.empty?
-
-          hints = derived_indexed_types.map do |type|
-            derived_indexing_type = schema_def_state.types_by_name.fetch(type.destination_type_ref.name)
-            alternate_field_name = (_ = derived_indexing_type).plural_root_query_field_name
-            grouping_field = type.id_source
-
-            "  - The root `#{alternate_field_name}` field groups by `#{grouping_field}`"
-          end
-
-          <<~EOS
-            Note: aggregation queries are relatively expensive, and some fields have been pre-aggregated to allow
-            more efficient queries for some common aggregation cases:
-
-            #{hints.join("\n")}
-          EOS
         end
 
         def define_date_grouping_arguments(grouping_field, omit_timezone: false)

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
@@ -1465,7 +1465,7 @@ module ElasticGraph
 
           schema_def_state.after_user_definition_complete do
             schema_def_state.object_types_by_name.values.select(&:directly_queryable?).sort_by(&:name).each do |type|
-              (_ = type).register_root_query_fields
+              type.register_root_query_fields
             end
           end
         end

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/namespace_type.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/namespace_type.rb
@@ -18,10 +18,22 @@ module ElasticGraph
       # another namespace type) under a shared path. It cannot be indexed, and any no-argument field
       # (on any parent type) whose return type is a namespace type is automatically resolved.
       #
-      # @example Define a namespace type
+      # @example Group an indexed type's root query fields under an `OlapQuery` namespace
       #   ElasticGraph.define_schema do |schema|
       #     schema.namespace_type "OlapQuery" do |t|
-      #       # in the block, `t` is a NamespaceType
+      #       t.documentation "Namespace for OLAP query fields."
+      #     end
+      #
+      #     schema.on_root_query_type do |t|
+      #       t.field "olap", "OlapQuery!"
+      #     end
+      #
+      #     schema.object_type "Widget" do |t|
+      #       t.field "id", "ID"
+      #       # Routes `widgets` and `widgetAggregations` onto `OlapQuery` instead of `Query`,
+      #       # exposing them as `Query.olap.widgets` and `Query.olap.widgetAggregations`.
+      #       t.root_query_fields plural: "widgets", on: "OlapQuery"
+      #       t.index "widgets"
       #     end
       #   end
       class NamespaceType < ObjectType

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/mixins/has_indices.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/mixins/has_indices.rbs
@@ -21,10 +21,12 @@ module ElasticGraph
           ?route_with: ::String,
           ?rollover_with: ::String
         ) ?{ ( Indexing::DerivedIndexedType) -> void } -> Indexing::DerivedIndexedType
-        def root_query_fields: (plural: ::String, ?singular: ::String?) ?{ (SchemaElements::Field) -> void } -> void
+        def root_query_fields: (plural: ::String, ?singular: ::String?, ?on: ::String) ?{ (SchemaElements::Field) -> void } -> void
         def plural_root_query_field_name: () -> ::String
         def singular_root_query_field_name: () -> ::String
         def root_query_fields_customizations: () -> (^(SchemaElements::Field) -> void)?
+        def root_query_fields_target_namespace: () -> ::String
+        def register_root_query_fields: () -> void
         def fields_with_sources: () -> ::Array[SchemaElements::Field]
         def indexing_fields_by_name_in_index: () -> ::Hash[::String, SchemaElements::Field]
       end

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/root_query_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/root_query_type_spec.rb
@@ -389,6 +389,129 @@ module ElasticGraph
           expect(type_names.grep(/\AQuery/)).to eq ["Query"]
         end
 
+        context "when `root_query_fields` uses `on:` to target a namespace type" do
+          it "places the list and aggregations fields on the named namespace type instead of `Query`" do
+            result = define_schema do |api|
+              api.namespace_type "OlapQuery"
+
+              api.on_root_query_type do |t|
+                t.field "olap", "OlapQuery!"
+              end
+
+              api.object_type "Widget" do |t|
+                t.root_query_fields plural: "widgets", singular: "widget", on: "OlapQuery"
+                t.field "id", "ID"
+                t.index "widgets"
+              end
+            end
+
+            expect(type_def_from(result, "Query")).to eq("type Query {\n  olap: OlapQuery!\n}")
+            expect(type_def_from(result, "OlapQuery")).to eq(<<~EOS.strip)
+              type OlapQuery {
+                widgets(
+                  filter: WidgetFilterInput
+                  #{correctly_cased "order_by"}: [WidgetSortOrderInput!]
+                  first: Int
+                  after: Cursor
+                  last: Int
+                  before: Cursor): WidgetConnection
+                #{correctly_cased "widget_aggregations"}(
+                  filter: WidgetFilterInput
+                  first: Int
+                  after: Cursor
+                  last: Int
+                  before: Cursor): WidgetAggregationConnection
+              }
+            EOS
+          end
+
+          it "supports nested namespace types" do
+            result = define_schema do |api|
+              api.namespace_type "OlapQuery" do |t|
+                t.field "domain", "DomainQuery!"
+              end
+              api.namespace_type "DomainQuery"
+
+              api.on_root_query_type do |t|
+                t.field "olap", "OlapQuery!"
+              end
+
+              api.object_type "Widget" do |t|
+                t.root_query_fields plural: "widgets", singular: "widget", on: "DomainQuery"
+                t.field "id", "ID"
+                t.index "widgets"
+              end
+            end
+
+            expect(type_def_from(result, "Query")).to eq("type Query {\n  olap: OlapQuery!\n}")
+            expect(type_def_from(result, "OlapQuery")).to eq("type OlapQuery {\n  domain: DomainQuery!\n}")
+            expect(type_def_from(result, "DomainQuery")).to start_with("type DomainQuery {\n  widgets(")
+          end
+
+          it "still routes other indexed types with no `on:` to `Query`" do
+            result = define_schema do |api|
+              api.namespace_type "OlapQuery"
+
+              api.on_root_query_type do |t|
+                t.field "olap", "OlapQuery!"
+              end
+
+              api.object_type "Widget" do |t|
+                t.root_query_fields plural: "widgets", singular: "widget", on: "OlapQuery"
+                t.field "id", "ID"
+                t.index "widgets"
+              end
+
+              api.object_type "Person" do |t|
+                t.root_query_fields plural: "people", singular: "person"
+                t.field "id", "ID"
+                t.index "people"
+              end
+            end
+
+            query_def = type_def_from(result, "Query")
+            expect(query_def).to include("olap: OlapQuery!")
+            expect(query_def).to include("people(")
+            expect(query_def).to include("#{correctly_cased("person_aggregations")}(")
+            expect(query_def).not_to include("widgets(")
+            expect(type_def_from(result, "OlapQuery")).to include("widgets(")
+          end
+
+          it "raises a clear error when `on:` references an undeclared type" do
+            expect {
+              define_schema do |api|
+                api.object_type "Widget" do |t|
+                  t.root_query_fields plural: "widgets", singular: "widget", on: "MissingNamespace"
+                  t.field "id", "ID"
+                  t.index "widgets"
+                end
+              end
+            }.to raise_error(Errors::SchemaError, a_string_including(
+              "`Widget` uses `root_query_fields on: \"MissingNamespace\"`",
+              "no type named `MissingNamespace` is defined"
+            ))
+          end
+
+          it "raises a clear error when `on:` references a non-namespace object type" do
+            expect {
+              define_schema do |api|
+                api.object_type "Regular" do |t|
+                  t.field "id", "ID"
+                end
+
+                api.object_type "Widget" do |t|
+                  t.root_query_fields plural: "widgets", singular: "widget", on: "Regular"
+                  t.field "id", "ID"
+                  t.index "widgets"
+                end
+              end
+            }.to raise_error(Errors::SchemaError, a_string_including(
+              "`Widget` uses `root_query_fields on: \"Regular\"`",
+              "`Regular` is not a namespace type"
+            ))
+          end
+        end
+
         it "can be customized using `on_root_query_type`" do
           available_field_names = []
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                          
                                                                                                                                                                                            
Adds an `on:` parameter to root_query_fields so an indexed type can route its root query fields onto a namespace type other than the default Query. This is the next step toward query namespacing; letting schemas group root fields under typed paths like OlapQuery.widgets instead of forcing everything onto Query.
                                               
## Why

PR3 made Query a regular namespace type but kept all root field registration in built_in_types.rb, where the orchestrator had to know how to build fields on Query. With this PR, each indexed type owns its own register_root_query_fields, resolving its own target namespace and defining the relates_to_many + aggregation hint on it.                                                                 
                                                                              
Query is now special in only three ways:
  1. It's auto-declared as a namespace type
  2. It's the default on: target                                                                                                                                                                          
  3. It has the on_root_query_type customization hook

This sets up cleanly for follow-up PRs that need on: "OtherNamespace" semantics (e.g., cycle/reachability validation across the namespace graph).                                                                                

## Changes                                                                                                                                                                                                                          
  - mixins/has_indices.rb:                                                                                                                                                                                                         
    - root_query_fields accepts an on: keyword arg (default "Query")                                                                                                                        
    - New register_root_query_fields method (per indexed type) handles its own field registration                                                                                                                                  
    - New resolve_root_query_fields_target validates the on: target exists and is a namespace type                                                                                                                                 
    - aggregation_efficiency_hint moved here from Results/built_in_types.rb since it's now per-type                                                                                                                                
  - schema_elements/built_in_types.rb: register_root_query_type shrinks to a small iterator that dispatches to each indexed type's register_root_query_fields                                                                      
  - results.rb: identify_extra_update_targets_by_object_type_name now excludes all namespace types (not just "Query") to avoid NoMethodError when relationships are generated on non-Query namespace types                         
  - New tests (graphql_schema/root_query_type_spec.rb):                                                                                                                                                                            
    - on: routes fields to the named namespace type                                                                                                                                                                                
    - Other indexed types without on: still go to Query                                                                                                                                                                            
    - Nested namespace types are supported                                                                                                                                                                                         
    - Clear errors for undeclared / non-namespace on: targets