### PR TITLE
Fix `not` filter to negate multi-condition sub-filters correctly

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_interpreter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_interpreter.rb
@@ -113,23 +113,21 @@ module ElasticGraph
             return
           end
 
-          # Prevent any negated filters from being unnecessarily double-negated by
-          # converting them to a positive filter (i.e., !!A == A).
-          if sub_filter[:bool].key?(:must_not)
-            # Pull clauses up to current bool_node to remove negation
-            sub_filter[:bool][:must_not].each do |negated_clause|
-              negated_clause_bool = negated_clause[:bool]
-              # `minimum_should_match` is not a list like the other clauses, and needs to be handled separately.
-              negated_clause_bool.except(:minimum_should_match).each { |k, v| bool_node[k].concat(v) }
-              if (min_should_match = negated_clause_bool[:minimum_should_match])
-                bool_node[:minimum_should_match] = min_should_match
-              end
-            end
-          end
+          sub_bool = sub_filter.fetch(:bool)
 
-          # Don't drop any other filters! Let's negate them now.
-          other_filters = sub_filter[:bool].except(:must_not)
-          bool_node[:must_not] << {bool: other_filters} unless other_filters.empty?
+          if sub_bool.keys == [:must_not] && sub_bool.fetch(:must_not).size == 1
+            # The sub-filter is purely a negation of a single clause, so negating it again would
+            # double-negate that clause. Since `NOT (NOT A) == A`, we can instead require the inner
+            # clause to positively match. Note that this is only sound because `must_not` is the
+            # *only* part of the sub-filter; if the sub-filter had any other clauses, they would be
+            # ANDed with the negated clause, and negating the conjunction as a whole would require
+            # an OR of the negated parts (per De Morgan's law) rather than a simple pull-up.
+            bool_node[:filter] << sub_bool.fetch(:must_not).first
+          else
+            # Negate the entire sub-filter as a single unit. The sub-filter's clauses are ANDed
+            # together, so wrapping them in one `must_not` clause gives us `NOT (A AND B AND ...)`.
+            bool_node[:must_not] << {bool: sub_bool}
+          end
         end
 
         # There are two cases for `any_satisfy`, each of which is handled differently:

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_interpreter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_interpreter.rb
@@ -115,14 +115,14 @@ module ElasticGraph
 
           sub_bool = sub_filter.fetch(:bool)
 
-          if sub_bool.keys == [:must_not] && sub_bool.fetch(:must_not).size == 1
+          if sub_bool.keys == [:must_not] && (negated_clauses = sub_bool.fetch(:must_not)).size == 1
             # The sub-filter is purely a negation of a single clause, so negating it again would
             # double-negate that clause. Since `NOT (NOT A) == A`, we can instead require the inner
             # clause to positively match. Note that this is only sound because `must_not` is the
             # *only* part of the sub-filter; if the sub-filter had any other clauses, they would be
             # ANDed with the negated clause, and negating the conjunction as a whole would require
             # an OR of the negated parts (per De Morgan's law) rather than a simple pull-up.
-            bool_node[:filter] << sub_bool.fetch(:must_not).first
+            bool_node[:filter] << negated_clauses.first
           else
             # Negate the entire sub-filter as a single unit. The sub-filter's clauses are ANDed
             # together, so wrapping them in one `must_not` clause gives us `NOT (A AND B AND ...)`.

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/filtering_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/filtering_spec.rb
@@ -1860,8 +1860,20 @@ module ElasticGraph
             }
           }})
 
+          # A double-negated multi-clause `any_of` must return the same results as the un-negated
+          # `any_of`. The pulled-up `any_of` is wrapped in a self-contained `bool` clause rather than
+          # emitted byte-for-byte identically, but the wrapper is inert, so `NOT (NOT A) == A` must
+          # still hold at the results level.
+          any_of_filter = {"any_of" => [
+            {"amount_cents" => {"lt" => 150}},
+            {"amount_cents" => {"gt" => 300}}
+          ]}
+          double_negated_any_of_result = search_with_freeform_filter({"not" => {"not" => any_of_filter}})
+          un_negated_any_of_result = search_with_freeform_filter(any_of_filter)
+
           expect(inner_not_result).to eq(outer_not_result).and match_array(ids_of(widget2))
           expect(triple_nested_not).to match_array(ids_of(widget1, widget3))
+          expect(double_negated_any_of_result).to eq(un_negated_any_of_result).and match_array(ids_of(widget1, widget3))
         end
 
         it "negates a multi-condition sub-filter as a single unit, per De Morgan's law, when one condition is itself a negation" do
@@ -1881,6 +1893,53 @@ module ElasticGraph
           }})
 
           expect(result).to match_array(ids_of(widget2, widget3, widget4))
