### PR TITLE
Support dotted embedding paths in nested sourced_from relationship chains

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/relationship_chain_resolver.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/relationship_chain_resolver.rb
@@ -76,9 +76,9 @@ module ElasticGraph
 
         private
 
-        # Recursively walks from leaf to root, collecting relationships and building path segments in reverse.
-        # Returns the root relationship (the one with no parent_ref) on success, or nil if an error was
-        # encountered.
+        # Recursively walks from leaf to root, collecting relationships and their path segments (leaf-to-root;
+        # `resolve` reverses both to root-to-leaf). Returns the root relationship (the one with no parent_ref) on
+        # success, or nil if an error was encountered.
         def resolve_chain(current_rel, path_segments, relationships, errors)
           relationships << current_rel
 
@@ -88,7 +88,7 @@ module ElasticGraph
           parent_rel = resolve_parent_ref(current_rel, parent_ref, relationships, errors)
           return nil unless parent_rel
 
-          build_path_segment(current_rel, parent_rel.parent_type, path_segments, errors)
+          append_path_segments(current_rel, parent_rel.parent_type, path_segments, errors)
           return nil if errors.any?
 
           resolve_chain(parent_rel, path_segments, relationships, errors)
@@ -136,41 +136,49 @@ module ElasticGraph
           parent_rel
         end
 
-        # Builds a PathSegment for the current level and appends it to path_segments.
-        # Uses the explicitly specified field name if provided, otherwise auto-discovers it.
-        def build_path_segment(current_rel, parent_type, path_segments, errors)
-          parent_ref = current_rel.parent_ref # : SchemaElements::Relationship::ParentRef
-          field = resolve_field(parent_ref, parent_type, current_rel, errors)
-          return unless field
+        # Builds this link's PathSegment(s) and appends them to path_segments. The embedding field may be a dotted
+        # path through intermediate object fields, so each path component becomes a segment.
+        # Only the final field, when a list, identifies which element to update: it carries the relationship's
+        # foreign key, matched against the element's `id`. A list before the final field would need its own match
+        # value that a single link can't supply, so it's rejected.
+        def append_path_segments(current_rel, parent_type, path_segments, errors)
+          *leading_fields, leaf_field = resolve_embedding_fields(current_rel, parent_type, errors)
+          return unless leaf_field
 
-          # For list fields, `source_field_name` identifies which element to update: the one whose
-          # `id` matches `event[source_field_name]`. We implicitly match on `id` because ElasticGraph
-          # relationships always join on `id` via foreign keys. For non-list fields, it's nil since
-          # there's no ambiguity.
-          path_segments << if field.type.list?
-            PathSegment.new(
-              field: field,
-              source_field_name: current_rel.foreign_key
-            )
-          else
-            PathSegment.new(
-              field: field,
-              source_field_name: nil
-            )
+          if (intermediate_list = leading_fields.find { |field| field.type.list? })
+            errors << "#{rel_description(current_rel)} embeds through list field `#{parent_type.name}.#{intermediate_list.name}` " \
+              "via `parent_relationship`, but only the final embedding field may be a list. To source through an " \
+              "intermediate list, give its embedded type its own `relates_to_one`/`relates_to_many` to the source " \
+              "type with a `parent_relationship`, so that list level is matched by its own foreign key."
+            return
           end
+
+          leaf_foreign_key = current_rel.foreign_key if leaf_field.type.list?
+          link_segments =
+            leading_fields.map { |field| PathSegment.new(field: field, source_field_name: nil) } +
+            [PathSegment.new(field: leaf_field, source_field_name: leaf_foreign_key)]
+
+          # `resolve_chain` walks leaf-to-root and reverses the whole list once at the end, so append this link's
+          # segments reversed for that final reverse to restore root-to-leaf order within the link.
+          path_segments.concat(link_segments.reverse)
         end
 
