### PR TITLE
Refactor: Extract sourced_from UpdateTarget resolution logic from Results

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/sourced_from_update_targets_resolver.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/sourced_from_update_targets_resolver.rb
@@ -1,0 +1,116 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/errors"
+require "elastic_graph/schema_definition/indexing/relationship_resolver"
+require "elastic_graph/schema_definition/indexing/update_target_resolver"
+
+module ElasticGraph
+  module SchemaDefinition
+    module Indexing
+      # Resolves all `sourced_from` field declarations across the schema into update targets,
+      # keyed by the source type name that publishes the events.
+      #
+      # @private
+      class SourcedFromUpdateTargetsResolver
+        def initialize(schema_def_state:)
+          @schema_def_state = schema_def_state
+          @sourced_field_errors = [] # : ::Array[::String]
+          @relationship_errors = [] # : ::Array[::String]
+          @update_targets_by_source_type_name = ::Hash.new { |h, k| h[k] = [] } # : ::Hash[::String, ::Array[SchemaArtifacts::RuntimeMetadata::UpdateTarget]]
+        end
+
+        # Returns a map of source type name → update targets that should be triggered by that type's events.
+        def resolve
+          @schema_def_state.object_types_by_name.except(*@schema_def_state.namespace_types_by_name.keys).each_value do |object_type|
+            resolve_for_type(object_type)
+          end
+
+          raise_if_errors
+          @update_targets_by_source_type_name
+        end
+
+        private
+
+        def resolve_for_type(object_type)
+          fields_with_sources_by_relationship_name = sourced_fields_by_relationship_name(object_type)
+          defined_relationships = object_type.relationships_by_name.keys
+
+          (defined_relationships | fields_with_sources_by_relationship_name.keys).each do |relationship_name|
+            empty_fields = [] # : ::Array[SchemaElements::Field]
+            sourced_fields = fields_with_sources_by_relationship_name.fetch(relationship_name) { empty_fields }
+            relationship_resolver = RelationshipResolver.new(
+              schema_def_state: @schema_def_state,
+              object_type: object_type,
+              relationship_name: relationship_name,
+              sourced_fields: sourced_fields
+            )
+
+            resolved_relationship, relationship_error = relationship_resolver.resolve
+            @relationship_errors << relationship_error if relationship_error
+
+            if object_type.own_index_def && resolved_relationship && sourced_fields.any?
+              resolve_update_target(object_type, resolved_relationship, sourced_fields)
+            end
+          end
+        end
+
+        def resolve_update_target(object_type, resolved_relationship, sourced_fields)
+          update_target_resolver = UpdateTargetResolver.new(
+            object_type: object_type,
+            resolved_relationship: resolved_relationship,
+            sourced_fields: sourced_fields,
+            field_path_resolver: @schema_def_state.field_path_resolver
+          )
+
+          update_target, errors = update_target_resolver.resolve
+          @update_targets_by_source_type_name[resolved_relationship.related_type.name] << update_target if update_target
+          @sourced_field_errors.concat(errors)
+
+          # Validate that has_had_multiple_sources! has been called when sourced_from is used
+          if (index_def = object_type.own_index_def) && !index_def.has_had_multiple_sources_flag
+            @sourced_field_errors << "Type `#{object_type.name}` uses `sourced_from` fields but its index `#{index_def.name}` " \
+              "has not been configured with `has_had_multiple_sources!`. To resolve this, add `i.has_had_multiple_sources!` within the " \
+              "`t.index \"#{index_def.name}\"` block. This flag is required because indices with multiple sources can contain " \
+              "incomplete documents, and ElasticGraph needs to know this to apply proper filtering. Once set, this flag should remain even " \
+              "if you later remove all `sourced_from` fields, as the index may still contain historical incomplete documents."
+          end
+        end
+
+        def sourced_fields_by_relationship_name(object_type)
+          if object_type.own_index_def.nil?
+            # For now, only indexed types can have `sourced_from` fields, and resolving `fields_with_sources` on an unindexed union type
+            # such as `_Entity` when we are using apollo can lead to exceptions when multiple entity types have the same field name
+            # that use different mapping types.
+            {} # : ::Hash[::String, ::Array[SchemaElements::Field]]
+          else
+            object_type
+              .fields_with_sources
+              .group_by { |f| (_ = f.source).relationship_name }
+          end
+        end
+
+        def raise_if_errors
+          full_errors = [] # : ::Array[::String]
+
+          if @sourced_field_errors.any?
+            full_errors << "Schema had #{@sourced_field_errors.size} error(s) related to `sourced_from` fields:\n\n#{@sourced_field_errors.map.with_index(1) { |e, i| "#{i}. #{e}" }.join("\n\n")}"
+          end
+
+          if @relationship_errors.any?
+            full_errors << "Schema had #{@relationship_errors.size} error(s) related to relationship fields:\n\n#{@relationship_errors.map.with_index(1) { |e, i| "#{i}. #{e}" }.join("\n\n")}"
+          end
+
+          unless full_errors.empty?
+            raise Errors::SchemaError, full_errors.join("\n\n")
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/sourced_from_update_targets_resolver.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/sourced_from_update_targets_resolver.rb
@@ -30,7 +30,7 @@ module ElasticGraph
           type_names_and_update_targets =
             @schema_def_state.object_types_by_name.except(*@schema_def_state.namespace_types_by_name.keys).each_value.flat_map do |object_type|
               resolve_for_type(object_type) do |error_type, error|
