### PR TITLE
Move JSON schema test support to elasticgraph-json_ingestion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,7 @@ Custom gems can be added via `Gemfile-custom` (see `Gemfile-custom.example`), th
 - Avoid defensive code for impossible cases. Don't add checks, tests, or handling for scenarios that should never occur due to the design of the system. If something can only happen due to a bug in the implementation, it's better to fail fast than to silently handle it.
 - Drop unnecessary namespace prefixes. When code is already inside `module ElasticGraph`, use `Indexer` instead of `::ElasticGraph::Indexer`, and `Errors::ConfigError` instead of `::ElasticGraph::Errors::ConfigError`. Use fully qualified names only when necessary to avoid ambiguity.
 - Prefer using `prepend` + `super` rather than `alias_method` when needing to hook in and override a method.
+- Keep `require` statements alphabetically sorted (by the required path string). This applies to both `lib` and `spec` files. When adding a new `require`, insert it in the correct alphabetical position rather than appending it to the end. An exception can be made if the files have to be required in a specific order (this should be **very** rare).
 
 ### RBS Type Signatures
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/field_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/schema/field_spec.rb
@@ -7,7 +7,10 @@
 # frozen_string_literal: true
 
 require "elastic_graph/graphql/schema/field"
+require "elastic_graph/schema_artifacts/from_disk"
+require "stringio"
 require "support/aggregations_helpers"
+require "tmpdir"
 
 module ElasticGraph
   class GraphQL
@@ -156,9 +159,9 @@ module ElasticGraph
           end
 
           it "raises an error if a sort enum value is omitted from runtime metadata (e.g. because it lacks a `sort_field`)" do
-            # `reload_schema_artifacts: true` is necessary to cause the runtime metadata to get pruned
-            # and put it into the state we are exercising here.
-            schema = define_schema(reload_schema_artifacts: true) do |s|
+            # Dumping the schema artifacts and reloading them from disk is necessary to cause the
+            # runtime metadata to get pruned and put it into the state we are exercising here.
+            schema = define_schema_from_reloaded_artifacts do |s|
               s.object_type "Photo" do |t|
                 t.field "id", "ID!"
               end
@@ -530,6 +533,23 @@ module ElasticGraph
 
         def define_schema(index_definitions: nil, **options, &schema_def)
           build_graphql(schema_definition: schema_def, index_definitions: index_definitions, **options).schema
+        end
+
+        # Builds a GraphQL schema from schema artifacts that have been dumped to disk and reloaded,
+        # which applies the extra pruning/validation (e.g. runtime metadata pruning) that only happens
+        # when artifacts round-trip through disk.
+        def define_schema_from_reloaded_artifacts(&schema_def)
+          results = generate_schema_artifacts(&schema_def)
+
+          ::Dir.mktmpdir do |tmp_dir|
+            results.state.factory.new_schema_artifact_manager(
+              schema_definition_results: results,
+              schema_artifacts_directory: tmp_dir,
+              output: ::StringIO.new
+            ).dump_artifacts
+
+            build_graphql(schema_artifacts: SchemaArtifacts::FromDisk.new(tmp_dir)).schema
+          end
         end
       end
     end

--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/record_preparer_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/record_preparer_spec.rb
@@ -576,11 +576,7 @@ module ElasticGraph
         end
 
         def define_schema(&schema_definition)
-          super(
-            schema_element_name_form: "snake_case",
-            extension_modules: json_ingestion_schema_definition_extension_modules,
-            &schema_definition
-          )
+          super(schema_element_name_form: "snake_case", &schema_definition)
         end
       end
 

