### PR TITLE
Validate namespace type graph at SDL generation time

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
@@ -113,6 +113,56 @@ module ElasticGraph
         state.user_definition_complete_callbacks.each(&:call)
       end
 
+      def validate_namespace_type_cycles
+        ns_types = state.namespace_types_by_name
+        visited = ::Set.new # : ::Set[::String]
+        ns_types.each_key do |type_name|
+          detect_namespace_type_cycle(type_name, ns_types, [], visited)
+        end
+      end
+
+      def detect_namespace_type_cycle(type_name, ns_types, path, visited)
+        if path.include?(type_name)
+          cycle = path.drop_while { |n| n != type_name } + [type_name]
+          raise Errors::SchemaError,
+            "Cycle detected among namespace types: #{cycle.map { |n| "`#{n}`" }.join(" -> ")}. " \
+            "Namespace types must form a tree rooted at `Query`."
+        end
+
+        return unless visited.add?(type_name)
+
+        ns_types.fetch(type_name).graphql_fields_by_name.each_value do |field|
+          return_type_name = field.type.fully_unwrapped.name
+          next unless ns_types.key?(return_type_name)
+
+          detect_namespace_type_cycle(return_type_name, ns_types, path + [type_name], visited)
+        end
+      end
+
+      def validate_namespace_type_reachability
+        ns_types = state.namespace_types_by_name
+        reachable = ::Set.new # : ::Set[::String]
+        collect_reachable_namespace_types("Query", ns_types, reachable)
+
+        orphans = ns_types.keys - reachable.to_a
+        return if orphans.empty?
+
+        raise Errors::SchemaError,
+          "Namespace type(s) declared but not reachable from `Query`: #{orphans.sort.map { |n| "`#{n}`" }.join(", ")}. " \
+          "Add a field pointing to each one (e.g., `schema.on_root_query_type { |t| t.field ... }`)."
+      end
+
+      def collect_reachable_namespace_types(type_name, ns_types, reachable)
+        return unless reachable.add?(type_name)
+
+        ns_types.fetch(type_name).graphql_fields_by_name.each_value do |field|
+          return_type_name = field.type.fully_unwrapped.name
+          next unless ns_types.key?(return_type_name)
+
+          collect_reachable_namespace_types(return_type_name, ns_types, reachable)
+        end
+      end
+
       def json_schema_with_metadata_merger
         @json_schema_with_metadata_merger ||= Indexing::JSONSchemaWithMetadata::Merger.new(self)
       end
@@ -258,8 +308,15 @@ module ElasticGraph
       # at the very end (after evaluating the "main" template). `Evaluator` calls this
       # automatically at the end.
       def generate_sdl
+        # Detect namespace cycles before `check_for_circular_dependencies!` so its generic error
+        # doesn't preempt our more specific one.
+        validate_namespace_type_cycles
         check_for_circular_dependencies!
         state.object_types_by_name.values.each(&:verify_graphql_correctness!)
+        # `all_types` applies `on_root_query_type` customizations, which must fire before we walk the
+        # namespace graph for reachability (otherwise `Query` has no fields from those callbacks yet).
+        all_types
+        validate_namespace_type_reachability
 
         type_defs = state.factory
           .new_graphql_sdl_enumerator(all_types)

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/results.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/results.rbs
@@ -47,6 +47,10 @@ module ElasticGraph
       def strip_trailing_whitespace: (::String) -> ::String
       def check_for_circular_dependencies!: () -> void
       def recursively_add_referenced_types_to: (SchemaElements::TypeReference, ::Hash[::String, ::Set[::String]]) -> void
+      def validate_namespace_type_cycles: () -> void
+      def detect_namespace_type_cycle: (::String, ::Hash[::String, SchemaElements::NamespaceType], ::Array[::String], ::Set[::String]) -> void
+      def validate_namespace_type_reachability: () -> void
+      def collect_reachable_namespace_types: (::String, ::Hash[::String, SchemaElements::NamespaceType], ::Set[::String]) -> void
 
       @all_types: Array[SchemaElements::graphQLType]?
       def all_types: () -> ::Array[SchemaElements::graphQLType]

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/namespace_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/index_mappings/namespace_type_spec.rb
@@ -21,6 +21,7 @@ module ElasticGraph
           end
 
           s.namespace_type "OlapQuery"
+          s.on_root_query_type { |t| t.field "olap", "OlapQuery" }
         end
 
         # Only the `widgets` index mapping is generated (no namespace type mapping).
@@ -40,6 +41,8 @@ module ElasticGraph
             t.field "olap", "OlapQuery"
             t.index "widgets"
           end
+
+          s.on_root_query_type { |t| t.field "olap", "OlapQuery" }
         end
 
         expect(widget_mapping.dig("properties")).to include("id" => {"type" => "keyword"})

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/namespace_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/namespace_spec.rb
@@ -175,6 +175,22 @@ module ElasticGraph
           }.not_to raise_error
         end
 