-        def resolve_field(parent_ref, parent_type, current_rel, errors)
-          if parent_ref.field_name
-            field = parent_type.indexing_fields_by_name_in_index[parent_ref.field_name]
-            unless field
-              errors << "#{rel_description(current_rel)} references field `#{parent_type.name}.#{parent_ref.field_name}` " \
-                "via `parent_relationship`, but that field does not exist."
-            end
-            field
-          else
-            find_field_by_type(parent_type, current_rel, errors)
+        # Resolves this link's embedding field(s) on `parent_type`, one per dotted-path component. An explicit
+        # `parent_field_name` is resolved by public name (consistent with `sourced_from` and `equivalent_field`);
+        # the resolved `name_in_index` is what flows into the qualified relationship and the painless script.
+        # Returns `[]` (and records an error) when it doesn't resolve.
+        def resolve_embedding_fields(current_rel, parent_type, errors)
+          parent_ref = current_rel.parent_ref # : SchemaElements::Relationship::ParentRef
+          field_name = parent_ref.field_name
+          return [find_field_by_type(parent_type, current_rel, errors)].compact unless field_name
+
+          field_path = @schema_def_state.field_path_resolver.resolve_public_path(parent_type, field_name) { true }
+          unless field_path
+            errors << "#{rel_description(current_rel)} references field `#{parent_type.name}.#{field_name}` " \
+              "via `parent_relationship`, but that field does not exist."
+            return [] # : ::Array[SchemaElements::Field]
           end
+          field_path.path_parts
         end
 
         def find_field_by_type(parent_type, current_rel, errors)

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/relationship_chain_resolver.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/relationship_chain_resolver.rb
@@ -88,7 +88,7 @@ module ElasticGraph
           parent_rel = resolve_parent_ref(current_rel, parent_ref, relationships, errors)
           return nil unless parent_rel
 
-          append_path_segments(current_rel, parent_rel.parent_type, path_segments, errors)
+          path_segments.concat(build_path_segments(current_rel, parent_rel.parent_type, errors))
           return nil if errors.any?
 
           resolve_chain(parent_rel, path_segments, relationships, errors)
@@ -136,48 +136,53 @@ module ElasticGraph
           parent_rel
         end
 
-        # Builds this link's PathSegment(s) and appends them to path_segments. The embedding field may be a dotted
-        # path through intermediate object fields, so each path component becomes a segment.
-        # Only the final field, when a list, identifies which element to update: it carries the relationship's
-        # foreign key, matched against the element's `id`. A list before the final field would need its own match
-        # value that a single link can't supply, so it's rejected.
-        def append_path_segments(current_rel, parent_type, path_segments, errors)
-          *leading_fields, leaf_field = resolve_embedding_fields(current_rel, parent_type, errors)
-          return unless leaf_field
+        # Builds this link's PathSegment(s). The embedding field may be a dotted path through intermediate object
+        # fields, so each path component becomes a segment. Only the final field, when a list, identifies which
+        # element to update: it carries the relationship's foreign key, matched against the element's `id`.
+        def build_path_segments(current_rel, parent_type, errors)
+          parts = resolve_embedding_fields(current_rel, parent_type, errors)
 
-          if (intermediate_list = leading_fields.find { |field| field.type.list? })
-            errors << "#{rel_description(current_rel)} embeds through list field `#{parent_type.name}.#{intermediate_list.name}` " \
-              "via `parent_relationship`, but only the final embedding field may be a list. To source through an " \
-              "intermediate list, give its embedded type its own `relates_to_one`/`relates_to_many` to the source " \
-              "type with a `parent_relationship`, so that list level is matched by its own foreign key."
-            return
+          link_segments = parts.map.with_index(1) do |field, index|
+            source_field_name = current_rel.foreign_key if index == parts.size && field.type.list?
+            PathSegment.new(field: field, source_field_name: source_field_name)
           end
 
-          leaf_foreign_key = current_rel.foreign_key if leaf_field.type.list?
-          link_segments =
-            leading_fields.map { |field| PathSegment.new(field: field, source_field_name: nil) } +
-            [PathSegment.new(field: leaf_field, source_field_name: leaf_foreign_key)]
-
-          # `resolve_chain` walks leaf-to-root and reverses the whole list once at the end, so append this link's
-          # segments reversed for that final reverse to restore root-to-leaf order within the link.
-          path_segments.concat(link_segments.reverse)
+          # `resolve_chain` walks leaf-to-root and reverses the whole list once at the end, so reverse
+          # the link segments to restore root-to-leaf order within the link.
+          link_segments.reverse
         end
 
         # Resolves this link's embedding field(s) on `parent_type`, one per dotted-path component. An explicit
         # `parent_field_name` is resolved by public name (consistent with `sourced_from` and `equivalent_field`);
         # the resolved `name_in_index` is what flows into the qualified relationship and the painless script.
