### PR TITLE
Refactor index_data.painless script and params

### DIFF
--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -2156,7 +2156,7 @@ scripts:
 
         // No timestamp values matched the params, so return `false`.
         return false;
-  update_index_data_c506543861091e70bd493c28d29b9b70:
+  update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d:
     context: update
     script:
       lang: painless
@@ -2182,11 +2182,6 @@ scripts:
 
         void validateSource(Map source, String id, String relationship, String sourceId, long eventVersion) {
           Map relationshipVersionsMap = source.__versions.get(relationship);
-
-          if (relationshipVersionsMap == null) {
-            throw new IllegalArgumentException("Expected source.__versions[" + relationship + "] to be initialized, but it was null");
-          }
-
           List previousSourceIdsForRelationship = relationshipVersionsMap.keySet().stream().filter(key -> key != sourceId).collect(Collectors.toList());
 
           if (previousSourceIdsForRelationship.size() > 0) {

--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -2156,7 +2156,7 @@ scripts:
 
         // No timestamp values matched the params, so return `false`.
         return false;
-  update_index_data_db769e42fd258f3884d2c5b721bb3c03:
+  update_index_data_1b6d53ffefa2dd2d9510366867200725:
     context: update
     script:
       lang: painless
@@ -2182,6 +2182,11 @@ scripts:
 
         void validateSource(Map source, String id, String relationship, String sourceId, long eventVersion) {
           Map relationshipVersionsMap = source.__versions.get(relationship);
+
+          if (relationshipVersionsMap == null) {
+            throw new IllegalArgumentException("Expected source.__versions[" + relationship + "] to be initialized by setup(), but it was null");
+          }
+
           List previousSourceIdsForRelationship = relationshipVersionsMap.keySet().stream().filter(key -> key != sourceId).collect(Collectors.toList());
 
           if (previousSourceIdsForRelationship.size() > 0) {

--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -1852,7 +1852,7 @@ indices:
       index.number_of_shards: 1
       index.max_result_window: 10000
 scripts:
-  update_WidgetCurrency_from_Widget_a63538953d45f84cba67edd655d129a8:
+  update_WidgetCurrency_from_Widget_e72813bd1a8767343222b77bf53be31c:
     context: update
     script:
       lang: painless
@@ -1996,7 +1996,7 @@ scripts:
           return false;
         }
 
-        Map data = params.data;
+        Map data = params.topLevelFields;
         // A variable to accumulate script errors so that we can surface _all_ issues and not just the first.
         List scriptErrors = new ArrayList();
         if (ctx._source.details == null) {
@@ -2156,67 +2156,67 @@ scripts:
 
         // No timestamp values matched the params, so return `false`.
         return false;
-  update_index_data_1fdfaf1c9261c96019decc89b515bd9a:
+  update_index_data_db769e42fd258f3884d2c5b721bb3c03:
     context: update
     script:
       lang: painless
       source: |-
-        Map source = ctx._source;
-        String sourceId = params.sourceId;
-        String relationship = params.relationship;
-
-        // Numbers in JSON appear to be parsed as doubles, but we want the version stored as a long, so we need to cast it here.
-        long eventVersion = (long) params.version;
-
-        if (source.__sources == null) {
-          source.__sources = [];
-        }
-
-        if (source.__versions == null) {
-          source.__versions = [:];
-        }
-
-        if (source.__versions[relationship] == null) {
-          source.__versions[relationship] = [:];
-        }
-
-        Map relationshipVersionsMap = source.__versions.get(relationship);
-        List previousSourceIdsForRelationship = relationshipVersionsMap.keySet().stream().filter(id -> id != sourceId).collect(Collectors.toList());
-
-        if (previousSourceIdsForRelationship.size() > 0) {
-          String previousIdDescription = previousSourceIdsForRelationship.size() == 1 ? previousSourceIdsForRelationship.get(0) : previousSourceIdsForRelationship.toString();
-          throw new IllegalArgumentException(
-            "Cannot update document " + params.id + " " +
-            "with data from related " + relationship + " " + sourceId + " " +
-            "because the related " + relationship + " has apparently changed (was: " + previousSourceIdsForRelationship + "), " +
-            "but mutations of relationships used with `sourced_from` are not supported because " +
-            "allowing it could break ElasticGraph's out-of-order processing guarantees."
-         );
-        }
-
-        Number maybeDocVersion = source.__versions.get(params.relationship)?.get(params.sourceId);
-
-        // Our JSON schema requires event versions to be non-negative, so we can safely use Long.MIN_VALUE as a stand-in when the value is null.
-        long docVersion = maybeDocVersion == null ? Long.MIN_VALUE : maybeDocVersion.longValue();
-
-        if (docVersion >= eventVersion) {
-          throw new IllegalArgumentException("ElasticGraph update was a no-op: [" +
-            params.id + "]: version conflict, current version [" +
-            docVersion + "] is higher or equal to the one provided [" +
-            eventVersion + "]");
-        } else {
-          source.putAll(params.data);
-          Map __counts = params.__counts;
-
-          if (__counts != null) {
-            if (source.__counts == null) {
-              source.__counts = [:];
-            }
-
-            source.__counts.putAll(__counts);
+        // --- Helper Functions --- //
+        void setup(Map source, String relationship, Map counts) {
+          if (source.__sources == null) {
+            source.__sources = [];
           }
 
-          source.id = params.id;
+          if (source.__versions == null) {
+            source.__versions = [:];
+          }
+
+          if (source.__versions[relationship] == null) {
+            source.__versions[relationship] = [:];
+          }
+
+          if (counts != null && source.__counts == null) {
+            source.__counts = [:];
+          }
+        }
+
+        void validateSource(Map source, String id, String relationship, String sourceId, long eventVersion) {
+          Map relationshipVersionsMap = source.__versions.get(relationship);
+          List previousSourceIdsForRelationship = relationshipVersionsMap.keySet().stream().filter(key -> key != sourceId).collect(Collectors.toList());
+
+          if (previousSourceIdsForRelationship.size() > 0) {
+            throw new IllegalArgumentException(
+              "Cannot update document " + id + " " +
+              "with data from related " + relationship + " " + sourceId + " " +
+              "because the related " + relationship + " has apparently changed (was: " + previousSourceIdsForRelationship + "), " +
+              "but mutations of relationships used with `sourced_from` are not supported because " +
+              "allowing it could break ElasticGraph's out-of-order processing guarantees."
+           );
+          }
+
+          Number maybeDocVersion = relationshipVersionsMap.get(sourceId);
+
+          // Our JSON schema requires event versions to be non-negative, so we can safely use Long.MIN_VALUE as a stand-in when the value is null.
+          long docVersion = maybeDocVersion == null ? Long.MIN_VALUE : maybeDocVersion.longValue();
+
+          if (docVersion >= eventVersion) {
+            throw new IllegalArgumentException("ElasticGraph update was a no-op: [" +
+              id + "]: version conflict, current version [" +
+              docVersion + "] is higher or equal to the one provided [" +
+              eventVersion + "]");
+          }
+        }
+
+        void applyTopLevelFields(Map source, Map topLevelFields, Map counts) {
+          source.putAll(topLevelFields);
+
+          if (counts != null) {
+            source.__counts.putAll(counts);
+          }
+        }
+
+        void recordSource(Map source, String id, String relationship, String sourceId, long eventVersion) {
+          source.id = id;
           source.__versions[relationship][sourceId] = eventVersion;
 
           // Record the relationship in `__sources` if it's not already there. We maintain it as an append-only set using a sorted list.
@@ -2233,3 +2233,16 @@ scripts:
             source.__sources.add(-sourceBinarySearchResult - 1, relationship);
           }
         }
+
+        // --- Main script body --- //
+        Map source = ctx._source;
+        String id = params.id;
+        String relationship = params.relationship;
+        String sourceId = params.sourceId;
+        long eventVersion = (long) params.version; // Cast to long since JSON parses numbers as doubles
+        Map counts = params.__counts;
+
+        setup(source, relationship, counts);
+        validateSource(source, id, relationship, sourceId, eventVersion);
+        applyTopLevelFields(source, params.topLevelFields, counts);
+        recordSource(source, id, relationship, sourceId, eventVersion);

--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -2156,7 +2156,7 @@ scripts:
 
         // No timestamp values matched the params, so return `false`.
         return false;
-  update_index_data_1b6d53ffefa2dd2d9510366867200725:
+  update_index_data_c506543861091e70bd493c28d29b9b70:
     context: update
     script:
       lang: painless
@@ -2184,7 +2184,7 @@ scripts:
           Map relationshipVersionsMap = source.__versions.get(relationship);
 
           if (relationshipVersionsMap == null) {
-            throw new IllegalArgumentException("Expected source.__versions[" + relationship + "] to be initialized by setup(), but it was null");
+            throw new IllegalArgumentException("Expected source.__versions[" + relationship + "] to be initialized, but it was null");
           }
 
           List previousSourceIdsForRelationship = relationshipVersionsMap.keySet().stream().filter(key -> key != sourceId).collect(Collectors.toList());
@@ -2212,7 +2212,8 @@ scripts:
           }
         }
 
-        void applyTopLevelFields(Map source, Map topLevelFields, Map counts) {
+        void applyTopLevelFields(Map source, String id, Map topLevelFields, Map counts) {
+          source.id = id;
           source.putAll(topLevelFields);
 
           if (counts != null) {
@@ -2220,8 +2221,7 @@ scripts:
           }
         }
 
-        void recordSource(Map source, String id, String relationship, String sourceId, long eventVersion) {
-          source.id = id;
+        void recordSource(Map source, String relationship, String sourceId, long eventVersion) {
           source.__versions[relationship][sourceId] = eventVersion;
 
           // Record the relationship in `__sources` if it's not already there. We maintain it as an append-only set using a sorted list.
@@ -2249,5 +2249,5 @@ scripts:
 
         setup(source, relationship, counts);
         validateSource(source, id, relationship, sourceId, eventVersion);
-        applyTopLevelFields(source, params.topLevelFields, counts);
-        recordSource(source, id, relationship, sourceId, eventVersion);
+        applyTopLevelFields(source, id, params.topLevelFields, counts);
+        recordSource(source, relationship, sourceId, eventVersion);

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -3096,7 +3096,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Address
   AddressAggregatedValues:
     graphql_fields_by_name:
@@ -3280,7 +3280,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: BrokerWholesaler
   ColorListFilterInput:
     graphql_fields_by_name:
@@ -3321,7 +3321,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Company
   Component:
     graphql_fields_by_name:
@@ -3429,7 +3429,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Component
   ComponentAggregatedValues:
     graphql_fields_by_name:
@@ -3729,7 +3729,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: DirectWholesaler
   DistributionChannel:
     graphql_fields_by_name:
@@ -3906,7 +3906,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: ElectricalPart
   ElectricalPartAggregatedValues:
     graphql_fields_by_name:
@@ -4389,7 +4389,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Manufacturer
   ManufacturerAggregatedValues:
     graphql_fields_by_name:
@@ -4549,7 +4549,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: MechanicalPart
   MechanicalPartAggregatedValues:
     graphql_fields_by_name:
@@ -5510,7 +5510,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: OnlineStore
   PageInfo:
     graphql_fields_by_name:
@@ -5707,7 +5707,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Person
   PersonAggregatedValues:
     graphql_fields_by_name:
@@ -5772,7 +5772,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: PhysicalStore
   PhysicalStoreAggregatedValues:
     graphql_fields_by_name:
@@ -6307,7 +6307,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Sponsor
   SponsorAggregatedValues:
     graphql_fields_by_name:
@@ -6689,7 +6689,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: formed_on
       routing_value_source: league
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Team
   TeamAggregatedValues:
     graphql_fields_by_name:
@@ -7737,7 +7737,7 @@ object_types_by_name:
       id_source: cost.currency
       rollover_timestamp_value_source: cost_currency_introduced_on
       routing_value_source: cost_currency_primary_continent
-      script_id: update_WidgetCurrency_from_Widget_a63538953d45f84cba67edd655d129a8
+      script_id: update_WidgetCurrency_from_Widget_e72813bd1a8767343222b77bf53be31c
       type: WidgetCurrency
     - data_params:
         amount_cents:
@@ -7817,7 +7817,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: created_at
       routing_value_source: workspace_id2
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Widget
     - data_params:
         widget_cost:
@@ -7848,7 +7848,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: widget
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Component
   WidgetAggregatedValues:
     graphql_fields_by_name:
@@ -8085,7 +8085,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: introduced_on
       routing_value_source: primary_continent
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: WidgetCurrency
   WidgetCurrencyAggregatedValues:
     graphql_fields_by_name:
@@ -9112,7 +9112,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: WidgetWorkspace
     - data_params:
         workspace_name:
@@ -9133,7 +9133,7 @@ object_types_by_name:
       relationship: workspace
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Widget
   WidgetWorkspaceAggregatedValues:
     graphql_fields_by_name:
@@ -9364,4 +9364,4 @@ static_script_ids_by_scoped_name:
   field/as_day_of_week: field_as_day_of_week_f2b5c7d9e8f75bf2457b52412bfb6537
   field/as_time_of_day: field_as_time_of_day_ed82aba44fc66bff5635bec4305c1c66
   filter/by_time_of_day: filter_by_time_of_day_ea12d0561b24961789ab68ed38435612
-  update/index_data: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+  update/index_data: update_index_data_db769e42fd258f3884d2c5b721bb3c03

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -3096,7 +3096,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Address
   AddressAggregatedValues:
     graphql_fields_by_name:
@@ -3280,7 +3280,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: BrokerWholesaler
   ColorListFilterInput:
     graphql_fields_by_name:
@@ -3321,7 +3321,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Company
   Component:
     graphql_fields_by_name:
@@ -3429,7 +3429,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Component
   ComponentAggregatedValues:
     graphql_fields_by_name:
@@ -3729,7 +3729,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: DirectWholesaler
   DistributionChannel:
     graphql_fields_by_name:
@@ -3906,7 +3906,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: ElectricalPart
   ElectricalPartAggregatedValues:
     graphql_fields_by_name:
@@ -4389,7 +4389,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Manufacturer
   ManufacturerAggregatedValues:
     graphql_fields_by_name:
@@ -4549,7 +4549,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: MechanicalPart
   MechanicalPartAggregatedValues:
     graphql_fields_by_name:
@@ -5510,7 +5510,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: OnlineStore
   PageInfo:
     graphql_fields_by_name:
@@ -5707,7 +5707,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Person
   PersonAggregatedValues:
     graphql_fields_by_name:
@@ -5772,7 +5772,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: PhysicalStore
   PhysicalStoreAggregatedValues:
     graphql_fields_by_name:
@@ -6307,7 +6307,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Sponsor
   SponsorAggregatedValues:
     graphql_fields_by_name:
@@ -6689,7 +6689,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: formed_on
       routing_value_source: league
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Team
   TeamAggregatedValues:
     graphql_fields_by_name:
@@ -7817,7 +7817,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: created_at
       routing_value_source: workspace_id2
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Widget
     - data_params:
         widget_cost:
@@ -7848,7 +7848,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: widget
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Component
   WidgetAggregatedValues:
     graphql_fields_by_name:
@@ -8085,7 +8085,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: introduced_on
       routing_value_source: primary_continent
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: WidgetCurrency
   WidgetCurrencyAggregatedValues:
     graphql_fields_by_name:
@@ -9112,7 +9112,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: WidgetWorkspace
     - data_params:
         workspace_name:
@@ -9133,7 +9133,7 @@ object_types_by_name:
       relationship: workspace
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Widget
   WidgetWorkspaceAggregatedValues:
     graphql_fields_by_name:
@@ -9364,4 +9364,4 @@ static_script_ids_by_scoped_name:
   field/as_day_of_week: field_as_day_of_week_f2b5c7d9e8f75bf2457b52412bfb6537
   field/as_time_of_day: field_as_time_of_day_ed82aba44fc66bff5635bec4305c1c66
   filter/by_time_of_day: filter_by_time_of_day_ea12d0561b24961789ab68ed38435612
-  update/index_data: update_index_data_1b6d53ffefa2dd2d9510366867200725
+  update/index_data: update_index_data_c506543861091e70bd493c28d29b9b70

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -3071,18 +3071,7 @@ object_types_by_name:
     index_definition_names:
     - addresses
     update_targets:
-    - data_params:
-        full_address:
-          cardinality: one
-        geo_location:
-          cardinality: one
-        manufacturer_id:
-          cardinality: one
-        shapes:
-          cardinality: one
-        timestamps:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -3097,6 +3086,17 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        full_address:
+          cardinality: one
+        geo_location:
+          cardinality: one
+        manufacturer_id:
+          cardinality: one
+        shapes:
+          cardinality: one
+        timestamps:
+          cardinality: one
       type: Address
   AddressAggregatedValues:
     graphql_fields_by_name:
@@ -3261,12 +3261,7 @@ object_types_by_name:
     index_definition_names:
     - distribution_channels
     update_targets:
-    - data_params:
-        __typename:
-          cardinality: one
-        active:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -3281,6 +3276,11 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        __typename:
+          cardinality: one
+        active:
+          cardinality: one
       type: BrokerWholesaler
   ColorListFilterInput:
     graphql_fields_by_name:
@@ -3300,14 +3300,7 @@ object_types_by_name:
     index_definition_names:
     - named_inventors
     update_targets:
-    - data_params:
-        __typename:
-          cardinality: one
-        name:
-          cardinality: one
-        stock_ticker:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -3322,6 +3315,13 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        __typename:
+          cardinality: one
+        name:
+          cardinality: one
+        stock_ticker:
+          cardinality: one
       type: Company
   Component:
     graphql_fields_by_name:
@@ -3400,22 +3400,7 @@ object_types_by_name:
     index_definition_names:
     - components
     update_targets:
-    - data_params:
-        created_at:
-          cardinality: one
-        name:
-          cardinality: one
-        owner_id:
-          cardinality: one
-        owner_ids:
-          cardinality: one
-        part_ids:
-          cardinality: one
-        position:
-          cardinality: one
-        tags:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -3430,6 +3415,21 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        created_at:
+          cardinality: one
+        name:
+          cardinality: one
+        owner_id:
+          cardinality: one
+        owner_ids:
+          cardinality: one
+        part_ids:
+          cardinality: one
+        position:
+          cardinality: one
+        tags:
+          cardinality: one
       type: Component
   ComponentAggregatedValues:
     graphql_fields_by_name:
@@ -3710,12 +3710,7 @@ object_types_by_name:
     index_definition_names:
     - distribution_channels
     update_targets:
-    - data_params:
-        __typename:
-          cardinality: one
-        active:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -3730,6 +3725,11 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        __typename:
+          cardinality: one
+        active:
+          cardinality: one
       type: DirectWholesaler
   DistributionChannel:
     graphql_fields_by_name:
@@ -3883,16 +3883,7 @@ object_types_by_name:
     index_definition_names:
     - electrical_parts
     update_targets:
-    - data_params:
-        created_at:
-          cardinality: one
-        manufacturer_id:
-          cardinality: one
-        name:
-          cardinality: one
-        voltage:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -3907,6 +3898,15 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        created_at:
+          cardinality: one
+        manufacturer_id:
+          cardinality: one
+        name:
+          cardinality: one
+        voltage:
+          cardinality: one
       type: ElectricalPart
   ElectricalPartAggregatedValues:
     graphql_fields_by_name:
@@ -4368,14 +4368,7 @@ object_types_by_name:
     index_definition_names:
     - manufacturers
     update_targets:
-    - data_params:
-        ceo:
-          cardinality: one
-        created_at:
-          cardinality: one
-        name:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -4390,6 +4383,13 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        ceo:
+          cardinality: one
+        created_at:
+          cardinality: one
+        name:
+          cardinality: one
       type: Manufacturer
   ManufacturerAggregatedValues:
     graphql_fields_by_name:
@@ -4526,16 +4526,7 @@ object_types_by_name:
     index_definition_names:
     - mechanical_parts
     update_targets:
-    - data_params:
-        created_at:
-          cardinality: one
-        manufacturer_id:
-          cardinality: one
-        material:
-          cardinality: one
-        name:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -4550,6 +4541,15 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        created_at:
+          cardinality: one
+        manufacturer_id:
+          cardinality: one
+        material:
+          cardinality: one
+        name:
+          cardinality: one
       type: MechanicalPart
   MechanicalPartAggregatedValues:
     graphql_fields_by_name:
@@ -5487,16 +5487,7 @@ object_types_by_name:
     index_definition_names:
     - distribution_channels
     update_targets:
-    - data_params:
-        __typename:
-          cardinality: one
-        active:
-          cardinality: one
-        established_on:
-          cardinality: one
-        name:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -5511,6 +5502,15 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        __typename:
+          cardinality: one
+        active:
+          cardinality: one
+        established_on:
+          cardinality: one
+        name:
+          cardinality: one
       type: OnlineStore
   PageInfo:
     graphql_fields_by_name:
@@ -5686,14 +5686,7 @@ object_types_by_name:
     index_definition_names:
     - named_inventors
     update_targets:
-    - data_params:
-        __typename:
-          cardinality: one
-        name:
-          cardinality: one
-        nationality:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -5708,6 +5701,13 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        __typename:
+          cardinality: one
+        name:
+          cardinality: one
+        nationality:
+          cardinality: one
       type: Person
   PersonAggregatedValues:
     graphql_fields_by_name:
@@ -5753,12 +5753,7 @@ object_types_by_name:
     index_definition_names:
     - physical_stores
     update_targets:
-    - data_params:
-        active:
-          cardinality: one
-        established_on:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -5773,6 +5768,11 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        active:
+          cardinality: one
+        established_on:
+          cardinality: one
       type: PhysicalStore
   PhysicalStoreAggregatedValues:
     graphql_fields_by_name:
@@ -6290,10 +6290,7 @@ object_types_by_name:
     index_definition_names:
     - sponsors
     update_targets:
-    - data_params:
-        name:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -6308,6 +6305,9 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        name:
+          cardinality: one
       type: Sponsor
   SponsorAggregatedValues:
     graphql_fields_by_name:
@@ -6639,7 +6639,23 @@ object_types_by_name:
     index_definition_names:
     - teams
     update_targets:
-    - data_params:
+    - id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      rollover_timestamp_value_source: formed_on
+      routing_value_source: league
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
         country_code:
           cardinality: one
         current_name:
@@ -6674,22 +6690,6 @@ object_types_by_name:
           cardinality: one
         won_championships_at:
           cardinality: one
-      id_source: id
-      metadata_params:
-        relationship:
-          value: __self
-        sourceId:
-          cardinality: one
-          source_path: id
-        sourceType:
-          cardinality: one
-          source_path: type
-        version:
-          cardinality: one
-      relationship: __self
-      rollover_timestamp_value_source: formed_on
-      routing_value_source: league
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Team
   TeamAggregatedValues:
     graphql_fields_by_name:
@@ -7707,7 +7707,11 @@ object_types_by_name:
     index_definition_names:
     - widgets
     update_targets:
-    - data_params:
+    - id_source: cost.currency
+      rollover_timestamp_value_source: cost_currency_introduced_on
+      routing_value_source: cost_currency_primary_continent
+      script_id: update_WidgetCurrency_from_Widget_e72813bd1a8767343222b77bf53be31c
+      top_level_fields_params:
         cost.amount_cents:
           cardinality: many
         cost_currency_introduced_on:
@@ -7734,12 +7738,24 @@ object_types_by_name:
           cardinality: many
         weight_in_ng:
           cardinality: many
-      id_source: cost.currency
-      rollover_timestamp_value_source: cost_currency_introduced_on
-      routing_value_source: cost_currency_primary_continent
-      script_id: update_WidgetCurrency_from_Widget_e72813bd1a8767343222b77bf53be31c
       type: WidgetCurrency
-    - data_params:
+    - id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      rollover_timestamp_value_source: created_at
+      routing_value_source: workspace_id2
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
         amount_cents:
           cardinality: one
         amounts:
@@ -7802,10 +7818,11 @@ object_types_by_name:
           cardinality: one
         workspace_id2:
           cardinality: one
-      id_source: id
+      type: Widget
+    - id_source: component_ids
       metadata_params:
         relationship:
-          value: __self
+          value: widget
         sourceId:
           cardinality: one
           source_path: id
@@ -7814,12 +7831,9 @@ object_types_by_name:
           source_path: type
         version:
           cardinality: one
-      relationship: __self
-      rollover_timestamp_value_source: created_at
-      routing_value_source: workspace_id2
+      relationship: widget
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
-      type: Widget
-    - data_params:
+      top_level_fields_params:
         widget_cost:
           cardinality: one
           source_path: cost
@@ -7835,20 +7849,6 @@ object_types_by_name:
         widget_workspace_id3:
           cardinality: one
           source_path: workspace_id2
-      id_source: component_ids
-      metadata_params:
-        relationship:
-          value: widget
-        sourceId:
-          cardinality: one
-          source_path: id
-        sourceType:
-          cardinality: one
-          source_path: type
-        version:
-          cardinality: one
-      relationship: widget
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Component
   WidgetAggregatedValues:
     graphql_fields_by_name:
@@ -8047,7 +8047,23 @@ object_types_by_name:
     index_definition_names:
     - widget_currencies
     update_targets:
-    - data_params:
+    - id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      rollover_timestamp_value_source: introduced_on
+      routing_value_source: primary_continent
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
         details:
           cardinality: one
         introduced_on:
@@ -8070,22 +8086,6 @@ object_types_by_name:
           cardinality: one
         widget_tags:
           cardinality: one
-      id_source: id
-      metadata_params:
-        relationship:
-          value: __self
-        sourceId:
-          cardinality: one
-          source_path: id
-        sourceType:
-          cardinality: one
-          source_path: type
-        version:
-          cardinality: one
-      relationship: __self
-      rollover_timestamp_value_source: introduced_on
-      routing_value_source: primary_continent
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: WidgetCurrency
   WidgetCurrencyAggregatedValues:
     graphql_fields_by_name:
@@ -9093,12 +9093,7 @@ object_types_by_name:
     index_definition_names:
     - widget_workspaces
     update_targets:
-    - data_params:
-        name:
-          cardinality: one
-        widget:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -9113,12 +9108,13 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
-      type: WidgetWorkspace
-    - data_params:
-        workspace_name:
+      top_level_fields_params:
+        name:
           cardinality: one
-          source_path: name
-      id_source: widget.id
+        widget:
+          cardinality: one
+      type: WidgetWorkspace
+    - id_source: widget.id
       metadata_params:
         relationship:
           value: workspace
@@ -9134,6 +9130,10 @@ object_types_by_name:
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        workspace_name:
+          cardinality: one
+          source_path: name
       type: Widget
   WidgetWorkspaceAggregatedValues:
     graphql_fields_by_name:

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -3085,7 +3085,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         full_address:
           cardinality: one
@@ -3275,7 +3275,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -3314,7 +3314,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -3414,7 +3414,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         created_at:
           cardinality: one
@@ -3724,7 +3724,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -3897,7 +3897,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         created_at:
           cardinality: one
@@ -4382,7 +4382,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         ceo:
           cardinality: one
@@ -4540,7 +4540,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         created_at:
           cardinality: one
@@ -5501,7 +5501,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -5700,7 +5700,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -5767,7 +5767,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         active:
           cardinality: one
@@ -6304,7 +6304,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         name:
           cardinality: one
@@ -6654,7 +6654,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: formed_on
       routing_value_source: league
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         country_code:
           cardinality: one
@@ -7754,7 +7754,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: created_at
       routing_value_source: workspace_id2
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         amount_cents:
           cardinality: one
@@ -7832,7 +7832,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: widget
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         widget_cost:
           cardinality: one
@@ -8062,7 +8062,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: introduced_on
       routing_value_source: primary_continent
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         details:
           cardinality: one
@@ -9107,7 +9107,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         name:
           cardinality: one
@@ -9129,7 +9129,7 @@ object_types_by_name:
       relationship: workspace
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         workspace_name:
           cardinality: one
@@ -9364,4 +9364,4 @@ static_script_ids_by_scoped_name:
   field/as_day_of_week: field_as_day_of_week_f2b5c7d9e8f75bf2457b52412bfb6537
   field/as_time_of_day: field_as_time_of_day_ed82aba44fc66bff5635bec4305c1c66
   filter/by_time_of_day: filter_by_time_of_day_ea12d0561b24961789ab68ed38435612
-  update/index_data: update_index_data_c506543861091e70bd493c28d29b9b70
+  update/index_data: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -3096,7 +3096,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Address
   AddressAggregatedValues:
     graphql_fields_by_name:
@@ -3280,7 +3280,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: BrokerWholesaler
   ColorListFilterInput:
     graphql_fields_by_name:
@@ -3321,7 +3321,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Company
   Component:
     graphql_fields_by_name:
@@ -3429,7 +3429,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Component
   ComponentAggregatedValues:
     graphql_fields_by_name:
@@ -3729,7 +3729,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: DirectWholesaler
   DistributionChannel:
     graphql_fields_by_name:
@@ -3906,7 +3906,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: ElectricalPart
   ElectricalPartAggregatedValues:
     graphql_fields_by_name:
@@ -4389,7 +4389,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Manufacturer
   ManufacturerAggregatedValues:
     graphql_fields_by_name:
@@ -4549,7 +4549,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: MechanicalPart
   MechanicalPartAggregatedValues:
     graphql_fields_by_name:
@@ -5510,7 +5510,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: OnlineStore
   PageInfo:
     graphql_fields_by_name:
@@ -5707,7 +5707,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Person
   PersonAggregatedValues:
     graphql_fields_by_name:
@@ -5772,7 +5772,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: PhysicalStore
   PhysicalStoreAggregatedValues:
     graphql_fields_by_name:
@@ -6307,7 +6307,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Sponsor
   SponsorAggregatedValues:
     graphql_fields_by_name:
@@ -6689,7 +6689,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: formed_on
       routing_value_source: league
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Team
   TeamAggregatedValues:
     graphql_fields_by_name:
@@ -7817,7 +7817,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: created_at
       routing_value_source: workspace_id2
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Widget
     - data_params:
         widget_cost:
@@ -7848,7 +7848,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: widget
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Component
   WidgetAggregatedValues:
     graphql_fields_by_name:
@@ -8085,7 +8085,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: introduced_on
       routing_value_source: primary_continent
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: WidgetCurrency
   WidgetCurrencyAggregatedValues:
     graphql_fields_by_name:
@@ -9112,7 +9112,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: WidgetWorkspace
     - data_params:
         workspace_name:
@@ -9133,7 +9133,7 @@ object_types_by_name:
       relationship: workspace
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Widget
   WidgetWorkspaceAggregatedValues:
     graphql_fields_by_name:
@@ -9364,4 +9364,4 @@ static_script_ids_by_scoped_name:
   field/as_day_of_week: field_as_day_of_week_f2b5c7d9e8f75bf2457b52412bfb6537
   field/as_time_of_day: field_as_time_of_day_ed82aba44fc66bff5635bec4305c1c66
   filter/by_time_of_day: filter_by_time_of_day_ea12d0561b24961789ab68ed38435612
-  update/index_data: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+  update/index_data: update_index_data_1b6d53ffefa2dd2d9510366867200725

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -2156,7 +2156,7 @@ scripts:
 
         // No timestamp values matched the params, so return `false`.
         return false;
-  update_index_data_c506543861091e70bd493c28d29b9b70:
+  update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d:
     context: update
     script:
       lang: painless
@@ -2182,11 +2182,6 @@ scripts:
 
         void validateSource(Map source, String id, String relationship, String sourceId, long eventVersion) {
           Map relationshipVersionsMap = source.__versions.get(relationship);
-
-          if (relationshipVersionsMap == null) {
-            throw new IllegalArgumentException("Expected source.__versions[" + relationship + "] to be initialized, but it was null");
-          }
-
           List previousSourceIdsForRelationship = relationshipVersionsMap.keySet().stream().filter(key -> key != sourceId).collect(Collectors.toList());
 
           if (previousSourceIdsForRelationship.size() > 0) {

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -2156,7 +2156,7 @@ scripts:
 
         // No timestamp values matched the params, so return `false`.
         return false;
-  update_index_data_db769e42fd258f3884d2c5b721bb3c03:
+  update_index_data_1b6d53ffefa2dd2d9510366867200725:
     context: update
     script:
       lang: painless
@@ -2182,6 +2182,11 @@ scripts:
 
         void validateSource(Map source, String id, String relationship, String sourceId, long eventVersion) {
           Map relationshipVersionsMap = source.__versions.get(relationship);
+
+          if (relationshipVersionsMap == null) {
+            throw new IllegalArgumentException("Expected source.__versions[" + relationship + "] to be initialized by setup(), but it was null");
+          }
+
           List previousSourceIdsForRelationship = relationshipVersionsMap.keySet().stream().filter(key -> key != sourceId).collect(Collectors.toList());
 
           if (previousSourceIdsForRelationship.size() > 0) {

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -1852,7 +1852,7 @@ indices:
       index.number_of_shards: 1
       index.max_result_window: 10000
 scripts:
-  update_WidgetCurrency_from_Widget_a63538953d45f84cba67edd655d129a8:
+  update_WidgetCurrency_from_Widget_e72813bd1a8767343222b77bf53be31c:
     context: update
     script:
       lang: painless
@@ -1996,7 +1996,7 @@ scripts:
           return false;
         }
 
-        Map data = params.data;
+        Map data = params.topLevelFields;
         // A variable to accumulate script errors so that we can surface _all_ issues and not just the first.
         List scriptErrors = new ArrayList();
         if (ctx._source.details == null) {
@@ -2156,67 +2156,67 @@ scripts:
 
         // No timestamp values matched the params, so return `false`.
         return false;
-  update_index_data_1fdfaf1c9261c96019decc89b515bd9a:
+  update_index_data_db769e42fd258f3884d2c5b721bb3c03:
     context: update
     script:
       lang: painless
       source: |-
-        Map source = ctx._source;
-        String sourceId = params.sourceId;
-        String relationship = params.relationship;
-
-        // Numbers in JSON appear to be parsed as doubles, but we want the version stored as a long, so we need to cast it here.
-        long eventVersion = (long) params.version;
-
-        if (source.__sources == null) {
-          source.__sources = [];
-        }
-
-        if (source.__versions == null) {
-          source.__versions = [:];
-        }
-
-        if (source.__versions[relationship] == null) {
-          source.__versions[relationship] = [:];
-        }
-
-        Map relationshipVersionsMap = source.__versions.get(relationship);
-        List previousSourceIdsForRelationship = relationshipVersionsMap.keySet().stream().filter(id -> id != sourceId).collect(Collectors.toList());
-
-        if (previousSourceIdsForRelationship.size() > 0) {
-          String previousIdDescription = previousSourceIdsForRelationship.size() == 1 ? previousSourceIdsForRelationship.get(0) : previousSourceIdsForRelationship.toString();
-          throw new IllegalArgumentException(
-            "Cannot update document " + params.id + " " +
-            "with data from related " + relationship + " " + sourceId + " " +
-            "because the related " + relationship + " has apparently changed (was: " + previousSourceIdsForRelationship + "), " +
-            "but mutations of relationships used with `sourced_from` are not supported because " +
-            "allowing it could break ElasticGraph's out-of-order processing guarantees."
-         );
-        }
-
-        Number maybeDocVersion = source.__versions.get(params.relationship)?.get(params.sourceId);
-
-        // Our JSON schema requires event versions to be non-negative, so we can safely use Long.MIN_VALUE as a stand-in when the value is null.
-        long docVersion = maybeDocVersion == null ? Long.MIN_VALUE : maybeDocVersion.longValue();
-
-        if (docVersion >= eventVersion) {
-          throw new IllegalArgumentException("ElasticGraph update was a no-op: [" +
-            params.id + "]: version conflict, current version [" +
-            docVersion + "] is higher or equal to the one provided [" +
-            eventVersion + "]");
-        } else {
-          source.putAll(params.data);
-          Map __counts = params.__counts;
-
-          if (__counts != null) {
-            if (source.__counts == null) {
-              source.__counts = [:];
-            }
-
-            source.__counts.putAll(__counts);
+        // --- Helper Functions --- //
+        void setup(Map source, String relationship, Map counts) {
+          if (source.__sources == null) {
+            source.__sources = [];
           }
 
-          source.id = params.id;
+          if (source.__versions == null) {
+            source.__versions = [:];
+          }
+
+          if (source.__versions[relationship] == null) {
+            source.__versions[relationship] = [:];
+          }
+
+          if (counts != null && source.__counts == null) {
+            source.__counts = [:];
+          }
+        }
+
+        void validateSource(Map source, String id, String relationship, String sourceId, long eventVersion) {
+          Map relationshipVersionsMap = source.__versions.get(relationship);
+          List previousSourceIdsForRelationship = relationshipVersionsMap.keySet().stream().filter(key -> key != sourceId).collect(Collectors.toList());
+
+          if (previousSourceIdsForRelationship.size() > 0) {
+            throw new IllegalArgumentException(
+              "Cannot update document " + id + " " +
+              "with data from related " + relationship + " " + sourceId + " " +
+              "because the related " + relationship + " has apparently changed (was: " + previousSourceIdsForRelationship + "), " +
+              "but mutations of relationships used with `sourced_from` are not supported because " +
+              "allowing it could break ElasticGraph's out-of-order processing guarantees."
+           );
+          }
+
+          Number maybeDocVersion = relationshipVersionsMap.get(sourceId);
+
+          // Our JSON schema requires event versions to be non-negative, so we can safely use Long.MIN_VALUE as a stand-in when the value is null.
+          long docVersion = maybeDocVersion == null ? Long.MIN_VALUE : maybeDocVersion.longValue();
+
+          if (docVersion >= eventVersion) {
+            throw new IllegalArgumentException("ElasticGraph update was a no-op: [" +
+              id + "]: version conflict, current version [" +
+              docVersion + "] is higher or equal to the one provided [" +
+              eventVersion + "]");
+          }
+        }
+
+        void applyTopLevelFields(Map source, Map topLevelFields, Map counts) {
+          source.putAll(topLevelFields);
+
+          if (counts != null) {
+            source.__counts.putAll(counts);
+          }
+        }
+
+        void recordSource(Map source, String id, String relationship, String sourceId, long eventVersion) {
+          source.id = id;
           source.__versions[relationship][sourceId] = eventVersion;
 
           // Record the relationship in `__sources` if it's not already there. We maintain it as an append-only set using a sorted list.
@@ -2233,3 +2233,16 @@ scripts:
             source.__sources.add(-sourceBinarySearchResult - 1, relationship);
           }
         }
+
+        // --- Main script body --- //
+        Map source = ctx._source;
+        String id = params.id;
+        String relationship = params.relationship;
+        String sourceId = params.sourceId;
+        long eventVersion = (long) params.version; // Cast to long since JSON parses numbers as doubles
+        Map counts = params.__counts;
+
+        setup(source, relationship, counts);
+        validateSource(source, id, relationship, sourceId, eventVersion);
+        applyTopLevelFields(source, params.topLevelFields, counts);
+        recordSource(source, id, relationship, sourceId, eventVersion);

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -2156,7 +2156,7 @@ scripts:
 
         // No timestamp values matched the params, so return `false`.
         return false;
-  update_index_data_1b6d53ffefa2dd2d9510366867200725:
+  update_index_data_c506543861091e70bd493c28d29b9b70:
     context: update
     script:
       lang: painless
@@ -2184,7 +2184,7 @@ scripts:
           Map relationshipVersionsMap = source.__versions.get(relationship);
 
           if (relationshipVersionsMap == null) {
-            throw new IllegalArgumentException("Expected source.__versions[" + relationship + "] to be initialized by setup(), but it was null");
+            throw new IllegalArgumentException("Expected source.__versions[" + relationship + "] to be initialized, but it was null");
           }
 
           List previousSourceIdsForRelationship = relationshipVersionsMap.keySet().stream().filter(key -> key != sourceId).collect(Collectors.toList());
@@ -2212,7 +2212,8 @@ scripts:
           }
         }
 
-        void applyTopLevelFields(Map source, Map topLevelFields, Map counts) {
+        void applyTopLevelFields(Map source, String id, Map topLevelFields, Map counts) {
+          source.id = id;
           source.putAll(topLevelFields);
 
           if (counts != null) {
@@ -2220,8 +2221,7 @@ scripts:
           }
         }
 
-        void recordSource(Map source, String id, String relationship, String sourceId, long eventVersion) {
-          source.id = id;
+        void recordSource(Map source, String relationship, String sourceId, long eventVersion) {
           source.__versions[relationship][sourceId] = eventVersion;
 
           // Record the relationship in `__sources` if it's not already there. We maintain it as an append-only set using a sorted list.
@@ -2249,5 +2249,5 @@ scripts:
 
         setup(source, relationship, counts);
         validateSource(source, id, relationship, sourceId, eventVersion);
-        applyTopLevelFields(source, params.topLevelFields, counts);
-        recordSource(source, id, relationship, sourceId, eventVersion);
+        applyTopLevelFields(source, id, params.topLevelFields, counts);
+        recordSource(source, relationship, sourceId, eventVersion);

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -3125,7 +3125,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Address
   AddressAggregatedValues:
     graphql_fields_by_name:
@@ -3309,7 +3309,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: BrokerWholesaler
   ColorListFilterInput:
     graphql_fields_by_name:
@@ -3350,7 +3350,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Company
   Component:
     graphql_fields_by_name:
@@ -3479,7 +3479,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Component
   ComponentAggregatedValues:
     graphql_fields_by_name:
@@ -3831,7 +3831,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: DirectWholesaler
   DistributionChannel:
     graphql_fields_by_name:
@@ -4008,7 +4008,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: ElectricalPart
   ElectricalPartAggregatedValues:
     graphql_fields_by_name:
@@ -4491,7 +4491,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Manufacturer
   ManufacturerAggregatedValues:
     graphql_fields_by_name:
@@ -4651,7 +4651,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: MechanicalPart
   MechanicalPartAggregatedValues:
     graphql_fields_by_name:
@@ -5633,7 +5633,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: OnlineStore
   PageInfo:
     graphql_fields_by_name:
@@ -5830,7 +5830,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Person
   PersonAggregatedValues:
     graphql_fields_by_name:
@@ -5895,7 +5895,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: PhysicalStore
   PhysicalStoreAggregatedValues:
     graphql_fields_by_name:
@@ -6436,7 +6436,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Sponsor
   SponsorAggregatedValues:
     graphql_fields_by_name:
@@ -6818,7 +6818,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: formed_on
       routing_value_source: league
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Team
   TeamAggregatedValues:
     graphql_fields_by_name:
@@ -7866,7 +7866,7 @@ object_types_by_name:
       id_source: cost.currency
       rollover_timestamp_value_source: cost_currency_introduced_on
       routing_value_source: cost_currency_primary_continent
-      script_id: update_WidgetCurrency_from_Widget_a63538953d45f84cba67edd655d129a8
+      script_id: update_WidgetCurrency_from_Widget_e72813bd1a8767343222b77bf53be31c
       type: WidgetCurrency
     - data_params:
         amount_cents:
@@ -7946,7 +7946,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: created_at
       routing_value_source: workspace_id2
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Widget
     - data_params:
         widget_cost:
@@ -7977,7 +7977,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: widget
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Component
   WidgetAggregatedValues:
     graphql_fields_by_name:
@@ -8214,7 +8214,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: introduced_on
       routing_value_source: primary_continent
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: WidgetCurrency
   WidgetCurrencyAggregatedValues:
     graphql_fields_by_name:
@@ -9241,7 +9241,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: WidgetWorkspace
     - data_params:
         workspace_name:
@@ -9262,7 +9262,7 @@ object_types_by_name:
       relationship: workspace
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
-      script_id: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
       type: Widget
   WidgetWorkspaceAggregatedValues:
     graphql_fields_by_name:
@@ -9536,4 +9536,4 @@ static_script_ids_by_scoped_name:
   field/as_day_of_week: field_as_day_of_week_f2b5c7d9e8f75bf2457b52412bfb6537
   field/as_time_of_day: field_as_time_of_day_ed82aba44fc66bff5635bec4305c1c66
   filter/by_time_of_day: filter_by_time_of_day_ea12d0561b24961789ab68ed38435612
-  update/index_data: update_index_data_1fdfaf1c9261c96019decc89b515bd9a
+  update/index_data: update_index_data_db769e42fd258f3884d2c5b721bb3c03

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -3125,7 +3125,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Address
   AddressAggregatedValues:
     graphql_fields_by_name:
@@ -3309,7 +3309,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: BrokerWholesaler
   ColorListFilterInput:
     graphql_fields_by_name:
@@ -3350,7 +3350,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Company
   Component:
     graphql_fields_by_name:
@@ -3479,7 +3479,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Component
   ComponentAggregatedValues:
     graphql_fields_by_name:
@@ -3831,7 +3831,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: DirectWholesaler
   DistributionChannel:
     graphql_fields_by_name:
@@ -4008,7 +4008,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: ElectricalPart
   ElectricalPartAggregatedValues:
     graphql_fields_by_name:
@@ -4491,7 +4491,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Manufacturer
   ManufacturerAggregatedValues:
     graphql_fields_by_name:
@@ -4651,7 +4651,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: MechanicalPart
   MechanicalPartAggregatedValues:
     graphql_fields_by_name:
@@ -5633,7 +5633,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: OnlineStore
   PageInfo:
     graphql_fields_by_name:
@@ -5830,7 +5830,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Person
   PersonAggregatedValues:
     graphql_fields_by_name:
@@ -5895,7 +5895,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: PhysicalStore
   PhysicalStoreAggregatedValues:
     graphql_fields_by_name:
@@ -6436,7 +6436,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Sponsor
   SponsorAggregatedValues:
     graphql_fields_by_name:
@@ -6818,7 +6818,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: formed_on
       routing_value_source: league
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Team
   TeamAggregatedValues:
     graphql_fields_by_name:
@@ -7946,7 +7946,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: created_at
       routing_value_source: workspace_id2
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Widget
     - data_params:
         widget_cost:
@@ -7977,7 +7977,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: widget
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Component
   WidgetAggregatedValues:
     graphql_fields_by_name:
@@ -8214,7 +8214,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: introduced_on
       routing_value_source: primary_continent
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: WidgetCurrency
   WidgetCurrencyAggregatedValues:
     graphql_fields_by_name:
@@ -9241,7 +9241,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: WidgetWorkspace
     - data_params:
         workspace_name:
@@ -9262,7 +9262,7 @@ object_types_by_name:
       relationship: workspace
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
-      script_id: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
       type: Widget
   WidgetWorkspaceAggregatedValues:
     graphql_fields_by_name:
@@ -9536,4 +9536,4 @@ static_script_ids_by_scoped_name:
   field/as_day_of_week: field_as_day_of_week_f2b5c7d9e8f75bf2457b52412bfb6537
   field/as_time_of_day: field_as_time_of_day_ed82aba44fc66bff5635bec4305c1c66
   filter/by_time_of_day: filter_by_time_of_day_ea12d0561b24961789ab68ed38435612
-  update/index_data: update_index_data_db769e42fd258f3884d2c5b721bb3c03
+  update/index_data: update_index_data_1b6d53ffefa2dd2d9510366867200725

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -3114,7 +3114,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         full_address:
           cardinality: one
@@ -3304,7 +3304,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -3343,7 +3343,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -3464,7 +3464,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         created_at:
           cardinality: one
@@ -3826,7 +3826,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -3999,7 +3999,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         created_at:
           cardinality: one
@@ -4484,7 +4484,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         ceo:
           cardinality: one
@@ -4642,7 +4642,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         created_at:
           cardinality: one
@@ -5624,7 +5624,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -5823,7 +5823,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -5890,7 +5890,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         active:
           cardinality: one
@@ -6433,7 +6433,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         name:
           cardinality: one
@@ -6783,7 +6783,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: formed_on
       routing_value_source: league
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         country_code:
           cardinality: one
@@ -7883,7 +7883,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: created_at
       routing_value_source: workspace_id2
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         amount_cents:
           cardinality: one
@@ -7961,7 +7961,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: widget
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         widget_cost:
           cardinality: one
@@ -8191,7 +8191,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: introduced_on
       routing_value_source: primary_continent
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         details:
           cardinality: one
@@ -9236,7 +9236,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         name:
           cardinality: one
@@ -9258,7 +9258,7 @@ object_types_by_name:
       relationship: workspace
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      script_id: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d
       top_level_fields_params:
         workspace_name:
           cardinality: one
@@ -9536,4 +9536,4 @@ static_script_ids_by_scoped_name:
   field/as_day_of_week: field_as_day_of_week_f2b5c7d9e8f75bf2457b52412bfb6537
   field/as_time_of_day: field_as_time_of_day_ed82aba44fc66bff5635bec4305c1c66
   filter/by_time_of_day: filter_by_time_of_day_ea12d0561b24961789ab68ed38435612
-  update/index_data: update_index_data_c506543861091e70bd493c28d29b9b70
+  update/index_data: update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -3100,18 +3100,7 @@ object_types_by_name:
     index_definition_names:
     - addresses
     update_targets:
-    - data_params:
-        full_address:
-          cardinality: one
-        geo_location:
-          cardinality: one
-        manufacturer_id:
-          cardinality: one
-        shapes:
-          cardinality: one
-        timestamps:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -3126,6 +3115,17 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        full_address:
+          cardinality: one
+        geo_location:
+          cardinality: one
+        manufacturer_id:
+          cardinality: one
+        shapes:
+          cardinality: one
+        timestamps:
+          cardinality: one
       type: Address
   AddressAggregatedValues:
     graphql_fields_by_name:
@@ -3290,12 +3290,7 @@ object_types_by_name:
     index_definition_names:
     - distribution_channels
     update_targets:
-    - data_params:
-        __typename:
-          cardinality: one
-        active:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -3310,6 +3305,11 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        __typename:
+          cardinality: one
+        active:
+          cardinality: one
       type: BrokerWholesaler
   ColorListFilterInput:
     graphql_fields_by_name:
@@ -3329,14 +3329,7 @@ object_types_by_name:
     index_definition_names:
     - named_inventors
     update_targets:
-    - data_params:
-        __typename:
-          cardinality: one
-        name:
-          cardinality: one
-        stock_ticker:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -3351,6 +3344,13 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        __typename:
+          cardinality: one
+        name:
+          cardinality: one
+        stock_ticker:
+          cardinality: one
       type: Company
   Component:
     graphql_fields_by_name:
@@ -3450,22 +3450,7 @@ object_types_by_name:
     index_definition_names:
     - components
     update_targets:
-    - data_params:
-        created_at:
-          cardinality: one
-        name:
-          cardinality: one
-        owner_id:
-          cardinality: one
-        owner_ids:
-          cardinality: one
-        part_ids:
-          cardinality: one
-        position:
-          cardinality: one
-        tags:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -3480,6 +3465,21 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        created_at:
+          cardinality: one
+        name:
+          cardinality: one
+        owner_id:
+          cardinality: one
+        owner_ids:
+          cardinality: one
+        part_ids:
+          cardinality: one
+        position:
+          cardinality: one
+        tags:
+          cardinality: one
       type: Component
   ComponentAggregatedValues:
     graphql_fields_by_name:
@@ -3812,12 +3812,7 @@ object_types_by_name:
     index_definition_names:
     - distribution_channels
     update_targets:
-    - data_params:
-        __typename:
-          cardinality: one
-        active:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -3832,6 +3827,11 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        __typename:
+          cardinality: one
+        active:
+          cardinality: one
       type: DirectWholesaler
   DistributionChannel:
     graphql_fields_by_name:
@@ -3985,16 +3985,7 @@ object_types_by_name:
     index_definition_names:
     - electrical_parts
     update_targets:
-    - data_params:
-        created_at:
-          cardinality: one
-        manufacturer_id:
-          cardinality: one
-        name:
-          cardinality: one
-        voltage:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -4009,6 +4000,15 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        created_at:
+          cardinality: one
+        manufacturer_id:
+          cardinality: one
+        name:
+          cardinality: one
+        voltage:
+          cardinality: one
       type: ElectricalPart
   ElectricalPartAggregatedValues:
     graphql_fields_by_name:
@@ -4470,14 +4470,7 @@ object_types_by_name:
     index_definition_names:
     - manufacturers
     update_targets:
-    - data_params:
-        ceo:
-          cardinality: one
-        created_at:
-          cardinality: one
-        name:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -4492,6 +4485,13 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        ceo:
+          cardinality: one
+        created_at:
+          cardinality: one
+        name:
+          cardinality: one
       type: Manufacturer
   ManufacturerAggregatedValues:
     graphql_fields_by_name:
@@ -4628,16 +4628,7 @@ object_types_by_name:
     index_definition_names:
     - mechanical_parts
     update_targets:
-    - data_params:
-        created_at:
-          cardinality: one
-        manufacturer_id:
-          cardinality: one
-        material:
-          cardinality: one
-        name:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -4652,6 +4643,15 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        created_at:
+          cardinality: one
+        manufacturer_id:
+          cardinality: one
+        material:
+          cardinality: one
+        name:
+          cardinality: one
       type: MechanicalPart
   MechanicalPartAggregatedValues:
     graphql_fields_by_name:
@@ -5610,16 +5610,7 @@ object_types_by_name:
     index_definition_names:
     - distribution_channels
     update_targets:
-    - data_params:
-        __typename:
-          cardinality: one
-        active:
-          cardinality: one
-        established_on:
-          cardinality: one
-        name:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -5634,6 +5625,15 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        __typename:
+          cardinality: one
+        active:
+          cardinality: one
+        established_on:
+          cardinality: one
+        name:
+          cardinality: one
       type: OnlineStore
   PageInfo:
     graphql_fields_by_name:
@@ -5809,14 +5809,7 @@ object_types_by_name:
     index_definition_names:
     - named_inventors
     update_targets:
-    - data_params:
-        __typename:
-          cardinality: one
-        name:
-          cardinality: one
-        nationality:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -5831,6 +5824,13 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        __typename:
+          cardinality: one
+        name:
+          cardinality: one
+        nationality:
+          cardinality: one
       type: Person
   PersonAggregatedValues:
     graphql_fields_by_name:
@@ -5876,12 +5876,7 @@ object_types_by_name:
     index_definition_names:
     - physical_stores
     update_targets:
-    - data_params:
-        active:
-          cardinality: one
-        established_on:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -5896,6 +5891,11 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        active:
+          cardinality: one
+        established_on:
+          cardinality: one
       type: PhysicalStore
   PhysicalStoreAggregatedValues:
     graphql_fields_by_name:
@@ -6419,10 +6419,7 @@ object_types_by_name:
     index_definition_names:
     - sponsors
     update_targets:
-    - data_params:
-        name:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -6437,6 +6434,9 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        name:
+          cardinality: one
       type: Sponsor
   SponsorAggregatedValues:
     graphql_fields_by_name:
@@ -6768,7 +6768,23 @@ object_types_by_name:
     index_definition_names:
     - teams
     update_targets:
-    - data_params:
+    - id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      rollover_timestamp_value_source: formed_on
+      routing_value_source: league
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
         country_code:
           cardinality: one
         current_name:
@@ -6803,22 +6819,6 @@ object_types_by_name:
           cardinality: one
         won_championships_at:
           cardinality: one
-      id_source: id
-      metadata_params:
-        relationship:
-          value: __self
-        sourceId:
-          cardinality: one
-          source_path: id
-        sourceType:
-          cardinality: one
-          source_path: type
-        version:
-          cardinality: one
-      relationship: __self
-      rollover_timestamp_value_source: formed_on
-      routing_value_source: league
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Team
   TeamAggregatedValues:
     graphql_fields_by_name:
@@ -7836,7 +7836,11 @@ object_types_by_name:
     index_definition_names:
     - widgets
     update_targets:
-    - data_params:
+    - id_source: cost.currency
+      rollover_timestamp_value_source: cost_currency_introduced_on
+      routing_value_source: cost_currency_primary_continent
+      script_id: update_WidgetCurrency_from_Widget_e72813bd1a8767343222b77bf53be31c
+      top_level_fields_params:
         cost.amount_cents:
           cardinality: many
         cost_currency_introduced_on:
@@ -7863,12 +7867,24 @@ object_types_by_name:
           cardinality: many
         weight_in_ng:
           cardinality: many
-      id_source: cost.currency
-      rollover_timestamp_value_source: cost_currency_introduced_on
-      routing_value_source: cost_currency_primary_continent
-      script_id: update_WidgetCurrency_from_Widget_e72813bd1a8767343222b77bf53be31c
       type: WidgetCurrency
-    - data_params:
+    - id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      rollover_timestamp_value_source: created_at
+      routing_value_source: workspace_id2
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
         amount_cents:
           cardinality: one
         amounts:
@@ -7931,10 +7947,11 @@ object_types_by_name:
           cardinality: one
         workspace_id2:
           cardinality: one
-      id_source: id
+      type: Widget
+    - id_source: component_ids
       metadata_params:
         relationship:
-          value: __self
+          value: widget
         sourceId:
           cardinality: one
           source_path: id
@@ -7943,12 +7960,9 @@ object_types_by_name:
           source_path: type
         version:
           cardinality: one
-      relationship: __self
-      rollover_timestamp_value_source: created_at
-      routing_value_source: workspace_id2
+      relationship: widget
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
-      type: Widget
-    - data_params:
+      top_level_fields_params:
         widget_cost:
           cardinality: one
           source_path: cost
@@ -7964,20 +7978,6 @@ object_types_by_name:
         widget_workspace_id3:
           cardinality: one
           source_path: workspace_id2
-      id_source: component_ids
-      metadata_params:
-        relationship:
-          value: widget
-        sourceId:
-          cardinality: one
-          source_path: id
-        sourceType:
-          cardinality: one
-          source_path: type
-        version:
-          cardinality: one
-      relationship: widget
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Component
   WidgetAggregatedValues:
     graphql_fields_by_name:
@@ -8176,7 +8176,23 @@ object_types_by_name:
     index_definition_names:
     - widget_currencies
     update_targets:
-    - data_params:
+    - id_source: id
+      metadata_params:
+        relationship:
+          value: __self
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: __self
+      rollover_timestamp_value_source: introduced_on
+      routing_value_source: primary_continent
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
         details:
           cardinality: one
         introduced_on:
@@ -8199,22 +8215,6 @@ object_types_by_name:
           cardinality: one
         widget_tags:
           cardinality: one
-      id_source: id
-      metadata_params:
-        relationship:
-          value: __self
-        sourceId:
-          cardinality: one
-          source_path: id
-        sourceType:
-          cardinality: one
-          source_path: type
-        version:
-          cardinality: one
-      relationship: __self
-      rollover_timestamp_value_source: introduced_on
-      routing_value_source: primary_continent
-      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: WidgetCurrency
   WidgetCurrencyAggregatedValues:
     graphql_fields_by_name:
@@ -9222,12 +9222,7 @@ object_types_by_name:
     index_definition_names:
     - widget_workspaces
     update_targets:
-    - data_params:
-        name:
-          cardinality: one
-        widget:
-          cardinality: one
-      id_source: id
+    - id_source: id
       metadata_params:
         relationship:
           value: __self
@@ -9242,12 +9237,13 @@ object_types_by_name:
       relationship: __self
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
-      type: WidgetWorkspace
-    - data_params:
-        workspace_name:
+      top_level_fields_params:
+        name:
           cardinality: one
-          source_path: name
-      id_source: widget.id
+        widget:
+          cardinality: one
+      type: WidgetWorkspace
+    - id_source: widget.id
       metadata_params:
         relationship:
           value: workspace
@@ -9263,6 +9259,10 @@ object_types_by_name:
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
       script_id: update_index_data_c506543861091e70bd493c28d29b9b70
+      top_level_fields_params:
+        workspace_name:
+          cardinality: one
+          source_path: name
       type: Widget
   WidgetWorkspaceAggregatedValues:
     graphql_fields_by_name:

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -3125,7 +3125,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Address
   AddressAggregatedValues:
     graphql_fields_by_name:
@@ -3309,7 +3309,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: BrokerWholesaler
   ColorListFilterInput:
     graphql_fields_by_name:
@@ -3350,7 +3350,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Company
   Component:
     graphql_fields_by_name:
@@ -3479,7 +3479,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Component
   ComponentAggregatedValues:
     graphql_fields_by_name:
@@ -3831,7 +3831,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: DirectWholesaler
   DistributionChannel:
     graphql_fields_by_name:
@@ -4008,7 +4008,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: ElectricalPart
   ElectricalPartAggregatedValues:
     graphql_fields_by_name:
@@ -4491,7 +4491,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Manufacturer
   ManufacturerAggregatedValues:
     graphql_fields_by_name:
@@ -4651,7 +4651,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: MechanicalPart
   MechanicalPartAggregatedValues:
     graphql_fields_by_name:
@@ -5633,7 +5633,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: OnlineStore
   PageInfo:
     graphql_fields_by_name:
@@ -5830,7 +5830,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Person
   PersonAggregatedValues:
     graphql_fields_by_name:
@@ -5895,7 +5895,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: PhysicalStore
   PhysicalStoreAggregatedValues:
     graphql_fields_by_name:
@@ -6436,7 +6436,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Sponsor
   SponsorAggregatedValues:
     graphql_fields_by_name:
@@ -6818,7 +6818,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: formed_on
       routing_value_source: league
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Team
   TeamAggregatedValues:
     graphql_fields_by_name:
@@ -7946,7 +7946,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: created_at
       routing_value_source: workspace_id2
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Widget
     - data_params:
         widget_cost:
@@ -7977,7 +7977,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: widget
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Component
   WidgetAggregatedValues:
     graphql_fields_by_name:
@@ -8214,7 +8214,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: introduced_on
       routing_value_source: primary_continent
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: WidgetCurrency
   WidgetCurrencyAggregatedValues:
     graphql_fields_by_name:
@@ -9241,7 +9241,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: WidgetWorkspace
     - data_params:
         workspace_name:
@@ -9262,7 +9262,7 @@ object_types_by_name:
       relationship: workspace
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
-      script_id: update_index_data_1b6d53ffefa2dd2d9510366867200725
+      script_id: update_index_data_c506543861091e70bd493c28d29b9b70
       type: Widget
   WidgetWorkspaceAggregatedValues:
     graphql_fields_by_name:
@@ -9536,4 +9536,4 @@ static_script_ids_by_scoped_name:
   field/as_day_of_week: field_as_day_of_week_f2b5c7d9e8f75bf2457b52412bfb6537
   field/as_time_of_day: field_as_time_of_day_ed82aba44fc66bff5635bec4305c1c66
   filter/by_time_of_day: filter_by_time_of_day_ea12d0561b24961789ab68ed38435612
-  update/index_data: update_index_data_1b6d53ffefa2dd2d9510366867200725
+  update/index_data: update_index_data_c506543861091e70bd493c28d29b9b70

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/operation/count_accumulator.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/operation/count_accumulator.rb
@@ -11,7 +11,7 @@ require "elastic_graph/constants"
 module ElasticGraph
   class Indexer
     module Operation
-      # Responsible for maintaining state and accumulating list counts while we traverse the `data` we are preparing
+      # Responsible for maintaining state and accumulating list counts while we traverse the `topLevelFields` we are preparing
       # to update in the index. Much of the complexity here is due to the fact that we have 3 kinds of list fields:
       # scalar lists, embedded object lists, and `nested` object lists.
       #
@@ -56,19 +56,19 @@ module ElasticGraph
         # @implements CountAccumulator
         def self.merge_list_counts_into(params, mapping:, list_counts_field_paths_for_source:)
           # Here we compute the counts of our list elements so that we can index it.
-          data = compute_list_counts_of(params.fetch("topLevelFields"), CountAccumulator.new_parent(
+          top_level_fields = compute_list_counts_of(params.fetch("topLevelFields"), CountAccumulator.new_parent(
             # We merge in `type: nested` since the `nested` type indicates a new count accumulator parent and we want that applied at the root.
             mapping.merge("type" => "nested"),
             list_counts_field_paths_for_source
           ))
 
-          # The root `__counts` field needs special handling due to our `sourced_from` feature. Anything in `data`
+          # The root `__counts` field needs special handling due to our `sourced_from` feature. Anything in `top_level_fields`
           # will overwrite what's in the specified fields when the script executes, but since there could be list
           # fields from multiple sources, we need `__counts` to get merged properly. So here we "promote" it from
-          # `data.__counts` to being a root-level parameter.
+          # `top_level_fields.__counts` to being a root-level parameter.
           params.merge(
-            "topLevelFields" => data.except(LIST_COUNTS_FIELD),
-            LIST_COUNTS_FIELD => data[LIST_COUNTS_FIELD]
+            "topLevelFields" => top_level_fields.except(LIST_COUNTS_FIELD),
+            LIST_COUNTS_FIELD => top_level_fields[LIST_COUNTS_FIELD]
           )
         end
 

--- a/elasticgraph-indexer/lib/elastic_graph/indexer/operation/count_accumulator.rb
+++ b/elasticgraph-indexer/lib/elastic_graph/indexer/operation/count_accumulator.rb
@@ -56,7 +56,7 @@ module ElasticGraph
         # @implements CountAccumulator
         def self.merge_list_counts_into(params, mapping:, list_counts_field_paths_for_source:)
           # Here we compute the counts of our list elements so that we can index it.
-          data = compute_list_counts_of(params.fetch("data"), CountAccumulator.new_parent(
+          data = compute_list_counts_of(params.fetch("topLevelFields"), CountAccumulator.new_parent(
             # We merge in `type: nested` since the `nested` type indicates a new count accumulator parent and we want that applied at the root.
             mapping.merge("type" => "nested"),
             list_counts_field_paths_for_source
@@ -67,7 +67,7 @@ module ElasticGraph
           # fields from multiple sources, we need `__counts` to get merged properly. So here we "promote" it from
           # `data.__counts` to being a root-level parameter.
           params.merge(
-            "data" => data.except(LIST_COUNTS_FIELD),
+            "topLevelFields" => data.except(LIST_COUNTS_FIELD),
             LIST_COUNTS_FIELD => data[LIST_COUNTS_FIELD]
           )
         end

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/datastore_indexing_router_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/datastore_indexing_router_spec.rb
@@ -240,21 +240,21 @@ module ElasticGraph
 
           expect(submitted_body[0]).to eq({update: {_id: "1", _index: "widgets", retry_on_conflict: 5}})
           expect(submitted_body[1]).to include(
-            script: a_hash_including(id: INDEX_DATA_UPDATE_SCRIPT_ID, params: a_hash_including("data")),
+            script: a_hash_including(id: INDEX_DATA_UPDATE_SCRIPT_ID, params: a_hash_including("topLevelFields")),
             scripted_upsert: true,
             upsert: {}
           )
 
           expect(submitted_body[2]).to eq({update: {_id: "2", _index: "widgets", retry_on_conflict: 5}})
           expect(submitted_body[3]).to include(
-            script: a_hash_including(id: INDEX_DATA_UPDATE_SCRIPT_ID, params: a_hash_including("data")),
+            script: a_hash_including(id: INDEX_DATA_UPDATE_SCRIPT_ID, params: a_hash_including("topLevelFields")),
             scripted_upsert: true,
             upsert: {}
           )
 
           expect(submitted_body[4]).to eq({update: {_id: "1", _index: "components", retry_on_conflict: 5}})
           expect(submitted_body[5]).to include(
-            script: a_hash_including(id: INDEX_DATA_UPDATE_SCRIPT_ID, params: a_hash_including("data")),
+            script: a_hash_including(id: INDEX_DATA_UPDATE_SCRIPT_ID, params: a_hash_including("topLevelFields")),
             scripted_upsert: true,
             upsert: {}
           )
@@ -265,7 +265,7 @@ module ElasticGraph
             upsert: {},
             script: a_hash_including(
               id: /WidgetCurrency_from_Widget_/,
-              params: {"data" => {"name" => ["thing1"]}, "id" => "USD"}
+              params: {"topLevelFields" => {"name" => ["thing1"]}, "id" => "USD"}
             )
           )
         end

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/operation/count_accumulator_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/operation/count_accumulator_spec.rb
@@ -148,7 +148,7 @@ module ElasticGraph
             params = script_params_for(data: data, source_type: "Manufacturer", destination_type: "Manufacturer")
 
             expect(params[LIST_COUNTS_FIELD]).to eq nil
-            expect(params["data"]).to exclude(LIST_COUNTS_FIELD)
+            expect(params["topLevelFields"]).to exclude(LIST_COUNTS_FIELD)
           end
         end
 
@@ -188,14 +188,14 @@ module ElasticGraph
               {"currency" => "USD", "amount_cents" => 725}
             ]})
 
-            expect(params.dig("data", "forbes_valuation_moneys_nested")).to eq [
+            expect(params.dig("topLevelFields", "forbes_valuation_moneys_nested")).to eq [
               {"currency" => "USD", "amount_cents" => 525},
               {"currency" => "USD", "amount_cents" => 725}
             ]
           end
 
           def current_players_counts_for_team_event(data)
-            script_params_for_team_event(data).dig("data", "current_players_nested").map do |player|
+            script_params_for_team_event(data).dig("topLevelFields", "current_players_nested").map do |player|
               player.fetch(LIST_COUNTS_FIELD)
             end
           end
@@ -259,7 +259,7 @@ module ElasticGraph
           end
 
           def seasons_for_team_event(data)
-            script_params_for_team_event(data).dig("data", "seasons_object")
+            script_params_for_team_event(data).dig("topLevelFields", "seasons_object")
           end
         end
 

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/operation/update_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/operation/update_spec.rb
@@ -73,7 +73,7 @@ module ElasticGraph
               {update: {_id: "17", _index: "widget_workspaces", retry_on_conflict: Update::CONFLICT_RETRIES}},
               {
                 script: {id: operations.first.update_target.script_id, params: {
-                  "data" => {"name" => ["thing1"]},
+                  "topLevelFields" => {"name" => ["thing1"]},
                   "id" => "17"
                 }},
                 scripted_upsert: true,
@@ -102,7 +102,7 @@ module ElasticGraph
               {update: {_id: "17", _index: "widget_workspaces", retry_on_conflict: Update::CONFLICT_RETRIES}},
               {
                 script: {id: INDEX_DATA_UPDATE_SCRIPT_ID, params: {
-                  "data" => {"name" => "thing1"},
+                  "topLevelFields" => {"name" => "thing1"},
                   "id" => "17",
                   "staticValue" => 47,
                   "sourceType" => "Widget",
@@ -156,7 +156,7 @@ module ElasticGraph
               {update: {_id: "17", _index: "widget_workspaces", retry_on_conflict: Update::CONFLICT_RETRIES}},
               {
                 script: {id: operations.first.update_target.script_id, params: {
-                  "data" => {"name" => []},
+                  "topLevelFields" => {"name" => []},
                   "id" => "17"
                 }},
                 scripted_upsert: true,
@@ -177,7 +177,7 @@ module ElasticGraph
               {update: {_id: "embedded_workspace_id", _index: "widget_workspaces", retry_on_conflict: Update::CONFLICT_RETRIES}},
               {
                 script: {id: operations.first.update_target.script_id, params: {
-                  "data" => {"name" => ["thing1"]},
+                  "topLevelFields" => {"name" => ["thing1"]},
                   "id" => "embedded_workspace_id"
                 }},
                 scripted_upsert: true,
@@ -202,7 +202,7 @@ module ElasticGraph
               {update: {_id: "17", _index: "widget_workspaces", retry_on_conflict: Update::CONFLICT_RETRIES}},
               {
                 script: {id: operations.first.update_target.script_id, params: {
-                  "data" => {"embedded_values.missing_field" => [], "name" => nil},
+                  "topLevelFields" => {"embedded_values.missing_field" => [], "name" => nil},
                   "id" => "17"
                 }},
                 scripted_upsert: true,
@@ -229,7 +229,7 @@ module ElasticGraph
               {update: {_id: "17", _index: "widget_workspaces", retry_on_conflict: Update::CONFLICT_RETRIES}},
               {
                 script: {id: operations.first.update_target.script_id, params: {
-                  "data" => {
+                  "topLevelFields" => {
                     "embedded_values" => ["thing1"],
                     "name" => {
                       "name" => "embedded_name",
@@ -261,7 +261,7 @@ module ElasticGraph
               {
                 script: {id: operations.first.update_target.script_id, params: {
                   # Float-typed integer values are coerced to true ints before indexing
-                  "data" => {"size" => [an_instance_of(::Integer).and(eq_to(4))]},
+                  "topLevelFields" => {"size" => [an_instance_of(::Integer).and(eq_to(4))]},
                   "id" => "17"
                 }},
                 scripted_upsert: true,
@@ -282,7 +282,7 @@ module ElasticGraph
               {update: {_id: "17", _index: "widget_workspaces", retry_on_conflict: Update::CONFLICT_RETRIES}},
               {
                 script: {id: operations.first.update_target.script_id, params: {
-                  "data" => {"name" => ["thing1"]},
+                  "topLevelFields" => {"name" => ["thing1"]},
                   "id" => "17"
                 }},
                 scripted_upsert: true,
@@ -291,7 +291,7 @@ module ElasticGraph
               {update: {_id: "18", _index: "widget_workspaces", retry_on_conflict: Update::CONFLICT_RETRIES}},
               {
                 script: {id: operations.first.update_target.script_id, params: {
-                  "data" => {"name" => ["thing1"]},
+                  "topLevelFields" => {"name" => ["thing1"]},
                   "id" => "18"
                 }},
                 scripted_upsert: true,
@@ -300,7 +300,7 @@ module ElasticGraph
               {update: {_id: "19", _index: "widget_workspaces", retry_on_conflict: Update::CONFLICT_RETRIES}},
               {
                 script: {id: operations.first.update_target.script_id, params: {
-                  "data" => {"name" => ["thing1"]},
+                  "topLevelFields" => {"name" => ["thing1"]},
                   "id" => "19"
                 }},
                 scripted_upsert: true,

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/operation/update_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/operation/update_spec.rb
@@ -91,7 +91,7 @@ module ElasticGraph
             expect(operations.size).to eq(1)
             operation = operations.first.with(update_target: normal_indexing_update_target_with(
               type: "Widget",
-              data_params: {"name" => dynamic_param_with(source_path: "name", cardinality: :one)},
+              top_level_fields_params: {"name" => dynamic_param_with(source_path: "name", cardinality: :one)},
               metadata_params: {
                 "staticValue" => static_param_with(47),
                 "sourceType" => dynamic_param_with(source_path: "type", cardinality: :one)
@@ -194,7 +194,7 @@ module ElasticGraph
             operations = operations_for_indexer(indexer)
 
             expect(operations.size).to eq(1)
-            operation = operations.first.with(update_target: operations.first.update_target.with(data_params: {
+            operation = operations.first.with(update_target: operations.first.update_target.with(top_level_fields_params: {
               "embedded_values.missing_field" => dynamic_param_with(source_path: "embedded_values.missing_field", cardinality: :many),
               "name" => dynamic_param_with(source_path: "some_field_that_is_not_in_record", cardinality: :one)
             }))
@@ -219,7 +219,7 @@ module ElasticGraph
             operations = operations_for_indexer(indexer)
             expect(operations.size).to eq(1)
 
-            operation = operations.first.with(update_target: operations.first.update_target.with(data_params: {
+            operation = operations.first.with(update_target: operations.first.update_target.with(top_level_fields_params: {
               # Here we've swapped the source_paths with the param names.
               "embedded_values" => dynamic_param_with(source_path: "name", cardinality: :many),
               "name" => dynamic_param_with(source_path: "embedded_values", cardinality: :one)

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/update_target.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/update_target.rb
@@ -66,7 +66,7 @@ module ElasticGraph
         end
 
         def params_for(doc_id:, event:, prepared_record:)
-          data = data_params.to_h do |name, param|
+          top_level_fields = data_params.to_h do |name, param|
             [name, param.value_for(prepared_record)]
           end
 
@@ -74,7 +74,7 @@ module ElasticGraph
             [name, param.value_for(event)]
           end
 
-          meta.merge({"id" => doc_id, "topLevelFields" => data})
+          meta.merge({"id" => doc_id, "topLevelFields" => top_level_fields})
         end
       end
     end

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/update_target.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/update_target.rb
@@ -22,7 +22,7 @@ module ElasticGraph
         :id_source,
         :routing_value_source,
         :rollover_timestamp_value_source,
-        :data_params,
+        :top_level_fields_params,
         :metadata_params
       )
         TYPE = "type"
@@ -31,7 +31,7 @@ module ElasticGraph
         ID_SOURCE = "id_source"
         ROUTING_VALUE_SOURCE = "routing_value_source"
         ROLLOVER_TIMESTAMP_VALUE_SOURCE = "rollover_timestamp_value_source"
-        DATA_PARAMS = "data_params"
+        TOP_LEVEL_FIELDS_PARAMS = "top_level_fields_params"
         METADATA_PARAMS = "metadata_params"
 
         def self.from_hash(hash)
@@ -42,7 +42,7 @@ module ElasticGraph
             id_source: hash[ID_SOURCE],
             routing_value_source: hash[ROUTING_VALUE_SOURCE],
             rollover_timestamp_value_source: hash[ROLLOVER_TIMESTAMP_VALUE_SOURCE],
-            data_params: Param.load_params_hash(hash[DATA_PARAMS] || {}),
+            top_level_fields_params: Param.load_params_hash(hash[TOP_LEVEL_FIELDS_PARAMS] || {}),
             metadata_params: Param.load_params_hash(hash[METADATA_PARAMS] || {})
           )
         end
@@ -50,13 +50,13 @@ module ElasticGraph
         def to_dumpable_hash
           {
             # Keys here are ordered alphabetically; please keep them that way.
-            DATA_PARAMS => Param.dump_params_hash(data_params),
             ID_SOURCE => id_source,
             METADATA_PARAMS => Param.dump_params_hash(metadata_params),
             RELATIONSHIP => relationship,
             ROLLOVER_TIMESTAMP_VALUE_SOURCE => rollover_timestamp_value_source,
             ROUTING_VALUE_SOURCE => routing_value_source,
             SCRIPT_ID => script_id,
+            TOP_LEVEL_FIELDS_PARAMS => Param.dump_params_hash(top_level_fields_params),
             TYPE => type
           }
         end
@@ -66,7 +66,7 @@ module ElasticGraph
         end
 
         def params_for(doc_id:, event:, prepared_record:)
-          top_level_fields = data_params.to_h do |name, param|
+          top_level_fields = top_level_fields_params.to_h do |name, param|
             [name, param.value_for(prepared_record)]
           end
 

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/update_target.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/update_target.rb
@@ -74,7 +74,7 @@ module ElasticGraph
             [name, param.value_for(event)]
           end
 
-          meta.merge({"id" => doc_id, "data" => data})
+          meta.merge({"id" => doc_id, "topLevelFields" => data})
         end
       end
     end

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/update_target.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/update_target.rbs
@@ -8,7 +8,7 @@ module ElasticGraph
         attr_reader id_source: ::String
         attr_reader routing_value_source: ::String?
         attr_reader rollover_timestamp_value_source: ::String?
-        attr_reader data_params: paramsHash
+        attr_reader top_level_fields_params: paramsHash
         attr_reader metadata_params: paramsHash
 
         def initialize: (
@@ -18,7 +18,7 @@ module ElasticGraph
           id_source: ::String,
           routing_value_source: ::String?,
           rollover_timestamp_value_source: ::String?,
-          data_params: paramsHash,
+          top_level_fields_params: paramsHash,
           metadata_params: paramsHash
         ) -> void
 
@@ -29,7 +29,7 @@ module ElasticGraph
           ?id_source: ::String,
           ?routing_value_source: ::String?,
           ?rollover_timestamp_value_source: ::String?,
-          ?data_params: paramsHash,
+          ?top_level_fields_params: paramsHash,
           ?metadata_params: paramsHash
         ) -> UpdateTarget
 
@@ -45,7 +45,7 @@ module ElasticGraph
         ID_SOURCE: "id_source"
         ROUTING_VALUE_SOURCE: "routing_value_source"
         ROLLOVER_TIMESTAMP_VALUE_SOURCE: "rollover_timestamp_value_source"
-        DATA_PARAMS: "data_params"
+        TOP_LEVEL_FIELDS_PARAMS: "top_level_fields_params"
         METADATA_PARAMS: "metadata_params"
 
         def self.from_hash: (::Hash[::String, untyped]) -> UpdateTarget

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
@@ -42,7 +42,7 @@ module ElasticGraph
                     id_source: "cost.currency",
                     routing_value_source: "cost.currency_name",
                     rollover_timestamp_value_source: "currency_introduced_on",
-                    data_params: {"workspace_id" => DynamicParam.new(source_path: "wid", cardinality: :one)},
+                    top_level_fields_params: {"workspace_id" => DynamicParam.new(source_path: "wid", cardinality: :one)},
                     metadata_params: {"relationshipName" => StaticParam.new(value: "currency")}
                   ),
                   UpdateTarget.new(
@@ -52,7 +52,7 @@ module ElasticGraph
                     id_source: "id",
                     routing_value_source: nil,
                     rollover_timestamp_value_source: nil,
-                    data_params: {},
+                    top_level_fields_params: {},
                     metadata_params: {}
                   )
                 ],
@@ -172,7 +172,7 @@ module ElasticGraph
                     "id_source" => "cost.currency",
                     "routing_value_source" => "cost.currency_name",
                     "rollover_timestamp_value_source" => "currency_introduced_on",
-                    "data_params" => {"workspace_id" => {"source_path" => "wid", "cardinality" => "one"}},
+                    "top_level_fields_params" => {"workspace_id" => {"source_path" => "wid", "cardinality" => "one"}},
                     "metadata_params" => {"relationshipName" => {"value" => "currency"}}
                   },
                   {
@@ -310,7 +310,7 @@ module ElasticGraph
               id_source: "cost.currency",
               routing_value_source: nil,
               rollover_timestamp_value_source: nil,
-              data_params: {"workspace_id" => dynamic_param_with(cardinality: :many)},
+              top_level_fields_params: {"workspace_id" => dynamic_param_with(cardinality: :many)},
               metadata_params: {}
             )]),
             "IndexDefinitionNamesOnly" => object_type_with(index_definition_names: ["foo", "bar"]),

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/update_target_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/update_target_spec.rb
@@ -84,7 +84,7 @@ module ElasticGraph
               }
             )
 
-            without_id_or_data = params.except("id", "data")
+            without_id_or_data = params.except("id", "topLevelFields")
 
             expect(without_id_or_data).to eq(
               "foo" => 43,
@@ -93,7 +93,7 @@ module ElasticGraph
             )
           end
 
-          it "extracts `event_params` from `prepared_record` and include them under `data`" do
+          it "extracts `event_params` from `prepared_record` and include them under `topLevelFields`" do
             params = params_for(
               data_params: {
                 "foo" => static_param_with(43),
@@ -108,7 +108,7 @@ module ElasticGraph
               }
             )
 
-            expect(params.fetch("data")).to eq(
+            expect(params.fetch("topLevelFields")).to eq(
               "foo" => 43,
               "bar" => "hello",
               "bazz" => [12]

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/update_target_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/update_target_spec.rb
@@ -25,21 +25,21 @@ module ElasticGraph
             id_source: nil,
             routing_value_source: nil,
             rollover_timestamp_value_source: nil,
-            data_params: {},
+            top_level_fields_params: {},
             metadata_params: {}
           )
         end
 
-        it "allows `data_params` to contain both dynamic params and static params" do
+        it "allows `top_level_fields_params` to contain both dynamic params and static params" do
           update_target = normal_indexing_update_target_with(
-            data_params: {
+            top_level_fields_params: {
               "name" => dynamic_param_with(source_path: "some_name", cardinality: :one),
               "relationshipName" => static_param_with("__self")
             }
           )
 
           dumped = update_target.to_dumpable_hash
-          expect(dumped.fetch("data_params")).to eq({
+          expect(dumped.fetch("top_level_fields_params")).to eq({
             "name" => {"cardinality" => "one", "source_path" => "some_name"},
             "relationshipName" => {"value" => "__self"}
           })
@@ -95,7 +95,7 @@ module ElasticGraph
 
           it "extracts `event_params` from `prepared_record` and include them under `topLevelFields`" do
             params = params_for(
-              data_params: {
+              top_level_fields_params: {
                 "foo" => static_param_with(43),
                 "bar" => dynamic_param_with(source_path: "some.nested.field", cardinality: :one),
                 "bazz" => dynamic_param_with(source_path: "some.other.field", cardinality: :many)
@@ -115,9 +115,9 @@ module ElasticGraph
             )
           end
 
-          def params_for(doc_id: "doc_id", event: {}, prepared_record: {}, data_params: {}, metadata_params: {})
+          def params_for(doc_id: "doc_id", event: {}, prepared_record: {}, top_level_fields_params: {}, metadata_params: {})
             update_target = normal_indexing_update_target_with(
-              data_params: data_params,
+              top_level_fields_params: top_level_fields_params,
               metadata_params: metadata_params
             )
 

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/update_target_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/update_target_spec.rb
@@ -84,9 +84,9 @@ module ElasticGraph
               }
             )
 
-            without_id_or_data = params.except("id", "topLevelFields")
+            without_id_or_top_level_fields = params.except("id", "topLevelFields")
 
-            expect(without_id_or_data).to eq(
+            expect(without_id_or_top_level_fields).to eq(
               "foo" => 43,
               "bar" => "hello",
               "bazz" => [12]

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_indexed_type.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_indexed_type.rb
@@ -336,7 +336,7 @@ module ElasticGraph
         SCRIPT_ERRORS_VAR = "scriptErrors"
 
         STATIC_SETUP_STATEMENTS = <<~EOS.strip
-          Map data = params.data;
+          Map data = params.topLevelFields;
           // A variable to accumulate script errors so that we can surface _all_ issues and not just the first.
           List #{SCRIPT_ERRORS_VAR} = new ArrayList();
         EOS

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_indexed_type.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_indexed_type.rb
@@ -270,7 +270,7 @@ module ElasticGraph
             routing_value_source: routing_value_source,
             rollover_timestamp_value_source: rollover_timestamp_value_source,
             metadata_params: {},
-            data_params: fields.map(&:source_field).to_h do |f|
+            top_level_fields_params: fields.map(&:source_field).to_h do |f|
               [f, SchemaArtifacts::RuntimeMetadata::DynamicParam.new(source_path: f, cardinality: :many)]
             end
           )

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/update_target_factory.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/update_target_factory.rb
@@ -16,7 +16,7 @@ module ElasticGraph
           type:,
           relationship:,
           id_source:,
-          data_params:,
+          top_level_fields_params:,
           routing_value_source:,
           rollover_timestamp_value_source:
         )
@@ -28,7 +28,7 @@ module ElasticGraph
             metadata_params: standard_metadata_params.merge({
               "relationship" => SchemaArtifacts::RuntimeMetadata::StaticParam.new(value: relationship)
             }),
-            data_params: data_params,
+            top_level_fields_params: top_level_fields_params,
             routing_value_source: routing_value_source,
             rollover_timestamp_value_source: rollover_timestamp_value_source
           )

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/update_target_resolver.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/update_target_resolver.rb
@@ -36,19 +36,19 @@ module ElasticGraph
         # Returns a tuple of the `update_target` (if valid), and a list of errors.
         def resolve
           relationship_errors = validate_relationship
-          data_params, data_params_errors = resolve_data_params
+          top_level_fields_params, top_level_fields_params_errors = resolve_top_level_fields_params
           routing_value_source, routing_error = resolve_field_source(RoutingSourceAdapter)
           rollover_timestamp_value_source, rollover_timestamp_error = resolve_field_source(RolloverTimestampSourceAdapter)
           equivalent_field_errors = resolved_relationship.relationship.validate_equivalent_fields(field_path_resolver)
 
-          all_errors = relationship_errors + data_params_errors + equivalent_field_errors + [routing_error, rollover_timestamp_error].compact
+          all_errors = relationship_errors + top_level_fields_params_errors + equivalent_field_errors + [routing_error, rollover_timestamp_error].compact
 
           if all_errors.empty?
             update_target = UpdateTargetFactory.new_normal_indexing_update_target(
               type: object_type.name,
               relationship: resolved_relationship.relationship_name,
               id_source: resolved_relationship.relation_metadata.foreign_key,
-              data_params: data_params,
+              top_level_fields_params: top_level_fields_params,
               routing_value_source: routing_value_source,
               rollover_timestamp_value_source: rollover_timestamp_value_source
             )
@@ -89,14 +89,14 @@ module ElasticGraph
           "`#{object_type.name}.#{resolved_relationship.relationship_name}` #{sourced_fields_description}"
         end
 
-        # Resolves the `sourced_fields` into a data params map, validating them along the way.
+        # Resolves the `sourced_fields` into a top-level fields params map, validating them along the way.
         #
-        # Returns a tuple of the data params and a list of any errors that occurred during resolution.
-        def resolve_data_params
+        # Returns a tuple of the top-level fields params and a list of any errors that occurred during resolution.
+        def resolve_top_level_fields_params
           related_type = resolved_relationship.related_type
           errors = [] # : ::Array[::String]
 
-          data_params = sourced_fields.filter_map do |field|
+          top_level_fields_params = sourced_fields.filter_map do |field|
             field_source = field.source # : SchemaElements::FieldSource
 
             referenced_field_path = field_path_resolver.resolve_public_path(related_type, field_source.field_path) do |parent_field|
@@ -129,7 +129,7 @@ module ElasticGraph
             end
           end.to_h
 
-          [data_params, errors]
+          [top_level_fields_params, errors]
         end
 
         # Helper method that assists with resolving `routing_value_source` and `rollover_timestamp_value_source`.

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
@@ -430,12 +430,12 @@ module ElasticGraph
         def self_update_target
           return nil if abstract? || !root_document_type?
 
-          # We exclude `id` from `data_params` because `Indexer::Operator::Update` automatically includes
-          # `params.id` so we don't want it duplicated at `params.topLevelFields.id` alongside other data params.
+          # We exclude `id` from `top_level_fields_params` because `Indexer::Operator::Update` automatically includes
+          # `params.id` so we don't want it duplicated at `params.topLevelFields.id` alongside other top-level fields params.
           #
           # In addition, we exclude fields that have an alternate `source` -- those fields will get populated
           # by a different event and we don't want to risk "stomping" their value via this update target.
-          data_params = indexing_fields_by_name_in_index.select { |name, field| name != "id" && field.source.nil? }.to_h do |field|
+          top_level_fields_params = indexing_fields_by_name_in_index.select { |name, field| name != "id" && field.source.nil? }.to_h do |field|
             [field, SchemaArtifacts::RuntimeMetadata::DynamicParam.new(source_path: field, cardinality: :one)]
           end
 
@@ -445,7 +445,7 @@ module ElasticGraph
             type: name,
             relationship: SELF_RELATIONSHIP_NAME,
             id_source: "id",
-            data_params: data_params,
+            top_level_fields_params: top_level_fields_params,
             # Some day we may want to consider supporting multiple indices. If/when we add support for that,
             # we'll need to change the runtime metadata here to have a map of these values, keyed by index
             # name.

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
@@ -431,7 +431,7 @@ module ElasticGraph
           return nil if abstract? || !root_document_type?
 
           # We exclude `id` from `data_params` because `Indexer::Operator::Update` automatically includes
-          # `params.id` so we don't want it duplicated at `params.data.id` alongside other data params.
+          # `params.id` so we don't want it duplicated at `params.topLevelFields.id` alongside other data params.
           #
           # In addition, we exclude fields that have an alternate `source` -- those fields will get populated
           # by a different event and we don't want to risk "stomping" their value via this update target.

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/scripts/update/index_data.painless
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/scripts/update/index_data.painless
@@ -1,59 +1,59 @@
-Map source = ctx._source;
-String sourceId = params.sourceId;
-String relationship = params.relationship;
-
-// Numbers in JSON appear to be parsed as doubles, but we want the version stored as a long, so we need to cast it here.
-long eventVersion = (long) params.version;
-
-if (source.__sources == null) {
-  source.__sources = [];
-}
-
-if (source.__versions == null) {
-  source.__versions = [:];
-}
-
-if (source.__versions[relationship] == null) {
-  source.__versions[relationship] = [:];
-}
-
-Map relationshipVersionsMap = source.__versions.get(relationship);
-List previousSourceIdsForRelationship = relationshipVersionsMap.keySet().stream().filter(id -> id != sourceId).collect(Collectors.toList());
-
-if (previousSourceIdsForRelationship.size() > 0) {
-  String previousIdDescription = previousSourceIdsForRelationship.size() == 1 ? previousSourceIdsForRelationship.get(0) : previousSourceIdsForRelationship.toString();
-  throw new IllegalArgumentException(
-    "Cannot update document " + params.id + " " +
-    "with data from related " + relationship + " " + sourceId + " " +
-    "because the related " + relationship + " has apparently changed (was: " + previousSourceIdsForRelationship + "), " +
-    "but mutations of relationships used with `sourced_from` are not supported because " +
-    "allowing it could break ElasticGraph's out-of-order processing guarantees."
- );
-}
-
-Number maybeDocVersion = source.__versions.get(params.relationship)?.get(params.sourceId);
-
-// Our JSON schema requires event versions to be non-negative, so we can safely use Long.MIN_VALUE as a stand-in when the value is null.
-long docVersion = maybeDocVersion == null ? Long.MIN_VALUE : maybeDocVersion.longValue();
-
-if (docVersion >= eventVersion) {
-  throw new IllegalArgumentException("ElasticGraph update was a no-op: [" +
-    params.id + "]: version conflict, current version [" +
-    docVersion + "] is higher or equal to the one provided [" +
-    eventVersion + "]");
-} else {
-  source.putAll(params.data);
-  Map __counts = params.__counts;
-
-  if (__counts != null) {
-    if (source.__counts == null) {
-      source.__counts = [:];
-    }
-
-    source.__counts.putAll(__counts);
+// --- Helper Functions --- //
+void setup(Map source, String relationship, Map counts) {
+  if (source.__sources == null) {
+    source.__sources = [];
   }
 
-  source.id = params.id;
+  if (source.__versions == null) {
+    source.__versions = [:];
+  }
+
+  if (source.__versions[relationship] == null) {
+    source.__versions[relationship] = [:];
+  }
+
+  if (counts != null && source.__counts == null) {
+    source.__counts = [:];
+  }
+}
+
+void validateSource(Map source, String id, String relationship, String sourceId, long eventVersion) {
+  Map relationshipVersionsMap = source.__versions.get(relationship);
+  List previousSourceIdsForRelationship = relationshipVersionsMap.keySet().stream().filter(key -> key != sourceId).collect(Collectors.toList());
+
+  if (previousSourceIdsForRelationship.size() > 0) {
+    throw new IllegalArgumentException(
+      "Cannot update document " + id + " " +
+      "with data from related " + relationship + " " + sourceId + " " +
+      "because the related " + relationship + " has apparently changed (was: " + previousSourceIdsForRelationship + "), " +
+      "but mutations of relationships used with `sourced_from` are not supported because " +
+      "allowing it could break ElasticGraph's out-of-order processing guarantees."
+   );
+  }
+
+  Number maybeDocVersion = relationshipVersionsMap.get(sourceId);
+
+  // Our JSON schema requires event versions to be non-negative, so we can safely use Long.MIN_VALUE as a stand-in when the value is null.
+  long docVersion = maybeDocVersion == null ? Long.MIN_VALUE : maybeDocVersion.longValue();
+
+  if (docVersion >= eventVersion) {
+    throw new IllegalArgumentException("ElasticGraph update was a no-op: [" +
+      id + "]: version conflict, current version [" +
+      docVersion + "] is higher or equal to the one provided [" +
+      eventVersion + "]");
+  }
+}
+
+void applyTopLevelFields(Map source, Map topLevelFields, Map counts) {
+  source.putAll(topLevelFields);
+
+  if (counts != null) {
+    source.__counts.putAll(counts);
+  }
+}
+
+void recordSource(Map source, String id, String relationship, String sourceId, long eventVersion) {
+  source.id = id;
   source.__versions[relationship][sourceId] = eventVersion;
 
   // Record the relationship in `__sources` if it's not already there. We maintain it as an append-only set using a sorted list.
@@ -70,3 +70,16 @@ if (docVersion >= eventVersion) {
     source.__sources.add(-sourceBinarySearchResult - 1, relationship);
   }
 }
+
+// --- Main script body --- //
+Map source = ctx._source;
+String id = params.id;
+String relationship = params.relationship;
+String sourceId = params.sourceId;
+long eventVersion = (long) params.version; // Cast to long since JSON parses numbers as doubles
+Map counts = params.__counts;
+
+setup(source, relationship, counts);
+validateSource(source, id, relationship, sourceId, eventVersion);
+applyTopLevelFields(source, params.topLevelFields, counts);
+recordSource(source, id, relationship, sourceId, eventVersion);

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/scripts/update/index_data.painless
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/scripts/update/index_data.painless
@@ -19,6 +19,11 @@ void setup(Map source, String relationship, Map counts) {
 
 void validateSource(Map source, String id, String relationship, String sourceId, long eventVersion) {
   Map relationshipVersionsMap = source.__versions.get(relationship);
+
+  if (relationshipVersionsMap == null) {
+    throw new IllegalArgumentException("Expected source.__versions[" + relationship + "] to be initialized, but it was null");
+  }
+
   List previousSourceIdsForRelationship = relationshipVersionsMap.keySet().stream().filter(key -> key != sourceId).collect(Collectors.toList());
 
   if (previousSourceIdsForRelationship.size() > 0) {

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/scripts/update/index_data.painless
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/scripts/update/index_data.painless
@@ -19,11 +19,6 @@ void setup(Map source, String relationship, Map counts) {
 
 void validateSource(Map source, String id, String relationship, String sourceId, long eventVersion) {
   Map relationshipVersionsMap = source.__versions.get(relationship);
-
-  if (relationshipVersionsMap == null) {
-    throw new IllegalArgumentException("Expected source.__versions[" + relationship + "] to be initialized, but it was null");
-  }
-
   List previousSourceIdsForRelationship = relationshipVersionsMap.keySet().stream().filter(key -> key != sourceId).collect(Collectors.toList());
 
   if (previousSourceIdsForRelationship.size() > 0) {

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/scripts/update/index_data.painless
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/scripts/update/index_data.painless
@@ -49,7 +49,8 @@ void validateSource(Map source, String id, String relationship, String sourceId,
   }
 }
 
-void applyTopLevelFields(Map source, Map topLevelFields, Map counts) {
+void applyTopLevelFields(Map source, String id, Map topLevelFields, Map counts) {
+  source.id = id;
   source.putAll(topLevelFields);
 
   if (counts != null) {
@@ -57,8 +58,7 @@ void applyTopLevelFields(Map source, Map topLevelFields, Map counts) {
   }
 }
 
-void recordSource(Map source, String id, String relationship, String sourceId, long eventVersion) {
-  source.id = id;
+void recordSource(Map source, String relationship, String sourceId, long eventVersion) {
   source.__versions[relationship][sourceId] = eventVersion;
 
   // Record the relationship in `__sources` if it's not already there. We maintain it as an append-only set using a sorted list.
@@ -86,5 +86,5 @@ Map counts = params.__counts;
 
 setup(source, relationship, counts);
 validateSource(source, id, relationship, sourceId, eventVersion);
-applyTopLevelFields(source, params.topLevelFields, counts);
-recordSource(source, id, relationship, sourceId, eventVersion);
+applyTopLevelFields(source, id, params.topLevelFields, counts);
+recordSource(source, relationship, sourceId, eventVersion);

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/update_target_factory.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/update_target_factory.rbs
@@ -6,7 +6,7 @@ module ElasticGraph
           type: ::String,
           relationship: ::String,
           id_source: ::String,
-          data_params: SchemaArtifacts::RuntimeMetadata::paramsHash,
+          top_level_fields_params: SchemaArtifacts::RuntimeMetadata::paramsHash,
           routing_value_source: ::String?,
           rollover_timestamp_value_source: ::String?
         ) -> SchemaArtifacts::RuntimeMetadata::UpdateTarget

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/update_target_resolver.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/update_target_resolver.rbs
@@ -21,7 +21,7 @@ module ElasticGraph
         def validate_relationship: () -> ::Array[::String]
         def relationship_error_prefix: () -> ::String
 
-        def resolve_data_params: () -> [
+        def resolve_top_level_fields_params: () -> [
           ::Hash[::String, SchemaArtifacts::RuntimeMetadata::DynamicParam],
           ::Array[::String]
         ]

--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts/append_only_set_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts/append_only_set_spec.rb
@@ -60,7 +60,7 @@ module ElasticGraph
           id_source: "cost.currency",
           routing_value_source: nil,
           rollover_timestamp_value_source: nil,
-          data_params: {"workspace_id" => dynamic_param_with(source_path: "workspace_id", cardinality: :many)}
+          top_level_fields_params: {"workspace_id" => dynamic_param_with(source_path: "workspace_id", cardinality: :many)}
         ))
       end
 
@@ -115,7 +115,7 @@ module ElasticGraph
           id_source: "cost.currency",
           routing_value_source: nil,
           rollover_timestamp_value_source: nil,
-          data_params: {
+          top_level_fields_params: {
             "workspace_id" => dynamic_param_with(source_path: "workspace_id", cardinality: :many),
             "options.size" => dynamic_param_with(source_path: "options.size", cardinality: :many),
             "options.color" => dynamic_param_with(source_path: "options.color", cardinality: :many)
@@ -173,7 +173,7 @@ module ElasticGraph
             id_source: "cost.currency",
             routing_value_source: nil,
             rollover_timestamp_value_source: nil,
-            data_params: {
+            top_level_fields_params: {
               "options.size" => dynamic_param_with(source_path: "options.size", cardinality: :many),
               "options.color" => dynamic_param_with(source_path: "options.color", cardinality: :many)
             }

--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts/immutable_value_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts/immutable_value_spec.rb
@@ -39,7 +39,7 @@ module ElasticGraph
           id_source: "cost.currency",
           routing_value_source: nil,
           rollover_timestamp_value_source: nil,
-          data_params: {"cost_currency_name" => dynamic_param_with(source_path: "cost_currency_name", cardinality: :many)}
+          top_level_fields_params: {"cost_currency_name" => dynamic_param_with(source_path: "cost_currency_name", cardinality: :many)}
         ))
       end
 
@@ -148,7 +148,7 @@ module ElasticGraph
             id_source: "cost.currency",
             routing_value_source: nil,
             rollover_timestamp_value_source: nil,
-            data_params: {
+            top_level_fields_params: {
               "cost_currency_unit" => dynamic_param_with(source_path: "cost_currency_unit", cardinality: :many),
               "cost_currency_symbol" => dynamic_param_with(source_path: "cost_currency_symbol", cardinality: :many)
             }

--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts/min_or_max_value_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts/min_or_max_value_spec.rb
@@ -57,7 +57,7 @@ module ElasticGraph
             id_source: "cost.currency",
             routing_value_source: nil,
             rollover_timestamp_value_source: nil,
-            data_params: {"created_at" => dynamic_param_with(source_path: "created_at", cardinality: :many)}
+            top_level_fields_params: {"created_at" => dynamic_param_with(source_path: "created_at", cardinality: :many)}
           ))
         end
       end
@@ -105,7 +105,7 @@ module ElasticGraph
             id_source: "cost.currency",
             routing_value_source: nil,
             rollover_timestamp_value_source: nil,
-            data_params: {"created_at" => dynamic_param_with(source_path: "created_at", cardinality: :many)}
+            top_level_fields_params: {"created_at" => dynamic_param_with(source_path: "created_at", cardinality: :many)}
           ))
         end
       end
@@ -156,7 +156,7 @@ module ElasticGraph
             id_source: "cost.currency",
             routing_value_source: nil,
             rollover_timestamp_value_source: nil,
-            data_params: {"created_at" => dynamic_param_with(source_path: "created_at", cardinality: :many)}
+            top_level_fields_params: {"created_at" => dynamic_param_with(source_path: "created_at", cardinality: :many)}
           ))
         end
 
@@ -204,7 +204,7 @@ module ElasticGraph
               id_source: "cost.currency",
               routing_value_source: nil,
               rollover_timestamp_value_source: nil,
-              data_params: {"created_at" => dynamic_param_with(source_path: "created_at", cardinality: :many)}
+              top_level_fields_params: {"created_at" => dynamic_param_with(source_path: "created_at", cardinality: :many)}
             ))
           end
         end

--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts_spec.rb
@@ -98,7 +98,7 @@ module ElasticGraph
             id_source: "cost.currency",
             routing_value_source: "cost_currency_name",
             rollover_timestamp_value_source: "currency_introduced_on",
-            data_params: {
+            top_level_fields_params: {
               "workspace_id" => dynamic_param_with(source_path: "workspace_id", cardinality: :many),
               "cost_currency_name" => dynamic_param_with(source_path: "cost_currency_name", cardinality: :many),
               "created_at" => dynamic_param_with(source_path: "created_at", cardinality: :many)

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/update_targets_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/update_targets_spec.rb
@@ -45,7 +45,7 @@ module ElasticGraph
             id_source: "widget_ids",
             routing_value_source: nil,
             relationship: "workspace",
-            data_params: {
+            top_level_fields_params: {
               "workspace_name" => dynamic_param_with(source_path: "name", cardinality: :one),
               "workspace_created_at" => dynamic_param_with(source_path: "created_at", cardinality: :one)
             }
@@ -66,7 +66,7 @@ module ElasticGraph
             id_source: "widget_ids",
             routing_value_source: nil,
             relationship: "workspace",
-            data_params: {
+            top_level_fields_params: {
               "workspace_name" => dynamic_param_with(source_path: "name", cardinality: :one)
             }
           )
@@ -80,7 +80,7 @@ module ElasticGraph
             id_source: "id",
             routing_value_source: "id",
             relationship: SELF_RELATIONSHIP_NAME,
-            data_params: {
+            top_level_fields_params: {
               # Importantly, `workspace_name` and `workspace_created_at` are NOT in this map.
               "name" => dynamic_param_with(source_path: "name", cardinality: :one)
             }
@@ -101,7 +101,7 @@ module ElasticGraph
             id_source: "widget_ids",
             routing_value_source: nil,
             relationship: "workspace",
-            data_params: {
+            top_level_fields_params: {
               "workspace_name" => dynamic_param_with(source_path: "name2", cardinality: :one)
             }
           )
@@ -121,7 +121,7 @@ module ElasticGraph
             id_source: "widget_ids",
             routing_value_source: nil,
             relationship: "workspace",
-            data_params: {
+            top_level_fields_params: {
               "workspace_name2" => dynamic_param_with(source_path: "name", cardinality: :one)
             }
           )
@@ -141,7 +141,7 @@ module ElasticGraph
             id_source: "widget_ids",
             routing_value_source: nil,
             relationship: "workspace",
-            data_params: {
+            top_level_fields_params: {
               "workspace_name" => dynamic_param_with(source_path: "nested.further_nested_in_index.name", cardinality: :one)
             }
           )
@@ -161,7 +161,7 @@ module ElasticGraph
             id_source: "widget_ids",
             routing_value_source: nil,
             relationship: "workspace",
-            data_params: {
+            top_level_fields_params: {
               "workspace_name" => dynamic_param_with(source_path: "nested.further_nested_in_index.name", cardinality: :one)
             }
           )
@@ -449,7 +449,7 @@ module ElasticGraph
         def expect_widget_update_target_with(
           update_targets,
           id_source:,
-          data_params:,
+          top_level_fields_params:,
           relationship:, routing_value_source: nil,
           rollover_timestamp_value_source: nil
         )
@@ -463,7 +463,7 @@ module ElasticGraph
           expect(widget_target.id_source).to eq id_source
           expect(widget_target.routing_value_source).to eq(routing_value_source)
           expect(widget_target.rollover_timestamp_value_source).to eq(rollover_timestamp_value_source)
-          expect(widget_target.data_params).to eq(data_params)
+          expect(widget_target.top_level_fields_params).to eq(top_level_fields_params)
           expect(widget_target.metadata_params).to eq(standard_metadata_params(relationship: relationship))
         end
 
@@ -1401,7 +1401,7 @@ module ElasticGraph
           expect(widget_workspace_target.id_source).to eq "workspace_id"
           expect(widget_workspace_target.routing_value_source).to eq(nil)
           expect(widget_workspace_target.rollover_timestamp_value_source).to eq(nil)
-          expect(widget_workspace_target.data_params).to eq({"id" => dynamic_param_with(source_path: "id", cardinality: :many)})
+          expect(widget_workspace_target.top_level_fields_params).to eq({"id" => dynamic_param_with(source_path: "id", cardinality: :many)})
           expect(widget_workspace_target.metadata_params).to eq({})
 
           widget_target = metadata.update_targets.find { |t| t.type == "Widget" }
@@ -1411,7 +1411,7 @@ module ElasticGraph
           expect(widget_target.id_source).to eq "id"
           expect(widget_target.routing_value_source).to eq("id")
           expect(widget_target.rollover_timestamp_value_source).to eq(nil)
-          expect(widget_target.data_params).to eq({
+          expect(widget_target.top_level_fields_params).to eq({
             "name" => dynamic_param_with(source_path: "name", cardinality: :one),
             "workspace_id" => dynamic_param_with(source_path: "workspace_id", cardinality: :one)
           })
@@ -1457,7 +1457,7 @@ module ElasticGraph
           expect(widget_target.id_source).to eq "id"
           expect(widget_target.routing_value_source).to eq("id")
           expect(widget_target.rollover_timestamp_value_source).to eq(nil)
-          expect(widget_target.data_params).to eq({"cost" => dynamic_param_with(source_path: "cost", cardinality: :one)})
+          expect(widget_target.top_level_fields_params).to eq({"cost" => dynamic_param_with(source_path: "cost", cardinality: :one)})
           expect(widget_target.metadata_params).to eq(standard_metadata_params(relationship: SELF_RELATIONSHIP_NAME))
         end
 
@@ -1576,7 +1576,7 @@ module ElasticGraph
           expect(metadata.update_targets.first.relationship).to eq nil
           expect(metadata.update_targets.first.script_id).to start_with "update_ThingWorkspace_from_Thing"
           expect(metadata.update_targets.first.id_source).to eq "workspace_id"
-          expect(metadata.update_targets.first.data_params).to eq({"id" => dynamic_param_with(source_path: "id", cardinality: :many)})
+          expect(metadata.update_targets.first.top_level_fields_params).to eq({"id" => dynamic_param_with(source_path: "id", cardinality: :many)})
           expect(metadata.update_targets.first.metadata_params).to eq({})
         end
 
@@ -1657,7 +1657,7 @@ module ElasticGraph
           expect(widget_target.rollover_timestamp_value_source).to be_nil # no default for rollover
         end
 
-        it "includes __typename in data_params for types that inherit an index (needed for field extraction during indexing)" do
+        it "includes __typename in top_level_fields_params for types that inherit an index (needed for field extraction during indexing)" do
           widget_metadata, component_metadata = object_type_metadata_for("Widget", "Component") do |s|
             s.object_type "Widget" do |t|
               t.field "id", "ID!"
@@ -1678,12 +1678,12 @@ module ElasticGraph
           end
 
           widget_target = widget_metadata.update_targets.find { |t| t.type == "Widget" }
-          expect(widget_target.data_params.keys).to include("__typename")
-          expect(widget_target.data_params["__typename"].source_path).to eq "__typename"
+          expect(widget_target.top_level_fields_params.keys).to include("__typename")
+          expect(widget_target.top_level_fields_params["__typename"].source_path).to eq "__typename"
 
           component_target = component_metadata.update_targets.find { |t| t.type == "Component" }
-          expect(component_target.data_params.keys).to include("__typename")
-          expect(component_target.data_params["__typename"].source_path).to eq "__typename"
+          expect(component_target.top_level_fields_params.keys).to include("__typename")
+          expect(component_target.top_level_fields_params["__typename"].source_path).to eq "__typename"
         end
       end
 

--- a/elasticgraph-support/lib/elastic_graph/constants.rb
+++ b/elasticgraph-support/lib/elastic_graph/constants.rb
@@ -140,7 +140,7 @@ module ElasticGraph
   #
   # Note: this constant is automatically kept up-to-date by our `schema_artifacts:dump` rake task.
   # @private
-  INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_db769e42fd258f3884d2c5b721bb3c03"
+  INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_1b6d53ffefa2dd2d9510366867200725"
 
   # When an update script has a no-op result we often want to communicate more information about
   # why it was a no-op back to ElatsicGraph from the script. The only way to do that is to throw

--- a/elasticgraph-support/lib/elastic_graph/constants.rb
+++ b/elasticgraph-support/lib/elastic_graph/constants.rb
@@ -140,7 +140,7 @@ module ElasticGraph
   #
   # Note: this constant is automatically kept up-to-date by our `schema_artifacts:dump` rake task.
   # @private
-  INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_1fdfaf1c9261c96019decc89b515bd9a"
+  INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_db769e42fd258f3884d2c5b721bb3c03"
 
   # When an update script has a no-op result we often want to communicate more information about
   # why it was a no-op back to ElatsicGraph from the script. The only way to do that is to throw

--- a/elasticgraph-support/lib/elastic_graph/constants.rb
+++ b/elasticgraph-support/lib/elastic_graph/constants.rb
@@ -140,7 +140,7 @@ module ElasticGraph
   #
   # Note: this constant is automatically kept up-to-date by our `schema_artifacts:dump` rake task.
   # @private
-  INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_c506543861091e70bd493c28d29b9b70"
+  INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_b9e2b105d736d8d16ae269ab6ff81e4d"
 
   # When an update script has a no-op result we often want to communicate more information about
   # why it was a no-op back to ElatsicGraph from the script. The only way to do that is to throw

--- a/elasticgraph-support/lib/elastic_graph/constants.rb
+++ b/elasticgraph-support/lib/elastic_graph/constants.rb
@@ -140,7 +140,7 @@ module ElasticGraph
   #
   # Note: this constant is automatically kept up-to-date by our `schema_artifacts:dump` rake task.
   # @private
-  INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_1b6d53ffefa2dd2d9510366867200725"
+  INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_c506543861091e70bd493c28d29b9b70"
 
   # When an update script has a no-op result we often want to communicate more information about
   # why it was a no-op back to ElatsicGraph from the script. The only way to do that is to throw

--- a/elasticgraph-warehouse_lambda/lib/elastic_graph/warehouse_lambda/warehouse_dumper.rb
+++ b/elasticgraph-warehouse_lambda/lib/elastic_graph/warehouse_lambda/warehouse_dumper.rb
@@ -116,7 +116,7 @@ module ElasticGraph
           next nil if op.update_target.type != op.event.fetch("type")
 
           params = op.to_datastore_bulk[1].fetch(:script).fetch(:params)
-          data = params.fetch("data").merge({
+          data = params.fetch("topLevelFields").merge({
             "id" => params.fetch("id"),
             "__eg_version" => params.fetch("version")
           })

--- a/spec_support/lib/elastic_graph/spec_support/runtime_metadata_support.rb
+++ b/spec_support/lib/elastic_graph/spec_support/runtime_metadata_support.rb
@@ -61,7 +61,7 @@ module ElasticGraph
           id_source: "source_id",
           routing_value_source: "routing_value_source",
           rollover_timestamp_value_source: "rollover_timestamp_value_source",
-          data_params: {},
+          top_level_fields_params: {},
           metadata_params: {}
         )
           UpdateTarget.new(
@@ -71,7 +71,7 @@ module ElasticGraph
             id_source: id_source,
             routing_value_source: routing_value_source,
             rollover_timestamp_value_source: rollover_timestamp_value_source,
-            data_params: data_params,
+            top_level_fields_params: top_level_fields_params,
             metadata_params: metadata_params
           )
         end
@@ -82,7 +82,7 @@ module ElasticGraph
           id_source: "source_id",
           routing_value_source: "routing_value_source",
           rollover_timestamp_value_source: "rollover_timestamp_value_source",
-          data_params: {},
+          top_level_fields_params: {},
           metadata_params: {}
         )
           UpdateTarget.new(
@@ -92,7 +92,7 @@ module ElasticGraph
             id_source: id_source,
             routing_value_source: routing_value_source,
             rollover_timestamp_value_source: rollover_timestamp_value_source,
-            data_params: data_params,
+            top_level_fields_params: top_level_fields_params,
             metadata_params: metadata_params
           )
         end


### PR DESCRIPTION
##  Summary

This is a preparatory refactoring of the `index_data` Painless update script to make it ready for nested `sourced_from` support. No behavior change.

  - Restructure the flat script into helper functions
  - Rename `params.data` → `params.topLevelFields` to clarify intent (since `putAll` only applies top-level fields)

## Script structure after refactoring

```java
setup(...)                // Initializes bookkeeping structures (__sources, __versions, __counts)
validateSource(...)       // Checks for relationship mutation and version staleness (throws if stale)
applyTopLevelFields(...)  // Sets id, does putAll for top-level fields and merges __counts
recordSource(...)         // Records version, maintains __sources sorted list
```

## Why rename params.data → params.topLevelFields?

When nested `sourced_from` support is added, the script will also receive `params.nestedFields` (data that gets stored in `__nested_sourced_data` and applied to nested elements). Renaming `data` to `topLevelFields` now makes the distinction clear and avoids a confusing rename later when both params coexist.