### PR TITLE
Fix float truncation in min/max derived field scripts

### DIFF
--- a/config/schema/artifacts/data_warehouse.yaml
+++ b/config/schema/artifacts/data_warehouse.yaml
@@ -144,7 +144,9 @@ tables:
         widget_options STRUCT<sizes ARRAY<STRING>, colors ARRAY<STRING>>,
         nested_fields STRUCT<max_widget_cost INT>,
         oldest_widget_created_at TIMESTAMP,
-        max_weight_in_ng BIGINT
+        max_weight_in_ng BIGINT,
+        min_weight_in_grams FLOAT,
+        max_weight_in_grams FLOAT
       )
   widget_records:
     table_schema: |-
@@ -177,6 +179,7 @@ tables:
         named_inventor STRUCT<id STRING, name STRING, nationality STRING, __typename STRING, stock_ticker STRING>,
         weight_in_ng_str BIGINT,
         weight_in_ng BIGINT,
+        weight_in_grams FLOAT,
         tags ARRAY<STRING>,
         amounts ARRAY<INT>,
         fees ARRAY<STRUCT<currency STRING, amount_cents INT>>,

--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -1322,6 +1322,10 @@ index_templates:
             format: strict_date_time
           max_weight_in_ng:
             type: long
+          min_weight_in_grams:
+            type: double
+          max_weight_in_grams:
+            type: double
           __counts:
             properties:
               widget_names2:
@@ -1469,6 +1473,8 @@ index_templates:
             type: long
           weight_in_ng:
             type: long
+          weight_in_grams:
+            type: double
           tags:
             type: keyword
           amounts:
@@ -1984,11 +1990,31 @@ indices:
       index.number_of_shards: 1
       index.max_result_window: 10000
 scripts:
-  update_WidgetCurrency_from_Widget_e72813bd1a8767343222b77bf53be31c:
+  update_WidgetCurrency_from_Widget_514248e200403f9ab1766130a517439a:
     context: update
     script:
       lang: painless
       source: |-
