### PR TITLE
Fix Psych::DisallowedClass when using schema_element_name_overrides

### DIFF
--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rb
@@ -83,7 +83,7 @@ module ElasticGraph
               {
                 # Keys here are ordered alphabetically; please keep them that way.
                 FORM => form.to_s,
-                OVERRIDES => overrides
+                OVERRIDES => overrides.to_h { |k, v| [k.to_s, v.to_s] }
               }
             end
 

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names_spec.rb
@@ -105,6 +105,15 @@ module ElasticGraph
           }.to raise_error(Errors::SchemaError, a_string_including("bar", "foo", "multi_word_snake"))
         end
 
+        it "roundtrips through `to_dumpable_hash` and `from_hash` when overrides have symbol keys" do
+          names = new_with(form: :camelCase, overrides: {foo: :bar})
+
+          reloaded = ExampleElementNames.from_hash(names.to_dumpable_hash)
+
+          expect(reloaded.foo).to eq "bar"
+          expect(reloaded.multi_word_snake).to eq "multiWordSnake"
+        end
+
         it "inspects nicely" do
           names = new_with(form: :camelCase, overrides: {foo: :bar})
 

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
@@ -402,6 +402,19 @@ module ElasticGraph
           end
         end
 
+        it "can be roundtripped through YAML's safe_load" do
+          schema = schema_with(
+            schema_element_names: SchemaElementNames.new(form: :camelCase, overrides: {gt: "greaterThan"})
+          )
+
+          yaml_string = ::YAML.dump(schema.to_dumpable_hash)
+          loaded_hash = ::YAML.safe_load(yaml_string)
+          roundtripped_schema = Schema.from_hash(loaded_hash)
+
+          expect(roundtripped_schema.schema_element_names.gt).to eq "greaterThan"
+          expect(roundtripped_schema.schema_element_names.lt).to eq "lt"
+        end
+
         it "dumps all hashes in alphabetical order for consistency" do
           full_dumped_runtime_metadata = ::YAML.safe_load_file(::File.join(
             CommonSpecHelpers::REPO_ROOT, "config", "schema", "artifacts", RUNTIME_METADATA_FILE


### PR DESCRIPTION
## Summary

- Fix `Psych::DisallowedClass: Tried to load unspecified class: Symbol` when `schema_element_name_overrides` contains symbol keys (the natural Ruby hash syntax)
- Convert symbol keys/values to strings in `to_dumpable_hash` so the YAML output is `safe_load`-compatible

Fixes #1021

## Test plan

- [x] Unit test: `SchemaElementNames` roundtrips through `to_dumpable_hash` → `from_hash` with symbol-keyed overrides
- [x] Higher-level test: `Schema` roundtrips through `YAML.dump` → `YAML.safe_load` → `Schema.from_hash` with symbol-keyed overrides
- [x] All existing tests pass (107 schema_artifacts specs, 17 rake_tasks integration specs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)