### PR TITLE
Add JSON ingestion indexing extensions

### DIFF
--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/indexing/field.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/indexing/field.rb
@@ -1,0 +1,168 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "delegate"
+require "elastic_graph/constants"
+require "elastic_graph/json_ingestion/schema_definition/indexing/json_schema_field_metadata"
+require "elastic_graph/schema_definition/indexing/field"
+require "elastic_graph/support/hash_util"
+
+module ElasticGraph
+  module JSONIngestion
+    module SchemaDefinition
+      # Namespace for JSON-schema-aware indexing components.
+      module Indexing
+        # Wraps an indexing field with JSON schema generation behavior.
+        #
+        # @api private
+        class Field < DelegateClass(ElasticGraph::SchemaDefinition::Indexing::Field)
+          # @dynamic __getobj__, json_schema_layers, json_schema_customizations
+          # @return [Array<Symbol>] JSON schema wrapper layers from the field type reference
+          attr_reader :json_schema_layers
+
+          # @return [Hash<Symbol, Object>] user-defined JSON schema customizations
+          attr_reader :json_schema_customizations
+
+          # JSON schema overrides that automatically apply to specific mapping types so that the JSON schema
+          # validation will reject values which cannot be indexed into fields of a specific mapping type.
+          #
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/number.html Elasticsearch numeric field type documentation
+          # @note We don't handle `integer` here because it's the default numeric type (handled by our definition of the `Int` scalar type).
+          # @note Likewise, we don't handle `long` here because a custom scalar type must be used for that since GraphQL's `Int` type can't handle long values.
+          JSON_SCHEMA_OVERRIDES_BY_MAPPING_TYPE = {
+            "byte" => {"minimum" => -(2**7), "maximum" => (2**7) - 1},
+            "short" => {"minimum" => -(2**15), "maximum" => (2**15) - 1},
+            "keyword" => {"maxLength" => DEFAULT_MAX_KEYWORD_LENGTH},
+            "text" => {"maxLength" => DEFAULT_MAX_TEXT_LENGTH}
+          }
+
+          # @param field [ElasticGraph::SchemaDefinition::Indexing::Field] the indexing field to wrap
+          # @param json_schema_layers [Array<Symbol>] JSON schema wrapper layers from the field type reference
+          # @param json_schema_customizations [Hash<Symbol, Object>] user-defined JSON schema customizations
+          def initialize(field, json_schema_layers:, json_schema_customizations:)
+            super(field)
+            @json_schema_layers = json_schema_layers
+            @json_schema_customizations = json_schema_customizations
+          end
+
+          # Returns the JSON schema definition for this field.
+          #
+          # @return [Hash<String, Object>] the JSON schema hash
+          def json_schema
+            @json_schema ||=
+              json_schema_layers
+                .reverse # resolve layers from innermost to outermost wrappings
+                .reduce(inner_json_schema) { |acc, layer| process_layer(layer, acc) }
+                .merge(outer_json_schema_customizations)
+                .merge({"description" => doc_comment}.compact)
+                .then { |hash| Support::HashUtil.stringify_keys(hash) }
+          end
+
+          # @return [JSONSchemaFieldMetadata] metadata about this field for inclusion in the JSON schema
+          def json_schema_metadata
+            JSONSchemaFieldMetadata.new(type: type.name, name_in_index: name_in_index)
+          end
+
+          def nullable?
+            json_schema_layers.include?(:nullable)
+          end
+
+          # Compares fields, including JSON schema metadata tracked by this wrapper.
+          #
+          # @param other [Object] the object to compare against
+          # @return [Boolean] true when the field and JSON schema metadata match
+          def ==(other)
+            case other
+            when Field
+              __getobj__ == other.__getobj__ &&
+                json_schema_layers == other.json_schema_layers &&
+                json_schema_customizations == other.json_schema_customizations
+            else
+              super
+            end
+          end
+
+          def eql?(other)
+            self == other
+          end
+
+          # Returns a hash code based on the wrapped field and JSON schema metadata.
+          #
+          # @return [Integer] the hash code
+          def hash
+            [__getobj__, json_schema_layers, json_schema_customizations].hash
+          end
+
+          private
+
+          def inner_json_schema
+            user_specified_customizations =
+              if user_specified_json_schema_customizations_go_on_outside?
+                {} # : ::Hash[::String, untyped]
+              else
+                Support::HashUtil.stringify_keys(json_schema_customizations)
+              end
+
+            customizations_from_mapping = JSON_SCHEMA_OVERRIDES_BY_MAPPING_TYPE[mapping["type"]] || {}
+            customizations = customizations_from_mapping.merge(user_specified_customizations)
+            # @type var field_type: _JSONFieldType
+            field_type = _ = indexing_field_type
+            customizations = field_type.format_field_json_schema_customizations(customizations)
+
+            ref = {"$ref" => "#/$defs/#{type.unwrapped_name}"}
+            return ref if customizations.empty?
+
+            # Combine any customizations with the type ref under an "allOf" subschema:
+            # all of these properties must hold true for the type to be valid.
+            #
+            # Note that if we simply combine the customizations with the `$ref`
+            # at the same level, it will not work, because other subschema
+            # properties are ignored when they are in the same object as a `$ref`:
+            # https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/2.0.0/tests/draft7/ref.json#L165-L168
+            {"allOf" => [ref, customizations]}
+          end
+
+          def outer_json_schema_customizations
+            return {} unless user_specified_json_schema_customizations_go_on_outside?
+            Support::HashUtil.stringify_keys(json_schema_customizations)
+          end
+
+          # Indicates if the user-specified JSON schema customizations should go on the inside
+          # (where they normally go) or on the outside. They only go on the outside when it's
+          # an array field, because then they apply to the array itself instead of the items in the
+          # array.
+          def user_specified_json_schema_customizations_go_on_outside?
+            json_schema_layers.include?(:array)
+          end
+
+          def process_layer(layer, schema)
+            case layer
+            when :nullable
+              # Here we use "anyOf" to ensure that JSON can either match the schema OR null.
+              #
+              # (Using "oneOf" would mean that if we had a schema that also allowed null,
+              # null would never be allowed, since "oneOf" must match exactly one subschema).
+              {
+                "anyOf" => [
+                  schema,
+                  {"type" => "null"}
+                ]
+              }
+            when :array
+              {"type" => "array", "items" => schema}
+            else
+              # :nocov: - layer is only ever `:nullable` or `:array` so we never get here.
+              schema
+              # :nocov:
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/indexing/field_reference.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/indexing/field_reference.rb
@@ -1,0 +1,79 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "delegate"
+require "elastic_graph/json_ingestion/schema_definition/indexing/field"
+require "elastic_graph/schema_definition/indexing/field_reference"
+
+module ElasticGraph
+  module JSONIngestion
+    module SchemaDefinition
+      module Indexing
+        # Wraps an indexing field reference with JSON schema state needed when resolving fields.
+        #
+        # @api private
+        class FieldReference < DelegateClass(ElasticGraph::SchemaDefinition::Indexing::FieldReference)
+          # @dynamic __getobj__, json_schema_layers, json_schema_customizations
+          # @return [Array<Symbol>] JSON schema wrapper layers from the field type reference
+          attr_reader :json_schema_layers
+
+          # @return [Hash<Symbol, Object>] user-defined JSON schema customizations
+          attr_reader :json_schema_customizations
+
+          # @param field_reference [ElasticGraph::SchemaDefinition::Indexing::FieldReference] the field reference to wrap
+          # @param json_schema_layers [Array<Symbol>] JSON schema wrapper layers from the field type reference
+          # @param json_schema_customizations [Hash<Symbol, Object>] user-defined JSON schema customizations
+          def initialize(field_reference, json_schema_layers:, json_schema_customizations:)
+            super(field_reference)
+            @json_schema_layers = json_schema_layers
+            @json_schema_customizations = json_schema_customizations
+          end
+
+          # Resolves this reference to a JSON-schema-aware indexing field.
+          #
+          # @return [Field, nil] the resolved field, or nil when the type is unresolved
+          def resolve
+            return nil unless (resolved_field = super)
+
+            Field.new(
+              resolved_field,
+              json_schema_layers: json_schema_layers,
+              json_schema_customizations: json_schema_customizations
+            )
+          end
+
+          # Compares field references, including JSON schema metadata tracked by this wrapper.
+          #
+          # @param other [Object] the object to compare against
+          # @return [Boolean] true when the field reference and JSON schema metadata match
+          def ==(other)
+            case other
+            when FieldReference
+              __getobj__ == other.__getobj__ &&
+                json_schema_layers == other.json_schema_layers &&
+                json_schema_customizations == other.json_schema_customizations
+            else
+              super
+            end
+          end
+
+          def eql?(other)
+            self == other
+          end
+
+          # Returns a hash code based on the wrapped field reference and JSON schema metadata.
+          #
+          # @return [Integer] the hash code
+          def hash
+            [__getobj__, json_schema_layers, json_schema_customizations].hash
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/indexing/field_type/enum.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/indexing/field_type/enum.rb
@@ -1,0 +1,55 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "delegate"
+require "elastic_graph/schema_definition/indexing/field_type/enum"
+
+module ElasticGraph
+  module JSONIngestion
+    module SchemaDefinition
+      module Indexing
+        # Namespace for JSON-schema-aware indexing field types.
+        module FieldType
+          # Wraps enum indexing field types with JSON schema serialization.
+          #
+          # @private
+          class Enum < DelegateClass(ElasticGraph::SchemaDefinition::Indexing::FieldType::Enum)
+            # @return [Hash<String, ::Object>] additional ElasticGraph metadata to put in the JSON schema for this enum type.
+            def json_schema_field_metadata_by_field_name
+              {}
+            end
+
+            # @param customizations [Hash<String, ::Object>] JSON schema customizations
+            # @return [Hash<String, ::Object>] formatted customizations.
+            def format_field_json_schema_customizations(customizations)
+              # Since an enum type already restricts the values to a small set of allowed values, we do not need to keep
+              # other customizations (such as the `maxLength` field customization EG automatically applies to fields
+              # indexed as a `keyword`--we don't allow enum values to exceed that length, anyway).
+              #
+              # It's desirable to restrict what customizations are applied because when a publisher uses the JSON schema
+              # to generate code using a library such as https://github.com/pwall567/json-kotlin-schema-codegen, we found
+              # that the presence of extra field customizations inhibits the library's ability to generate code in the way
+              # we want (it causes the type of the enum to change since the JSON schema changes from a direct `$ref` to
+              # being wrapped in an `allOf`).
+              #
+              # However, we still want to apply `enum` customizations--this allows a user to "narrow" the set of allowed
+              # values for a field. For example, a `Currency` enum could contain every currency, and a user may want to
+              # restrict a specific `currency` field to a subset of currencies (e.g. to just USD, CAD, and EUR).
+              customizations.slice("enum")
+            end
+
+            # @return [Hash<String, ::Object>] the JSON schema for this enum type.
+            def to_json_schema
+              {"type" => "string", "enum" => enum_value_names}
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/indexing/field_type/object.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/indexing/field_type/object.rb
@@ -1,0 +1,127 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "delegate"
+require "elastic_graph/schema_definition/indexing/field_type/object"
+require "elastic_graph/support/hash_util"
+
+module ElasticGraph
+  module JSONIngestion
+    module SchemaDefinition
+      module Indexing
+        module FieldType
+          # Wraps object/interface indexing field types with JSON schema serialization.
+          #
+          # @private
+          class Object < DelegateClass(ElasticGraph::SchemaDefinition::Indexing::FieldType::Object)
+            # @dynamic __getobj__, json_schema_options
+            # @return [Hash<Symbol, Object>] JSON schema options for this object type
+            attr_reader :json_schema_options
+
+            # @param field_type [ElasticGraph::SchemaDefinition::Indexing::FieldType::Object] the object field type to wrap
+            # @param json_schema_options [Hash<Symbol, Object>] JSON schema options for this object type
+            def initialize(field_type, json_schema_options:)
+              super(field_type)
+              @json_schema_options = json_schema_options
+            end
+
+            # @return [Hash<String, JSONSchemaFieldMetadata>] field metadata keyed by field name
+            def json_schema_field_metadata_by_field_name
+              subfields.to_h { |field| [field.name, field.json_schema_metadata] }
+            end
+
+            # @param customizations [Hash<String, Object>] the customizations to format
+            # @return [Hash<String, Object>] the formatted customizations
+            def format_field_json_schema_customizations(customizations)
+              customizations
+            end
+
+            # @return [Hash<String, Object>] the JSON schema definition for this object type
+            def to_json_schema
+              @to_json_schema ||=
+                if json_schema_options.empty?
+                  # Fields that are `sourced_from` an alternate type must not be included in this type's JSON schema,
+                  # since events of this type won't include them.
+                  core_other_source_subfields, core_json_schema_candidate_subfields = subfields.partition(&:source)
+                  # @type var other_source_subfields: ::Array[Indexing::Field]
+                  other_source_subfields = _ = core_other_source_subfields
+                  validate_sourced_fields_have_no_json_schema_overrides(other_source_subfields)
+                  # @type var json_schema_candidate_subfields: ::Array[Indexing::Field]
+                  json_schema_candidate_subfields = _ = core_json_schema_candidate_subfields
+                  json_schema_subfields = json_schema_candidate_subfields.reject(&:runtime_field_script)
+                  required_fields = json_schema_subfields
+                  required_fields = required_fields.reject(&:nullable?) if schema_def_state.allow_omitted_json_schema_fields
+
+                  {
+                    "type" => "object",
+                    "properties" => json_schema_subfields.to_h { |field| [field.name, field.json_schema] }.merge(json_schema_typename_field),
+                    # Note: `__typename` is intentionally not included in the `required` list. If `__typename` is present
+                    # we want it validated (as we do by merging in `json_schema_typename_field`) but we only want
+                    # to require it in the context of a union type. The union's JSON schema requires the field.
+                    "required" => required_fields.map(&:name).freeze,
+                    "additionalProperties" => (false unless schema_def_state.allow_extra_json_schema_fields),
+                    "description" => doc_comment
+                  }.compact.freeze
+                else
+                  Support::HashUtil.stringify_keys(json_schema_options)
+                end
+            end
+
+            def ==(other)
+              case other
+              when Object
+                __getobj__ == other.__getobj__ &&
+                  json_schema_options == other.json_schema_options
+              else
+                super
+              end
+            end
+
+            def eql?(other)
+              self == other
+            end
+
+            def hash
+              [__getobj__, json_schema_options].hash
+            end
+
+            private
+
+            # Returns a `__typename` property which we use for union types.
+            #
+            # This must always be set to the name of the type (thus the const value).
+            #
+            # We also add a "default" value. This does not impact validation, but rather
+            # aids tools like our Kotlin codegen to save publishers from having to set the
+            # property explicitly when creating events.
+            def json_schema_typename_field
+              {
+                "__typename" => {
+                  "type" => "string",
+                  "const" => type_name,
+                  "default" => type_name
+                }
+              }
+            end
+
+            def validate_sourced_fields_have_no_json_schema_overrides(other_source_subfields)
+              problem_fields = other_source_subfields.reject { |field| field.json_schema_customizations.empty? }
+              return if problem_fields.empty?
+
+              field_descriptions = problem_fields.map(&:name).sort.map { |field| "`#{field}`" }.join(", ")
+              raise Errors::SchemaError,
+                "`#{type_name}` has #{problem_fields.size} field(s) (#{field_descriptions}) that are `sourced_from` " \
+                "another type and also have JSON schema customizations. Instead, put the JSON schema " \
+                "customizations on the source type's field definitions."
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/indexing/field_type/scalar.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/indexing/field_type/scalar.rb
@@ -1,0 +1,42 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "delegate"
+require "elastic_graph/schema_definition/indexing/field_type/scalar"
+require "elastic_graph/support/hash_util"
+
+module ElasticGraph
+  module JSONIngestion
+    module SchemaDefinition
+      module Indexing
+        module FieldType
+          # Wraps scalar indexing field types with JSON schema serialization.
+          #
+          # @private
+          class Scalar < DelegateClass(ElasticGraph::SchemaDefinition::Indexing::FieldType::Scalar)
+            # @return [Hash] empty hash, as scalar types have no subfields
+            def json_schema_field_metadata_by_field_name
+              {}
+            end
+
+            # @param customizations [Hash<String, Object>] the customizations to format
+            # @return [Hash<String, Object>] the formatted customizations
+            def format_field_json_schema_customizations(customizations)
+              customizations
+            end
+
+            # @return [Hash<String, Object>] the JSON schema definition for this scalar type
+            def to_json_schema
+              Support::HashUtil.stringify_keys(scalar_type.json_schema_options)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/indexing/field_type/union.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/indexing/field_type/union.rb
@@ -1,0 +1,55 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "delegate"
+require "elastic_graph/schema_definition/indexing/field_type/union"
+
+module ElasticGraph
+  module JSONIngestion
+    module SchemaDefinition
+      module Indexing
+        module FieldType
+          # Wraps union indexing field types with JSON schema serialization.
+          #
+          # @private
+          class Union < DelegateClass(ElasticGraph::SchemaDefinition::Indexing::FieldType::Union)
+            # @return [Hash] empty hash, as union types have no subfields
+            def json_schema_field_metadata_by_field_name
+              {}
+            end
+
+            # @param customizations [Hash<String, Object>] the customizations to format
+            # @return [Hash<String, Object>] the formatted customizations
+            def format_field_json_schema_customizations(customizations)
+              customizations
+            end
+
+            # @return [Hash<String, Object>] the JSON schema definition for this union type
+            def to_json_schema
+              subtype_json_schemas = subtypes_by_name.keys.map { |name| {"$ref" => "#/$defs/#{name}"} }
+
+              # A union type can represent multiple subtypes, referenced by the "anyOf" clause below.
+              # We also add a requirement for the presence of __typename to indicate which type
+              # is being referenced (this property is pre-defined on the type itself as a constant).
+              #
+              # Note: Although both "oneOf" and "anyOf" keywords are valid for combining schemas
+              # to form a union, and validate equivalently when no object can satisfy multiple of the
+              # subschemas (which is the case here given the __typename requirements are mutually
+              # exclusive), we chose to use "oneOf" here because it works better with this library:
+              # https://github.com/pwall567/json-kotlin-schema-codegen
+              {
+                "required" => %w[__typename],
+                "oneOf" => subtype_json_schemas
+              }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/indexing/field.rbs
+++ b/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/indexing/field.rbs
@@ -1,0 +1,41 @@
+module ElasticGraph
+  module JSONIngestion
+    module SchemaDefinition
+      module Indexing
+        class FieldSupertype < ::ElasticGraph::SchemaDefinition::Indexing::Field
+          def initialize: (::ElasticGraph::SchemaDefinition::Indexing::Field) -> void
+        end
+
+        class Field < FieldSupertype
+          attr_reader json_schema_layers: ::ElasticGraph::SchemaDefinition::jsonSchemaLayersArray
+          attr_reader json_schema_customizations: ::Hash[::Symbol, untyped]
+
+          @json_schema: ::Hash[::String, untyped]?
+
+          JSON_SCHEMA_OVERRIDES_BY_MAPPING_TYPE: ::Hash[::String, ::Hash[::String, untyped]]
+
+          def initialize: (
+            ::ElasticGraph::SchemaDefinition::Indexing::Field field,
+            json_schema_layers: ::ElasticGraph::SchemaDefinition::jsonSchemaLayersArray,
+            json_schema_customizations: ::Hash[::Symbol, untyped]
+          ) -> void
+
+          def json_schema: () -> ::Hash[::String, untyped]
+          def json_schema_metadata: () -> JSONSchemaFieldMetadata
+          def nullable?: () -> bool
+          def ==: (untyped other) -> bool
+          def eql?: (untyped other) -> bool
+          def hash: () -> ::Integer
+          def __getobj__: () -> ::ElasticGraph::SchemaDefinition::Indexing::Field
+
+          private
+
+          def inner_json_schema: () -> ::Hash[::String, untyped]
+          def outer_json_schema_customizations: () -> ::Hash[::String, untyped]
+          def user_specified_json_schema_customizations_go_on_outside?: () -> bool
+          def process_layer: (::Symbol layer, ::Hash[::String, untyped] schema) -> ::Hash[::String, untyped]
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/indexing/field_reference.rbs
+++ b/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/indexing/field_reference.rbs
@@ -1,0 +1,28 @@
+module ElasticGraph
+  module JSONIngestion
+    module SchemaDefinition
+      module Indexing
+        class FieldReferenceSupertype < ::ElasticGraph::SchemaDefinition::Indexing::FieldReference
+          def initialize: (::ElasticGraph::SchemaDefinition::Indexing::FieldReference) -> void
+        end
+
+        class FieldReference < FieldReferenceSupertype
+          attr_reader json_schema_layers: ::ElasticGraph::SchemaDefinition::jsonSchemaLayersArray
+          attr_reader json_schema_customizations: ::Hash[::Symbol, untyped]
+
+          def initialize: (
+            ::ElasticGraph::SchemaDefinition::Indexing::FieldReference field_reference,
+            json_schema_layers: ::ElasticGraph::SchemaDefinition::jsonSchemaLayersArray,
+            json_schema_customizations: ::Hash[::Symbol, untyped]
+          ) -> void
+
+          def resolve: () -> Field?
+          def ==: (untyped other) -> bool
+          def eql?: (untyped other) -> bool
+          def hash: () -> ::Integer
+          def __getobj__: () -> ::ElasticGraph::SchemaDefinition::Indexing::FieldReference
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/indexing/field_type.rbs
+++ b/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/indexing/field_type.rbs
@@ -1,0 +1,14 @@
+module ElasticGraph
+  module JSONIngestion
+    module SchemaDefinition
+      module Indexing
+        interface _JSONFieldType
+          def to_mapping: () -> ::Hash[::String, untyped]
+          def json_schema_field_metadata_by_field_name: () -> ::Hash[::String, JSONSchemaFieldMetadata]
+          def format_field_json_schema_customizations: (::Hash[::String, untyped]) -> ::Hash[::String, untyped]
+          def to_json_schema: () -> ::Hash[::String, untyped]
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/indexing/field_type/enum.rbs
+++ b/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/indexing/field_type/enum.rbs
@@ -1,0 +1,19 @@
+module ElasticGraph
+  module JSONIngestion
+    module SchemaDefinition
+      module Indexing
+        module FieldType
+          class EnumSupertype < ::ElasticGraph::SchemaDefinition::Indexing::FieldType::Enum
+            def initialize: (::ElasticGraph::SchemaDefinition::Indexing::FieldType::Enum) -> void
+          end
+
+          class Enum < EnumSupertype
+            def json_schema_field_metadata_by_field_name: () -> ::Hash[::String, JSONSchemaFieldMetadata]
+            def format_field_json_schema_customizations: (::Hash[::String, untyped]) -> ::Hash[::String, untyped]
+            def to_json_schema: () -> ::Hash[::String, untyped]
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/indexing/field_type/object.rbs
+++ b/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/indexing/field_type/object.rbs
@@ -1,0 +1,37 @@
+module ElasticGraph
+  module JSONIngestion
+    module SchemaDefinition
+      module Indexing
+        module FieldType
+          class ObjectSupertype < ::ElasticGraph::SchemaDefinition::Indexing::FieldType::Object
+            def initialize: (::ElasticGraph::SchemaDefinition::Indexing::FieldType::Object) -> void
+          end
+
+          class Object < ObjectSupertype
+            attr_reader json_schema_options: ::Hash[::Symbol, untyped]
+
+            @to_json_schema: ::Hash[::String, untyped]?
+
+            def initialize: (
+              ::ElasticGraph::SchemaDefinition::Indexing::FieldType::Object field_type,
+              json_schema_options: ::Hash[::Symbol, untyped]
+            ) -> void
+
+            def json_schema_field_metadata_by_field_name: () -> ::Hash[::String, JSONSchemaFieldMetadata]
+            def format_field_json_schema_customizations: (::Hash[::String, untyped]) -> ::Hash[::String, untyped]
+            def to_json_schema: () -> ::Hash[::String, untyped]
+            def ==: (untyped other) -> bool
+            def eql?: (untyped other) -> bool
+            def hash: () -> ::Integer
+            def __getobj__: () -> ::ElasticGraph::SchemaDefinition::Indexing::FieldType::Object
+
+            private
+
+            def json_schema_typename_field: () -> ::Hash[::String, untyped]
+            def validate_sourced_fields_have_no_json_schema_overrides: (::Array[Field]) -> void
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/indexing/field_type/scalar.rbs
+++ b/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/indexing/field_type/scalar.rbs
@@ -1,0 +1,19 @@
+module ElasticGraph
+  module JSONIngestion
+    module SchemaDefinition
+      module Indexing
+        module FieldType
+          class ScalarSupertype < ::ElasticGraph::SchemaDefinition::Indexing::FieldType::Scalar
+            def initialize: (::ElasticGraph::SchemaDefinition::Indexing::FieldType::Scalar) -> void
+          end
+
+          class Scalar < ScalarSupertype
+            def json_schema_field_metadata_by_field_name: () -> ::Hash[::String, JSONSchemaFieldMetadata]
+            def format_field_json_schema_customizations: (::Hash[::String, untyped]) -> ::Hash[::String, untyped]
+            def to_json_schema: () -> ::Hash[::String, untyped]
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/indexing/field_type/union.rbs
+++ b/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/indexing/field_type/union.rbs
@@ -1,0 +1,19 @@
+module ElasticGraph
+  module JSONIngestion
+    module SchemaDefinition
+      module Indexing
+        module FieldType
+          class UnionSupertype < ::ElasticGraph::SchemaDefinition::Indexing::FieldType::Union
+            def initialize: (::ElasticGraph::SchemaDefinition::Indexing::FieldType::Union) -> void
+          end
+
+          class Union < UnionSupertype
+            def json_schema_field_metadata_by_field_name: () -> ::Hash[::String, JSONSchemaFieldMetadata]
+            def format_field_json_schema_customizations: (::Hash[::String, untyped]) -> ::Hash[::String, untyped]
+            def to_json_schema: () -> ::Hash[::String, untyped]
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why
Keep the JSON ingestion indexing extensions separate from the schema-extension wiring so the indexing behavior is easier to review.