+        // Compares two values of a min or max field, coercing numeric values as needed.
+        //
+        // Different `Number` implementations (e.g. `Integer` vs `Long`, or `Long` vs `Double`) cannot be
+        // compared with `compareTo` (it throws a `ClassCastException`), and JSON parsing can produce any
+        // of them for the same field (e.g. `2` parses as an `Integer` while `2.9` parses as a `Double`).
+        // Integral values are compared as `long`s to preserve full precision (a `double` cannot exactly
+        // represent all integral values above 2^53), while comparisons involving a floating point value
+        // are performed as `double`s to avoid truncating fractional parts.
+        int minOrMaxValue_compareValues(def value1, def value2) {
+          if (value1 instanceof Number && value2 instanceof Number) {
+            if (value1 instanceof Float || value1 instanceof Double || value2 instanceof Float || value2 instanceof Double) {
+              return Double.compare(((Number)value1).doubleValue(), ((Number)value2).doubleValue());
+            }
+
+            return Long.compare(((Number)value1).longValue(), ((Number)value2).longValue());
+          }
+
+          return value1.compareTo(value2);
+        }
+
         // Idempotently inserts the given value in the `sortedList`, returning `true` if the list was updated.
         boolean appendOnlySet_idempotentlyInsertValue(def value, List sortedList) {
           // As per https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Collections.html#binarySearch(java.util.List,java.lang.Object):
@@ -2074,58 +2100,46 @@ scripts:
 
         boolean maxValue_idempotentlyUpdateValue(List values, def parentObject, String fieldName) {
           def currentFieldValue = parentObject[fieldName];
-          // Normalize incoming list numerics to long to avoid Integer/Long class cast issues
-          List coercedValues = new ArrayList();
-          for (def v : values) {
-            if (v != null) {
-              if (v instanceof Number) {
-                coercedValues.add(((Number)v).longValue());
-              } else {
-                coercedValues.add(v);
-              }
+
+          // Track the winning value itself (rather than a coerced copy of it) so that the exact value
+          // from the source event or existing document gets stored, with no coercion applied.
+          def maxValue = currentFieldValue;
+          boolean updated = false;
+
+          for (def value : values) {
+            if (value != null && (maxValue == null || minOrMaxValue_compareValues(value, maxValue) > 0)) {
+              maxValue = value;
+              updated = true;
             }
           }
-          def maxNewValue = coercedValues.isEmpty() ? null : Collections.max(coercedValues);
 
-          def coercedCurrentFieldValue = null;
-          if (currentFieldValue != null) {
-            coercedCurrentFieldValue = (currentFieldValue instanceof Number) ? ((Number)currentFieldValue).longValue() : currentFieldValue;
+          if (updated) {
+            parentObject[fieldName] = maxValue;
           }
 
-          if (maxNewValue != null && (coercedCurrentFieldValue == null || maxNewValue.compareTo(coercedCurrentFieldValue) > 0)) {
-            parentObject[fieldName] = maxNewValue;
-            return true;
-          }
-
-          return false;
+          return updated;
         }
 
         boolean minValue_idempotentlyUpdateValue(List values, def parentObject, String fieldName) {
           def currentFieldValue = parentObject[fieldName];
-          // Normalize incoming list numerics to long to avoid Integer/Long class cast issues
-          List coercedValues = new ArrayList();
-          for (def v : values) {
-            if (v != null) {
-              if (v instanceof Number) {
-                coercedValues.add(((Number)v).longValue());
-              } else {
-                coercedValues.add(v);
-              }
+
+          // Track the winning value itself (rather than a coerced copy of it) so that the exact value
+          // from the source event or existing document gets stored, with no coercion applied.
+          def minValue = currentFieldValue;
+          boolean updated = false;
+
+          for (def value : values) {
+            if (value != null && (minValue == null || minOrMaxValue_compareValues(value, minValue) < 0)) {
+              minValue = value;
+              updated = true;
             }
           }
-          def minNewValue = coercedValues.isEmpty() ? null : Collections.min(coercedValues);
 
-          def coercedCurrentFieldValue = null;
-          if (currentFieldValue != null) {
-            coercedCurrentFieldValue = (currentFieldValue instanceof Number) ? ((Number)currentFieldValue).longValue() : currentFieldValue;
+          if (updated) {
+            parentObject[fieldName] = minValue;
           }
 
-          if (minNewValue != null && (coercedCurrentFieldValue == null || minNewValue.compareTo(coercedCurrentFieldValue) < 0)) {
-            parentObject[fieldName] = minNewValue;
-            return true;
-          }
-
-          return false;
+          return updated;
         }
 
         Map data = params.topLevelFields;
@@ -2159,7 +2173,9 @@ scripts:
         boolean details__symbol_was_noop = !immutableValue_idempotentlyUpdateValue(scriptErrors, data["cost_currency_symbol"], ctx._source.details, "details.symbol", "symbol", true, true);
         boolean details__unit_was_noop = !immutableValue_idempotentlyUpdateValue(scriptErrors, data["cost_currency_unit"], ctx._source.details, "details.unit", "unit", false, false);
         boolean introduced_on_was_noop = !immutableValue_idempotentlyUpdateValue(scriptErrors, data["cost_currency_introduced_on"], ctx._source, "introduced_on", "introduced_on", true, false);
+        boolean max_weight_in_grams_was_noop = !maxValue_idempotentlyUpdateValue(data["weight_in_grams"], ctx._source, "max_weight_in_grams");
         boolean max_weight_in_ng_was_noop = !maxValue_idempotentlyUpdateValue(data["weight_in_ng"], ctx._source, "max_weight_in_ng");
+        boolean min_weight_in_grams_was_noop = !minValue_idempotentlyUpdateValue(data["weight_in_grams"], ctx._source, "min_weight_in_grams");
         boolean name_was_noop = !immutableValue_idempotentlyUpdateValue(scriptErrors, data["cost_currency_name"], ctx._source, "name", "name", true, false);
         boolean nested_fields__max_widget_cost_was_noop = !maxValue_idempotentlyUpdateValue(data["cost.amount_cents"], ctx._source.nested_fields, "max_widget_cost");
         boolean oldest_widget_created_at_was_noop = !minValue_idempotentlyUpdateValue(data["created_at"], ctx._source, "oldest_widget_created_at");
@@ -2176,7 +2192,7 @@ scripts:
 
         // For records with no new values to index, only skip the update if the document itself doesn't already exist.
         // Otherwise create an (empty) document to reflect the fact that the id has been seen.
-        if (ctx._source.id != null && details__symbol_was_noop && details__unit_was_noop && introduced_on_was_noop && max_weight_in_ng_was_noop && name_was_noop && nested_fields__max_widget_cost_was_noop && oldest_widget_created_at_was_noop && primary_continent_was_noop && widget_fee_currencies_was_noop && widget_names2_was_noop && widget_options__colors_was_noop && widget_options__sizes_was_noop && widget_tags_was_noop) {
+        if (ctx._source.id != null && details__symbol_was_noop && details__unit_was_noop && introduced_on_was_noop && max_weight_in_grams_was_noop && max_weight_in_ng_was_noop && min_weight_in_grams_was_noop && name_was_noop && nested_fields__max_widget_cost_was_noop && oldest_widget_created_at_was_noop && primary_continent_was_noop && widget_fee_currencies_was_noop && widget_names2_was_noop && widget_options__colors_was_noop && widget_options__sizes_was_noop && widget_tags_was_noop) {
           ctx.op = 'none';
         } else {
           // Here we set `_source.id` because if we don't, it'll never be set, making these docs subtly

--- a/config/schema/artifacts/json_schemas.yaml
+++ b/config/schema/artifacts/json_schemas.yaml
@@ -1194,6 +1194,10 @@ json_schema_version: 1
         "$ref": "#/$defs/LongString"
       weight_in_ng:
         "$ref": "#/$defs/JsonSafeLong"
+      weight_in_grams:
+        anyOf:
+        - "$ref": "#/$defs/Float"
+        - type: 'null'
       tags:
         type: array
         items:
@@ -1247,6 +1251,7 @@ json_schema_version: 1
     - named_inventor
     - weight_in_ng_str
     - weight_in_ng
+    - weight_in_grams
     - tags
     - amounts
     - fees

--- a/config/schema/artifacts/json_schemas_by_version/v1.yaml
+++ b/config/schema/artifacts/json_schemas_by_version/v1.yaml
@@ -1644,6 +1644,13 @@ json_schema_version: 1
         ElasticGraph:
           type: JsonSafeLong!
           nameInIndex: weight_in_ng
+      weight_in_grams:
+        anyOf:
+        - "$ref": "#/$defs/Float"
+        - type: 'null'
+        ElasticGraph:
+          type: Float
+          nameInIndex: weight_in_grams
       tags:
         type: array
         items:
@@ -1709,6 +1716,7 @@ json_schema_version: 1
     - named_inventor
     - weight_in_ng_str
     - weight_in_ng
+    - weight_in_grams
     - tags
     - amounts
     - fees

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -815,6 +815,14 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: voltage
+      weight_in_grams_ASC:
+        sort_field:
+          direction: asc
+          field_path: weight_in_grams
+      weight_in_grams_DESC:
+        sort_field:
+          direction: desc
+          field_path: weight_in_grams
       weight_in_ng_ASC:
         sort_field:
           direction: asc
@@ -1169,6 +1177,14 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: introduced_on
+      max_weight_in_grams_ASC:
+        sort_field:
+          direction: asc
+          field_path: max_weight_in_grams
+      max_weight_in_grams_DESC:
+        sort_field:
+          direction: desc
+          field_path: max_weight_in_grams
       max_weight_in_ng_ASC:
         sort_field:
           direction: asc
@@ -1177,6 +1193,14 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: max_weight_in_ng
+      min_weight_in_grams_ASC:
+        sort_field:
+          direction: asc
+          field_path: min_weight_in_grams
+      min_weight_in_grams_DESC:
+        sort_field:
+          direction: desc
+          field_path: min_weight_in_grams
       name_ASC:
         sort_field:
           direction: asc
@@ -1507,6 +1531,14 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: timestamps.created_at
+      weight_in_grams_ASC:
+        sort_field:
+          direction: asc
+          field_path: weight_in_grams
+      weight_in_grams_DESC:
+        sort_field:
+          direction: desc
+          field_path: weight_in_grams
       weight_in_ng_ASC:
         sort_field:
           direction: asc
@@ -1821,6 +1853,14 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: the_opts.the_sighs
+      weight_in_grams_ASC:
+        sort_field:
+          direction: asc
+          field_path: weight_in_grams
+      weight_in_grams_DESC:
+        sort_field:
+          direction: desc
+          field_path: weight_in_grams
       weight_in_ng_ASC:
         sort_field:
           direction: asc
@@ -3059,7 +3099,11 @@ index_definitions_by_name:
         source: __self
       introduced_on:
         source: __self
+      max_weight_in_grams:
+        source: __self
       max_weight_in_ng:
+        source: __self
+      min_weight_in_grams:
         source: __self
       name:
         source: __self
@@ -3205,6 +3249,8 @@ index_definitions_by_name:
       the_opts.size:
         source: __self
       the_opts.the_sighs:
+        source: __self
+      weight_in_grams:
         source: __self
       weight_in_ng:
         source: __self
@@ -5479,6 +5525,9 @@ object_types_by_name:
       voltage:
         resolver:
           name: get_record_field_value
+      weight_in_grams:
+        resolver:
+          name: get_record_field_value
       weight_in_ng:
         resolver:
           name: get_record_field_value
@@ -5629,6 +5678,9 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       voltage:
+        resolver:
+          name: object_with_lookahead
+      weight_in_grams:
         resolver:
           name: object_with_lookahead
       weight_in_ng:
@@ -5840,6 +5892,9 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       voltage:
+        resolver:
+          name: object_with_lookahead
+      weight_in_grams:
         resolver:
           name: object_with_lookahead
       weight_in_ng:
@@ -8392,6 +8447,9 @@ object_types_by_name:
         name_in_index: the_opts
         resolver:
           name: get_record_field_value
+      weight_in_grams:
+        resolver:
+          name: get_record_field_value
       weight_in_ng:
         resolver:
           name: get_record_field_value
@@ -8411,7 +8469,7 @@ object_types_by_name:
     - id_source: cost.currency
       rollover_timestamp_value_source: cost_currency_introduced_on
       routing_value_source: cost_currency_primary_continent
-      script_id: update_WidgetCurrency_from_Widget_e72813bd1a8767343222b77bf53be31c
+      script_id: update_WidgetCurrency_from_Widget_514248e200403f9ab1766130a517439a
       top_level_fields_params:
         cost.amount_cents:
           cardinality: many
@@ -8436,6 +8494,8 @@ object_types_by_name:
         options.size:
           cardinality: many
         tags:
+          cardinality: many
+        weight_in_grams:
           cardinality: many
         weight_in_ng:
           cardinality: many
@@ -8512,6 +8572,8 @@ object_types_by_name:
         tags:
           cardinality: one
         the_opts:
+          cardinality: one
+        weight_in_grams:
           cardinality: one
         weight_in_ng:
           cardinality: one
@@ -8644,6 +8706,9 @@ object_types_by_name:
         name_in_index: the_opts
         resolver:
           name: object_with_lookahead
+      weight_in_grams:
+        resolver:
+          name: object_with_lookahead
       weight_in_ng:
         resolver:
           name: object_with_lookahead
@@ -8717,7 +8782,13 @@ object_types_by_name:
       introduced_on:
         resolver:
           name: get_record_field_value
+      max_weight_in_grams:
+        resolver:
+          name: get_record_field_value
       max_weight_in_ng:
+        resolver:
+          name: get_record_field_value
+      min_weight_in_grams:
         resolver:
           name: get_record_field_value
       name:
@@ -8769,7 +8840,11 @@ object_types_by_name:
           cardinality: one
         introduced_on:
           cardinality: one
+        max_weight_in_grams:
+          cardinality: one
         max_weight_in_ng:
+          cardinality: one
+        min_weight_in_grams:
           cardinality: one
         name:
           cardinality: one
@@ -8799,7 +8874,13 @@ object_types_by_name:
       introduced_on:
         resolver:
           name: object_with_lookahead
+      max_weight_in_grams:
+        resolver:
+          name: object_with_lookahead
       max_weight_in_ng:
+        resolver:
+          name: object_with_lookahead
+      min_weight_in_grams:
         resolver:
           name: object_with_lookahead
       name:
@@ -8903,7 +8984,13 @@ object_types_by_name:
       introduced_on:
         resolver:
           name: object_with_lookahead
+      max_weight_in_grams:
+        resolver:
+          name: object_with_lookahead
       max_weight_in_ng:
+        resolver:
+          name: object_with_lookahead
+      min_weight_in_grams:
         resolver:
           name: object_with_lookahead
       name:
@@ -9079,6 +9166,9 @@ object_types_by_name:
           name: object_with_lookahead
       the_options:
         name_in_index: the_opts
+        resolver:
+          name: object_with_lookahead
+      weight_in_grams:
         resolver:
           name: object_with_lookahead
       weight_in_ng:
@@ -9391,6 +9481,9 @@ object_types_by_name:
       timestamps:
         resolver:
           name: get_record_field_value
+      weight_in_grams:
+        resolver:
+          name: get_record_field_value
       weight_in_ng:
         resolver:
           name: get_record_field_value
@@ -9507,6 +9600,9 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       timestamps:
+        resolver:
+          name: object_with_lookahead
+      weight_in_grams:
         resolver:
           name: object_with_lookahead
       weight_in_ng:
@@ -9694,6 +9790,9 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       timestamps:
+        resolver:
+          name: object_with_lookahead
+      weight_in_grams:
         resolver:
           name: object_with_lookahead
       weight_in_ng:

--- a/config/schema/artifacts/schema.graphql
+++ b/config/schema/artifacts/schema.graphql
@@ -7079,6 +7079,11 @@ type NamedEntityAggregatedValues {
   voltage: IntAggregatedValues
 
   """
+  Computed aggregate values for the `weight_in_grams` field.
+  """
+  weight_in_grams: FloatAggregatedValues
+
+  """
   Computed aggregate values for the `weight_in_ng` field.
   """
   weight_in_ng: JsonSafeLongAggregatedValues
@@ -7534,6 +7539,13 @@ input NamedEntityFilterInput {
   voltage: IntFilterInput
 
   """
+  Used to filter on the `weight_in_grams` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  weight_in_grams: FloatFilterInput
+
+  """
   Used to filter on the `weight_in_ng` field.
 
   When `null` or an empty object is passed, matches all documents.
@@ -7781,6 +7793,11 @@ type NamedEntityGroupedBy {
   The `voltage` field value for this group.
   """
   voltage: Int
+
+  """
+  The `weight_in_grams` field value for this group.
+  """
+  weight_in_grams: Float
 
   """
   The `weight_in_ng` field value for this group.
@@ -8391,6 +8408,16 @@ enum NamedEntitySortOrderInput {
   Sorts descending by the `voltage` field.
   """
   voltage_DESC
+
+  """
+  Sorts ascending by the `weight_in_grams` field.
+  """
+  weight_in_grams_ASC
+
+  """
+  Sorts descending by the `weight_in_grams` field.
+  """
+  weight_in_grams_DESC
 
   """
   Sorts ascending by the `weight_in_ng` field.
@@ -17049,6 +17076,7 @@ type Widget implements NamedEntity {
   size: Size
   tags: [String!]!
   the_options: WidgetOptions
+  weight_in_grams: Float
   weight_in_ng: JsonSafeLong!
   weight_in_ng_str: LongString!
   workspace_id: ID
@@ -17205,6 +17233,11 @@ type WidgetAggregatedValues {
   the_options: WidgetOptionsAggregatedValues
 
   """
+  Computed aggregate values for the `weight_in_grams` field.
+  """
+  weight_in_grams: FloatAggregatedValues
+
+  """
   Computed aggregate values for the `weight_in_ng` field.
   """
   weight_in_ng: JsonSafeLongAggregatedValues
@@ -17323,7 +17356,9 @@ type WidgetCurrency {
   details: CurrencyDetails
   id: ID!
   introduced_on: Date
+  max_weight_in_grams: Float
   max_weight_in_ng: JsonSafeLong
+  min_weight_in_grams: Float
   name: String
   nested_fields: WidgetCurrencyNestedFields
   oldest_widget_created_at: DateTime
@@ -17392,9 +17427,19 @@ type WidgetCurrencyAggregatedValues {
   introduced_on: DateAggregatedValues
 
   """
+  Computed aggregate values for the `max_weight_in_grams` field.
+  """
+  max_weight_in_grams: FloatAggregatedValues
+
+  """
   Computed aggregate values for the `max_weight_in_ng` field.
   """
   max_weight_in_ng: JsonSafeLongAggregatedValues
+
+  """
+  Computed aggregate values for the `min_weight_in_grams` field.
+  """
+  min_weight_in_grams: FloatAggregatedValues
 
   """
   Computed aggregate values for the `name` field.
@@ -17607,11 +17652,25 @@ input WidgetCurrencyFilterInput {
   introduced_on: DateFilterInput
 
   """
+  Used to filter on the `max_weight_in_grams` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  max_weight_in_grams: FloatFilterInput
+
+  """
   Used to filter on the `max_weight_in_ng` field.
 
   When `null` or an empty object is passed, matches all documents.
   """
   max_weight_in_ng: JsonSafeLongFilterInput
+
+  """
+  Used to filter on the `min_weight_in_grams` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  min_weight_in_grams: FloatFilterInput
 
   """
   Used to filter on the `name` field.
@@ -17693,9 +17752,19 @@ type WidgetCurrencyGroupedBy {
   introduced_on: DateGroupedBy
 
   """
+  The `max_weight_in_grams` field value for this group.
+  """
+  max_weight_in_grams: Float
+
+  """
   The `max_weight_in_ng` field value for this group.
   """
   max_weight_in_ng: JsonSafeLong
+
+  """
+  The `min_weight_in_grams` field value for this group.
+  """
+  min_weight_in_grams: Float
 
   """
   The `name` field value for this group.
@@ -17886,6 +17955,16 @@ enum WidgetCurrencySortOrderInput {
   introduced_on_DESC
 
   """
+  Sorts ascending by the `max_weight_in_grams` field.
+  """
+  max_weight_in_grams_ASC
+
+  """
+  Sorts descending by the `max_weight_in_grams` field.
+  """
+  max_weight_in_grams_DESC
+
+  """
   Sorts ascending by the `max_weight_in_ng` field.
   """
   max_weight_in_ng_ASC
@@ -17894,6 +17973,16 @@ enum WidgetCurrencySortOrderInput {
   Sorts descending by the `max_weight_in_ng` field.
   """
   max_weight_in_ng_DESC
+
+  """
+  Sorts ascending by the `min_weight_in_grams` field.
+  """
+  min_weight_in_grams_ASC
+
+  """
+  Sorts descending by the `min_weight_in_grams` field.
+  """
+  min_weight_in_grams_DESC
 
   """
   Sorts ascending by the `name` field.
@@ -18219,6 +18308,13 @@ input WidgetFilterInput {
   the_options: WidgetOptionsFilterInput
 
   """
+  Used to filter on the `weight_in_grams` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  weight_in_grams: FloatFilterInput
+
+  """
   Used to filter on the `weight_in_ng` field.
 
   When `null` or an empty object is passed, matches all documents.
@@ -18411,6 +18507,11 @@ type WidgetGroupedBy {
   The `the_options` field value for this group.
   """
   the_options: WidgetOptionsGroupedBy
+
+  """
+  The `weight_in_grams` field value for this group.
+  """
+  weight_in_grams: Float
 
   """
   The `weight_in_ng` field value for this group.
@@ -19014,6 +19115,11 @@ type WidgetOrAddressAggregatedValues {
   timestamps: AddressTimestampsAggregatedValues
 
   """
+  Computed aggregate values for the `weight_in_grams` field.
+  """
+  weight_in_grams: FloatAggregatedValues
+
+  """
   Computed aggregate values for the `weight_in_ng` field.
   """
   weight_in_ng: JsonSafeLongAggregatedValues
@@ -19437,6 +19543,13 @@ input WidgetOrAddressFilterInput {
   timestamps: AddressTimestampsFilterInput
 
   """
+  Used to filter on the `weight_in_grams` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  weight_in_grams: FloatFilterInput
+
+  """
   Used to filter on the `weight_in_ng` field.
 
   When `null` or an empty object is passed, matches all documents.
@@ -19639,6 +19752,11 @@ type WidgetOrAddressGroupedBy {
   The `timestamps` field value for this group.
   """
   timestamps: AddressTimestampsGroupedBy
+
+  """
+  The `weight_in_grams` field value for this group.
+  """
+  weight_in_grams: Float
 
   """
   The `weight_in_ng` field value for this group.
@@ -20151,6 +20269,16 @@ enum WidgetOrAddressSortOrderInput {
   timestamps_created_at_DESC
 
   """
+  Sorts ascending by the `weight_in_grams` field.
+  """
+  weight_in_grams_ASC
+
+  """
+  Sorts descending by the `weight_in_grams` field.
+  """
+  weight_in_grams_DESC
+
+  """
   Sorts ascending by the `weight_in_ng` field.
   """
   weight_in_ng_ASC
@@ -20544,6 +20672,16 @@ enum WidgetSortOrderInput {
   Sorts descending by the `the_options.the_size` field.
   """
   the_options_the_size_DESC
+
+  """
+  Sorts ascending by the `weight_in_grams` field.
+  """
+  weight_in_grams_ASC
+
+  """
+  Sorts descending by the `weight_in_grams` field.
+  """
+  weight_in_grams_DESC
 
   """
   Sorts ascending by the `weight_in_ng` field.

--- a/config/schema/artifacts_with_apollo/data_warehouse.yaml
+++ b/config/schema/artifacts_with_apollo/data_warehouse.yaml
@@ -144,7 +144,9 @@ tables:
         widget_options STRUCT<sizes ARRAY<STRING>, colors ARRAY<STRING>>,
         nested_fields STRUCT<max_widget_cost INT>,
         oldest_widget_created_at TIMESTAMP,
-        max_weight_in_ng BIGINT
+        max_weight_in_ng BIGINT,
+        min_weight_in_grams FLOAT,
+        max_weight_in_grams FLOAT
       )
   widget_records:
     table_schema: |-
@@ -177,6 +179,7 @@ tables:
         named_inventor STRUCT<id STRING, name STRING, nationality STRING, __typename STRING, stock_ticker STRING>,
         weight_in_ng_str BIGINT,
         weight_in_ng BIGINT,
+        weight_in_grams FLOAT,
         tags ARRAY<STRING>,
         amounts ARRAY<INT>,
         fees ARRAY<STRUCT<currency STRING, amount_cents INT>>,

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -1322,6 +1322,10 @@ index_templates:
             format: strict_date_time
           max_weight_in_ng:
             type: long
+          min_weight_in_grams:
+            type: double
+          max_weight_in_grams:
+            type: double
           __counts:
             properties:
               widget_names2:
@@ -1469,6 +1473,8 @@ index_templates:
             type: long
           weight_in_ng:
             type: long
+          weight_in_grams:
+            type: double
           tags:
             type: keyword
           amounts:
@@ -1984,11 +1990,31 @@ indices:
       index.number_of_shards: 1
       index.max_result_window: 10000
 scripts:
-  update_WidgetCurrency_from_Widget_e72813bd1a8767343222b77bf53be31c:
+  update_WidgetCurrency_from_Widget_514248e200403f9ab1766130a517439a:
     context: update
     script:
       lang: painless
       source: |-
+        // Compares two values of a min or max field, coercing numeric values as needed.
+        //
+        // Different `Number` implementations (e.g. `Integer` vs `Long`, or `Long` vs `Double`) cannot be
+        // compared with `compareTo` (it throws a `ClassCastException`), and JSON parsing can produce any
+        // of them for the same field (e.g. `2` parses as an `Integer` while `2.9` parses as a `Double`).
+        // Integral values are compared as `long`s to preserve full precision (a `double` cannot exactly
+        // represent all integral values above 2^53), while comparisons involving a floating point value
+        // are performed as `double`s to avoid truncating fractional parts.
+        int minOrMaxValue_compareValues(def value1, def value2) {
+          if (value1 instanceof Number && value2 instanceof Number) {
+            if (value1 instanceof Float || value1 instanceof Double || value2 instanceof Float || value2 instanceof Double) {
+              return Double.compare(((Number)value1).doubleValue(), ((Number)value2).doubleValue());
+            }
+
+            return Long.compare(((Number)value1).longValue(), ((Number)value2).longValue());
+          }
+
+          return value1.compareTo(value2);
+        }
+
         // Idempotently inserts the given value in the `sortedList`, returning `true` if the list was updated.
         boolean appendOnlySet_idempotentlyInsertValue(def value, List sortedList) {
           // As per https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Collections.html#binarySearch(java.util.List,java.lang.Object):
@@ -2074,58 +2100,46 @@ scripts:
 
         boolean maxValue_idempotentlyUpdateValue(List values, def parentObject, String fieldName) {
           def currentFieldValue = parentObject[fieldName];
-          // Normalize incoming list numerics to long to avoid Integer/Long class cast issues
-          List coercedValues = new ArrayList();
-          for (def v : values) {
-            if (v != null) {
-              if (v instanceof Number) {
-                coercedValues.add(((Number)v).longValue());
-              } else {
-                coercedValues.add(v);
-              }
+
+          // Track the winning value itself (rather than a coerced copy of it) so that the exact value
+          // from the source event or existing document gets stored, with no coercion applied.
+          def maxValue = currentFieldValue;
+          boolean updated = false;
+
+          for (def value : values) {
+            if (value != null && (maxValue == null || minOrMaxValue_compareValues(value, maxValue) > 0)) {
+              maxValue = value;
+              updated = true;
             }
           }
-          def maxNewValue = coercedValues.isEmpty() ? null : Collections.max(coercedValues);
 
-          def coercedCurrentFieldValue = null;
-          if (currentFieldValue != null) {
-            coercedCurrentFieldValue = (currentFieldValue instanceof Number) ? ((Number)currentFieldValue).longValue() : currentFieldValue;
+          if (updated) {
+            parentObject[fieldName] = maxValue;
           }
 
-          if (maxNewValue != null && (coercedCurrentFieldValue == null || maxNewValue.compareTo(coercedCurrentFieldValue) > 0)) {
-            parentObject[fieldName] = maxNewValue;
-            return true;
-          }
-
-          return false;
+          return updated;
         }
 
         boolean minValue_idempotentlyUpdateValue(List values, def parentObject, String fieldName) {
           def currentFieldValue = parentObject[fieldName];
-          // Normalize incoming list numerics to long to avoid Integer/Long class cast issues
-          List coercedValues = new ArrayList();
-          for (def v : values) {
-            if (v != null) {
-              if (v instanceof Number) {
-                coercedValues.add(((Number)v).longValue());
-              } else {
-                coercedValues.add(v);
-              }
+
+          // Track the winning value itself (rather than a coerced copy of it) so that the exact value
+          // from the source event or existing document gets stored, with no coercion applied.
+          def minValue = currentFieldValue;
+          boolean updated = false;
+
+          for (def value : values) {
+            if (value != null && (minValue == null || minOrMaxValue_compareValues(value, minValue) < 0)) {
+              minValue = value;
+              updated = true;
             }
           }
-          def minNewValue = coercedValues.isEmpty() ? null : Collections.min(coercedValues);
 
-          def coercedCurrentFieldValue = null;
-          if (currentFieldValue != null) {
-            coercedCurrentFieldValue = (currentFieldValue instanceof Number) ? ((Number)currentFieldValue).longValue() : currentFieldValue;
+          if (updated) {
+            parentObject[fieldName] = minValue;
           }
 
-          if (minNewValue != null && (coercedCurrentFieldValue == null || minNewValue.compareTo(coercedCurrentFieldValue) < 0)) {
-            parentObject[fieldName] = minNewValue;
-            return true;
-          }
-
-          return false;
+          return updated;
         }
 
         Map data = params.topLevelFields;
@@ -2159,7 +2173,9 @@ scripts:
         boolean details__symbol_was_noop = !immutableValue_idempotentlyUpdateValue(scriptErrors, data["cost_currency_symbol"], ctx._source.details, "details.symbol", "symbol", true, true);
         boolean details__unit_was_noop = !immutableValue_idempotentlyUpdateValue(scriptErrors, data["cost_currency_unit"], ctx._source.details, "details.unit", "unit", false, false);
         boolean introduced_on_was_noop = !immutableValue_idempotentlyUpdateValue(scriptErrors, data["cost_currency_introduced_on"], ctx._source, "introduced_on", "introduced_on", true, false);
+        boolean max_weight_in_grams_was_noop = !maxValue_idempotentlyUpdateValue(data["weight_in_grams"], ctx._source, "max_weight_in_grams");
         boolean max_weight_in_ng_was_noop = !maxValue_idempotentlyUpdateValue(data["weight_in_ng"], ctx._source, "max_weight_in_ng");
+        boolean min_weight_in_grams_was_noop = !minValue_idempotentlyUpdateValue(data["weight_in_grams"], ctx._source, "min_weight_in_grams");
         boolean name_was_noop = !immutableValue_idempotentlyUpdateValue(scriptErrors, data["cost_currency_name"], ctx._source, "name", "name", true, false);
         boolean nested_fields__max_widget_cost_was_noop = !maxValue_idempotentlyUpdateValue(data["cost.amount_cents"], ctx._source.nested_fields, "max_widget_cost");
         boolean oldest_widget_created_at_was_noop = !minValue_idempotentlyUpdateValue(data["created_at"], ctx._source, "oldest_widget_created_at");
@@ -2176,7 +2192,7 @@ scripts:
 
         // For records with no new values to index, only skip the update if the document itself doesn't already exist.
         // Otherwise create an (empty) document to reflect the fact that the id has been seen.
-        if (ctx._source.id != null && details__symbol_was_noop && details__unit_was_noop && introduced_on_was_noop && max_weight_in_ng_was_noop && name_was_noop && nested_fields__max_widget_cost_was_noop && oldest_widget_created_at_was_noop && primary_continent_was_noop && widget_fee_currencies_was_noop && widget_names2_was_noop && widget_options__colors_was_noop && widget_options__sizes_was_noop && widget_tags_was_noop) {
+        if (ctx._source.id != null && details__symbol_was_noop && details__unit_was_noop && introduced_on_was_noop && max_weight_in_grams_was_noop && max_weight_in_ng_was_noop && min_weight_in_grams_was_noop && name_was_noop && nested_fields__max_widget_cost_was_noop && oldest_widget_created_at_was_noop && primary_continent_was_noop && widget_fee_currencies_was_noop && widget_names2_was_noop && widget_options__colors_was_noop && widget_options__sizes_was_noop && widget_tags_was_noop) {
           ctx.op = 'none';
         } else {
           // Here we set `_source.id` because if we don't, it'll never be set, making these docs subtly

--- a/config/schema/artifacts_with_apollo/json_schemas.yaml
+++ b/config/schema/artifacts_with_apollo/json_schemas.yaml
@@ -1194,6 +1194,10 @@ json_schema_version: 1
         "$ref": "#/$defs/LongString"
       weight_in_ng:
         "$ref": "#/$defs/JsonSafeLong"
+      weight_in_grams:
+        anyOf:
+        - "$ref": "#/$defs/Float"
+        - type: 'null'
       tags:
         type: array
         items:
@@ -1247,6 +1251,7 @@ json_schema_version: 1
     - named_inventor
     - weight_in_ng_str
     - weight_in_ng
+    - weight_in_grams
     - tags
     - amounts
     - fees

--- a/config/schema/artifacts_with_apollo/json_schemas_by_version/v1.yaml
+++ b/config/schema/artifacts_with_apollo/json_schemas_by_version/v1.yaml
@@ -1644,6 +1644,13 @@ json_schema_version: 1
         ElasticGraph:
           type: JsonSafeLong!
           nameInIndex: weight_in_ng
+      weight_in_grams:
+        anyOf:
+        - "$ref": "#/$defs/Float"
+        - type: 'null'
+        ElasticGraph:
+          type: Float
+          nameInIndex: weight_in_grams
       tags:
         type: array
         items:
@@ -1709,6 +1716,7 @@ json_schema_version: 1
     - named_inventor
     - weight_in_ng_str
     - weight_in_ng
+    - weight_in_grams
     - tags
     - amounts
     - fees

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -815,6 +815,14 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: voltage
+      weight_in_grams_ASC:
+        sort_field:
+          direction: asc
+          field_path: weight_in_grams
+      weight_in_grams_DESC:
+        sort_field:
+          direction: desc
+          field_path: weight_in_grams
       weight_in_ng_ASC:
         sort_field:
           direction: asc
@@ -1169,6 +1177,14 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: introduced_on
+      max_weight_in_grams_ASC:
+        sort_field:
+          direction: asc
+          field_path: max_weight_in_grams
+      max_weight_in_grams_DESC:
+        sort_field:
+          direction: desc
+          field_path: max_weight_in_grams
       max_weight_in_ng_ASC:
         sort_field:
           direction: asc
@@ -1177,6 +1193,14 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: max_weight_in_ng
+      min_weight_in_grams_ASC:
+        sort_field:
+          direction: asc
+          field_path: min_weight_in_grams
+      min_weight_in_grams_DESC:
+        sort_field:
+          direction: desc
+          field_path: min_weight_in_grams
       name_ASC:
         sort_field:
           direction: asc
@@ -1507,6 +1531,14 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: timestamps.created_at
+      weight_in_grams_ASC:
+        sort_field:
+          direction: asc
+          field_path: weight_in_grams
+      weight_in_grams_DESC:
+        sort_field:
+          direction: desc
+          field_path: weight_in_grams
       weight_in_ng_ASC:
         sort_field:
           direction: asc
@@ -1821,6 +1853,14 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: the_opts.the_sighs
+      weight_in_grams_ASC:
+        sort_field:
+          direction: asc
+          field_path: weight_in_grams
+      weight_in_grams_DESC:
+        sort_field:
+          direction: desc
+          field_path: weight_in_grams
       weight_in_ng_ASC:
         sort_field:
           direction: asc
@@ -3088,7 +3128,11 @@ index_definitions_by_name:
         source: __self
       introduced_on:
         source: __self
+      max_weight_in_grams:
+        source: __self
       max_weight_in_ng:
+        source: __self
+      min_weight_in_grams:
         source: __self
       name:
         source: __self
@@ -3234,6 +3278,8 @@ index_definitions_by_name:
       the_opts.size:
         source: __self
       the_opts.the_sighs:
+        source: __self
+      weight_in_grams:
         source: __self
       weight_in_ng:
         source: __self
@@ -5602,6 +5648,9 @@ object_types_by_name:
       voltage:
         resolver:
           name: get_record_field_value
+      weight_in_grams:
+        resolver:
+          name: get_record_field_value
       weight_in_ng:
         resolver:
           name: get_record_field_value
@@ -5752,6 +5801,9 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       voltage:
+        resolver:
+          name: object_with_lookahead
+      weight_in_grams:
         resolver:
           name: object_with_lookahead
       weight_in_ng:
@@ -5963,6 +6015,9 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       voltage:
+        resolver:
+          name: object_with_lookahead
+      weight_in_grams:
         resolver:
           name: object_with_lookahead
       weight_in_ng:
@@ -8521,6 +8576,9 @@ object_types_by_name:
         name_in_index: the_opts
         resolver:
           name: get_record_field_value
+      weight_in_grams:
+        resolver:
+          name: get_record_field_value
       weight_in_ng:
         resolver:
           name: get_record_field_value
@@ -8540,7 +8598,7 @@ object_types_by_name:
     - id_source: cost.currency
       rollover_timestamp_value_source: cost_currency_introduced_on
       routing_value_source: cost_currency_primary_continent
-      script_id: update_WidgetCurrency_from_Widget_e72813bd1a8767343222b77bf53be31c
+      script_id: update_WidgetCurrency_from_Widget_514248e200403f9ab1766130a517439a
       top_level_fields_params:
         cost.amount_cents:
           cardinality: many
@@ -8565,6 +8623,8 @@ object_types_by_name:
         options.size:
           cardinality: many
         tags:
+          cardinality: many
+        weight_in_grams:
           cardinality: many
         weight_in_ng:
           cardinality: many
@@ -8641,6 +8701,8 @@ object_types_by_name:
         tags:
           cardinality: one
         the_opts:
+          cardinality: one
+        weight_in_grams:
           cardinality: one
         weight_in_ng:
           cardinality: one
@@ -8773,6 +8835,9 @@ object_types_by_name:
         name_in_index: the_opts
         resolver:
           name: object_with_lookahead
+      weight_in_grams:
+        resolver:
+          name: object_with_lookahead
       weight_in_ng:
         resolver:
           name: object_with_lookahead
@@ -8846,7 +8911,13 @@ object_types_by_name:
       introduced_on:
         resolver:
           name: get_record_field_value
+      max_weight_in_grams:
+        resolver:
+          name: get_record_field_value
       max_weight_in_ng:
+        resolver:
+          name: get_record_field_value
+      min_weight_in_grams:
         resolver:
           name: get_record_field_value
       name:
@@ -8898,7 +8969,11 @@ object_types_by_name:
           cardinality: one
         introduced_on:
           cardinality: one
+        max_weight_in_grams:
+          cardinality: one
         max_weight_in_ng:
+          cardinality: one
+        min_weight_in_grams:
           cardinality: one
         name:
           cardinality: one
@@ -8928,7 +9003,13 @@ object_types_by_name:
       introduced_on:
         resolver:
           name: object_with_lookahead
+      max_weight_in_grams:
+        resolver:
+          name: object_with_lookahead
       max_weight_in_ng:
+        resolver:
+          name: object_with_lookahead
+      min_weight_in_grams:
         resolver:
           name: object_with_lookahead
       name:
@@ -9032,7 +9113,13 @@ object_types_by_name:
       introduced_on:
         resolver:
           name: object_with_lookahead
+      max_weight_in_grams:
+        resolver:
+          name: object_with_lookahead
       max_weight_in_ng:
+        resolver:
+          name: object_with_lookahead
+      min_weight_in_grams:
         resolver:
           name: object_with_lookahead
       name:
@@ -9208,6 +9295,9 @@ object_types_by_name:
           name: object_with_lookahead
       the_options:
         name_in_index: the_opts
+        resolver:
+          name: object_with_lookahead
+      weight_in_grams:
         resolver:
           name: object_with_lookahead
       weight_in_ng:
@@ -9520,6 +9610,9 @@ object_types_by_name:
       timestamps:
         resolver:
           name: get_record_field_value
+      weight_in_grams:
+        resolver:
+          name: get_record_field_value
       weight_in_ng:
         resolver:
           name: get_record_field_value
@@ -9636,6 +9729,9 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       timestamps:
+        resolver:
+          name: object_with_lookahead
+      weight_in_grams:
         resolver:
           name: object_with_lookahead
       weight_in_ng:
@@ -9823,6 +9919,9 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       timestamps:
+        resolver:
+          name: object_with_lookahead
+      weight_in_grams:
         resolver:
           name: object_with_lookahead
       weight_in_ng:

--- a/config/schema/artifacts_with_apollo/schema.graphql
+++ b/config/schema/artifacts_with_apollo/schema.graphql
@@ -7361,6 +7361,11 @@ type NamedEntityAggregatedValues {
   voltage: IntAggregatedValues
 
   """
+  Computed aggregate values for the `weight_in_grams` field.
+  """
+  weight_in_grams: FloatAggregatedValues
+
+  """
   Computed aggregate values for the `weight_in_ng` field.
   """
   weight_in_ng: JsonSafeLongAggregatedValues
@@ -7816,6 +7821,13 @@ input NamedEntityFilterInput {
   voltage: IntFilterInput
 
   """
+  Used to filter on the `weight_in_grams` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  weight_in_grams: FloatFilterInput
+
+  """
   Used to filter on the `weight_in_ng` field.
 
   When `null` or an empty object is passed, matches all documents.
@@ -8063,6 +8075,11 @@ type NamedEntityGroupedBy {
   The `voltage` field value for this group.
   """
   voltage: Int
+
+  """
+  The `weight_in_grams` field value for this group.
+  """
+  weight_in_grams: Float
 
   """
   The `weight_in_ng` field value for this group.
@@ -8673,6 +8690,16 @@ enum NamedEntitySortOrderInput {
   Sorts descending by the `voltage` field.
   """
   voltage_DESC
+
+  """
+  Sorts ascending by the `weight_in_grams` field.
+  """
+  weight_in_grams_ASC
+
+  """
+  Sorts descending by the `weight_in_grams` field.
+  """
+  weight_in_grams_DESC
 
   """
   Sorts ascending by the `weight_in_ng` field.
@@ -17372,6 +17399,7 @@ type Widget implements NamedEntity @key(fields: "id") {
   size: Size
   tags: [String!]!
   the_options: WidgetOptions
+  weight_in_grams: Float
   weight_in_ng: JsonSafeLong!
   weight_in_ng_str: LongString!
   workspace_id: ID
@@ -17528,6 +17556,11 @@ type WidgetAggregatedValues {
   the_options: WidgetOptionsAggregatedValues
 
   """
+  Computed aggregate values for the `weight_in_grams` field.
+  """
+  weight_in_grams: FloatAggregatedValues
+
+  """
   Computed aggregate values for the `weight_in_ng` field.
   """
   weight_in_ng: JsonSafeLongAggregatedValues
@@ -17646,7 +17679,9 @@ type WidgetCurrency @key(fields: "id") {
   details: CurrencyDetails
   id: ID!
   introduced_on: Date
+  max_weight_in_grams: Float
   max_weight_in_ng: JsonSafeLong
+  min_weight_in_grams: Float
   name: String
   nested_fields: WidgetCurrencyNestedFields
   oldest_widget_created_at: DateTime
@@ -17715,9 +17750,19 @@ type WidgetCurrencyAggregatedValues {
   introduced_on: DateAggregatedValues
 
   """
+  Computed aggregate values for the `max_weight_in_grams` field.
+  """
+  max_weight_in_grams: FloatAggregatedValues
+
+  """
   Computed aggregate values for the `max_weight_in_ng` field.
   """
   max_weight_in_ng: JsonSafeLongAggregatedValues
+
+  """
+  Computed aggregate values for the `min_weight_in_grams` field.
+  """
+  min_weight_in_grams: FloatAggregatedValues
 
   """
   Computed aggregate values for the `name` field.
@@ -17930,11 +17975,25 @@ input WidgetCurrencyFilterInput {
   introduced_on: DateFilterInput
 
   """
+  Used to filter on the `max_weight_in_grams` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  max_weight_in_grams: FloatFilterInput
+
+  """
   Used to filter on the `max_weight_in_ng` field.
 
   When `null` or an empty object is passed, matches all documents.
   """
   max_weight_in_ng: JsonSafeLongFilterInput
+
+  """
+  Used to filter on the `min_weight_in_grams` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  min_weight_in_grams: FloatFilterInput
 
   """
   Used to filter on the `name` field.
@@ -18016,9 +18075,19 @@ type WidgetCurrencyGroupedBy {
   introduced_on: DateGroupedBy
 
   """
+  The `max_weight_in_grams` field value for this group.
+  """
+  max_weight_in_grams: Float
+
+  """
   The `max_weight_in_ng` field value for this group.
   """
   max_weight_in_ng: JsonSafeLong
+
+  """
+  The `min_weight_in_grams` field value for this group.
+  """
+  min_weight_in_grams: Float
 
   """
   The `name` field value for this group.
@@ -18209,6 +18278,16 @@ enum WidgetCurrencySortOrderInput {
   introduced_on_DESC
 
   """
+  Sorts ascending by the `max_weight_in_grams` field.
+  """
+  max_weight_in_grams_ASC
+
+  """
+  Sorts descending by the `max_weight_in_grams` field.
+  """
+  max_weight_in_grams_DESC
+
+  """
   Sorts ascending by the `max_weight_in_ng` field.
   """
   max_weight_in_ng_ASC
@@ -18217,6 +18296,16 @@ enum WidgetCurrencySortOrderInput {
   Sorts descending by the `max_weight_in_ng` field.
   """
   max_weight_in_ng_DESC
+
+  """
+  Sorts ascending by the `min_weight_in_grams` field.
+  """
+  min_weight_in_grams_ASC
+
+  """
+  Sorts descending by the `min_weight_in_grams` field.
+  """
+  min_weight_in_grams_DESC
 
   """
   Sorts ascending by the `name` field.
@@ -18542,6 +18631,13 @@ input WidgetFilterInput {
   the_options: WidgetOptionsFilterInput
 
   """
+  Used to filter on the `weight_in_grams` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  weight_in_grams: FloatFilterInput
+
+  """
   Used to filter on the `weight_in_ng` field.
 
   When `null` or an empty object is passed, matches all documents.
@@ -18734,6 +18830,11 @@ type WidgetGroupedBy {
   The `the_options` field value for this group.
   """
   the_options: WidgetOptionsGroupedBy
+
+  """
+  The `weight_in_grams` field value for this group.
+  """
+  weight_in_grams: Float
 
   """
   The `weight_in_ng` field value for this group.
@@ -19337,6 +19438,11 @@ type WidgetOrAddressAggregatedValues {
   timestamps: AddressTimestampsAggregatedValues
 
   """
+  Computed aggregate values for the `weight_in_grams` field.
+  """
+  weight_in_grams: FloatAggregatedValues
+
+  """
   Computed aggregate values for the `weight_in_ng` field.
   """
   weight_in_ng: JsonSafeLongAggregatedValues
@@ -19760,6 +19866,13 @@ input WidgetOrAddressFilterInput {
   timestamps: AddressTimestampsFilterInput
 
   """
+  Used to filter on the `weight_in_grams` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  weight_in_grams: FloatFilterInput
+
+  """
   Used to filter on the `weight_in_ng` field.
 
   When `null` or an empty object is passed, matches all documents.
@@ -19962,6 +20075,11 @@ type WidgetOrAddressGroupedBy {
   The `timestamps` field value for this group.
   """
   timestamps: AddressTimestampsGroupedBy
+
+  """
+  The `weight_in_grams` field value for this group.
+  """
+  weight_in_grams: Float
 
   """
   The `weight_in_ng` field value for this group.
@@ -20474,6 +20592,16 @@ enum WidgetOrAddressSortOrderInput {
   timestamps_created_at_DESC
 
   """
+  Sorts ascending by the `weight_in_grams` field.
+  """
+  weight_in_grams_ASC
+
+  """
+  Sorts descending by the `weight_in_grams` field.
+  """
+  weight_in_grams_DESC
+
+  """
   Sorts ascending by the `weight_in_ng` field.
   """
   weight_in_ng_ASC
@@ -20867,6 +20995,16 @@ enum WidgetSortOrderInput {
   Sorts descending by the `the_options.the_size` field.
   """
   the_options_the_size_DESC
+
+  """
+  Sorts ascending by the `weight_in_grams` field.
+  """
+  weight_in_grams_ASC
+
+  """
+  Sorts descending by the `weight_in_grams` field.
+  """
+  weight_in_grams_DESC
 
   """
   Sorts ascending by the `weight_in_ng` field.

--- a/config/schema/widgets.rb
+++ b/config/schema/widgets.rb
@@ -135,6 +135,7 @@ ElasticGraph.define_schema do |schema|
     t.field "named_inventor", "NamedInventor"
     t.field "weight_in_ng_str", "LongString!" # Weight in nanograms, to exercise Long support.
     t.field "weight_in_ng", "JsonSafeLong!" # Weight in nanograms, to exercise Long support.
+    t.field "weight_in_grams", "Float" # Weight in grams, to exercise Float support (e.g. in min/max derived fields).
     t.field "tags", "[String!]!", sortable: false, singular: "tag"
     t.field "amounts", "[Int!]!", sortable: false do |f|
       f.mapping index: false
@@ -187,6 +188,8 @@ ElasticGraph.define_schema do |schema|
       derive.append_only_set "widget_fee_currencies", from: "fees.currency"
       derive.max_value "nested_fields.max_widget_cost", from: "cost.amount_cents"
       derive.max_value "max_weight_in_ng", from: "weight_in_ng"
+      derive.min_value "min_weight_in_grams", from: "weight_in_grams"
+      derive.max_value "max_weight_in_grams", from: "weight_in_grams"
       derive.min_value "oldest_widget_created_at", from: "created_at"
     end
   end
@@ -219,6 +222,8 @@ ElasticGraph.define_schema do |schema|
     t.field "nested_fields", "WidgetCurrencyNestedFields"
     t.field "oldest_widget_created_at", "DateTime"
     t.field "max_weight_in_ng", "JsonSafeLong"
+    t.field "min_weight_in_grams", "Float"
+    t.field "max_weight_in_grams", "Float"
     t.index "widget_currencies" do |i|
       i.rollover :yearly, "introduced_on"
       i.route_with "primary_continent"

--- a/elasticgraph-indexer/spec/acceptance/derived_indexing_types_spec.rb
+++ b/elasticgraph-indexer/spec/acceptance/derived_indexing_types_spec.rb
@@ -291,6 +291,44 @@ module ElasticGraph
       expect(doc.dig("nested_fields", "max_widget_cost")).to eq(large_value)
     end
 
+    it "derives min/max `Float` values without truncating their fractional parts" do
+      light = widget("SMALL", "RED", "USD", name: "light", tags: [], weight_in_grams: 2.9)
+      heavy = widget("LARGE", "RED", "USD", name: "heavy", tags: [], weight_in_grams: 2.4)
+
+      index_records(light)
+      index_records(heavy)
+
+      doc = fetch_from_index("WidgetCurrency", "USD")
+      expect(doc.fetch("min_weight_in_grams")).to eq(2.4)
+      expect(doc.fetch("max_weight_in_grams")).to eq(2.9)
+    end
+
+    it "derives min/max `Float` values when an integral value is indexed before a fractional value" do
+      # JSON `2` parses as an `Integer` while JSON `2.9` parses as a `Double`, so this exercises
+      # comparisons between mixed numeric types (which cannot be compared with `compareTo`).
+      integral = widget("SMALL", "RED", "USD", name: "integral", tags: [], weight_in_grams: 2)
+      fractional = widget("LARGE", "RED", "USD", name: "fractional", tags: [], weight_in_grams: 2.9)
+
+      index_records(integral)
+      index_records(fractional)
+
+      doc = fetch_from_index("WidgetCurrency", "USD")
+      expect(doc.fetch("min_weight_in_grams")).to eq(2)
+      expect(doc.fetch("max_weight_in_grams")).to eq(2.9)
+    end
+
+    it "derives min/max `Float` values when a fractional value is indexed before an integral value" do
+      integral = widget("SMALL", "RED", "USD", name: "integral", tags: [], weight_in_grams: 2)
+      fractional = widget("LARGE", "RED", "USD", name: "fractional", tags: [], weight_in_grams: 2.9)
+
+      index_records(fractional)
+      index_records(integral)
+
+      doc = fetch_from_index("WidgetCurrency", "USD")
+      expect(doc.fetch("min_weight_in_grams")).to eq(2)
+      expect(doc.fetch("max_weight_in_grams")).to eq(2.9)
+    end
+
     def expect_payload_from_lookup_and_search(payload)
       doc = fetch_from_index("WidgetCurrency", payload.fetch("id"))
       expect(doc).to include(payload)

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_fields/min_or_max_value.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/derived_fields/min_or_max_value.rb
@@ -33,7 +33,7 @@ module ElasticGraph
 
           # @return [Array<String>] painless functions required by a min or max value field.
           def function_definitions
-            [MinOrMaxValue.function_def(min_or_max)]
+            [COMPARE_VALUES, MinOrMaxValue.function_def(min_or_max)]
           end
 
           # @param min_or_max [:min, :max] which type of function to generate.
@@ -44,33 +44,52 @@ module ElasticGraph
             <<~EOS
               boolean #{min_or_max}Value_idempotentlyUpdateValue(List values, def parentObject, String fieldName) {
                 def currentFieldValue = parentObject[fieldName];
-                // Normalize incoming list numerics to long to avoid Integer/Long class cast issues
-                List coercedValues = new ArrayList();
-                for (def v : values) {
-                  if (v != null) {
-                    if (v instanceof Number) {
-                      coercedValues.add(((Number)v).longValue());
-                    } else {
-                      coercedValues.add(v);
-                    }
+
+                // Track the winning value itself (rather than a coerced copy of it) so that the exact value
+                // from the source event or existing document gets stored, with no coercion applied.
+                def #{min_or_max}Value = currentFieldValue;
+                boolean updated = false;
+
+                for (def value : values) {
+                  if (value != null && (#{min_or_max}Value == null || minOrMaxValue_compareValues(value, #{min_or_max}Value) #{operator} 0)) {
+                    #{min_or_max}Value = value;
+                    updated = true;
                   }
                 }
-                def #{min_or_max}NewValue = coercedValues.isEmpty() ? null : Collections.#{min_or_max}(coercedValues);
 
-                def coercedCurrentFieldValue = null;
-                if (currentFieldValue != null) {
-                  coercedCurrentFieldValue = (currentFieldValue instanceof Number) ? ((Number)currentFieldValue).longValue() : currentFieldValue;
+                if (updated) {
+                  parentObject[fieldName] = #{min_or_max}Value;
                 }
 
-                if (#{min_or_max}NewValue != null && (coercedCurrentFieldValue == null || #{min_or_max}NewValue.compareTo(coercedCurrentFieldValue) #{operator} 0)) {
-                  parentObject[fieldName] = #{min_or_max}NewValue;
-                  return true;
-                }
-
-                return false;
+                return updated;
               }
             EOS
           end
+
+          private
+
+          # Painless function which compares two values of a min or max field, coercing numeric values as needed.
+          COMPARE_VALUES = <<~EOS
+            // Compares two values of a min or max field, coercing numeric values as needed.
+            //
+            // Different `Number` implementations (e.g. `Integer` vs `Long`, or `Long` vs `Double`) cannot be
+            // compared with `compareTo` (it throws a `ClassCastException`), and JSON parsing can produce any
+            // of them for the same field (e.g. `2` parses as an `Integer` while `2.9` parses as a `Double`).
+            // Integral values are compared as `long`s to preserve full precision (a `double` cannot exactly
+            // represent all integral values above 2^53), while comparisons involving a floating point value
+            // are performed as `double`s to avoid truncating fractional parts.
+            int minOrMaxValue_compareValues(def value1, def value2) {
+              if (value1 instanceof Number && value2 instanceof Number) {
+                if (value1 instanceof Float || value1 instanceof Double || value2 instanceof Float || value2 instanceof Double) {
+                  return Double.compare(((Number)value1).doubleValue(), ((Number)value2).doubleValue());
+                }
+
+                return Long.compare(((Number)value1).longValue(), ((Number)value2).longValue());
+              }
+
+              return value1.compareTo(value2);
+            }
+          EOS
         end
       end
     end

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/derived_fields/min_or_max_value.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/derived_fields/min_or_max_value.rbs
@@ -8,6 +8,10 @@ module ElasticGraph
           def self.new: (::String, ::String, :min | :max) -> instance
 
           def self.function_def: (:min | :max) -> ::String
+
+          private
+
+          COMPARE_VALUES: ::String
         end
       end
     end

--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts/min_or_max_value_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts/min_or_max_value_spec.rb
@@ -16,6 +16,7 @@ module ElasticGraph
 
       context "for just a `max_value` field" do
         include_context "widget currency script support", expected_function_defs: [
+          Indexing::DerivedFields::MinOrMaxValue::COMPARE_VALUES,
           Indexing::DerivedFields::MinOrMaxValue.function_def(:max)
         ]
 
@@ -64,6 +65,7 @@ module ElasticGraph
 
       context "for just a `min_value` field" do
         include_context "widget currency script support", expected_function_defs: [
+          Indexing::DerivedFields::MinOrMaxValue::COMPARE_VALUES,
           Indexing::DerivedFields::MinOrMaxValue.function_def(:min)
         ]
 
@@ -112,6 +114,7 @@ module ElasticGraph
 
       context "for both a `min_value` and `max_value` field" do
         include_context "widget currency script support", expected_function_defs: [
+          Indexing::DerivedFields::MinOrMaxValue::COMPARE_VALUES,
           Indexing::DerivedFields::MinOrMaxValue.function_def(:max),
           Indexing::DerivedFields::MinOrMaxValue.function_def(:min)
         ]

--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/update_scripts_spec.rb
@@ -16,6 +16,7 @@ module ElasticGraph
 
       describe "for a derived indexing type" do
         include_context "widget currency script support", expected_function_defs: [
+          Indexing::DerivedFields::MinOrMaxValue::COMPARE_VALUES,
           Indexing::DerivedFields::AppendOnlySet::IDEMPOTENTLY_INSERT_VALUE,
           Indexing::DerivedFields::AppendOnlySet::IDEMPOTENTLY_INSERT_VALUES,
           Indexing::DerivedFields::ImmutableValue::IDEMPOTENTLY_SET_VALUE,

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/indexing/derived_fields/min_or_max_value_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/indexing/derived_fields/min_or_max_value_spec.rb
@@ -1,0 +1,68 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/schema_definition/indexing/derived_fields/min_or_max_value"
+
+module ElasticGraph
+  module SchemaDefinition
+    module Indexing
+      module DerivedFields
+        RSpec.describe MinOrMaxValue do
+          describe ".function_def" do
+            it "compares candidate values with `<` for a `min` field" do
+              function_def = MinOrMaxValue.function_def(:min)
+
+              expect(function_def).to include("boolean minValue_idempotentlyUpdateValue(List values, def parentObject, String fieldName)")
+              expect(function_def).to include("minOrMaxValue_compareValues(value, minValue) < 0")
+            end
+
+            it "compares candidate values with `>` for a `max` field" do
+              function_def = MinOrMaxValue.function_def(:max)
+
+              expect(function_def).to include("boolean maxValue_idempotentlyUpdateValue(List values, def parentObject, String fieldName)")
+              expect(function_def).to include("minOrMaxValue_compareValues(value, maxValue) > 0")
+            end
+
+            it "stores the original winning value without coercing it, to avoid corrupting the indexed value" do
+              expect(MinOrMaxValue.function_def(:min)).to include("parentObject[fieldName] = minValue;").and exclude("longValue", "doubleValue")
+              expect(MinOrMaxValue.function_def(:max)).to include("parentObject[fieldName] = maxValue;").and exclude("longValue", "doubleValue")
+            end
+          end
+
+          describe "the `minOrMaxValue_compareValues` painless function" do
+            it "compares integral values as `long`s to preserve full precision while avoiding `ClassCastException` on mixed `Integer`/`Long` values" do
+              expect(MinOrMaxValue::COMPARE_VALUES).to include("Long.compare(((Number)value1).longValue(), ((Number)value2).longValue())")
+            end
+
+            it "compares as `double`s when either value is a floating point number, to avoid truncating fractional parts" do
+              expect(MinOrMaxValue::COMPARE_VALUES).to include(
+                "value1 instanceof Float || value1 instanceof Double || value2 instanceof Float || value2 instanceof Double",
+                "Double.compare(((Number)value1).doubleValue(), ((Number)value2).doubleValue())"
+              )
+            end
+
+            it "compares non-numeric values (e.g. `Date`/`DateTime`/`LocalTime` strings) via their natural `compareTo`" do
+              expect(MinOrMaxValue::COMPARE_VALUES).to include("return value1.compareTo(value2);")
+            end
+          end
+
+          describe "#function_definitions" do
+            it "includes the comparison function so that the min/max function can use it" do
+              field = MinOrMaxValue.new("min_cost", "cost", :min)
+
+              expect(field.function_definitions).to eq [
+                MinOrMaxValue::COMPARE_VALUES,
+                MinOrMaxValue.function_def(:min)
+              ]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec_support/lib/elastic_graph/spec_support/factories/widgets.rb
+++ b/spec_support/lib/elastic_graph/spec_support/factories/widgets.rb
@@ -122,6 +122,7 @@ FactoryBot.define do
     named_inventor { inventor }
     weight_in_ng { Faker::Number.between(from: 2**51, to: (2**53) - 1) }
     weight_in_ng_str { Faker::Number.between(from: 2**60, to: 2**61) }
+    weight_in_grams { Faker::Number.between(from: 1.0, to: 100.0) }
     tags { Array.new(Faker::Number.between(from: 0, to: 4)) { Faker::Alphanumeric.alpha(number: 6) } }
     amounts { Array.new(Faker::Number.between(from: 0, to: 4)) { Faker::Number.between(from: 100, to: 10000) } }
     fees { build_list(:money, Faker::Number.between(from: 0, to: 4)) }


### PR DESCRIPTION
## Why

`min_value`/`max_value` derived fields sourced from `Float` fields silently corrupt data: the generated painless function coerces every incoming number (and the stored value) to a `long`, so fractional values are stored truncated (2.9 becomes 2) and compared truncated (2.4 vs 2.9 compare as equal). The coercion was added in 8d3d6647 to fix a `ClassCastException` on mixed `Integer`/`Long` values, but it over-coerces.

## What

- Replaced the coerce-then-`Collections.min`/`max` approach with a loop that tracks the winning element, using a new numeric-aware `minOrMaxValue_compareValues` painless function: integral values compare via `Long.compare` (preserving full precision beyond 2^53 for `JsonSafeLong`/`LongString` sources), comparisons involving a floating point value use `Double.compare` (handling JSON producing mixed `Integer`/`Double` values for the same `Float` field), and non-numeric values (`Date`/`DateTime`/`LocalTime` strings) keep their natural `compareTo`.
- The original (un-coerced) winning value is what gets stored, so indexed values are never altered.
- Regenerated schema artifacts; the `update_WidgetCurrency_from_Widget_*` script ID changed since the script contents changed.
- Added a `Float`-sourced min/max derived field to the test schema plus acceptance coverage for fractional values and mixed integral/fractional values (in both indexing orders), and unit coverage for the generated function text.

## Risk Assessment

Low. The derived-field update script contents (and therefore the MD5-derived script ID) change, so deployments will pick up the new script when schema artifacts are dumped and cluster configuration is applied. Behavior for existing integral and string-valued min/max fields is unchanged (verified by the existing regression tests).