### PR TITLE
Group JSON ingestion schema state

### DIFF
--- a/config/site/support/doctest_helper.rb
+++ b/config/site/support/doctest_helper.rb
@@ -97,7 +97,7 @@ module ElasticGraph
       ElasticGraph.define_schema do |schema|
         # `schema.json_schema_version` raises an error when the version is set more than once.
         # By default we set it above. Here we clear it to allow our example to set it.
-        schema.state.json_schema_version = nil
+        schema.state.json_ingestion_state.json_schema_version = nil
       end
     end
 

--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/api_extension.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/api_extension.rb
@@ -64,18 +64,18 @@ module ElasticGraph
         #     schema.json_schema_version 1
         #   end
         def json_schema_version(version)
-          state = json_ingestion_state
+          ingestion_state = json_ingestion_state
 
           if !version.is_a?(Integer) || version < 1
             raise Errors::SchemaError, "`json_schema_version` must be a positive integer. Specified version: #{version}"
           end
 
-          if state.json_schema_version
-            raise Errors::SchemaError, "`json_schema_version` can only be set once on a schema. Previously-set version: #{state.json_schema_version}"
+          if ingestion_state.json_schema_version
+            raise Errors::SchemaError, "`json_schema_version` can only be set once on a schema. Previously-set version: #{ingestion_state.json_schema_version}"
           end
 
-          state.json_schema_version = version
-          state.json_schema_version_setter_location = caller_locations(1, 1).to_a.first
+          ingestion_state.json_schema_version = version
+          ingestion_state.json_schema_version_setter_location = caller_locations(1, 1).to_a.first
           nil
         end
 
@@ -128,7 +128,7 @@ module ElasticGraph
         #     schema.json_schema_strictness allow_omitted_fields: true, allow_extra_fields: false
         #   end
         def json_schema_strictness(allow_omitted_fields: false, allow_extra_fields: true)
-          state = json_ingestion_state
+          ingestion_state = json_ingestion_state
 
           unless [true, false].include?(allow_omitted_fields)
             raise Errors::SchemaError, "`allow_omitted_fields` must be true or false"
@@ -138,8 +138,8 @@ module ElasticGraph
             raise Errors::SchemaError, "`allow_extra_fields` must be true or false"
           end
 
-          state.allow_omitted_json_schema_fields = allow_omitted_fields
-          state.allow_extra_json_schema_fields = allow_extra_fields
+          ingestion_state.allow_omitted_json_schema_fields = allow_omitted_fields
+          ingestion_state.allow_extra_json_schema_fields = allow_extra_fields
           nil
         end
 
@@ -167,11 +167,11 @@ module ElasticGraph
 
         private
 
-        # Returns the API's `state` narrowed to include this gem's `StateExtension`. Centralizes
-        # the Steep cast that's needed because Steep can't see the `extend(StateExtension)` applied
-        # at runtime in `extended`.
+        # Returns the API's JSON ingestion state. Centralizes the Steep cast that's needed
+        # because Steep can't see the `extend(StateExtension)` applied at runtime in `extended`.
         def json_ingestion_state
-          state # : ElasticGraph::SchemaDefinition::State & StateExtension
+          extension_state = state # : ElasticGraph::SchemaDefinition::State & StateExtension
+          extension_state.json_ingestion_state
         end
       end
     end

--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/indexing/field_type/object.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/indexing/field_type/object.rb
@@ -57,7 +57,8 @@ module ElasticGraph
                   json_schema_subfields = json_schema_candidate_subfields.reject(&:runtime_field_script)
                   required_fields = json_schema_subfields
                   state = schema_def_state # : ::ElasticGraph::SchemaDefinition::State & ::ElasticGraph::JSONIngestion::SchemaDefinition::StateExtension
