### PR TITLE
Fix QueryDetailsTracker keyword initialization

### DIFF
--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_details_tracker_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_details_tracker_spec.rb
@@ -11,6 +11,21 @@ require "elastic_graph/graphql/query_details_tracker"
 module ElasticGraph
   class GraphQL
     RSpec.describe QueryDetailsTracker do
+      describe ".empty" do
+        it "initializes all tracker fields" do
+          tracker = QueryDetailsTracker.empty
+
+          expect(tracker.shard_routing_values).to eq ::Set.new
+          expect(tracker.search_index_expressions).to eq ::Set.new
+          expect(tracker.query_counts_per_datastore_request).to eq []
+          expect(tracker.datastore_query_server_duration_ms).to eq 0
+          expect(tracker.datastore_query_client_duration_ms).to eq 0
+          expect(tracker.queried_shard_count).to eq 0
+          expect(tracker.extension_data).to eq({})
+          expect(tracker.mutex).to be_a ::Thread::Mutex
+        end
+      end
+
       describe "#[]=" do
         let(:tracker) { QueryDetailsTracker.empty }
 


### PR DESCRIPTION
## Why
`QueryDetailsTracker.empty` initializes the tracker with keyword arguments, but the underlying `Struct` was positional-only. On Ruby/JRuby versions that reject those keywords, health checks can raise `ArgumentError: unknown keywords: shard_routing_values`.

## What
- Enable keyword initialization for the mutable tracker struct
- Add a direct `.empty` unit spec covering all initialized fields

## Risk Assessment
Low — this aligns the Struct constructor with existing call sites and RBS; behavior remains the same aside from accepting the intended keyword initializer.