### PR TITLE
Move away from pinned SHAs for flatware-rspec and filewatcher.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,10 +17,7 @@ group :development do
   gem "coderay", "~> 1.1", ">= 1.1.3"
   gem "factory_bot", "~> 6.6"
   gem "faker", "~> 3.8"
-
-  # Pin to a GitHub SHA until Ruby 4.0 support has been released
-  gem "flatware-rspec", "~> 2.3", ">= 2.3.4", github: "briandunn/flatware", ref: "0403ac1137cc7958fe06db2c0563dfbab0bd24db", platforms: :ruby
-
+  gem "flatware-rspec", "~> 2.4", platforms: :ruby
   gem "httpx", "~> 1.7", ">= 1.7.8"
   gem "memory_profiler", "~> 1.1"
   gem "nokogiri", "~> 1.19", ">= 1.19.3"
@@ -47,8 +44,7 @@ end
 
 # Documentation/website gems
 group :site do
-  # Pin to a GitHub SHA until Ruby 4.0 support has been released: https://github.com/filewatcher/filewatcher/issues/286
-  gem "filewatcher", "~> 2.1", github: "filewatcher/filewatcher", ref: "596fad65f3b442fee6cf30a3d8daf2767d63f8c9"
+  gem "filewatcher", "~> 3.0", ">= 3.0.1"
 
   platforms :ruby do
     gem "html-proofer", "~> 5.2", ">= 5.2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,4 @@
 GIT
-  remote: https://github.com/briandunn/flatware.git
-  revision: 0403ac1137cc7958fe06db2c0563dfbab0bd24db
-  ref: 0403ac1137cc7958fe06db2c0563dfbab0bd24db
-  specs:
-    flatware (2.3.4)
-      benchmark
-      drb
-      logger
-      thor (< 2.0)
-    flatware-rspec (2.3.4)
-      flatware (= 2.3.4)
-      rspec (>= 3.6)
-
-GIT
-  remote: https://github.com/filewatcher/filewatcher.git
-  revision: 596fad65f3b442fee6cf30a3d8daf2767d63f8c9
-  ref: 596fad65f3b442fee6cf30a3d8daf2767d63f8c9
-  specs:
-    filewatcher (2.1.0)
-      logger (~> 1.7)
-      module_methods (~> 0.1.0)
-
-GIT
   remote: https://github.com/myronmarston/rouge.git
   revision: 12c0da6aa98e0d0a0762c47103b64290c88620a1
   ref: 12c0da6aa98e0d0a0762c47103b64290c88620a1
@@ -354,6 +331,17 @@ GEM
       fiber-storage
     fiber-storage (1.0.1)
     fileutils (1.8.0)
+    filewatcher (3.0.1)
+      logger (~> 1.7)
+      module_methods (~> 1.0)
+    flatware (2.4.0)
+      benchmark
+      drb
+      logger
+      thor (< 2.0)
+    flatware-rspec (2.4.0)
+      flatware (= 2.4.0)
+      rspec (>= 3.8)
     forwardable-extended (2.6.0)
     google-protobuf (4.35.0)
       bigdecimal
@@ -451,7 +439,7 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    module_methods (0.1.0)
+    module_methods (1.0.0)
     multi_json (1.21.1)
     multi_json (1.21.1-java)
       concurrent-ruby (~> 1.2)
@@ -711,8 +699,8 @@ DEPENDENCIES
   elasticgraph-warehouse_lambda (= 1.2.1.pre)!
   factory_bot (~> 6.6)
   faker (~> 3.8)
-  filewatcher (~> 2.1)!
-  flatware-rspec (~> 2.3, >= 2.3.4)!
+  filewatcher (~> 3.0, >= 3.0.1)
+  flatware-rspec (~> 2.4)
   graphql-c_parser (~> 1.1, >= 1.1.3)
   html-proofer (~> 5.2, >= 5.2.1)
   httpx (~> 1.7, >= 1.7.8)
@@ -825,9 +813,9 @@ CHECKSUMS
   fiber-local (1.1.0) sha256=c885f94f210fb9b05737de65d511136ea602e00c5105953748aa0f8793489f06
   fiber-storage (1.0.1) sha256=f48e5b6d8b0be96dac486332b55cee82240057065dc761c1ea692b2e719240e1
   fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
-  filewatcher (2.1.0)
-  flatware (2.3.4)
-  flatware-rspec (2.3.4)
+  filewatcher (3.0.1) sha256=b0f51e568cf112f72392053ae5ff5afa267592489091ee9f93c20fc275597f5a
+  flatware (2.4.0) sha256=67623b700d53b2ce1d1ef98bef938600a136c804630fb2e74eade69c67e04559
+  flatware-rspec (2.4.0) sha256=5c7494fab9bdddd3edd7348cccaf6ec2a483bbe473998700f086add713182938
   forwardable-extended (2.6.0) sha256=1bec948c469bbddfadeb3bd90eb8c85f6e627a412a3e852acfd7eaedbac3ec97
   google-protobuf (4.35.0) sha256=95346162c792ed78c9a28cbf2d937a53f706de6df36a27471582f63f03c30c0d
   google-protobuf (4.35.0-arm64-darwin) sha256=66ab26d3fc82b8950702e53ab16c198e3c0ea3f2a38aaaf1f32152da45593ac5
@@ -867,7 +855,7 @@ CHECKSUMS
   metrics (0.15.0) sha256=61ded5bac95118e995b1bc9ed4a5f19bc9814928a312a85b200abbdac9039072
   mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
-  module_methods (0.1.0) sha256=71cabd8e5b8537316a2e4a543a778726f34fab048d6d5fe97f3766c7b4e406a1
+  module_methods (1.0.0) sha256=92f28a9254b8c1a7f4e68aa52242ecabdac3343ce41909aac3fcc3bf2ac8ec5e
   multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
   multi_json (1.21.1-java) sha256=45d4895647d645a64bea1fa510b50e645af1f94ec6738497127de38d40f6d968
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996


### PR DESCRIPTION
Both have released versions that support Ruby 4.0.