+        it "allows a namespace type wired via `Query.<field>` even when its only subfields come from indexed types using `root_query_fields on:`" do
+          expect {
+            define_schema do |schema|
+              schema.namespace_type "OlapQuery"
+
+              schema.object_type "Widget" do |t|
+                t.field "id", "ID"
+                t.root_query_fields plural: "widgets", on: "OlapQuery"
+                t.index "widgets"
+              end
+
+              schema.on_root_query_type { |t| t.field "olap", "OlapQuery!" }
+            end
+          }.not_to raise_error
+        end
+
         it "raises when namespace types form a cycle" do
           expect {
             define_schema do |schema|

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/namespace_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/namespace_spec.rb
@@ -70,6 +70,7 @@ module ElasticGraph
         it "does not generate any derived types for a namespace type" do
           result = define_schema do |schema|
             schema.namespace_type "OlapQuery"
+            schema.on_root_query_type { |t| t.field "olap", "OlapQuery" }
           end
 
           # Only `OlapQuery` itself appears in the schema -- no `*Connection`, `*Edge`, `*FilterInput`,
@@ -136,9 +137,77 @@ module ElasticGraph
           )
         end
 
+        it "raises when a namespace type is declared but not reachable from `Query`" do
+          expect {
+            define_schema do |schema|
+              schema.namespace_type "OlapQuery"
+            end
+          }.to raise_error(
+            Errors::SchemaError, /Namespace type\(s\) declared but not reachable from `Query`: `OlapQuery`/
+          )
+        end
+
+        it "lists all unreachable namespace types in alphabetical order" do
+          expect {
+            define_schema do |schema|
+              schema.namespace_type "WarehouseQuery"
+              schema.namespace_type "OlapQuery"
+            end
+          }.to raise_error(Errors::SchemaError, /`OlapQuery`, `WarehouseQuery`/)
+        end
+
+        it "allows namespace types reachable transitively from `Query`, including via multiple paths" do
+          expect {
+            define_schema do |schema|
+              schema.namespace_type "OlapQuery" do |t|
+                t.field "domain", "DomainQuery"
+              end
+              schema.namespace_type "WarehouseQuery" do |t|
+                t.field "domain", "DomainQuery"
+              end
+              schema.namespace_type "DomainQuery"
+
+              schema.on_root_query_type do |t|
+                t.field "olap", "OlapQuery!"
+                t.field "warehouse", "WarehouseQuery!"
+              end
+            end
+          }.not_to raise_error
+        end
+
+        it "raises when namespace types form a cycle" do
+          expect {
+            define_schema do |schema|
+              schema.namespace_type "OlapQuery" do |t|
+                t.field "domain", "DomainQuery"
+              end
+              schema.namespace_type "DomainQuery" do |t|
+                t.field "olap", "OlapQuery"
+              end
+            end
+          }.to raise_error(
+            Errors::SchemaError, /Cycle detected among namespace types: `OlapQuery` -> `DomainQuery` -> `OlapQuery`/
+          )
+        end
+
+        it "raises when a namespace type references itself" do
+          expect {
+            define_schema do |schema|
+              schema.namespace_type "OlapQuery" do |t|
+                t.field "self", "OlapQuery"
+              end
+            end
+          }.to raise_error(
+            Errors::SchemaError, /Cycle detected among namespace types: `OlapQuery` -> `OlapQuery`/
+          )
+        end
+
         def namespace_type(name, *args, include_docs: false, &block)
           result = define_schema do |api|
             api.namespace_type(name, *args, &block)
+            api.on_root_query_type do |t|
+              t.field correctly_cased(name.sub(/Query\z/, "").downcase), "#{name}!"
+            end
           end
 
           # We add a line break to match the expectations which use heredocs.

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/json_schema_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/json_schema_spec.rb
@@ -2899,6 +2899,8 @@ module ElasticGraph
           end
 
           s.namespace_type "OlapQuery"
+
+          s.on_root_query_type { |t| t.field "olap", "OlapQuery" }
         end
 
         expect(schemas.keys).to include(EVENT_ENVELOPE_JSON_SCHEMA_NAME, "Widget")
@@ -2918,6 +2920,8 @@ module ElasticGraph
             t.field "olap", "OlapQuery"
             t.index "widgets"
           end
+
+          s.on_root_query_type { |t| t.field "olap", "OlapQuery" }
         end
 
         expect(schemas.keys).to exclude("OlapQuery")

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/namespace_type_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/namespace_type_spec.rb
@@ -32,6 +32,7 @@ module ElasticGraph
             t.field "domain", "DomainQuery"
           end
           s.namespace_type "DomainQuery"
