### PR TITLE
Simplify sort-clause de-duplication and document single-key invariant

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
@@ -283,9 +283,11 @@ module ElasticGraph
 
       def remove_duplicate_sort_clauses(sort_clauses)
         seen_fields = Set.new
-        sort_clauses.select do |clause|
-          clause.keys.all? { |key| seen_fields.add?(key) }
-        end
+        # Each sort clause is a single-key hash (enforced upstream by
+        # `DecodedCursor::Factory.from_sort_list`), so we keep a clause only when its field
+        # hasn't already been used by an earlier clause. `Set#add?` returns `nil` (falsey)
+        # when the field was already present, which drops the duplicate clause.
+        sort_clauses.select { |clause| seen_fields.add?(clause.keys.first) }
       end
 
       def decoded_cursor_factory


### PR DESCRIPTION
## What

`DatastoreQuery#remove_duplicate_sort_clauses` used:

```ruby
sort_clauses.select do |clause|
  clause.keys.all? { |key| seen_fields.add?(key) }
end
```

This relied on `Set#add?`'s side effect *inside* `all?`, conflating filtering with mutation. For a multi-key clause, `all?` short-circuits as soon as a previously-seen key is encountered, leaving the remaining keys of that clause **unrecorded** in `seen_fields` — a subtle correctness bug.

In practice this branch is unreachable: sort clauses are always single-key, enforced upstream by `DecodedCursor::Factory.from_sort_list`, which raises `Errors::InvalidSortFieldsError` ("Each must be a flat hash with one entry") for anything else.

## Changes

- Simplified the method to operate directly on the single key via `seen_fields.add?(clause.keys.first)`.
- Added a comment documenting the single-key invariant and why `add?` correctly drops duplicates.

This follows the project guideline to *avoid defensive code for impossible cases* rather than adding multi-key handling for a scenario that can't occur.

## Testing

```
bundle exec rspec elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/sorting_spec.rb \
                  elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/merge_spec.rb
# 45 examples, 0 failures
```