### PR TITLE
Instantiate indexing field types through factory

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/factory.rb
@@ -7,6 +7,10 @@
 # frozen_string_literal: true
 
 require "elastic_graph/constants"
+require "elastic_graph/schema_definition/indexing/field_type/enum"
+require "elastic_graph/schema_definition/indexing/field_type/object"
+require "elastic_graph/schema_definition/indexing/field_type/scalar"
+require "elastic_graph/schema_definition/indexing/field_type/union"
 require "elastic_graph/schema_definition/mixins/has_readable_to_s_and_inspect"
 require "elastic_graph/schema_definition/results"
 require "elastic_graph/schema_definition/indexing/index"
@@ -118,6 +122,11 @@ module ElasticGraph
                    @@field_new.call(schema_def_state: @state, **kwargs, &block)
                  end
       @@field_new = prevent_non_factory_instantiation_of(SchemaElements::Field)
+
+      def new_enum_indexing_field_type(enum_value_names)
+        @@enum_indexing_field_type_new.call(enum_value_names)
+      end
+      @@enum_indexing_field_type_new = prevent_non_factory_instantiation_of(Indexing::FieldType::Enum)
 
       def new_graphql_sdl_enumerator(all_types)
         @@graphql_sdl_enumerator_new.call(@state, all_types)
@@ -237,12 +246,29 @@ module ElasticGraph
       end
       @@object_type_new = prevent_non_factory_instantiation_of(SchemaElements::ObjectType)
 
+      def new_object_indexing_field_type(type_name:, subfields:, mapping_options:, json_schema_options:, doc_comment:)
+        @@object_indexing_field_type_new.call(
+          schema_def_state: @state,
+          type_name: type_name,
+          subfields: subfields,
+          mapping_options: mapping_options,
+          json_schema_options: json_schema_options,
+          doc_comment: doc_comment
+        )
+      end
+      @@object_indexing_field_type_new = prevent_non_factory_instantiation_of(Indexing::FieldType::Object)
+
       def new_scalar_type(name)
         @@scalar_type_new.call(@state, name.to_s) do |scalar_type|
           yield scalar_type
         end
       end
       @@scalar_type_new = prevent_non_factory_instantiation_of(SchemaElements::ScalarType)
+
+      def new_scalar_indexing_field_type(scalar_type:)
+        @@scalar_indexing_field_type_new.call(scalar_type: scalar_type)
+      end
+      @@scalar_indexing_field_type_new = prevent_non_factory_instantiation_of(Indexing::FieldType::Scalar)
 
       def new_sort_order_enum_value(enum_value, sort_order_field_path)
         @@sort_order_enum_value_new.call(enum_value, sort_order_field_path)
@@ -267,6 +293,11 @@ module ElasticGraph
         end
       end
       @@union_type_new = prevent_non_factory_instantiation_of(SchemaElements::UnionType)
+
+      def new_union_indexing_field_type(subtypes_by_name)
+        @@union_indexing_field_type_new.call(subtypes_by_name)
+      end
+      @@union_indexing_field_type_new = prevent_non_factory_instantiation_of(Indexing::FieldType::Union)
 
       def new_field_source(relationship_name:, field_path:)
         @@field_source_new.call(relationship_name, field_path)

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_subtypes.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_subtypes.rb
@@ -22,7 +22,7 @@ module ElasticGraph
             [type.name, _ = type.to_indexing_field_type]
           end
 
-          Indexing::FieldType::Union.new(subtypes_by_name)
+          schema_def_state.factory.new_union_indexing_field_type(subtypes_by_name)
         end
 
         def graphql_fields_by_name

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/enum_type.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/enum_type.rb
@@ -158,7 +158,7 @@ module ElasticGraph
 
         # @return [Indexing::FieldType::Enum] indexing representation of this enum type
         def to_indexing_field_type
-          Indexing::FieldType::Enum.new(values_by_name.keys)
+          schema_def_state.factory.new_enum_indexing_field_type(values_by_name.keys)
         end
 
         # @return [EnumType] converts the enum type to its input form for when different naming is used for input vs output enums.

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/scalar_type.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/scalar_type.rb
@@ -215,7 +215,7 @@ module ElasticGraph
 
         # @private
         def to_indexing_field_type