--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/test_support.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/test_support.rb
@@ -1,0 +1,50 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/json_ingestion/schema_definition/api_extension"
+require "elastic_graph/schema_artifacts/runtime_metadata/schema_element_names"
+require "elastic_graph/schema_definition/test_support"
+
+module ElasticGraph
+  module JSONIngestion
+    module SchemaDefinition
+      # Mixin for tests that define schemas using the JSON ingestion extension. Supplements the base
+      # {ElasticGraph::SchemaDefinition::TestSupport} by injecting {APIExtension} and defaulting the
+      # JSON schema version (which {APIExtension} requires) so that tests need not set it explicitly.
+      #
+      # @private
+      module TestSupport
+        include ElasticGraph::SchemaDefinition::TestSupport
+
+        # Mirrors the base signature but adds `json_schema_version` and builds the schema elements
+        # itself, since the base `define_schema` doesn't thread `json_schema_version` through to
+        # `define_schema_with_schema_elements`.
+        def define_schema(schema_element_name_form:, schema_element_name_overrides: {}, json_schema_version: 1, **options, &block)
+          schema_elements = SchemaArtifacts::RuntimeMetadata::SchemaElementNames.new(
+            form: schema_element_name_form,
+            overrides: schema_element_name_overrides
+          )
+
+          define_schema_with_schema_elements(schema_elements, json_schema_version: json_schema_version, **options, &block)
+        end
+
+        def define_schema_with_schema_elements(schema_elements, json_schema_version: 1, extension_modules: [], **options)
+          super(schema_elements, extension_modules: [APIExtension] | Array(extension_modules), **options) do |base_api|
+            api = base_api # : ElasticGraph::SchemaDefinition::API & APIExtension
+            yield api if block_given?
+
+            # Set the version only when the caller requested one and didn't set it themselves, so
+            # that tests get a working default without triggering a "can only be set once" error.
+            state = api.state # : ElasticGraph::SchemaDefinition::State & StateExtension
+            api.json_schema_version(json_schema_version) if json_schema_version && state.json_schema_version.nil?
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/test_support.rbs
+++ b/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/test_support.rbs
@@ -1,0 +1,23 @@
+module ElasticGraph
+  module JSONIngestion
+    module SchemaDefinition
+      module TestSupport
+        include ElasticGraph::SchemaDefinition::TestSupport
+
+        def define_schema: (
+          schema_element_name_form: ElasticGraph::SchemaArtifacts::RuntimeMetadata::SchemaElementNames::form,
+          ?schema_element_name_overrides: ::Hash[::Symbol, ::String],
+          ?json_schema_version: ::Integer?,
+          **untyped
+        ) ?{ (ElasticGraph::SchemaDefinition::API) -> void } -> ElasticGraph::SchemaDefinition::Results
+
+        def define_schema_with_schema_elements: (
+          ElasticGraph::SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
+          ?json_schema_version: ::Integer?,
+          ?extension_modules: ::Array[::Module],
+          **untyped
+        ) ?{ (ElasticGraph::SchemaDefinition::API) -> void } -> ElasticGraph::SchemaDefinition::Results
+      end
+    end
+  end
+end

--- a/elasticgraph-json_ingestion/spec/unit/elastic_graph/json_ingestion/schema_definition/factory_extension_spec.rb
+++ b/elasticgraph-json_ingestion/spec/unit/elastic_graph/json_ingestion/schema_definition/factory_extension_spec.rb
@@ -11,35 +11,31 @@ module ElasticGraph
     module SchemaDefinition
       RSpec.describe FactoryExtension do
         it "extends enum types created without customization blocks" do
-          api = build_api
-          api.enum_type "EmptyEnum"
+          define_schema(schema_element_name_form: "snake_case") do |api|
+            # Create the enum without a customization block (the case being exercised), then add a
+            # value afterward so the schema is valid (enums must have at least one value).
+            api.enum_type "SomeEnum"
+            enum_type = api.state.enum_types_by_name.fetch("SomeEnum")
+            enum_type.value "SOME_VALUE"
 
-          # An enum's derived GraphQL types are built from a derived scalar twin, which can only be
-          # built if `EnumTypeExtension` configured the twin's `json_schema`; otherwise building it
-          # raises a "lacks `json_schema`" error.
-          expect {
-            api.state.enum_types_by_name.fetch("EmptyEnum").derived_graphql_types
-          }.not_to raise_error
+            # An enum's derived GraphQL types are built from a derived scalar twin, which can only be
+            # built if `EnumTypeExtension` configured the twin's `json_schema`; otherwise building it
+            # raises a "lacks `json_schema`" error.
+            expect {
+              enum_type.derived_graphql_types
+            }.not_to raise_error
+          end
         end
 
         it "extends interface types created without customization blocks" do
-          api = build_api
-          api.interface_type "EmptyInterface"
+          define_schema(schema_element_name_form: "snake_case") do |api|
+            api.interface_type "EmptyInterface"
 
