### PR TITLE
Upgrade OpenSearch from 3.4.0 to 3.6.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
             datastore: "elasticsearch:9.0.0"
           - build_part: "run_datastore_specs"
             ruby: "4.0"
-            datastore: "opensearch:3.4.0"
+            datastore: "opensearch:3.6.0"
           - build_part: "run_datastore_specs"
             ruby: "4.0"
             datastore: "opensearch:2.19.0"
@@ -114,7 +114,7 @@ jobs:
       contents: read
       packages: write
     env:
-      OPENSEARCH_VERSION: "3.4.0"
+      OPENSEARCH_VERSION: "3.6.0"
 
     steps:
       - name: Harden Runner

--- a/elasticgraph-local/lib/elastic_graph/local/tested_datastore_versions.yaml
+++ b/elasticgraph-local/lib/elastic_graph/local/tested_datastore_versions.yaml
@@ -5,5 +5,5 @@ elasticsearch:
 - 9.2.4 # latest version as of 2026-01-19.
 - 9.0.0 # lowest version ElasticGraph currently supports
 opensearch:
-- 3.4.0  # latest minor release as of 2026-01-19.
+- 3.6.0  # latest minor release as of 2026-06-01.
 - 2.19.0 # lowest version ElasticGraph currently supports


### PR DESCRIPTION
## Summary

- Upgrade OpenSearch max tested version from 3.4.0 to 3.6.0

## Test plan

- [x] CI build passes with OpenSearch 3.6.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)