-          Indexing::FieldType::Scalar.new(scalar_type: self)
+          schema_def_state.factory.new_scalar_indexing_field_type(scalar_type: self)
         end
 
         # @private

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_with_subfields.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_with_subfields.rb
@@ -491,8 +491,7 @@ module ElasticGraph
 
         # @private
         def to_indexing_field_type
-          Indexing::FieldType::Object.new(
-            schema_def_state: schema_def_state,
+          schema_def_state.factory.new_object_indexing_field_type(
             type_name: name,
             subfields: indexing_fields_by_name_in_index.values.map(&:to_indexing_field).compact,
             mapping_options: mapping_options,

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/factory.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/factory.rbs
@@ -47,6 +47,9 @@ module ElasticGraph
       ) ?{ (SchemaElements::Field) -> void } -> SchemaElements::Field
       @@field_new: ::Method
 
+      def new_enum_indexing_field_type: (::Array[::String]) -> Indexing::FieldType::Enum
+      @@enum_indexing_field_type_new: ::Method
+
       def new_graphql_sdl_enumerator: (::Array[SchemaElements::graphQLType]) -> SchemaElements::GraphQLSDLEnumerator
       @@graphql_sdl_enumerator_new: ::Method
 
@@ -81,11 +84,23 @@ module ElasticGraph
       def new_object_type: (::String) ?{ (SchemaElements::ObjectType) -> void } -> SchemaElements::ObjectType
       @@object_type_new: ::Method
 
+      def new_object_indexing_field_type: (
+        type_name: ::String,
+        subfields: ::Array[Indexing::Field],
+        mapping_options: Mixins::HasTypeInfo::optionsHash,
+        json_schema_options: Mixins::HasTypeInfo::optionsHash,
+        doc_comment: ::String?
+      ) -> Indexing::FieldType::Object
+      @@object_indexing_field_type_new: ::Method
+
       def new_namespace_type: (::String) ?{ (SchemaElements::NamespaceType) -> void } -> SchemaElements::NamespaceType
       @@namespace_type_new: ::Method
 
       def new_scalar_type: (::String) { (SchemaElements::ScalarType) -> void } -> SchemaElements::ScalarType
       @@scalar_type_new: ::Method
+
+      def new_scalar_indexing_field_type: (scalar_type: SchemaElements::ScalarType) -> Indexing::FieldType::Scalar
+      @@scalar_indexing_field_type_new: ::Method
 
       def new_sort_order_enum_value: (SchemaElements::EnumValue, ::Array[SchemaElements::Field]) -> SchemaElements::SortOrderEnumValue
       @@sort_order_enum_value_new: ::Method
@@ -103,6 +118,9 @@ module ElasticGraph
 
       def new_union_type: (::String) { (SchemaElements::UnionType) -> void } -> SchemaElements::UnionType
       @@union_type_new: ::Method
+
+      def new_union_indexing_field_type: (::Hash[::String, Indexing::FieldType::Object]) -> Indexing::FieldType::Union
+      @@union_indexing_field_type_new: ::Method
 
       def new_field_source: (relationship_name: ::String, field_path: ::String) -> SchemaElements::FieldSource
       @@field_source_new: ::Method


### PR DESCRIPTION
## Why

The JSON ingestion extension needs to extend indexing field type instances through the schema definition factory instead of wrapping them separately.

## What

- Add factory methods for enum, object, scalar, and union indexing field types.
- Route core `to_indexing_field_type` call sites through those factory methods.
- Update the factory RBS signatures.

## Verification

- `bundle exec rspec elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/json_schema_spec.rb`
- `script/type_check`
- `script/lint`
- `script/run_gem_specs elasticgraph-schema_definition` was not run to completion because the test datastore was not running at `http://localhost:9234`.

References https://github.com/block/elasticgraph/pull/1204#discussion_r3315720406.