-                errors = error_type == :relationship ? relationship_errors : sourced_field_errors
+                errors = (error_type == :relationship) ? relationship_errors : sourced_field_errors
                 errors << error
               end
             end

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/sourced_from_update_targets_resolver.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/sourced_from_update_targets_resolver.rb
@@ -18,30 +18,37 @@ module ElasticGraph
       #
       # @private
       class SourcedFromUpdateTargetsResolver
-        def initialize(schema_def_state:)
+        def initialize(schema_def_state)
           @schema_def_state = schema_def_state
-          @sourced_field_errors = [] # : ::Array[::String]
-          @relationship_errors = [] # : ::Array[::String]
-          @update_targets_by_source_type_name = ::Hash.new { |h, k| h[k] = [] } # : ::Hash[::String, ::Array[SchemaArtifacts::RuntimeMetadata::UpdateTarget]]
         end
 
         # Returns a map of source type name → update targets that should be triggered by that type's events.
         def resolve
-          @schema_def_state.object_types_by_name.except(*@schema_def_state.namespace_types_by_name.keys).each_value do |object_type|
-            resolve_for_type(object_type)
-          end
+          sourced_field_errors = [] # : ::Array[::String]
+          relationship_errors = [] # : ::Array[::String]
 
-          raise_if_errors
-          @update_targets_by_source_type_name
+          type_names_and_update_targets =
+            @schema_def_state.object_types_by_name.except(*@schema_def_state.namespace_types_by_name.keys).each_value.flat_map do |object_type|
+              resolve_for_type(object_type) do |error_type, error|
+                errors = error_type == :relationship ? relationship_errors : sourced_field_errors
+                errors << error
+              end
+            end
+
+          raise_if_errors(sourced_field_errors, relationship_errors)
+
+          type_names_and_update_targets
+            .group_by(&:first)
+            .transform_values { |pairs| pairs.map(&:last) }
         end
 
         private
 
-        def resolve_for_type(object_type)
+        def resolve_for_type(object_type, &error_reporter)
           fields_with_sources_by_relationship_name = sourced_fields_by_relationship_name(object_type)
           defined_relationships = object_type.relationships_by_name.keys
 
-          (defined_relationships | fields_with_sources_by_relationship_name.keys).each do |relationship_name|
+          (defined_relationships | fields_with_sources_by_relationship_name.keys).filter_map do |relationship_name|
             empty_fields = [] # : ::Array[SchemaElements::Field]
             sourced_fields = fields_with_sources_by_relationship_name.fetch(relationship_name) { empty_fields }
             relationship_resolver = RelationshipResolver.new(
@@ -52,10 +59,10 @@ module ElasticGraph
             )
 
             resolved_relationship, relationship_error = relationship_resolver.resolve
-            @relationship_errors << relationship_error if relationship_error
+            yield :relationship, relationship_error if relationship_error
 
             if object_type.own_index_def && resolved_relationship && sourced_fields.any?
-              resolve_update_target(object_type, resolved_relationship, sourced_fields)
+              resolve_update_target(object_type, resolved_relationship, sourced_fields, &error_reporter)
             end
           end
         end
@@ -69,17 +76,19 @@ module ElasticGraph
           )
 
           update_target, errors = update_target_resolver.resolve
-          @update_targets_by_source_type_name[resolved_relationship.related_type.name] << update_target if update_target
-          @sourced_field_errors.concat(errors)
+          errors.each { |error| yield :sourced_field, error }
 
           # Validate that has_had_multiple_sources! has been called when sourced_from is used
