### PR TITLE
Upgrade Elasticsearch from 9.2.4 to 9.4.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
           - "3.4"
           - "4.0"
         datastore:
-          - "elasticsearch:9.2.4"
+          - "elasticsearch:9.4.2"
         include:
           # Datastore-specific tests on non-primary datastores.
           # These run only `:uses_datastore` tagged tests since non-datastore tests don't vary by datastore.
@@ -51,30 +51,30 @@ jobs:
           # Part 3: graphql acceptance + local (halted), Part 4: all remaining gems.
           - build_part: "run_specs_for_jruby"
             ruby: "jruby-10.0"
-            datastore: "elasticsearch:9.2.4"
+            datastore: "elasticsearch:9.4.2"
             build_part_args: "1"
           - build_part: "run_specs_for_jruby"
             ruby: "jruby-10.0"
-            datastore: "elasticsearch:9.2.4"
+            datastore: "elasticsearch:9.4.2"
             build_part_args: "2"
           - build_part: "run_specs_for_jruby"
             ruby: "jruby-10.0"
-            datastore: "elasticsearch:9.2.4"
+            datastore: "elasticsearch:9.4.2"
             build_part_args: "3"
           - build_part: "run_specs_for_jruby"
             ruby: "jruby-10.0"
-            datastore: "elasticsearch:9.2.4"
+            datastore: "elasticsearch:9.4.2"
             build_part_args: "4"
           # Other build parts run on max Ruby and primary datastore only.
           - build_part: "run_misc_checks"
             ruby: "4.0"
-            datastore: "elasticsearch:9.2.4"
+            datastore: "elasticsearch:9.4.2"
           - build_part: "run_specs_with_vcr"
             ruby: "4.0"
-            datastore: "elasticsearch:9.2.4"
+            datastore: "elasticsearch:9.4.2"
           - build_part: "run_specs_file_by_file"
             ruby: "4.0"
-            datastore: "elasticsearch:9.2.4"
+            datastore: "elasticsearch:9.4.2"
 
     steps:
       - name: Harden Runner

--- a/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/for_index_spec.rb
+++ b/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/for_index_spec.rb
@@ -20,9 +20,9 @@ module ElasticGraph
 
             expect {
               configure_index_definition(schema_def(number_of_shards: 47))
-            }.to raise_error(Errors::BadDatastoreRequest, a_string_including("Can't update non dynamic settings", "index.number_of_shards"))
+            }.to raise_error(Errors::BadDatastoreRequest, a_string_including("Can't update non dynamic setting", "index.number_of_shards"))
               .and make_datastore_write_calls("main", "PUT /#{unique_index_name}/_settings")
-              .and log_warning(/Can't update non dynamic settings/)
+              .and log_warning(/Can't update non dynamic setting/)
           end
 
           it "handles empty indexed types" do

--- a/elasticgraph-local/lib/elastic_graph/local/tested_datastore_versions.yaml
+++ b/elasticgraph-local/lib/elastic_graph/local/tested_datastore_versions.yaml
@@ -2,7 +2,7 @@
 # This file determines the versions the ElasticGraph CI build tests against, and is also
 # used to provide the default versions offered by the `elasticgraph-local` rake tasks.
 elasticsearch:
-- 9.2.4 # latest version as of 2026-01-19.
+- 9.4.2 # latest version as of 2026-06-01.
 - 9.0.0 # lowest version ElasticGraph currently supports
 opensearch:
 - 3.4.0  # latest minor release as of 2026-01-19.


### PR DESCRIPTION
## Summary

- Upgrade Elasticsearch max tested version from 9.2.4 to 9.4.2

## Test plan

- [x] CI build passes with ES 9.4.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)