-          interface_type = api.state.object_types_by_name.fetch("EmptyInterface")
-          interface_type.json_schema minProperties: 1
+            interface_type = api.state.object_types_by_name.fetch("EmptyInterface")
+            interface_type.json_schema minProperties: 1
 
-          expect(interface_type.json_schema_options).to eq({minProperties: 1})
-        end
-
-        def build_api
-          schema_elements = SchemaArtifacts::RuntimeMetadata::SchemaElementNames.new(form: "snake_case")
-          ::ElasticGraph::SchemaDefinition::API.new(
-            schema_elements,
-            true,
-            extension_modules: json_ingestion_schema_definition_extension_modules,
-            output: log_device
-          )
+            expect(interface_type.json_schema_options).to eq({minProperties: 1})
+          end
         end
       end
     end

--- a/elasticgraph-json_ingestion/spec/unit/elastic_graph/json_ingestion/schema_definition/test_support_spec.rb
+++ b/elasticgraph-json_ingestion/spec/unit/elastic_graph/json_ingestion/schema_definition/test_support_spec.rb
@@ -1,0 +1,114 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/errors"
+
+module ElasticGraph
+  module JSONIngestion
+    module SchemaDefinition
+      # Verifies the JSON-ingestion `TestSupport` behavior that supplements the base
+      # `ElasticGraph::SchemaDefinition::TestSupport`: injecting `APIExtension` and defaulting
+      # the JSON schema version so specs don't have to set it explicitly.
+      RSpec.describe "JSON ingestion TestSupport" do
+        it "defaults the JSON schema version to 1 so specs need not set it" do
+          results = define_schema(schema_element_name_form: "snake_case") do |schema|
+            schema.object_type "Widget" do |t|
+              t.field "id", "ID!"
+              t.index "widgets"
+            end
+          end
+
+          expect(results.available_json_schema_versions).to contain_exactly(1)
+        end
+
+        it "uses an explicitly-provided `json_schema_version`" do
+          results = define_schema(schema_element_name_form: "snake_case", json_schema_version: 5) do |schema|
+            schema.object_type "Widget" do |t|
+              t.field "id", "ID!"
+              t.index "widgets"
+            end
+          end
+
+          expect(results.available_json_schema_versions).to contain_exactly(5)
+        end
+
+        it "leaves the version unset when `json_schema_version: nil`, so accessing it fails" do
+          results = define_schema(schema_element_name_form: "snake_case", json_schema_version: nil) do |schema|
+            schema.object_type "Widget" do |t|
+              t.field "id", "ID!"
+              t.index "widgets"
+            end
+          end
+
+          expect {
+            results.available_json_schema_versions
+          }.to raise_error(Errors::SchemaError, a_string_including("must be specified in the schema"))
+        end
+
+        it "does not clobber a version the caller sets in the block" do
+          results = define_schema(schema_element_name_form: "snake_case") do |schema|
+            schema.json_schema_version 7
+
+            schema.object_type "Widget" do |t|
+              t.field "id", "ID!"
+              t.index "widgets"
+            end
+          end
+
+          expect(results.available_json_schema_versions).to contain_exactly(7)
+        end
+
+        it "injects `APIExtension` even when the caller passes other `extension_modules`" do
+          other_extension = Module.new do
+            def self.extended(api)
+              api.state.reserved_type_names << "ReservedByOtherExtension"
+            end
+          end
+
+          results = define_schema(schema_element_name_form: "snake_case", extension_modules: [other_extension]) do |schema|
+            # `json_schema_version` is only available when `APIExtension` was injected.
+            schema.json_schema_version 1
+
+            schema.object_type "Widget" do |t|
+              t.field "id", "ID!"
+              t.index "widgets"
+            end
+          end
+
+          expect(results.available_json_schema_versions).to contain_exactly(1)
+        end
+
+        describe "#generate_schema_artifacts" do
+          it "defaults the JSON schema version to 1 so specs need not set it" do
+            artifacts = generate_schema_artifacts do |schema|
+              schema.object_type "Widget" do |t|
+                t.field "id", "ID!"
+                t.index "widgets"
+              end
+            end
+
+            expect(artifacts.available_json_schema_versions).to contain_exactly(1)
+          end
+
+          it "does not clobber a version the block sets itself" do
+            artifacts = generate_schema_artifacts do |schema|
+              schema.json_schema_version 7
+
+              schema.object_type "Widget" do |t|
+                t.field "id", "ID!"
+                t.index "widgets"
+              end
+            end
+
+            expect(artifacts.available_json_schema_versions).to contain_exactly(7)
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/test_support.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/test_support.rb
@@ -7,10 +7,8 @@
 # frozen_string_literal: true
 
 require "elastic_graph/errors"
