### PR TITLE
Deduplicate schema extension modules

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
@@ -77,7 +77,7 @@ module ElasticGraph
 
         @factory = @state.factory
 
-        extension_modules.each { |mod| extend(mod) }
+        extension_modules.uniq.each { |mod| extend(mod) }
 
         # These lines must come _after_ the extension modules are applied, so that the extension modules
         # have a chance to hook into the factory in order to customize built in types if desired.

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/built_in_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/built_in_types_spec.rb
@@ -1349,6 +1349,19 @@ module ElasticGraph
           expect(type_def_from(result, "DateTime")).to eq "scalar DateTime @deprecated"
         end
 
+        it "only applies each extension module once" do
+          applied_count = 0
+          api_extension = Module.new do
+            define_singleton_method :extended do |_api|
+              applied_count += 1
+            end
+          end
+
+          define_schema(extension_modules: [api_extension, api_extension]) {}
+
+          expect(applied_count).to eq 1
+        end
+
         describe "#on_built_in_types" do
           it "can tag built in types" do
             result = define_schema do |api|


### PR DESCRIPTION
## Why

- Passing the same schema definition extension module more than once should not apply its hooks multiple times.

## What

- Deduplicate extension modules before extending the schema definition API.
- Add a focused spec covering duplicate extension module inputs.