### PR TITLE
Drop always-id match_field from ListPathSegment runtime metadata

### DIFF
--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/sourced_from_nested_path_segment.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/sourced_from_nested_path_segment.rb
@@ -12,7 +12,7 @@ module ElasticGraph
       # @private
       module SourcedFromNestedPathSegment
         def self.from_hash(hash)
-          if hash.key?(ListPathSegment::MATCH_FIELD)
+          if hash.key?(ListPathSegment::SOURCE_FIELD)
             ListPathSegment.from_hash(hash)
           else
             ObjectPathSegment.from_hash(hash)
@@ -21,24 +21,25 @@ module ElasticGraph
       end
 
       # Represents a segment in a nested sourced path that navigates into a list field,
-      # matching an element by a key field.
+      # matching an element by its `id` against the value at `source_field`. The match is
+      # always on `id` (relationships join on `id` via foreign keys), so it's implicit rather
+      # than stored here.
       #
       # A future PR will add `to_painless_param` to convert these segments into the
       # camelCase hash format expected by the painless script (with a "type" discriminator).
       #
       # @private
-      class ListPathSegment < ::Data.define(:field, :match_field, :source_field)
+      class ListPathSegment < ::Data.define(:field, :source_field)
         FIELD = "field"
-        MATCH_FIELD = "match_field"
         SOURCE_FIELD = "source_field"
 
         def to_dumpable_hash
           # Keys here are ordered alphabetically; please keep them that way
-          {FIELD => field, MATCH_FIELD => match_field, SOURCE_FIELD => source_field}
+          {FIELD => field, SOURCE_FIELD => source_field}
         end
 
         def self.from_hash(hash)
-          new(field: hash[FIELD], match_field: hash[MATCH_FIELD], source_field: hash[SOURCE_FIELD])
+          new(field: hash[FIELD], source_field: hash[SOURCE_FIELD])
         end
       end
 

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/sourced_from_nested_path_segment.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/sourced_from_nested_path_segment.rbs
@@ -3,15 +3,13 @@ module ElasticGraph
     module RuntimeMetadata
       class ListPathSegmentSuperType
         attr_reader field: ::String
-        attr_reader match_field: ::String
         attr_reader source_field: ::String
 
-        def initialize: (field: ::String, match_field: ::String, source_field: ::String) -> void
+        def initialize: (field: ::String, source_field: ::String) -> void
       end
 
       class ListPathSegment < ListPathSegmentSuperType
         FIELD: "field"
-        MATCH_FIELD: "match_field"
         SOURCE_FIELD: "source_field"
 
         def self.from_hash: (::Hash[::String, untyped]) -> ListPathSegment

--- a/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
+++ b/elasticgraph-schema_artifacts/spec/unit/elastic_graph/schema_artifacts/runtime_metadata/schema_spec.rb
@@ -130,7 +130,7 @@ module ElasticGraph
                 has_had_multiple_sources: false,
                 sourced_from_nested_paths_by_relationship: {
                   "currency" => [
-                    ListPathSegment.new(field: "costs", match_field: "id", source_field: "cost_id"),
+                    ListPathSegment.new(field: "costs", source_field: "cost_id"),
                     ObjectPathSegment.new(field: "details")
                   ]
                 }
@@ -281,7 +281,7 @@ module ElasticGraph
                 },
                 "sourced_from_nested_paths_by_relationship" => {
                   "currency" => [
-                    {"field" => "costs", "match_field" => "id", "source_field" => "cost_id"},
+                    {"field" => "costs", "source_field" => "cost_id"},
                     {"field" => "details"}
                   ]
                 }


### PR DESCRIPTION
## What

Removes the `match_field` attribute from `ListPathSegment` in the runtime metadata, and switches the list-vs-object segment discriminator in `SourcedFromNestedPathSegment.from_hash` from `match_field` to `source_field`.

## Why

`match_field` was always `"id"` — ElasticGraph relationships join on `id` via foreign keys, so the value carried no information. Serializing a constant into runtime metadata adds noise without value, and keeping it would have meant emitting `match_field: "id"` into `runtime_metadata.yaml` once nested sourced paths are actually populated.

This mirrors the equivalent cleanup already applied to the schema-definition `PathSegment` in #1238. The match is now implicit: list elements are matched on `id` against the value at `source_field`. If non-`id` primary keys are supported in the future, the field can be reintroduced then.

## Scope / risk

Low. `ListPathSegment` is not yet constructed by any production code — only by the round-trip serialization unit test — so there is no schema-artifact churn and nothing downstream consumes the removed field. Specs and type checks pass.