+        #
+        # Only the final path component may be a list: it carries the relationship's foreign key, matched against
+        # the element's `id`. An intermediate list would need its own match value that a single link can't supply,
+        # so we refuse to descend through it (which halts `resolve_public_path`) and report the dedicated error.
         # Returns `[]` (and records an error) when it doesn't resolve.
         def resolve_embedding_fields(current_rel, parent_type, errors)
           parent_ref = current_rel.parent_ref # : SchemaElements::Relationship::ParentRef
           field_name = parent_ref.field_name
           return [find_field_by_type(parent_type, current_rel, errors)].compact unless field_name
 
-          field_path = @schema_def_state.field_path_resolver.resolve_public_path(parent_type, field_name) { true }
+          field_path = @schema_def_state.field_path_resolver.resolve_public_path(parent_type, field_name) do |parent_field|
+            if parent_field.type.list?
+              errors << "#{rel_description(current_rel)} embeds through list field `#{parent_field.parent_type.name}.#{parent_field.name}` " \
+                "via `parent_relationship`, but only the final embedding field may be a list. To source through an " \
+                "intermediate list, give its embedded type its own `relates_to_one`/`relates_to_many` to the source " \
+                "type with a `parent_relationship`, so that list level is matched by its own foreign key."
+              return [] # : ::Array[SchemaElements::Field]
+            end
+
+            true
+          end
+
           unless field_path
             errors << "#{rel_description(current_rel)} references field `#{parent_type.name}.#{field_name}` " \
               "via `parent_relationship`, but that field does not exist."
             return [] # : ::Array[SchemaElements::Field]
           end
+
           field_path.path_parts
         end
 

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/relationship_chain_resolver.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/relationship_chain_resolver.rbs
@@ -34,12 +34,11 @@ module ElasticGraph
           ::Array[::String]
         ) -> SchemaElements::Relationship?
 
-        def append_path_segments: (
+        def build_path_segments: (
           SchemaElements::Relationship,
           indexableType,
-          ::Array[PathSegment],
           ::Array[::String]
-        ) -> void
+        ) -> ::Array[PathSegment]
 
         def resolve_embedding_fields: (SchemaElements::Relationship, indexableType, ::Array[::String]) -> ::Array[SchemaElements::Field]
         def find_field_by_type: (indexableType, SchemaElements::Relationship, ::Array[::String]) -> SchemaElements::Field?

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/relationship_chain_resolver.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/relationship_chain_resolver.rbs
@@ -34,14 +34,14 @@ module ElasticGraph
           ::Array[::String]
         ) -> SchemaElements::Relationship?
 