+          s.on_root_query_type { |t| t.field "olap", "OlapQuery" }
         end
 
         expect(metadata.graphql_fields_by_name.fetch("domain").resolver).to eq(
@@ -47,6 +48,7 @@ module ElasticGraph
             t.field "domain", "DomainQuery"
             t.index "widgets"
           end
+          s.on_root_query_type { |t| t.field "domain", "DomainQuery" }
         end
 
         expect(metadata.graphql_fields_by_name.fetch("domain").resolver).to eq(
@@ -63,6 +65,7 @@ module ElasticGraph
             s.namespace_type "OlapQuery" do |t|
               t.field "plain", "Plain"
             end
+            s.on_root_query_type { |t| t.field "olap", "OlapQuery" }
           end
         }.to raise_error(Errors::SchemaError, a_string_including("`OlapQuery.plain` needs a resolver"))
       end
@@ -75,6 +78,7 @@ module ElasticGraph
             end
           end
           s.namespace_type "DomainQuery"
+          s.on_root_query_type { |t| t.field "olap", "OlapQuery" }
         end
 
         expect(metadata.graphql_fields_by_name.fetch("domain").resolver).to eq(
@@ -91,6 +95,7 @@ module ElasticGraph
               end
             end
             s.namespace_type "DomainQuery"
+            s.on_root_query_type { |t| t.field "olap", "OlapQuery" }
           end
         }.to raise_error(Errors::SchemaError, a_string_including("`OlapQuery.domain` needs a resolver"))
       end
@@ -102,6 +107,7 @@ module ElasticGraph
               f.resolve_with :get_record_field_value
             end
           end
+          s.on_root_query_type { |t| t.field "olap", "OlapQuery" }
         end
 
         expect(metadata.graphql_fields_by_name.fetch("name").resolver).to eq(


### PR DESCRIPTION
Part 5 of the stacked PR series implementing query namespacing (https://github.com/block/elasticgraph/discussions/1130).

## Summary                                                                                                                                                                                                                                            
Adds two schema-level validations that fire during generate_sdl:                                                                                              
  - Cycle detection: namespace types must form a DAG rooted at Query. A cycle raises a specific error naming the cycle path.
  - Reachability: namespace types not reachable from Query raise an error (alphabetical list), forcing schema authors to either delete the orphan or wire it up.
                                                                                                                                            
## Why                                                                                                                                                                                                      
Now that namespace types can reference other namespace types (e.g. t.field "domain", "DomainQuery") and indexed types can route to any namespace (PR 4's on: parameter), it's easy to:
  - Declare a namespace type and forget to wire it into Query, silently producing an unreachable type with no entry point.                                                                                 
  - Accidentally create cycles (A.b: B, B.a: A), which would otherwise surface as the generic "Your schema has self-referential types" message — with no hint that the types involved are namespaces.
                                                                                                               
Both become likely as teams adopt namespacing for anything more than a single top-level grouping. Catching these at schema-definition time (rather than at query time, or silently) is a small investment for a much better authoring experience.                                                                                                                                                                 
                                                              
## What changed                                                                                                                                                                                                                    
  - results.rb:          
    - validate_namespace_type_cycles: walks every namespace type (not just from Query) so it works before on_root_query_type customizations apply. Runs before check_for_circular_dependencies! so its more specific error wins.                                                                                                                                                              
    - validate_namespace_type_reachability — runs after all_types (which triggers on_root_query_type customizations, populating Query's fields). BFS from Query; orphans raise with an alphabetical list.
    - generate_sdl wires both in at the appropriate points.                                                                                                                                                
  - namespace_spec.rb: 5 new tests covering orphan, orphan-alphabetical, reachable-via-multiple-paths happy path, cycle, and self-reference.
  - results.rbs: RBS signatures for the new private methods.                                                                                                                                               
  - Unit specs (json_schema_spec.rb, index_mappings/namespace_type_spec.rb, runtime_metadata/object_types_by_name/namespace_type_spec.rb): added schema.on_root_query_type { ... } to specs that declared an unreachable namespace type. CI runs with VALIDATE_GRAPHQL_SCHEMAS=1, which forces SDL generation on every define_schema call, so the reachability validator fired on these specs too. Their assertions still check the runtime-metadata behavior they were written to cover.                                         
                                                                                                        
## Error message examples                                                                                                                                                                                                             
  Namespace type(s) declared but not reachable from `Query`: `OlapQuery`, `WarehouseQuery`.                                                                    
  Add a field pointing to each one (e.g., `schema.on_root_query_type { |t| t.field ... }`).                                                                                           
                                                          
  Cycle detected among namespace types: `OlapQuery` -> `DomainQuery` -> `OlapQuery`.                                                                                                                       
  Namespace types must form a tree rooted at `Query`.