-                  required_fields = required_fields.reject(&:nullable?) if state.allow_omitted_json_schema_fields
+                  json_ingestion_state = state.json_ingestion_state
+                  required_fields = required_fields.reject(&:nullable?) if json_ingestion_state.allow_omitted_json_schema_fields
 
                   {
                     "type" => "object",
@@ -66,7 +67,7 @@ module ElasticGraph
                     # we want it validated (as we do by merging in `json_schema_typename_field`) but we only want
                     # to require it in the context of a union type. The union's JSON schema requires the field.
                     "required" => required_fields.map(&:name).freeze,
-                    "additionalProperties" => (false unless state.allow_extra_json_schema_fields),
+                    "additionalProperties" => (false unless json_ingestion_state.allow_extra_json_schema_fields),
                     "description" => doc_comment
                   }.compact.freeze
                 else

--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/indexing/json_schema_with_metadata.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/indexing/json_schema_with_metadata.rb
@@ -52,13 +52,14 @@ module ElasticGraph
             attr_reader :unused_deprecated_elements
 
             def initialize(schema_def_results)
-              json_ingestion_state = schema_def_results.state # : ::ElasticGraph::SchemaDefinition::State & SchemaDefinition::StateExtension
+              state = schema_def_results.state # : ::ElasticGraph::SchemaDefinition::State & SchemaDefinition::StateExtension
+              json_ingestion_state = state.json_ingestion_state
               @field_metadata_by_type_and_field_name = schema_def_results.json_schema_field_metadata_by_type_and_field_name
               @renamed_types_by_old_name = json_ingestion_state.renamed_types_by_old_name
               @deleted_types_by_old_name = json_ingestion_state.deleted_types_by_old_name
               @renamed_fields_by_type_name_and_old_field_name = json_ingestion_state.renamed_fields_by_type_name_and_old_field_name
               @deleted_fields_by_type_name_and_old_field_name = json_ingestion_state.deleted_fields_by_type_name_and_old_field_name