-        def build_path_segment: (
+        def append_path_segments: (
           SchemaElements::Relationship,
           indexableType,
           ::Array[PathSegment],
           ::Array[::String]
         ) -> void
 
-        def resolve_field: (SchemaElements::Relationship::ParentRef, indexableType, SchemaElements::Relationship, ::Array[::String]) -> SchemaElements::Field?
+        def resolve_embedding_fields: (SchemaElements::Relationship, indexableType, ::Array[::String]) -> ::Array[SchemaElements::Field]
         def find_field_by_type: (indexableType, SchemaElements::Relationship, ::Array[::String]) -> SchemaElements::Field?
         def rel_description: (SchemaElements::Relationship) -> ::String
       end

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/update_targets_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/update_targets_spec.rb
@@ -1959,9 +1959,9 @@ module ElasticGraph
           # `StatLine` is the source type, so its metadata carries the nested update targets we assert on.
           object_type_metadata_for "StatLine" do |s|
             if embed_players_under
-              s.object_type "TeamNestedFields" do |t|
+              s.object_type s.state.type_ref(embed_players_under).fully_unwrapped.name do |t|
                 t.field "players", players_field do |f|
-                  f.mapping type: "object" if players_field.start_with?("[")
+                  f.mapping type: "object" if f.type.list?
                 end
               end
             end
@@ -1971,11 +1971,11 @@ module ElasticGraph
 
               if embed_players_under
                 t.field "nested", embed_players_under do |f|
-                  f.mapping type: "object" if embed_players_under.start_with?("[")
+                  f.mapping type: "object" if f.type.list?
                 end
               elsif players_field
                 t.field "players", players_field do |f|
-                  f.mapping type: "object" if players_field.start_with?("[")
+                  f.mapping type: "object" if f.type.list?
                 end
               end
 

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/update_targets_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/update_targets_spec.rb
@@ -1513,6 +1513,64 @@ module ElasticGraph
             expect_statline_update_target_with(metadata)
           end
 
+          it "resolves a `parent_field_name` by public field name even when the embedding field has a distinct `name_in_index`" do
+            metadata = nested_sourced_from_schema(
+              on_team: ->(t) {
+                t.field "players", "[Player!]!", name_in_index: "the_players" do |f|
+                  f.mapping type: "object"
+                end
+              },
+              players_field: nil,
+              on_player_relationship: ->(r) { r.parent_relationship "Team", "statLines", parent_field_name: "players" }
+            )
+
+            expect_statline_update_target_with(metadata, relationship: "the_players.statLine")
+          end
+
+          context "when the embedding field is reached via a dotted `parent_field_name` path" do
+            it "descends an object segment to a leaf list segment, keying the target by the full qualified relationship" do
+              metadata = nested_sourced_from_schema(
+                embed_players_under: "TeamNestedFields",
+                on_player_relationship: ->(r) { r.parent_relationship "Team", "statLines", parent_field_name: "nested.players" }
+              )
+
+              expect_statline_update_target_with(metadata, relationship: "nested.players.statLine")
+            end
+
+            it "omits `path_identifier_params` when the leaf of the dotted path is an object (not a list)" do
+              metadata = nested_sourced_from_schema(
+                embed_players_under: "TeamNestedFields",
+                players_field: "Player!",
+                on_player_relationship: ->(r) { r.parent_relationship "Team", "statLines", parent_field_name: "nested.players" }
+              )
+
+              expect_statline_update_target_with(metadata, relationship: "nested.players.statLine", path_identifier_params: {})
+            end
+
+            it "raises a clear error pointing at the multi-link solution when an intermediate segment is a list" do
+              expect {
+                nested_sourced_from_schema(
+                  embed_players_under: "[TeamNestedFields!]!",
+                  on_player_relationship: ->(r) { r.parent_relationship "Team", "statLines", parent_field_name: "nested.players" }
+                )
+              }.to raise_error Errors::SchemaError, a_string_including(
+                "`Player.statLine` embeds through list field `Team.nested` via `parent_relationship`, but only the final embedding field may be a list.",
+                "give its embedded type its own `relates_to_one`/`relates_to_many` to the source type with a `parent_relationship`"
+              )
+            end
+
+            it "raises a clear error when the dotted path does not resolve to a field" do
+              expect {
+                nested_sourced_from_schema(
+                  embed_players_under: "TeamNestedFields",
+                  on_player_relationship: ->(r) { r.parent_relationship "Team", "statLines", parent_field_name: "nested.nonexistent" }
+                )
+              }.to raise_error Errors::SchemaError, a_string_including(
+                "`Player.statLine` references field `Team.nested.nonexistent` via `parent_relationship`, but that field does not exist."
+              )
+            end
+          end
+
           it "raises an error when `parent_relationship` is called twice on the same relationship" do
             expect {
               nested_sourced_from_schema(
@@ -1633,6 +1691,77 @@ module ElasticGraph
             # The qualified relationship spans every embedding field from the root index down to the leaf,
             # proving the chain recursed through all four levels.
             expect(nested_update_targets_by_relationship(metadata).keys).to contain_exactly("teams.players.gameAppearances.statLine")
+          end
+
+          it "resolves a deeply nested chain mixing object dotted-path hops, multiple list links, and `name_in_index` renames" do
+            # Embedding path (root -> leaf), * = list level. Each list level is its own `parent_relationship` link;
+            # the object hops are folded into the links' dotted `parent_field_name`s:
+            #   Team .roster(the_roster) .squads* .lineup .players(the_players)* -> Player.goals (sourced)
+            metadata =
+              object_type_metadata_for "StatLine" do |s|
+                s.object_type "Team" do |t|
+                  t.field "id", "ID!"
+                  t.field "roster", "Roster", name_in_index: "the_roster"
+                  t.relates_to_many "statLines", "StatLine", via: "teamId", dir: :in, indexing_only: true
+                  t.index("teams") { |i| i.has_had_multiple_sources! }
+                end
+
+                s.object_type "Roster" do |t|
+                  t.field "squads", "[Squad!]!" do |f|
+                    f.mapping type: "object"
+                  end
+                end
+
+                s.object_type "Squad" do |t|
+                  t.field "id", "ID!"
+                  t.field "lineup", "Lineup"
+                  t.relates_to_many "statLines", "StatLine", via: "squadId", dir: :in, indexing_only: true do |r|
+                    r.parent_relationship "Team", "statLines", parent_field_name: "roster.squads"
+                  end
+                end
+
+                s.object_type "Lineup" do |t|
+                  t.field "players", "[Player!]!", name_in_index: "the_players" do |f|
+                    f.mapping type: "object"
+                  end
+                end
+
+                s.object_type "Player" do |t|
+                  t.field "id", "ID!"
+                  t.field "goals", "Int" do |f|
+                    f.sourced_from "statLine", "stats.goals"
+                  end
+                  t.relates_to_one "statLine", "StatLine", via: "playerId", dir: :in, indexing_only: true do |r|
+                    r.parent_relationship "Squad", "statLines", parent_field_name: "lineup.players"
+                  end
+                end
+
+                s.object_type "StatLineStats" do |t|
+                  t.field "goals", "Int"
+                end
+
+                s.object_type "StatLine" do |t|
+                  t.field "id", "ID!"
+                  t.field "teamId", "ID"
+                  t.field "squadId", "ID"
+                  t.field "playerId", "ID"
+                  t.field "stats", "StatLineStats"
+                  t.index "stat_lines"
+                end
+              end
+
+            target = nested_update_targets_by_relationship(metadata).fetch("the_roster.squads.lineup.the_players.statLine")
+
+            expect(target.type).to eq "Team"
+            expect(target.id_source).to eq "teamId"
+            expect(target.sourced_from_nested_params.field_params).to eq(
+              "goals" => dynamic_param_with(source_path: "stats.goals", cardinality: :one)
+            )
+            # One identifier per list level; the object hops contribute none.
+            expect(target.sourced_from_nested_params.path_identifier_params).to eq(
+              "squadId" => dynamic_param_with(source_path: "squadId", cardinality: :one),
+              "playerId" => dynamic_param_with(source_path: "playerId", cardinality: :one)
+            )
           end
 
           it "raises an error when the parent type does not exist" do
@@ -1816,6 +1945,7 @@ module ElasticGraph
           on_player_relationship: ->(r) { r.parent_relationship "Team", "statLines" },
           player_indexing_only: true,
           players_field: "[Player!]!",
+          embed_players_under: nil,
           index_teams: true,
           index_players: false,
           multiple_sources: true,
@@ -1828,10 +1958,22 @@ module ElasticGraph
         )
           # `StatLine` is the source type, so its metadata carries the nested update targets we assert on.
           object_type_metadata_for "StatLine" do |s|
+            if embed_players_under
+              s.object_type "TeamNestedFields" do |t|
+                t.field "players", players_field do |f|
+                  f.mapping type: "object" if players_field.start_with?("[")
+                end
+              end
+            end
+
             s.object_type "Team" do |t|
               t.field "id", "ID!"
 
-              if players_field
+              if embed_players_under
+                t.field "nested", embed_players_under do |f|
+                  f.mapping type: "object" if embed_players_under.start_with?("[")
+                end
+              elsif players_field
                 t.field "players", players_field do |f|
                   f.mapping type: "object" if players_field.start_with?("[")
                 end


### PR DESCRIPTION
 ## Why

The nested `sourced_from` feature is meant to work for any schema, but as merged it only handled embedding fields that sit directly on each relationship's parent type. Real schemas can nest the embedded type one or more object levels down — e.g. a list of `Player`s reached via `roster.players` rather than a top-level `players` field. In that case, resolving the `parent_relationship` failed with a "field does not exist" error, so you simply couldn't source into a nested element unless it happened to be a direct field.

This closes that gap: an embedding field referenced via `parent_field_name` may now be a dotted path that descends through intermediate object fields. The embedding path is expanded into one navigation segment per component, so the sourced data can reach elements nested arbitrarily deep.

## Scope / behavior notes

- Intermediate lists are rejected (only the final embedding field may be a list), with an error that points at the supported alternative — model the intermediate list as its own `parent_relationship` link, so each list level is matched by its own foreign key. Multi-link chains already support arbitrary list nesting this way.
- Naming convention: `parent_field_name` now resolves by the field's declared name, consistent with how `sourced_from` source paths and `equivalent_field` already resolve. Previously it incidentally required the internal `name_in_index`. Note "declared name" is not the same as "exposed in GraphQL" — `indexing_only` embedding fields are still resolvable, since they have a declared name even though they're hidden from the schema. 

## Testing

Unit coverage added for: object→list and object-leaf dotted paths, public-name resolution with a distinct `name_in_index`, the intermediate-list rejection, an unresolvable path, and a deeply nested chain that mixes object hops, multiple list links, and `name_in_index` renames.