### PR TITLE
Guard against missing rbs_collection.yaml ignore entries

### DIFF
--- a/elasticgraph/spec/unit/elastic_graph/gem_spec.rb
+++ b/elasticgraph/spec/unit/elastic_graph/gem_spec.rb
@@ -9,6 +9,7 @@
 require_relative "../../../../script/list_eg_gems"
 require "elastic_graph/support/json_schema/meta_schema_validator"
 require "elastic_graph/support/json_schema/validator"
+require "yaml"
 
 module ElasticGraph
   RSpec.describe "ElasticGraph gems" do
@@ -195,6 +196,24 @@ module ElasticGraph
         extra_config_attributes = (gem_name == "elasticgraph-graphql") ? [:extension_settings] : []
         include_examples "an ElasticGraph gem", gem_name, extra_config_attributes: extra_config_attributes
       end
+    end
+
+    # Every EG gem that ships RBS signatures (i.e. has a `sig` directory) must be listed in
+    # `rbs_collection.yaml` with `ignore: true`. Otherwise, `rbs collection install` pulls the
+    # gem's signatures in via bundler while those same signatures _also_ exist locally in this
+    # monorepo, and Steep fails with "declaration is duplicated" errors. The bootstrap gem
+    # `elasticgraph` (no dash) ships no signatures, so it is intentionally excluded.
+    it "ignores every EG gem that ships RBS signatures in `rbs_collection.yaml` to avoid Steep `declaration is duplicated` errors" do
+      eg_gems_with_sig = ::ElasticGraphGems.list.select do |gem_name|
+        ::File.directory?(::File.join(CommonSpecHelpers::REPO_ROOT, gem_name, "sig"))
+      end
+
+      rbs_config = ::YAML.safe_load_file(::File.join(CommonSpecHelpers::REPO_ROOT, "rbs_collection.yaml"))
+      ignored_eg_gems = rbs_config.fetch("gems")
+        .select { |gem| gem.fetch("name").start_with?("elasticgraph") && gem["ignore"] == true }
+        .map { |gem| gem.fetch("name") }
+
+      expect(ignored_eg_gems).to match_array(eg_gems_with_sig)
     end
 
     # We don't expect any variation in these gemspec attributes.

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -74,6 +74,8 @@ gems:
     ignore: true
   - name: elasticgraph-indexer_lambda
     ignore: true
+  - name: elasticgraph-json_ingestion
+    ignore: true
   - name: elasticgraph-lambda_support
     ignore: true
   - name: elasticgraph-local


### PR DESCRIPTION
## Why

A batch of dependency-bump PRs (#1236, #1245, #1267, #1272, #1276, #1277, #1279, #1280) are all failing Steep with `declaration is duplicated` errors.

Root cause: the new `elasticgraph-json_ingestion` gem ships RBS signatures (`sig/`) and is a dev dependency of 6 other EG gems, but it was never added to `rbs_collection.yaml` with `ignore: true`. When `rbs collection install` runs, it pulls the gem's signatures in via bundler while those same signatures _also_ exist locally in this monorepo, so Steep sees duplicate declarations and fails.

Every EG gem that ships signatures must be ignored in `rbs_collection.yaml` for this reason (see the explanatory comment in that file). Nothing in CI caught the omission.

## What

- **Fix**: add `elasticgraph-json_ingestion` to `rbs_collection.yaml` with `ignore: true`.
- **Guard**: add a spec to `gem_spec.rb` asserting that the EG gems with a `sig/` directory match (via `match_array`) the `elasticgraph*` entries marked `ignore: true`. This catches both a newly-added gem missing its entry _and_ a stale entry, so this mistake can't recur silently.

The bootstrap gem `elasticgraph` (no dash) ships no signatures and is correctly exempt.

## Verification

- New spec fails before the yaml fix (`missing elements: ["elasticgraph-json_ingestion"]`), passes after.
- `bundle exec rspec elasticgraph/spec/unit/elastic_graph/gem_spec.rb` → 205 examples, 0 failures.
- `script/type_check` → No type error detected. 🫖

🤖 Generated with [Claude Code](https://claude.com/claude-code)