-          if (index_def = object_type.own_index_def) && !index_def.has_had_multiple_sources_flag
-            @sourced_field_errors << "Type `#{object_type.name}` uses `sourced_from` fields but its index `#{index_def.name}` " \
+          index_def = object_type.own_index_def # : Index
+          unless index_def.has_had_multiple_sources_flag
+            yield :sourced_field, "Type `#{object_type.name}` uses `sourced_from` fields but its index `#{index_def.name}` " \
               "has not been configured with `has_had_multiple_sources!`. To resolve this, add `i.has_had_multiple_sources!` within the " \
               "`t.index \"#{index_def.name}\"` block. This flag is required because indices with multiple sources can contain " \
               "incomplete documents, and ElasticGraph needs to know this to apply proper filtering. Once set, this flag should remain even " \
               "if you later remove all `sourced_from` fields, as the index may still contain historical incomplete documents."
           end
+
+          [resolved_relationship.related_type.name, update_target] if update_target
         end
 
         def sourced_fields_by_relationship_name(object_type)
@@ -95,15 +104,15 @@ module ElasticGraph
           end
         end
 
-        def raise_if_errors
+        def raise_if_errors(sourced_field_errors, relationship_errors)
           full_errors = [] # : ::Array[::String]
 
-          if @sourced_field_errors.any?
-            full_errors << "Schema had #{@sourced_field_errors.size} error(s) related to `sourced_from` fields:\n\n#{@sourced_field_errors.map.with_index(1) { |e, i| "#{i}. #{e}" }.join("\n\n")}"
+          if sourced_field_errors.any?
+            full_errors << "Schema had #{sourced_field_errors.size} error(s) related to `sourced_from` fields:\n\n#{sourced_field_errors.map.with_index(1) { |e, i| "#{i}. #{e}" }.join("\n\n")}"
           end
 
-          if @relationship_errors.any?
-            full_errors << "Schema had #{@relationship_errors.size} error(s) related to relationship fields:\n\n#{@relationship_errors.map.with_index(1) { |e, i| "#{i}. #{e}" }.join("\n\n")}"
+          if relationship_errors.any?
+            full_errors << "Schema had #{relationship_errors.size} error(s) related to relationship fields:\n\n#{relationship_errors.map.with_index(1) { |e, i| "#{i}. #{e}" }.join("\n\n")}"
           end
 
           unless full_errors.empty?

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
@@ -12,8 +12,7 @@ require "elastic_graph/schema_artifacts/runtime_metadata/schema"
 require "elastic_graph/schema_artifacts/artifacts_helper_methods"
 require "elastic_graph/schema_definition/indexing/event_envelope"
 require "elastic_graph/schema_definition/indexing/json_schema_with_metadata"
-require "elastic_graph/schema_definition/indexing/relationship_resolver"
-require "elastic_graph/schema_definition/indexing/update_target_resolver"
+require "elastic_graph/schema_definition/indexing/sourced_from_update_targets_resolver"
 require "elastic_graph/schema_definition/mixins/has_readable_to_s_and_inspect"
 require "elastic_graph/schema_definition/schema_elements/field_path"
 require "elastic_graph/schema_definition/scripting/file_system_repository"
@@ -143,11 +142,14 @@ module ElasticGraph
       end
 
       def build_runtime_metadata
-        extra_update_targets_by_object_type_name = identify_extra_update_targets_by_object_type_name
+        sourced_update_targets_by_source_type_name = Indexing::SourcedFromUpdateTargetsResolver.new(schema_def_state: state).resolve
 
         object_types_by_name = all_types
           .select { |t| t.respond_to?(:graphql_fields_by_name) }
-          .to_h { |type| [type.name, (_ = type).runtime_metadata(extra_update_targets_by_object_type_name.fetch(type.name) { [] })] }
+          .to_h do |type|
+            empty = [] # : ::Array[SchemaArtifacts::RuntimeMetadata::UpdateTarget]
+            [type.name, (_ = type).runtime_metadata(sourced_update_targets_by_source_type_name.fetch(type.name) { empty })]
+          end
 
         scalar_types_by_name = state.scalar_types_by_name.transform_values(&:runtime_metadata)
 
@@ -178,80 +180,6 @@ module ElasticGraph
           graphql_resolvers_by_name: state.graphql_resolvers_by_name,
           static_script_ids_by_scoped_name: STATIC_SCRIPT_REPO.script_ids_by_scoped_name
         ).tap { |rm| verify_runtime_metadata(rm) }