+        end
+
+        it "negates a sub-filter of multiple negated conditions as a unit, per De Morgan's law" do
+          index_into(
+            graphql,
+            _widget1 = build(:widget, amount_cents: nil, name: nil),
+            widget2 = build(:widget, amount_cents: nil, name: "bar"),
+            widget3 = build(:widget, amount_cents: 100, name: nil),
+            widget4 = build(:widget, amount_cents: 250, name: "bar")
+          )
+
+          # Both sub-conditions negate (`equal_to_any_of: [nil]` compiles to a `must_not`), so the
+          # sub-filter is `{must_not: [<amount_cents>, <name>]}`. This is the discriminator case: the
+          # sub-filter is purely `must_not` but has more than one clause, so it must NOT pull each
+          # clause up (which would wrongly produce `amount_cents != nil AND name != nil`). Per De
+          # Morgan's law, `NOT (amount_cents = nil AND name = nil)` must match every widget with a
+          # non-nil `amount_cents` OR a non-nil `name`--i.e. every widget except the all-nil one.
+          result = search_with_freeform_filter({"not" => {
+            "amount_cents" => {"equal_to_any_of" => [nil]},
+            "name" => {"equal_to_any_of" => [nil]}
+          }})
+
+          expect(result).to match_array(ids_of(widget2, widget3, widget4))
+        end
+
+        it "negates a sub-filter mixing a negated condition and an `any_of` as a unit, per De Morgan's law" do
+          index_into(
+            graphql,
+            _widget1 = build(:widget, amount_cents: nil, name: "foo"),
+            widget2 = build(:widget, amount_cents: 100, name: "foo"),
+            widget3 = build(:widget, amount_cents: nil, name: "baz"),
+            _widget4 = build(:widget, amount_cents: nil, name: "bar")
+          )
+
+          # The sub-filter mixes a `must_not` clause (`amount_cents = nil`) with a `should` clause
+          # (the `any_of`), so `should`/`minimum_should_match` must not bleed out of the negation.
+          # Per De Morgan's law, `NOT (amount_cents = nil AND (name = "foo" OR name = "bar"))` must
+          # match a widget with a non-nil `amount_cents` OR a name other than "foo"/"bar".
+          result = search_with_freeform_filter({"not" => {
+            "amount_cents" => {"equal_to_any_of" => [nil]},
+            "any_of" => [
+              {"name" => {"equal_to_any_of" => ["foo"]}},
+              {"name" => {"equal_to_any_of" => ["bar"]}}
+            ]
+          }})
+
+          expect(result).to match_array(ids_of(widget2, widget3))
         end
 
         it "keeps a double-negated `any_of` independently required alongside a sibling `any_of`" do

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/filtering_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/filtering_spec.rb
@@ -1864,6 +1864,51 @@ module ElasticGraph
           expect(triple_nested_not).to match_array(ids_of(widget1, widget3))
         end
 
+        it "negates a multi-condition sub-filter as a single unit, per De Morgan's law, when one condition is itself a negation" do
+          index_into(
+            graphql,
+            _widget1 = build(:widget, amount_cents: nil, name: "foo"),
+            widget2 = build(:widget, amount_cents: nil, name: "bar"),
+            widget3 = build(:widget, amount_cents: 100, name: "foo"),
+            widget4 = build(:widget, amount_cents: 250, name: "bar")
+          )
+
+          # `NOT (amount_cents = nil AND name = "foo")` must match every widget that has a non-nil
+          # `amount_cents` OR a name other than "foo"--not just the widgets satisfying both.
+          result = search_with_freeform_filter({"not" => {
+            "amount_cents" => {"equal_to_any_of" => [nil]},
+            "name" => {"equal_to_any_of" => ["foo"]}
+          }})
+
+          expect(result).to match_array(ids_of(widget2, widget3, widget4))
+        end
+
+        it "keeps a double-negated `any_of` independently required alongside a sibling `any_of`" do
+          index_into(
+            graphql,
+            widget1 = build(:widget, amount_cents: 100),
+            _widget2 = build(:widget, amount_cents: 205),
+            _widget3 = build(:widget, amount_cents: 400),
+            widget4 = build(:widget, amount_cents: 550)
+          )
+
+          # This must behave as `(< 150 OR > 500) AND (< 300 OR > 450)`; the two OR groups must
+          # not collapse into a single `< 150 OR > 500 OR < 300 OR > 450` group (which would
+          # wrongly match `_widget2`).
+          result = search_with_freeform_filter({
+            "any_of" => [
+              {"amount_cents" => {"lt" => 150}},
+              {"amount_cents" => {"gt" => 500}}
+            ],
+            "not" => {"not" => {"any_of" => [
+              {"amount_cents" => {"lt" => 300}},
+              {"amount_cents" => {"gt" => 450}}
+            ]}}
+          })
+
+          expect(result).to match_array(ids_of(widget1, widget4))
+        end
+
         it "matches no documents when set to `nil`" do
           index_into(
             graphql,

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/filtering_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/filtering_spec.rb
@@ -1961,7 +1961,7 @@ module ElasticGraph
             ],
             "not" => {"not" => {"any_of" => [
               {"amount_cents" => {"lt" => 300}},
-              {"amount_cents" => {"gt" => 450}}
+              {"amount_cents" => {"gt" => 350}}
             ]}}
           })
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/filtering_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/filtering_spec.rb
@@ -1889,6 +1889,30 @@ module ElasticGraph
           }})
         end
 
