### PR TITLE
Use << instead of = [...] for extension_modules in docs

### DIFF
--- a/elasticgraph-apollo/README.md
+++ b/elasticgraph-apollo/README.md
@@ -68,7 +68,7 @@ index 2943335..26633c3 100644
    local_config_yaml: settings_file,
    path_to_schema: "#{project_root}/config/schema.rb"
  ) do |tasks|
-+  tasks.schema_definition_extension_modules = [ElasticGraph::Apollo::SchemaDefinition::APIExtension]
++  tasks.schema_definition_extension_modules << ElasticGraph::Apollo::SchemaDefinition::APIExtension
 +
    # Set this to true once you're beyond the prototyping stage.
    tasks.enforce_json_schema_version = false

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/api_extension.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/schema_definition/api_extension.rb
@@ -35,7 +35,7 @@ module ElasticGraph
   #     local_config_yaml: "config/settings/local.yaml",
   #     path_to_schema: "config/schema.rb"
   #   ) do |tasks|
-  #     tasks.schema_definition_extension_modules = [ElasticGraph::Apollo::SchemaDefinition::APIExtension]
+  #     tasks.schema_definition_extension_modules << ElasticGraph::Apollo::SchemaDefinition::APIExtension
   #   end
   module Apollo
     # Namespace for all Apollo schema definition support.
@@ -55,7 +55,7 @@ module ElasticGraph
       #     local_config_yaml: "config/settings/local.yaml",
       #     path_to_schema: "config/schema.rb"
       #   ) do |tasks|
-      #     tasks.schema_definition_extension_modules = [ElasticGraph::Apollo::SchemaDefinition::APIExtension]
+      #     tasks.schema_definition_extension_modules << ElasticGraph::Apollo::SchemaDefinition::APIExtension
       #   end
       module APIExtension
         # Applies an apollo tag to built-in types so that they are included in the Apollo contract schema.

--- a/elasticgraph-local/lib/elastic_graph/local/rake_tasks.rb
+++ b/elasticgraph-local/lib/elastic_graph/local/rake_tasks.rb
@@ -168,7 +168,7 @@ module ElasticGraph
       #     local_config_yaml: "config/settings/local.yaml",
       #     path_to_schema: "config/schema.rb"
       #   ) do |tasks|
-      #     tasks.schema_definition_extension_modules = [ElasticGraph::Apollo::SchemaDefinition::APIExtension]
+      #     tasks.schema_definition_extension_modules << ElasticGraph::Apollo::SchemaDefinition::APIExtension
       #   end
       #
       # @example Extension that defines a `@since` directive and offers a `since` API on fields
@@ -207,7 +207,7 @@ module ElasticGraph
       #     local_config_yaml: "config/settings/local.yaml",
       #     path_to_schema: "config/schema.rb"
       #   ) do |tasks|
-      #     tasks.schema_definition_extension_modules = [SinceExtension]
+      #     tasks.schema_definition_extension_modules << SinceExtension
       #   end
       #
       # @dynamic schema_definition_extension_modules, schema_definition_extension_modules=

--- a/elasticgraph-warehouse/README.md
+++ b/elasticgraph-warehouse/README.md
@@ -57,7 +57,7 @@ index 2943335..26633c3 100644
    local_config_yaml: settings_file,
    path_to_schema: "#{project_root}/config/schema.rb"
  ) do |tasks|
-+  tasks.schema_definition_extension_modules = [ElasticGraph::Warehouse::SchemaDefinition::APIExtension]
++  tasks.schema_definition_extension_modules << ElasticGraph::Warehouse::SchemaDefinition::APIExtension
 +
    # Set this to true once you're beyond the prototyping stage.
    tasks.enforce_json_schema_version = false

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse.rb
@@ -19,9 +19,7 @@ module ElasticGraph
   #     local_config_yaml: "config/settings/local.yaml",
   #     path_to_schema: "config/schema.rb"
   #   ) do |tasks|
-  #     tasks.schema_definition_extension_modules = [
-  #       ElasticGraph::Warehouse::SchemaDefinition::APIExtension
-  #     ]
+  #     tasks.schema_definition_extension_modules << ElasticGraph::Warehouse::SchemaDefinition::APIExtension
   #   end
   module Warehouse
     # The name of the generated data warehouse configuration file.

--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/api_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/api_extension.rb
@@ -29,9 +29,7 @@ module ElasticGraph
       #     local_config_yaml: "config/settings/local.yaml",
       #     path_to_schema: "config/schema.rb"
       #   ) do |tasks|
-      #     tasks.schema_definition_extension_modules = [
-      #       ElasticGraph::Warehouse::SchemaDefinition::APIExtension
-      #     ]
+      #     tasks.schema_definition_extension_modules << ElasticGraph::Warehouse::SchemaDefinition::APIExtension
       #   end
       module APIExtension
         # Maps built-in ElasticGraph scalar types to their warehouse column types.


### PR DESCRIPTION
## Summary

- Updates all documentation examples and READMEs to use `tasks.schema_definition_extension_modules << Module` instead of `tasks.schema_definition_extension_modules = [Module]`
- The `= [module]` pattern overwrites any previously appended modules, preventing composability when multiple extensions are needed
- The project's own `Rakefile` already uses `<<` correctly; this aligns docs with that pattern

## Test plan

- [ ] Verify YARD doc rendering looks correct
- [ ] Confirm no behavioral changes (all modifications are in comments/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)