-      end
-
-      # Builds a map, keyed by object type name, of extra `update_targets` that have been generated
-      # from any fields that use `sourced_from` on other types.
-      def identify_extra_update_targets_by_object_type_name
-        sourced_field_errors = [] # : ::Array[::String]
-        relationship_errors = [] # : ::Array[::String]
-
-        state.object_types_by_name.except(*state.namespace_types_by_name.keys).values.each_with_object(
-          ::Hash.new { |h, k| h[k] = [] } # : ::Hash[untyped, ::Array[SchemaArtifacts::RuntimeMetadata::UpdateTarget]]
-        ) do |object_type, accum|
-          fields_with_sources_by_relationship_name =
-            if object_type.own_index_def.nil?
-              # only indexed types can have `sourced_from` fields, and resolving `fields_with_sources` on an unindexed union type
-              # such as `_Entity` when we are using apollo can lead to exceptions when multiple entity types have the same field name
-              # that use different mapping types.
-              {} # : ::Hash[::String, ::Array[SchemaElements::Field]]
-            else
-              object_type
-                .fields_with_sources
-                .group_by { |f| (_ = f.source).relationship_name }
-            end
-
-          defined_relationships = object_type.relationships_by_name.keys
-
-          (defined_relationships | fields_with_sources_by_relationship_name.keys).each do |relationship_name|
-            sourced_fields = fields_with_sources_by_relationship_name.fetch(relationship_name) { [] }
-            relationship_resolver = Indexing::RelationshipResolver.new(
-              schema_def_state: state,
-              object_type: object_type,
-              relationship_name: relationship_name,
-              sourced_fields: sourced_fields
-            )
-
-            resolved_relationship, relationship_error = relationship_resolver.resolve
-            relationship_errors << relationship_error if relationship_error
-
-            if object_type.own_index_def && resolved_relationship && sourced_fields.any?
-              update_target_resolver = Indexing::UpdateTargetResolver.new(
-                object_type: object_type,
-                resolved_relationship: resolved_relationship,
-                sourced_fields: sourced_fields,
-                field_path_resolver: state.field_path_resolver
-              )
-
-              update_target, errors = update_target_resolver.resolve
-              accum[resolved_relationship.related_type.name] << update_target if update_target
-              sourced_field_errors.concat(errors)
-
-              # Validate that has_had_multiple_sources! has been called when sourced_from is used
-              if (index_def = object_type.own_index_def) && !index_def.has_had_multiple_sources_flag
-                sourced_field_errors << "Type `#{object_type.name}` uses `sourced_from` fields but its index `#{index_def.name}` " \
-                  "has not been configured with `has_had_multiple_sources!`. To resolve this, add `i.has_had_multiple_sources!` within the " \
-                  "`t.index \"#{index_def.name}\"` block. This flag is required because indices with multiple sources can contain " \
-                  "incomplete documents, and ElasticGraph needs to know this to apply proper filtering. Once set, this flag should remain even " \
-                  "if you later remove all `sourced_from` fields, as the index may still contain historical incomplete documents."
-              end
-            end
-          end
-        end.tap do
-          full_errors = [] # : ::Array[::String]
-
-          if sourced_field_errors.any?
-            full_errors << "Schema had #{sourced_field_errors.size} error(s) related to `sourced_from` fields:\n\n#{sourced_field_errors.map.with_index(1) { |e, i| "#{i}. #{e}" }.join("\n\n")}"
-          end
-
-          if relationship_errors.any?
-            full_errors << "Schema had #{relationship_errors.size} error(s) related to relationship fields:\n\n#{relationship_errors.map.with_index(1) { |e, i| "#{i}. #{e}" }.join("\n\n")}"
-          end
-
-          unless full_errors.empty?
-            raise Errors::SchemaError, full_errors.join("\n\n")
-          end
-        end
       end
 
       # Generates the SDL defined by your schema. Intended to be called only once

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
@@ -142,7 +142,7 @@ module ElasticGraph
       end
 
       def build_runtime_metadata
