### PR TITLE
Cover warehouse factory extension no-block paths

### DIFF
--- a/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/factory_extension.rb
+++ b/elasticgraph-warehouse/lib/elastic_graph/warehouse/schema_definition/factory_extension.rb
@@ -28,9 +28,7 @@ module ElasticGraph
         def new_enum_type(name)
           super(name) do |type|
             type.extend EnumTypeExtension
-            # :nocov: -- currently all invocations have a block
             yield type if block_given?
-            # :nocov:
           end
         end
 
@@ -59,9 +57,7 @@ module ElasticGraph
         def new_interface_type(name)
           super(name) do |type|
             type.extend ObjectInterfaceAndUnionExtension
-            # :nocov: -- currently all invocations have a block
             yield type if block_given?
-            # :nocov:
           end
         end
 
@@ -73,9 +69,7 @@ module ElasticGraph
         def new_object_type(name)
           super(name) do |type|
             type.extend ObjectInterfaceAndUnionExtension
-            # :nocov: -- currently all invocations have a block
             yield type if block_given?
-            # :nocov:
           end
         end
 
@@ -87,9 +81,7 @@ module ElasticGraph
         def new_scalar_type(name)
           super(name) do |type|
             type.extend ScalarTypeExtension
-            # :nocov: -- currently all invocations have a block
             yield type if block_given?
-            # :nocov:
           end
         end
 
@@ -101,9 +93,7 @@ module ElasticGraph
         def new_union_type(name)
           super(name) do |type|
             type.extend ObjectInterfaceAndUnionExtension
-            # :nocov: -- currently all invocations have a block
             yield type if block_given?
-            # :nocov:
           end
         end
 

--- a/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/factory_extension_spec.rb
+++ b/elasticgraph-warehouse/spec/unit/elastic_graph/warehouse/schema_definition/factory_extension_spec.rb
@@ -1,0 +1,60 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/spec_support/schema_definition_helpers"
+require "elastic_graph/warehouse/schema_definition/api_extension"
+
+module ElasticGraph
+  module Warehouse
+    module SchemaDefinition
+      RSpec.describe FactoryExtension do
+        include_context "SchemaDefinitionHelpers"
+
+        it "extends enum types created without customization blocks" do
+          define_schema(schema_element_name_form: "snake_case", extension_modules: [APIExtension]) do |api|
+            api.enum_type "Status"
+
+            expect(api.state.enum_types_by_name.fetch("Status")).to be_a(EnumTypeExtension)
+          end
+        end
+
+        it "extends interface types created without customization blocks" do
+          define_schema(schema_element_name_form: "snake_case", extension_modules: [APIExtension]) do |api|
+            api.interface_type "Identifiable"
+
+            expect(api.state.object_types_by_name.fetch("Identifiable")).to be_a(ObjectInterfaceAndUnionExtension)
+          end
+        end
+
+        it "extends object types created without customization blocks" do
+          define_schema(schema_element_name_form: "snake_case", extension_modules: [APIExtension]) do |api|
+            api.object_type "Widget"
+
+            expect(api.state.object_types_by_name.fetch("Widget")).to be_a(ObjectInterfaceAndUnionExtension)
+          end
+        end
+
+        it "allows scalar type validation to fail normally without a customization block" do
+          define_schema(schema_element_name_form: "snake_case", extension_modules: [APIExtension]) do |api|
+            expect {
+              api.scalar_type "Money"
+            }.to raise_error(Errors::SchemaError, a_string_including("Scalar types require `mapping` to be configured"))
+          end
+        end
+
+        it "extends union types created without customization blocks" do
+          define_schema(schema_element_name_form: "snake_case", extension_modules: [APIExtension]) do |api|
+            api.union_type "SearchResult"
+
+            expect(api.state.object_types_by_name.fetch("SearchResult")).to be_a(ObjectInterfaceAndUnionExtension)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Remove `:nocov:` exclusions around optional-yield guards in the warehouse factory extension.
- Add focused unit coverage for schema elements created without customization blocks.

## Validation

- `script/lint`
- `script/type_check`
- `script/run_gem_specs elasticgraph-warehouse`