+        specify "`not` negates a sub-filter mixing a negated condition and an `any_of` as a unit, per De Morgan's law" do
+          query = new_query(client_filter: {"not" => {
+            "age" => {"equal_to_any_of" => [nil]},
+            "any_of" => [
+              {"height" => {"gt" => 100}},
+              {"height" => {"lt" => 50}}
+            ]
+          }})
+
+          # The sub-filter mixes a `must_not` clause (`age = nil`) with a `should` clause (the
+          # `any_of`). Both must stay inside the single negating `must_not` so that neither the
+          # negated `age` clause is pulled up nor the `should`/`minimum_should_match` bleeds out.
+          expect(datastore_body_of(query)).to query_datastore_with({bool: {
+            must_not: [{bool: {
+              must_not: [{bool: {filter: [{exists: {"field" => "age"}}]}}],
+              minimum_should_match: 1,
+              should: [
+                {bool: {filter: [{range: {"height" => {gt: 100}}}]}},
+                {bool: {filter: [{range: {"height" => {lt: 50}}}]}}
+              ]
+            }}]
+          }})
+        end
+
         specify "`not: {all_of: [...]}` returns only the documents that are unmatched by `all_of: [...]`" do
           query = new_query(client_filter: {
             "not" => {

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/filtering_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/filtering_spec.rb
@@ -558,7 +558,7 @@ module ElasticGraph
           query = new_query(client_filter: {"not" => {"age" => {"equal_to_any_of" => [nil]}}})
 
           expect(datastore_body_of(query)).to query_datastore_with({
-            bool: {filter: [{exists: {"field" => "age"}}]}
+            bool: {filter: [{bool: {filter: [{exists: {"field" => "age"}}]}}]}
           })
         end
 
@@ -596,7 +596,7 @@ module ElasticGraph
 
           expect(datastore_body_of(query)).to query_datastore_with({bool: {
             filter: [
-              {exists: {"field" => "age"}},
+              {bool: {filter: [{exists: {"field" => "age"}}]}},
               {terms: {"color" => %w[blue green]}}
             ]
           }})
@@ -609,7 +609,7 @@ module ElasticGraph
           })
 
           expect(datastore_body_of(query)).to query_datastore_with({bool: {
-            filter: [{exists: {"field" => "age"}}],
+            filter: [{bool: {filter: [{exists: {"field" => "age"}}]}}],
             must_not: [{bool: {filter: [{terms: {"color" => %w[blue green]}}]}}]
           }})
         end
@@ -1808,10 +1808,85 @@ module ElasticGraph
             ]
           }
 
-          query1 = new_query(client_filter: {"not" => {"not" => inner_filter}})
-          query2 = new_query(client_filter: inner_filter)
+          query = new_query(client_filter: {"not" => {"not" => inner_filter}})
 