-        sourced_update_targets_by_source_type_name = Indexing::SourcedFromUpdateTargetsResolver.new(schema_def_state: state).resolve
+        sourced_update_targets_by_source_type_name = Indexing::SourcedFromUpdateTargetsResolver.new(state).resolve
 
         object_types_by_name = all_types
           .select { |t| t.respond_to?(:graphql_fields_by_name) }

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/sourced_from_update_targets_resolver.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/sourced_from_update_targets_resolver.rbs
@@ -1,0 +1,22 @@
+module ElasticGraph
+  module SchemaDefinition
+    module Indexing
+      class SourcedFromUpdateTargetsResolver
+        @schema_def_state: State
+        @sourced_field_errors: ::Array[::String]
+        @relationship_errors: ::Array[::String]
+        @update_targets_by_source_type_name: ::Hash[::String, ::Array[SchemaArtifacts::RuntimeMetadata::UpdateTarget]]
+
+        def initialize: (schema_def_state: State) -> void
+        def resolve: () -> ::Hash[::String, ::Array[SchemaArtifacts::RuntimeMetadata::UpdateTarget]]
+
+        private
+
+        def resolve_for_type: (indexableType) -> void
+        def resolve_update_target: (indexableType, ResolvedRelationship, ::Array[SchemaElements::Field]) -> void
+        def sourced_fields_by_relationship_name: (indexableType) -> ::Hash[::String, ::Array[SchemaElements::Field]]
+        def raise_if_errors: () -> void
+      end
+    end
+  end
+end

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/sourced_from_update_targets_resolver.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/sourced_from_update_targets_resolver.rbs
@@ -3,19 +3,16 @@ module ElasticGraph
     module Indexing
       class SourcedFromUpdateTargetsResolver
         @schema_def_state: State
-        @sourced_field_errors: ::Array[::String]
-        @relationship_errors: ::Array[::String]
-        @update_targets_by_source_type_name: ::Hash[::String, ::Array[SchemaArtifacts::RuntimeMetadata::UpdateTarget]]
 
-        def initialize: (schema_def_state: State) -> void
+        def initialize: (State) -> void
         def resolve: () -> ::Hash[::String, ::Array[SchemaArtifacts::RuntimeMetadata::UpdateTarget]]
 
         private
 
-        def resolve_for_type: (indexableType) -> void
-        def resolve_update_target: (indexableType, ResolvedRelationship, ::Array[SchemaElements::Field]) -> void
+        def resolve_for_type: (indexableType) { (::Symbol, ::String) -> void } -> ::Array[[::String, SchemaArtifacts::RuntimeMetadata::UpdateTarget]]
+        def resolve_update_target: (indexableType, ResolvedRelationship, ::Array[SchemaElements::Field]) { (::Symbol, ::String) -> void } -> [::String, SchemaArtifacts::RuntimeMetadata::UpdateTarget]?
         def sourced_fields_by_relationship_name: (indexableType) -> ::Hash[::String, ::Array[SchemaElements::Field]]
-        def raise_if_errors: () -> void
+        def raise_if_errors: (::Array[::String], ::Array[::String]) -> void
       end
     end
   end

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/results.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/results.rbs
@@ -39,7 +39,6 @@ module ElasticGraph
       def generate_datastore_config: () -> ::Hash[::String, untyped]
       def build_dynamic_scripts: () -> ::Array[Scripting::Script]
       def build_runtime_metadata: () -> SchemaArtifacts::RuntimeMetadata::Schema
-      def identify_extra_update_targets_by_object_type_name: () -> ::Hash[::String, ::Array[SchemaArtifacts::RuntimeMetadata::UpdateTarget]]
       def generate_sdl: () -> ::String
       def build_public_json_schema: () -> ::Hash[::String, untyped]
       def json_schema_indexing_field_types_by_name: () -> ::Hash[::String, Indexing::_FieldType]


### PR DESCRIPTION
## Summary

Pure refactoring PR — moves the `identify_extra_update_targets_by_object_type_name` logic out of `Results` into a dedicated `Indexing::SourcedFromUpdateTargetsResolver` class.

## Motivation

`Results` is a large class with many responsibilities. The `sourced_from` update target resolution is a self-contained concern (~75 lines) that benefits from its own class:
  - Easier to understand in isolation
  - Prepares for upcoming nested `sourced_from` support, which will add additional resolution logic to the same class

## What changed

- New `SourcedFromUpdateTargetsResolver` resolves all `sourced_from` field declarations into update targets keyed by source type name
- `Results#build_runtime_metadata` now delegates to the new class in a single line

## Test plan

- No test changes needed — this is a pure extraction with identical behavior
- Existing `sourced_from` tests in `elasticgraph-schema_definition/spec/` exercise the same code paths