-require "elastic_graph/schema_artifacts/from_disk"
 require "elastic_graph/schema_artifacts/runtime_metadata/schema_element_names"
 require "elastic_graph/schema_definition/api"
-require "elastic_graph/schema_definition/schema_artifact_manager"
 
 module ElasticGraph
   module SchemaDefinition
@@ -24,12 +22,10 @@ module ElasticGraph
         schema_element_name_form:,
         schema_element_name_overrides: {},
         index_document_sizes: true,
-        json_schema_version: 1,
         extension_modules: [],
         derived_type_name_formats: {},
         type_name_overrides: {},
         enum_value_overrides_by_type: {},
-        reload_schema_artifacts: false,
         output: nil,
         &block
       )
@@ -41,12 +37,10 @@ module ElasticGraph
         define_schema_with_schema_elements(
           schema_elements,
           index_document_sizes: index_document_sizes,
-          json_schema_version: json_schema_version,
           extension_modules: extension_modules,
           derived_type_name_formats: derived_type_name_formats,
           type_name_overrides: type_name_overrides,
           enum_value_overrides_by_type: enum_value_overrides_by_type,
-          reload_schema_artifacts: reload_schema_artifacts,
           output: output,
           &block
         )
@@ -55,12 +49,10 @@ module ElasticGraph
       def define_schema_with_schema_elements(
         schema_elements,
         index_document_sizes: true,
-        json_schema_version: 1,
         extension_modules: [],
         derived_type_name_formats: {},
         type_name_overrides: {},
         enum_value_overrides_by_type: {},
-        reload_schema_artifacts: false,
         output: nil
       )
         api = API.new(
@@ -75,36 +67,7 @@ module ElasticGraph
 
         yield api if block_given?
 
-        # Set the json_schema_version to the provided value, if needed. The `json_schema_version` API only
-        # exists when an extension that implements JSON schema generation (such as
-        # `elasticgraph-json_ingestion`) is loaded; without one there is no JSON schema version to set.
-        if !json_schema_version.nil? && api.respond_to?(:json_schema_version)
-          # :nocov: -- only entered when a JSON schema extension is loaded, which is not the case in elasticgraph-schema_definition's tests.
-          versioned_api = api # : untyped
-          versioned_api.json_schema_version(json_schema_version) if versioned_api.state.json_schema_version.nil?
-          # :nocov:
-        end
-
-        # :nocov: -- the else branch and code past this aren't used by tests in elasticgraph-schema_definition.
-        return api.results unless reload_schema_artifacts
-
-        # Reloading the schema artifacts takes extra time that we don't usually want to spend (so it's opt-in)
-        # but it can be useful in some cases because there is a bit of extra pruning/validation that it applies.
-        if api.respond_to?(:enforce_json_schema_version)
-          versioned_api = api # : untyped
-          versioned_api.enforce_json_schema_version false
-        end
-        tmp_dir = ::Dir.mktmpdir
-        artifacts_manager = api.factory.new_schema_artifact_manager(
-          schema_definition_results: api.results,
-          schema_artifacts_directory: tmp_dir,
-          output: ::StringIO.new
-        )
-
-        artifacts_manager.dump_artifacts
-
-        SchemaArtifacts::FromDisk.new(tmp_dir)
-        # :nocov:
+        api.results
       end
 
       DOC_COMMENTS = (

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/test_support.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/test_support.rbs
@@ -5,26 +5,22 @@ module ElasticGraph
         schema_element_name_form: SchemaArtifacts::RuntimeMetadata::SchemaElementNames::form,
         ?schema_element_name_overrides: ::Hash[::Symbol, ::String],
         ?index_document_sizes: bool,
-        ?json_schema_version: ::Integer,
         ?extension_modules: ::Array[::Module],
         ?derived_type_name_formats: ::Hash[::Symbol, ::String],
         ?type_name_overrides: ::Hash[::Symbol, ::String],
         ?enum_value_overrides_by_type: ::Hash[::Symbol, ::Hash[::Symbol, ::String]],
         ?output: io?,
-        ?reload_schema_artifacts: bool,
-      ) ?{ (API) -> void } -> (Results | SchemaArtifacts::FromDisk)
+      ) ?{ (API) -> void } -> Results
 
       def define_schema_with_schema_elements: (
         SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
         ?index_document_sizes: bool,
-        ?json_schema_version: ::Integer,
         ?extension_modules: ::Array[::Module],
         ?derived_type_name_formats: ::Hash[::Symbol, ::String],
         ?type_name_overrides: ::Hash[::Symbol, ::String],
         ?enum_value_overrides_by_type: ::Hash[::Symbol, ::Hash[::Symbol, ::String]],
         ?output: io?,
-        ?reload_schema_artifacts: bool,
-      ) ?{ (API) -> void } -> (Results | SchemaArtifacts::FromDisk)
+      ) ?{ (API) -> void } -> Results
 
       DOC_COMMENTS: ::String
 

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/define_schema_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/define_schema_spec.rb
@@ -7,7 +7,6 @@
 # frozen_string_literal: true
 
 require "elastic_graph/errors"
