### PR TITLE
Slow Dependabot cadence and trim fragile-gem exclusions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
     allow:
       - dependency-type: "all" # Allow both direct and transitive updates for all packages.
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 10
     groups:
       # 1 PR for every single dependency is overkill (it's tedious to have to wade through 20 dependabot PRs!).
@@ -27,8 +27,6 @@ updates:
         exclude-patterns:
           - "elasticsearch" # listed here as gem releases align with releases of Elasticsearch itself, and a PR notifies us of it
           - "graphql"
-          - "json_schemer"
-          - "rack"
           - "rbs"
           - "standard"
           - "steep"
@@ -38,7 +36,7 @@ updates:
     allow:
       - dependency-type: "all" # Allow both direct and transitive updates for all packages.
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 1
     groups:
       release-gems:
@@ -49,7 +47,7 @@ updates:
     allow:
       - dependency-type: "all" # Allow both direct and transitive updates for all packages.
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 1
     groups:
       npm:
@@ -60,7 +58,7 @@ updates:
     allow:
       - dependency-type: "all" # Allow both direct and transitive updates for all packages.
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 1
     groups:
       apollo-docker:
@@ -71,7 +69,7 @@ updates:
     allow:
       - dependency-type: "all" # Allow both direct and transitive updates for all packages.
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 1
     groups:
       elasticsearch-docker:
@@ -82,7 +80,7 @@ updates:
     allow:
       - dependency-type: "all" # Allow both direct and transitive updates for all packages.
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 1
     groups:
       opensearch-docker:
@@ -93,7 +91,7 @@ updates:
     allow:
       - dependency-type: "all" # Allow both direct and transitive updates for all packages.
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 1
     groups:
       pip:


### PR DESCRIPTION
## Why

Weekly Dependabot runs produced a batch of PRs to review every week — more frequently than this project needs. Monthly cuts review sessions ~4x while covering the same set of updates, just batched into fewer sessions.

## What

- Flipped all ecosystems with a `weekly` schedule to `monthly` in `.github/dependabot.yml` (`bundler`, `npm`, `docker`, `pip`); `github-actions` was already `monthly`.
- Folded `json_schemer` and `rack` back into the `most-gems` grouped PR. They were broken out due to a history of build failures on upgrade, but have been stable for a long time and no longer warrant their own PRs.

## Notes

- Security (CVE-driven) updates fire independent of the `schedule` interval, so this does not change vulnerability exposure.
- Remaining gems kept broken out into their own PRs (now monthly): `elasticsearch`, `graphql`, `rbs`, `standard`, `steep`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)