-              @state = schema_def_results.state
+              @state = state
               @derived_indexing_type_names = schema_def_results.derived_indexing_type_names
 
               @unused_deprecated_elements = (

--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/json_ingestion_state.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/json_ingestion_state.rb
@@ -1,0 +1,81 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/json_ingestion/schema_definition/deprecated_element"
+
+module ElasticGraph
+  module JSONIngestion
+    module SchemaDefinition
+      # Holds the JSON ingestion extension's schema definition state.
+      #
+      # @private
+      class JSONIngestionState
+        # @dynamic json_schema_version, json_schema_version=
+        # @dynamic json_schema_version_setter_location, json_schema_version_setter_location=
+        # @dynamic enforce_json_schema_version, enforce_json_schema_version=
+        # @dynamic allow_omitted_json_schema_fields, allow_omitted_json_schema_fields=
+        # @dynamic allow_extra_json_schema_fields, allow_extra_json_schema_fields=
+        # @dynamic renamed_types_by_old_name, deleted_types_by_old_name
+        # @dynamic renamed_fields_by_type_name_and_old_field_name, deleted_fields_by_type_name_and_old_field_name
+        attr_accessor :json_schema_version, :json_schema_version_setter_location, :enforce_json_schema_version, :allow_omitted_json_schema_fields, :allow_extra_json_schema_fields
+        attr_reader :renamed_types_by_old_name, :deleted_types_by_old_name, :renamed_fields_by_type_name_and_old_field_name, :deleted_fields_by_type_name_and_old_field_name
+
+        def initialize(schema_def_state:)
+          @schema_def_state = schema_def_state
+          @json_schema_version = nil
+          @json_schema_version_setter_location = nil
+          @enforce_json_schema_version = true
+          @allow_omitted_json_schema_fields = false
+          @allow_extra_json_schema_fields = true
+          @renamed_types_by_old_name = {}
+          @deleted_types_by_old_name = {}
+          @renamed_fields_by_type_name_and_old_field_name = ::Hash.new { |h, k| h[k] = {} }
+          @deleted_fields_by_type_name_and_old_field_name = ::Hash.new { |h, k| h[k] = {} }
+        end
+
+        def register_renamed_type(type_name, from:, defined_at:, defined_via:)
+          renamed_types_by_old_name[from] = DeprecatedElement.new(
+            schema_def_state: @schema_def_state,
+            name: type_name,
+            defined_at: defined_at,
+            defined_via: defined_via
+          )
+        end
+
+        def register_deleted_type(type_name, defined_at:, defined_via:)
+          deleted_types_by_old_name[type_name] = DeprecatedElement.new(
+            schema_def_state: @schema_def_state,
+            name: type_name,
+            defined_at: defined_at,
+            defined_via: defined_via
+          )
+        end
+
+        def register_renamed_field(type_name, from:, to:, defined_at:, defined_via:)
+          renamed_fields_by_old_field_name = renamed_fields_by_type_name_and_old_field_name[type_name]
+          renamed_fields_by_old_field_name[from] = DeprecatedElement.new(
+            schema_def_state: @schema_def_state,
+            name: to,
+            defined_at: defined_at,
+            defined_via: defined_via
+          )
+        end
+
+        def register_deleted_field(type_name, field_name, defined_at:, defined_via:)
+          deleted_fields_by_old_field_name = deleted_fields_by_type_name_and_old_field_name[type_name]
+          deleted_fields_by_old_field_name[field_name] = DeprecatedElement.new(
+            schema_def_state: @schema_def_state,
+            name: field_name,
+            defined_at: defined_at,
+            defined_via: defined_via
+          )
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/json_schema_builder.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/json_schema_builder.rb
@@ -19,12 +19,13 @@ module ElasticGraph
       class JSONSchemaBuilder
         def initialize(state:, all_types:, derived_indexing_type_names:)
           @state = state
+          @json_ingestion_state = state.json_ingestion_state
           @all_types = all_types
           @derived_indexing_type_names = derived_indexing_type_names
         end
 
         def public_json_schema
-          json_schema_version = @state.json_schema_version
+          json_schema_version = @json_ingestion_state.json_schema_version
           if json_schema_version.nil?
             raise Errors::SchemaError, "`json_schema_version` must be specified in the schema. To resolve, add `schema.json_schema_version 1` in a schema definition block."
           end

--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/results_extension.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/results_extension.rb
@@ -67,11 +67,11 @@ module ElasticGraph
 
         private
 
-        # Returns the wrapped state narrowed to include this gem's `StateExtension`. Centralizes
-        # the Steep cast that's needed because Steep can't see the `extend(StateExtension)` applied
-        # at runtime in {APIExtension.extended}.
+        # Returns the wrapped state's JSON ingestion state. Centralizes the Steep cast that's needed
+        # because Steep can't see the `extend(StateExtension)` applied at runtime in {APIExtension.extended}.
         def json_ingestion_state
-          state # : ElasticGraph::SchemaDefinition::State & StateExtension
+          extension_state = state # : ElasticGraph::SchemaDefinition::State & StateExtension
+          extension_state.json_ingestion_state
         end
 
         def json_ingestion_json_schema_builder
@@ -80,9 +80,10 @@ module ElasticGraph
             # runs the `on_built_in_types` callbacks, including the GeoLocation JSON schema field
             # customizations registered by `APIExtension.extended`.
             materialized_all_types = all_types
+            extension_state = state # : ElasticGraph::SchemaDefinition::State & StateExtension
 
             JSONSchemaBuilder.new(
-              state: json_ingestion_state,
+              state: extension_state,
               all_types: materialized_all_types,
               derived_indexing_type_names: derived_indexing_type_names
             )

--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/schema_artifact_manager_extension.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/schema_artifact_manager_extension.rb
@@ -22,10 +22,10 @@ module ElasticGraph
         # Overrides `dump_artifacts` to add JSON schema version bump checking before dumping.
         def dump_artifacts
           schema_results = json_ingestion_schema_definition_results
-          state = json_ingestion_state
+          ingestion_state = json_ingestion_state
 
           json_ingestion_check_if_needs_json_schema_version_bump do |recommended_json_schema_version|
-            if state.enforce_json_schema_version
+            if ingestion_state.enforce_json_schema_version
               # @type var setter_location: ::Thread::Backtrace::Location
               # We use `_ =` because while `json_schema_version_setter_location` can be nil,
               # it'll never be nil if we get here and we want the type to be non-nilable.
@@ -59,7 +59,8 @@ module ElasticGraph
         end
 
         def json_ingestion_state
-          json_ingestion_schema_definition_results.state # : ElasticGraph::SchemaDefinition::State & StateExtension
+          extension_state = json_ingestion_schema_definition_results.state # : ElasticGraph::SchemaDefinition::State & StateExtension
+          extension_state.json_ingestion_state
         end
 
         # Overrides the base `artifacts_from_schema_def` method to add JSON schema artifacts.

--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/schema_elements/field_extension.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/schema_elements/field_extension.rb
@@ -135,7 +135,8 @@ module ElasticGraph
           private
 
           def json_ingestion_state
-            schema_def_state # : ::ElasticGraph::SchemaDefinition::State & SchemaDefinition::StateExtension
+            extension_state = schema_def_state # : ::ElasticGraph::SchemaDefinition::State & SchemaDefinition::StateExtension
+            extension_state.json_ingestion_state
           end
         end
       end

--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/schema_elements/type_with_subfields_extension.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/schema_elements/type_with_subfields_extension.rb
@@ -75,7 +75,8 @@ module ElasticGraph
           private
 
           def json_ingestion_state
-            schema_def_state # : ::ElasticGraph::SchemaDefinition::State & SchemaDefinition::StateExtension
+            extension_state = schema_def_state # : ::ElasticGraph::SchemaDefinition::State & SchemaDefinition::StateExtension
+            extension_state.json_ingestion_state
           end
         end
       end

--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/state_extension.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/state_extension.rb
@@ -6,7 +6,7 @@
 #
 # frozen_string_literal: true
 
-require "elastic_graph/json_ingestion/schema_definition/deprecated_element"
+require "elastic_graph/json_ingestion/schema_definition/json_ingestion_state"
 
 module ElasticGraph
   module JSONIngestion
@@ -15,66 +15,11 @@ module ElasticGraph
       #
       # @private
       module StateExtension
-        # @dynamic json_schema_version, json_schema_version=
-        # @dynamic json_schema_version_setter_location, json_schema_version_setter_location=
-        # @dynamic enforce_json_schema_version, enforce_json_schema_version=
-        # @dynamic allow_omitted_json_schema_fields, allow_omitted_json_schema_fields=
-        # @dynamic allow_extra_json_schema_fields, allow_extra_json_schema_fields=
-        # @dynamic renamed_types_by_old_name, renamed_types_by_old_name=
-        # @dynamic deleted_types_by_old_name, deleted_types_by_old_name=
-        # @dynamic renamed_fields_by_type_name_and_old_field_name, renamed_fields_by_type_name_and_old_field_name=
-        # @dynamic deleted_fields_by_type_name_and_old_field_name, deleted_fields_by_type_name_and_old_field_name=
-        attr_accessor :json_schema_version, :json_schema_version_setter_location, :enforce_json_schema_version, :allow_omitted_json_schema_fields, :allow_extra_json_schema_fields,
-          :renamed_types_by_old_name, :deleted_types_by_old_name, :renamed_fields_by_type_name_and_old_field_name, :deleted_fields_by_type_name_and_old_field_name
+        # @dynamic json_ingestion_state
+        attr_reader :json_ingestion_state
 
         def self.extended(state)
-          state.json_schema_version = nil
-          state.json_schema_version_setter_location = nil
-          state.enforce_json_schema_version = true
-          state.allow_omitted_json_schema_fields = false
-          state.allow_extra_json_schema_fields = true
-          state.renamed_types_by_old_name = {}
-          state.deleted_types_by_old_name = {}
-          state.renamed_fields_by_type_name_and_old_field_name = ::Hash.new { |h, k| h[k] = {} }
-          state.deleted_fields_by_type_name_and_old_field_name = ::Hash.new { |h, k| h[k] = {} }
-        end
-
-        def register_renamed_type(type_name, from:, defined_at:, defined_via:)
-          renamed_types_by_old_name[from] = DeprecatedElement.new(
-            schema_def_state: self,
-            name: type_name,
-            defined_at: defined_at,
-            defined_via: defined_via
-          )
-        end
-
-        def register_deleted_type(type_name, defined_at:, defined_via:)
-          deleted_types_by_old_name[type_name] = DeprecatedElement.new(
-            schema_def_state: self,
-            name: type_name,
-            defined_at: defined_at,
-            defined_via: defined_via
-          )
-        end
-
-        def register_renamed_field(type_name, from:, to:, defined_at:, defined_via:)
-          renamed_fields_by_old_field_name = renamed_fields_by_type_name_and_old_field_name[type_name]
-          renamed_fields_by_old_field_name[from] = DeprecatedElement.new(
-            schema_def_state: self,
-            name: to,
-            defined_at: defined_at,
-            defined_via: defined_via
-          )
-        end
-
-        def register_deleted_field(type_name, field_name, defined_at:, defined_via:)
-          deleted_fields_by_old_field_name = deleted_fields_by_type_name_and_old_field_name[type_name]
-          deleted_fields_by_old_field_name[field_name] = DeprecatedElement.new(
-            schema_def_state: self,
-            name: field_name,
-            defined_at: defined_at,
-            defined_via: defined_via
-          )
+          state.instance_variable_set(:@json_ingestion_state, JSONIngestionState.new(schema_def_state: state))
         end
       end
     end

--- a/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/api_extension.rbs
+++ b/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/api_extension.rbs
@@ -11,7 +11,7 @@ module ElasticGraph
 
         private
 
-        def json_ingestion_state: () -> (::ElasticGraph::SchemaDefinition::State & StateExtension)
+        def json_ingestion_state: () -> JSONIngestionState
       end
     end
   end

--- a/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/deprecated_element.rbs
+++ b/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/deprecated_element.rbs
@@ -2,13 +2,13 @@ module ElasticGraph
   module JSONIngestion
     module SchemaDefinition
       class DeprecatedElement
-        attr_reader schema_def_state: ::ElasticGraph::SchemaDefinition::State & StateExtension
+        attr_reader schema_def_state: ::ElasticGraph::SchemaDefinition::State
         attr_reader name: ::String
         attr_reader defined_at: ::Thread::Backtrace::Location
         attr_reader defined_via: ::String
 
         def initialize: (
-          schema_def_state: ::ElasticGraph::SchemaDefinition::State & StateExtension,
+          schema_def_state: ::ElasticGraph::SchemaDefinition::State,
           name: ::String,
           defined_at: ::Thread::Backtrace::Location,
           defined_via: ::String

--- a/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/json_ingestion_state.rbs
+++ b/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/json_ingestion_state.rbs
@@ -1,0 +1,27 @@
+module ElasticGraph
+  module JSONIngestion
+    module SchemaDefinition
+      class JSONIngestionState
+        attr_accessor json_schema_version: ::Integer?
+        attr_accessor json_schema_version_setter_location: ::Thread::Backtrace::Location?
+        attr_accessor enforce_json_schema_version: bool
+        attr_accessor allow_omitted_json_schema_fields: bool
+        attr_accessor allow_extra_json_schema_fields: bool
+        attr_reader renamed_types_by_old_name: ::Hash[::String, DeprecatedElement]
+        attr_reader deleted_types_by_old_name: ::Hash[::String, DeprecatedElement]
+        attr_reader renamed_fields_by_type_name_and_old_field_name: ::Hash[::String, ::Hash[::String, DeprecatedElement]]
+        attr_reader deleted_fields_by_type_name_and_old_field_name: ::Hash[::String, ::Hash[::String, DeprecatedElement]]
+
+        def initialize: (schema_def_state: ::ElasticGraph::SchemaDefinition::State) -> void
+        def register_renamed_type: (::String, from: ::String, defined_at: ::Thread::Backtrace::Location, defined_via: ::String) -> void
+        def register_deleted_type: (::String, defined_at: ::Thread::Backtrace::Location, defined_via: ::String) -> void
+        def register_renamed_field: (::String, from: ::String, to: ::String, defined_at: ::Thread::Backtrace::Location, defined_via: ::String) -> void
+        def register_deleted_field: (::String, ::String, defined_at: ::Thread::Backtrace::Location, defined_via: ::String) -> void
+
+        private
+
+        @schema_def_state: ::ElasticGraph::SchemaDefinition::State
+      end
+    end
+  end
+end

--- a/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/json_schema_builder.rbs
+++ b/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/json_schema_builder.rbs
@@ -13,7 +13,8 @@ module ElasticGraph
 
         private
 
-        @state: ::ElasticGraph::SchemaDefinition::State & StateExtension
+        @state: ::ElasticGraph::SchemaDefinition::State
+        @json_ingestion_state: JSONIngestionState
         @all_types: ::Array[::ElasticGraph::SchemaDefinition::SchemaElements::graphQLType]
         @derived_indexing_type_names: ::Set[::String]
         @indexing_field_types_by_name: ::Hash[::String, Indexing::_JSONFieldType]?

--- a/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/results_extension.rbs
+++ b/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/results_extension.rbs
@@ -20,7 +20,7 @@ module ElasticGraph
         @json_ingestion_json_schema_builder: JSONSchemaBuilder?
         @json_ingestion_json_schema_with_metadata_merger: Indexing::JSONSchemaWithMetadata::Merger?
 
-        def json_ingestion_state: () -> (::ElasticGraph::SchemaDefinition::State & StateExtension)
+        def json_ingestion_state: () -> JSONIngestionState
         def json_ingestion_json_schema_builder: () -> JSONSchemaBuilder
         def json_ingestion_json_schema_with_metadata_merger: () -> Indexing::JSONSchemaWithMetadata::Merger
       end

--- a/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/schema_artifact_manager_extension.rbs
+++ b/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/schema_artifact_manager_extension.rbs
@@ -8,7 +8,7 @@ module ElasticGraph
         @json_ingestion_json_schema_merge_reporter: JSONSchemaMergeReporter?
 
         def json_ingestion_schema_definition_results: () -> (::ElasticGraph::SchemaDefinition::Results & ResultsExtension)
-        def json_ingestion_state: () -> (::ElasticGraph::SchemaDefinition::State & StateExtension)
+        def json_ingestion_state: () -> JSONIngestionState
         def artifacts_from_schema_def: () -> ::Array[::ElasticGraph::SchemaDefinition::SchemaArtifact[untyped]]
         def json_ingestion_json_schemas_artifact: () -> ::ElasticGraph::SchemaDefinition::SchemaArtifact[::Hash[::String, untyped]]
         def json_ingestion_check_if_needs_json_schema_version_bump: () { (::Integer) -> void } -> void

--- a/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/schema_elements/field_extension.rbs
+++ b/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/schema_elements/field_extension.rbs
@@ -14,7 +14,7 @@ module ElasticGraph
 
           private
 
-          def json_ingestion_state: () -> (::ElasticGraph::SchemaDefinition::State & SchemaDefinition::StateExtension)
+          def json_ingestion_state: () -> SchemaDefinition::JSONIngestionState
         end
       end
     end

--- a/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/schema_elements/type_with_subfields_extension.rbs
+++ b/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/schema_elements/type_with_subfields_extension.rbs
@@ -11,7 +11,7 @@ module ElasticGraph
 
           private
 
-          def json_ingestion_state: () -> (::ElasticGraph::SchemaDefinition::State & SchemaDefinition::StateExtension)
+          def json_ingestion_state: () -> SchemaDefinition::JSONIngestionState
         end
       end
     end

--- a/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/state_extension.rbs
+++ b/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/state_extension.rbs
@@ -2,21 +2,9 @@ module ElasticGraph
   module JSONIngestion
     module SchemaDefinition
       module StateExtension: ::ElasticGraph::SchemaDefinition::State
-        attr_accessor json_schema_version: ::Integer?
-        attr_accessor json_schema_version_setter_location: ::Thread::Backtrace::Location?
-        attr_accessor enforce_json_schema_version: bool
-        attr_accessor allow_omitted_json_schema_fields: bool
-        attr_accessor allow_extra_json_schema_fields: bool
-        attr_accessor renamed_types_by_old_name: ::Hash[::String, DeprecatedElement]
-        attr_accessor deleted_types_by_old_name: ::Hash[::String, DeprecatedElement]
-        attr_accessor renamed_fields_by_type_name_and_old_field_name: ::Hash[::String, ::Hash[::String, DeprecatedElement]]
-        attr_accessor deleted_fields_by_type_name_and_old_field_name: ::Hash[::String, ::Hash[::String, DeprecatedElement]]
+        attr_reader json_ingestion_state: JSONIngestionState
 
         def self.extended: (::ElasticGraph::SchemaDefinition::State & StateExtension) -> void
-        def register_renamed_type: (::String, from: ::String, defined_at: ::Thread::Backtrace::Location, defined_via: ::String) -> void
-        def register_deleted_type: (::String, defined_at: ::Thread::Backtrace::Location, defined_via: ::String) -> void
-        def register_renamed_field: (::String, from: ::String, to: ::String, defined_at: ::Thread::Backtrace::Location, defined_via: ::String) -> void
-        def register_deleted_field: (::String, ::String, defined_at: ::Thread::Backtrace::Location, defined_via: ::String) -> void
       end
     end
   end

--- a/elasticgraph-json_ingestion/spec/unit/elastic_graph/json_ingestion/schema_definition/deprecated_element_spec.rb
+++ b/elasticgraph-json_ingestion/spec/unit/elastic_graph/json_ingestion/schema_definition/deprecated_element_spec.rb
@@ -25,21 +25,23 @@ module ElasticGraph
             end
           end.state
 
-          expect(state.deleted_types_by_old_name.keys).to eq ["OldType"]
-          expect(state.renamed_types_by_old_name.keys).to eq ["OldWidget"]
-          expect(state.deleted_fields_by_type_name_and_old_field_name.fetch("Widget").keys).to eq ["legacy_name"]
-          expect(state.renamed_fields_by_type_name_and_old_field_name.fetch("Widget").keys).to eq ["old_name"]
+          json_ingestion_state = state.json_ingestion_state
 
-          expect(state.deleted_types_by_old_name.fetch("OldType").description).to match(
+          expect(json_ingestion_state.deleted_types_by_old_name.keys).to eq ["OldType"]
+          expect(json_ingestion_state.renamed_types_by_old_name.keys).to eq ["OldWidget"]
+          expect(json_ingestion_state.deleted_fields_by_type_name_and_old_field_name.fetch("Widget").keys).to eq ["legacy_name"]
+          expect(json_ingestion_state.renamed_fields_by_type_name_and_old_field_name.fetch("Widget").keys).to eq ["old_name"]
+
+          expect(json_ingestion_state.deleted_types_by_old_name.fetch("OldType").description).to match(
             /\A`schema\.deleted_type "OldType"` at .+:\d+\z/
           )
-          expect(state.renamed_types_by_old_name.fetch("OldWidget").description).to match(
+          expect(json_ingestion_state.renamed_types_by_old_name.fetch("OldWidget").description).to match(
             /\A`type\.renamed_from "OldWidget"` at .+:\d+\z/
           )
-          expect(state.deleted_fields_by_type_name_and_old_field_name.fetch("Widget").fetch("legacy_name").description).to match(
+          expect(json_ingestion_state.deleted_fields_by_type_name_and_old_field_name.fetch("Widget").fetch("legacy_name").description).to match(
             /\A`type\.deleted_field "legacy_name"` at .+:\d+\z/
           )
-          expect(state.renamed_fields_by_type_name_and_old_field_name.fetch("Widget").fetch("old_name").description).to match(
+          expect(json_ingestion_state.renamed_fields_by_type_name_and_old_field_name.fetch("Widget").fetch("old_name").description).to match(
             /\A`field\.renamed_from "old_name"` at .+:\d+\z/
           )
         end

--- a/elasticgraph-json_ingestion/spec/unit/elastic_graph/json_ingestion/schema_definition/json_schema_spec.rb
+++ b/elasticgraph-json_ingestion/spec/unit/elastic_graph/json_ingestion/schema_definition/json_schema_spec.rb
@@ -2979,7 +2979,7 @@ module ElasticGraph
             s.enforce_json_schema_version false
           end
 
-          expect(result.state.enforce_json_schema_version).to eq false
+          expect(result.state.json_ingestion_state.enforce_json_schema_version).to eq false
         end
 
         it "fails if json_schema_version enforcement is set to a non-boolean value" do

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/test_support.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/test_support.rb
@@ -81,7 +81,8 @@ module ElasticGraph
         if !json_schema_version.nil? && api.respond_to?(:json_schema_version)
           # :nocov: -- only entered when a JSON schema extension is loaded, which is not the case in elasticgraph-schema_definition's tests.
           versioned_api = api # : untyped
-          versioned_api.json_schema_version(json_schema_version) if versioned_api.state.json_schema_version.nil?
+          json_ingestion_state = versioned_api.state.json_ingestion_state
+          versioned_api.json_schema_version(json_schema_version) if json_ingestion_state.json_schema_version.nil?
           # :nocov:
         end
 


### PR DESCRIPTION
## Why
Keep JSON ingestion-specific schema definition state off the shared `SchemaDefinition::State` surface. This follows up on #1259 by grouping the extension state behind one accessor.

## What
- Add `JSONIngestionState` and attach it via `State#json_ingestion_state`
- Move JSON schema config and deprecated-element registries into the contained state
- Update typed helpers, specs, doctests, and schema test support to use the contained state

## Risk Assessment
Low — internal schema-definition state refactor; public DSL behavior remains unchanged.

## References
- Stack Info: Stacked on #1259
- Follow-up to https://github.com/block/elasticgraph/pull/1259#discussion_r3499545861

Validation:
- `script/lint --fix`
- `script/spellcheck -w`
- `script/type_check`
- `RUBYOPT=--disable-frozen-string-literal bundle exec rake site:doctest`
- `bundle exec rspec elasticgraph-json_ingestion/spec/unit/elastic_graph/json_ingestion/schema_definition/deprecated_element_spec.rb elasticgraph-json_ingestion/spec/unit/elastic_graph/json_ingestion/schema_definition/json_schema_spec.rb elasticgraph-json_ingestion/spec/unit/elastic_graph/json_ingestion/schema_definition/indexing/json_schema_with_metadata_spec.rb`
- `script/run_gem_specs elasticgraph-json_ingestion`
- Not fully run locally: `script/run_gem_specs elasticgraph-schema_definition` and `script/quick_build`; local datastore boot is blocked because Docker is not running (`~/.docker/run/docker.sock` is unavailable).
- Attempted `RUBYOPT=--disable-frozen-string-literal bundle exec rake site:validate`; the CI-relevant doctest failure is fixed, but local execution later stops in `site:npm_install` with an npm dependency resolution issue.