-require "elastic_graph/json_ingestion/schema_definition/api_extension"
 require "elastic_graph/spec_support/have_readable_to_s_and_inspect_output"
 require_relative "graphql_schema_spec_support"
 
@@ -92,37 +91,6 @@ module ElasticGraph
             "`SomeReservedName` cannot be used as a schema type",
             "reserved name"
           )
-        end
-
-        it "allows test schemas to skip JSON schema version setup" do
-          result = define_schema(json_schema_version: nil) do |schema|
-            schema.object_type("Widget") do |t|
-              t.field "id", "ID"
-            end
-          end
-
-          expect(type_def_from(result, "Widget")).to eq(<<~EOS.strip)
-            type Widget {
-              id: ID
-            }
-          EOS
-        end
-
-        it "allows test schemas to set the JSON schema version themselves" do
-          # If the test support logic re-set the version it would fail with a "can only be set once" error.
-          result = define_schema(extension_modules: [JSONIngestion::SchemaDefinition::APIExtension]) do |schema|
-            schema.json_schema_version 7
-
-            schema.object_type("Widget") do |t|
-              t.field "id", "ID"
-            end
-          end
-
-          expect(type_def_from(result, "Widget")).to eq(<<~EOS.strip)
-            type Widget {
-              id: ID
-            }
-          EOS
         end
 
         it "produces the same GraphQL output, regardless of the order the types are defined in" do

--- a/spec_support/lib/elastic_graph/spec_support/builds_datastore_core.rb
+++ b/spec_support/lib/elastic_graph/spec_support/builds_datastore_core.rb
@@ -32,7 +32,6 @@ module ElasticGraph
       schema_artifacts: nil,
       schema_definition_extension_modules: [],
       datastore_backend: nil,
-      reload_schema_artifacts: false,
       **config_overrides,
       &customize_config
     )
@@ -63,7 +62,6 @@ module ElasticGraph
             type_name_overrides: type_name_overrides,
             enum_value_overrides_by_type: enum_value_overrides_by_type,
             extension_modules: schema_definition_extension_modules,
-            reload_schema_artifacts: reload_schema_artifacts,
             &schema_definition
           )
         elsif schema_artifacts_directory

--- a/spec_support/lib/elastic_graph/spec_support/json_ingestion_schema_definition.rb
+++ b/spec_support/lib/elastic_graph/spec_support/json_ingestion_schema_definition.rb
@@ -7,42 +7,39 @@
 # frozen_string_literal: true
 
 require "elastic_graph/json_ingestion/schema_definition/api_extension"
+require "elastic_graph/json_ingestion/schema_definition/test_support"
 
 module ElasticGraph
+  # Wires the JSON ingestion schema definition support into specs tagged
+  # `:json_ingestion_schema_definition`. Mixing in
+  # {JSONIngestion::SchemaDefinition::TestSupport} overrides `define_schema` /
+  # `define_schema_with_schema_elements` to inject `APIExtension` and default the JSON schema version.
+  # `generate_schema_artifacts` is handled separately below because it calls `TestSupport.define_schema`
+  # as a module method (which the instance-level mixin doesn't reach).
   module JSONIngestionSchemaDefinition
