### PR TITLE
Fix stray double quote in SearchFailedError message

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_search_router.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_search_router.rb
@@ -153,7 +153,7 @@ module ElasticGraph
           # or other sensitive values that we don't want logged.
           <<~ERROR
             #{index + 1}) Header: #{::JSON.generate(query.to_datastore_msearch_header)}
-            #{response.fetch("error").inspect}"
+            #{response.fetch("error").inspect}
             On cluster: #{query.cluster_name}
           ERROR
         end.join("\n\n")

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
@@ -209,7 +209,9 @@ module ElasticGraph
             "2) ", '{"index":"widgets_rollover__*"}', '{"bad stuff" => "happened"}'
           ).and(excluding(
             # These are parts of the body of the request, which we don't want included because it could contain PII!.
-            "track_total_hits", "size"
+            "track_total_hits", "size",
+            # The error should not contain a stray double quote dangling after the inspected error hash.
+            '{"bad stuff" => "happened"}"'
           )))
         end
 


### PR DESCRIPTION
## What

The heredoc that formats datastore search failures in `DatastoreSearchRouter#raise_search_failed_if_any_failures` had a dangling `"` immediately after the inspected error hash:

```ruby
#{response.fetch("error").inspect}"
```

This leaked a literal double quote into the operator-facing `Errors::SearchFailedError` message (e.g. `{"bad stuff" => "happened"}"`).

## Changes

- Removed the stray `"` from the heredoc in `elasticgraph-graphql/lib/elastic_graph/graphql/datastore_search_router.rb`.
- Extended the existing "raises `Errors::SearchFailedError`" spec to assert the message does **not** contain the dangling quote, guarding against regression.

## Testing

```
bundle exec rspec elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
# 22 examples, 0 failures
```