## What
- Add JSON ingestion extension modules for indexing field references and field types
- Make core indexing field references and enum/scalar/union field types extendable via the existing MemoizableData helper, matching the object field type
- Keep JSON ingestion behavior in extension modules; no wrapper classes

## Risk Assessment
Low to medium - this changes internal indexing value objects to use the existing MemoizableData wrapper so JSON ingestion can attach extension modules, without changing core mapping behavior.

## References
- Stacked on #1203.
- `bundle exec rspec elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/json_schema_spec.rb elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/json_schema_field_metadata_spec.rb elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/indexing/json_schema_with_metadata_spec.rb elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/factory_spec.rb` passed.
- `script/type_check` passed.
- `script/lint` passed.

## Stack
Current PR is marked with `->`.

- [#1199 Add JSON ingestion gem shell](https://github.com/block/elasticgraph/pull/1199)
- [#1200 Add schema definition extension plumbing](https://github.com/block/elasticgraph/pull/1200)
- [#1201 Move JSON schema helpers to json ingestion gem](https://github.com/block/elasticgraph/pull/1201)
- [#1203 Namespace JSON schema helpers under JSON ingestion](https://github.com/block/elasticgraph/pull/1203)
- -> [#1204 Add JSON ingestion indexing extensions](https://github.com/block/elasticgraph/pull/1204)
- [#1215 Wire JSON ingestion schema extension modules](https://github.com/block/elasticgraph/pull/1215)
- [#1205 Use JSON ingestion as schema definition extension](https://github.com/block/elasticgraph/pull/1205)
- [#1202 Document JSON ingestion schema APIs](https://github.com/block/elasticgraph/pull/1202)
- [#1224 Migrate JSON ingestion specs into gem](https://github.com/block/elasticgraph/pull/1224)
- [#1220 Add configurable indexing event decoder](https://github.com/block/elasticgraph/pull/1220)