-          expect(datastore_body_of(query1)).to eq(datastore_body_of(query2))
+          # The double negation is unwrapped (`NOT (NOT A) == A`), with the `any_of` kept as a
+          # single self-contained clause so that its `should`/`minimum_should_match` cannot bleed
+          # into (or get clobbered by) sibling filter clauses.
+          expect(datastore_body_of(query)).to query_datastore_with({bool: {filter: [{bool: {
+            minimum_should_match: 1,
+            should: [
+              {bool: {filter: [{terms: {"age" => [25, 30]}}]}},
+              {bool: {filter: [{range: {"height" => {gt: 10}}}]}}
+            ]
+          }}]}})
+        end
+
+        specify "an `any_of` alongside a double-negated `any_of` keeps the two OR groups independently required" do
+          query = new_query(client_filter: {
+            "any_of" => [
+              {"age" => {"gt" => 90}},
+              {"age" => {"lt" => 10}}
+            ],
+            "not" => {"not" => {"any_of" => [
+              {"height" => {"gt" => 100}},
+              {"height" => {"lt" => 50}}
+            ]}}
+          })
+
+          # The pulled-up double negation must not merge its `should` clauses (or its
+          # `minimum_should_match`) into the sibling `any_of`'s--that would turn
+          # `(A OR B) AND (C OR D)` into `A OR B OR C OR D`.
+          expect(datastore_body_of(query)).to query_datastore_with({bool: {
+            minimum_should_match: 1,
+            should: [
+              {bool: {filter: [{range: {"age" => {gt: 90}}}]}},
+              {bool: {filter: [{range: {"age" => {lt: 10}}}]}}
+            ],
+            filter: [{bool: {
+              minimum_should_match: 1,
+              should: [
+                {bool: {filter: [{range: {"height" => {gt: 100}}}]}},
+                {bool: {filter: [{range: {"height" => {lt: 50}}}]}}
+              ]
+            }}]
+          }})
+        end
+
+        specify "`not` negates multiple sub-filter conditions as a unit, per De Morgan's law, when one is itself a negation" do
+          query = new_query(client_filter: {"not" => {
+            "age" => {"equal_to_any_of" => [nil]},
+            "height" => {"gt" => 10}
+          }})
+
+          # `NOT (age = nil AND height > 10)` must be `age != nil OR height <= 10`. The negated
+          # `age = nil` clause must not be pulled up out of the `NOT` as an independently required
+          # `exists` clause--that would produce `age != nil AND height <= 10` instead.
+          expect(datastore_body_of(query)).to query_datastore_with({bool: {
+            must_not: [{bool: {
+              must_not: [{bool: {filter: [{exists: {"field" => "age"}}]}}],
+              filter: [{range: {"height" => {gt: 10}}}]
+            }}]
+          }})
+        end
+
+        specify "`not` negates multiple negated sub-filter conditions as a unit, per De Morgan's law" do
+          query = new_query(client_filter: {"not" => {
+            "age" => {"equal_to_any_of" => [nil]},
+            "name" => {"equal_to_any_of" => [nil]}
+          }})
+
+          # `NOT (age = nil AND name = nil)` must be `age != nil OR name != nil`. The negated
+          # clauses must not each be un-negated and pulled up as independently required `exists`
+          # clauses--that would produce `age != nil AND name != nil` instead.
+          expect(datastore_body_of(query)).to query_datastore_with({bool: {
+            must_not: [{bool: {
+              must_not: [
+                {bool: {filter: [{exists: {"field" => "age"}}]}},
+                {bool: {filter: [{exists: {"field" => "name"}}]}}
+              ]
+            }}]
+          }})
         end
 
         specify "`not: {all_of: [...]}` returns only the documents that are unmatched by `all_of: [...]`" do
@@ -1983,7 +2058,7 @@ module ElasticGraph
             "age" => {"not" => {"not" => {"any_of" => []}}}
           })
 
-          expect(datastore_body_of(query)).to query_datastore_with(always_false_condition)
+          expect(datastore_body_of(query)).to query_datastore_with({bool: {filter: [always_false_condition]}})
         end
 
         # Note: the GraphQL schema does not allow `any_of: {}` (`any_of` is a list field). However, we're testing


### PR DESCRIPTION
## Why
`not:` filters over multiple conditions silently return wrong results. The double-negation pull-up optimization in `FilterInterpreter#process_not_expression` violates De Morgan's law: when the negated sub-filter contains `must_not` clauses plus other clauses (or multiple `must_not` clauses), each `must_not` clause is un-negated and merged into the shared parent bool node as an independently required condition, producing `NOT A AND NOT B` where `NOT A OR NOT B` is required. For example, `{not: {age: {equalToAnyOf: [null]}, height: {gt: 10}}}` matches documents where `age` exists AND `height <= 10` instead of OR. Pulled-up `should` clauses were also concatenated into the parent's `should` list (with `minimum_should_match` overwritten), collapsing `{anyOf: [A, B], not: {not: {anyOf: [C, D]}}}` into a single flat `A OR B OR C OR D` instead of `(A OR B) AND (C OR D)`.

## What
- `not:` now negates the entire sub-filter as a single unit (`must_not: [{bool: <sub-filter>}]`), so multi-condition sub-filters follow De Morgan's law.
- The double-negation pull-up (`NOT (NOT A) == A`) is retained only in the one case where it's sound: a sub-filter consisting of exactly one `must_not` clause and nothing else. The inner clause is appended to the parent's `filter` list as a self-contained clause instead of being flattened into the shared bool node, so its `should`/`minimum_should_match` can't bleed into (or clobber) sibling clauses.
- Updated unit spec expectations that pinned the old flattened query structure (semantics unchanged), and added unit + integration regression specs covering the three wrong-result scenarios above.

## Risk Assessment
This changes the generated datastore query structure for `not:` filters: the double-negation case now emits a nested `bool` clause under `filter` rather than flattened clauses, and multi-condition negations emit a single nested `must_not` clause. Elasticsearch/OpenSearch handle nested bools natively; behavior only changes for queries that were previously returning wrong results.