-    def define_schema(extension_modules: [], **options, &block)
-      super(
-        extension_modules: json_ingestion_schema_definition_extension_modules(extension_modules),
-        **options,
-        &block
-      )
-    end
+    include JSONIngestion::SchemaDefinition::TestSupport
 
-    def define_schema_with_schema_elements(schema_elements, extension_modules: [], **options, &block)
-      super(
-        schema_elements,
-        extension_modules: json_ingestion_schema_definition_extension_modules(extension_modules),
-        **options,
-        &block
-      )
-    end
+    def generate_schema_artifacts(extension_modules: [], **options)
+      super(extension_modules: json_ingestion_schema_definition_extension_modules(extension_modules), **options) do |schema|
+        yield schema
 
-    def generate_schema_artifacts(extension_modules: [], **options, &block)
-      super(
-        extension_modules: json_ingestion_schema_definition_extension_modules(extension_modules),
-        **options,
-        &block
-      )
+        # Default the JSON schema version (which `APIExtension` requires) unless the block set it,
+        # so specs need not set it explicitly. Mirrors the `define_schema*` behavior in
+        # {JSONIngestion::SchemaDefinition::TestSupport}.
+        schema.json_schema_version(1) if schema.state.json_schema_version.nil?
+      end
     end
 
     private
 
+    # Prepends `APIExtension` to the given `extension_modules`. Useful for specs that construct
+    # schema-definition machinery directly (e.g. `RakeTasks.new`) rather than via `define_schema`.
     def json_ingestion_schema_definition_extension_modules(extension_modules = [])
       [JSONIngestion::SchemaDefinition::APIExtension] | Array(extension_modules)
     end
   end
 
   RSpec.configure do |config|
-    config.prepend JSONIngestionSchemaDefinition, :json_ingestion_schema_definition
+    config.include JSONIngestionSchemaDefinition, :json_ingestion_schema_definition
   end
 end

--- a/spec_support/spec_helper.rb
+++ b/spec_support/spec_helper.rb
@@ -366,8 +366,7 @@ module ElasticGraph
       schema_element_name_overrides: {},
       derived_type_name_formats: {},
       type_name_overrides: {},
-      enum_value_overrides_by_type: {},
-      reload_schema_artifacts: false
+      enum_value_overrides_by_type: {}
     )
       require "elastic_graph/schema_definition/test_support"
       require "stringio"
@@ -387,7 +386,6 @@ module ElasticGraph
         type_name_overrides: type_name_overrides,
         enum_value_overrides_by_type: enum_value_overrides_by_type,
         extension_modules: extension_modules,
-        reload_schema_artifacts: reload_schema_artifacts,
         output: output
       ) do |schema|
         if block_given?


### PR DESCRIPTION
## Why

`ElasticGraph::SchemaDefinition::TestSupport` (in `elasticgraph-schema_definition`) is the base test helper every gem's schema-definition specs build on. It carried logic for `json_schema_version` / `enforce_json_schema_version` — features that only exist when `elasticgraph-json_ingestion` is loaded. That's a layering violation: the base gem shouldn't know about a feature only its dependent extension provides (the logic was even `# :nocov:`'d since the base gem's own suite never loads the extension).

## What

- **`elasticgraph-schema_definition` is now JSON-agnostic**: dropped the `json_schema_version:` and `reload_schema_artifacts:` kwargs and the version-setting / dump-and-reload logic from `TestSupport`.
- **`elasticgraph-json_ingestion` ships its own `TestSupport`**: it `include`s the base module and overrides `define_schema` / `define_schema_with_schema_elements` to inject `APIExtension` and default `json_schema_version` (1; pass `nil` to skip). Covered by a new spec.
- **Spec glue** (`spec_support/.../json_ingestion_schema_definition.rb`) mixes in the new module and switches `config.prepend` → `config.include` so the override composes correctly with `SchemaDefinitionHelpers`' `output` defaulting.
- **Dropped the rarely-used `reload_schema_artifacts` option** (from `TestSupport`, `generate_schema_artifacts`, and `builds_datastore_core`). Its single consumer — one `field_spec` test — now inlines its own dump-and-reload.

## Verification

- `script/type_check` and lint clean.
- `elasticgraph-json_ingestion`, `-schema_definition`, `-indexer`, `-graphql`, `-datastore_core`, `-admin`, `-health_check` all pass at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)