### PR TITLE
Replace standalone bundle with a fork-based runner in the file-by-file CI part

### DIFF
--- a/script/ci_parts/run_specs_file_by_file
+++ b/script/ci_parts/run_specs_file_by_file
@@ -6,22 +6,15 @@ source "script/ci_parts/setup_env" "test" $1 $2
 # of entire gems when just one spec file is run.
 unset COVERAGE
 
-# Setup standalone binstubs for RSpec that we use below.
-bundle install --standalone && bundle binstubs rspec-core --standalone
-
 function run_gem_specs_file_by_file() {
   gem=$1
   pushd $gem
-    for file in `find spec -iname '*_spec.rb'`; do
-      echo "Running $file"
-
-      # Note: here we avoid using `bundle exec`, opting for a binstub instead.
-      # Our `bundle install` command (with `--standalone` and `binstubs` options) creates the
-      # rspec binstub in a way where it won't actually load bundler at runtime. This is
-      # *slightly* faster. Not enough to usually matter, but it adds up when we boot rspec
-      # once for each spec file as we do here!
-      ../bin/rspec $file -b --format progress --no-profile
-    done
+    # Note: here we avoid booting `rspec` (and paying for `bundle exec`) once per spec
+    # file. The runner script boots bundler and rspec-core a single time and then runs
+    # each spec file in a `fork`, so every file still executes in its own isolated
+    # process. That saves 1-2 seconds per spec file, which adds up over the hundreds of
+    # spec files this build part covers.
+    ../script/rspec_file_by_file `find spec -iname '*_spec.rb'`
   popd
 }
 

--- a/script/rspec_file_by_file
+++ b/script/rspec_file_by_file
@@ -23,9 +23,20 @@
 # https://github.com/elastic/elastic-transport-ruby/pull/128 for an example of a gem
 # that breaks when loaded without activation.
 
+invocation_env = ENV.to_h
+
 ENV["BUNDLE_GEMFILE"] ||= ::File.expand_path("../Gemfile", __dir__)
 require "bundler/setup"
 require "rspec/core"
+
+# Booting bundler above mutated ENV (BUNDLE_GEMFILE, RUBYOPT, etc.) and captured that
+# mutated state in `Bundler::ORIGINAL_ENV`, which children inherit. A freshly booted
+# `rspec` process wouldn't have any of that: it would load bundler lazily (if at all)
+# with the unmodified environment, so e.g. `Bundler.with_original_env` in a spec would
+# restore the clean invocation environment for shelled-out commands. Restore both here
+# so forked children observe the same environment a fresh process would.
+ENV.replace(invocation_env)
+::Bundler::ORIGINAL_ENV.replace(invocation_env)
 
 ARGV.each do |spec_file|
   puts "Running #{spec_file}"

--- a/script/rspec_file_by_file
+++ b/script/rspec_file_by_file
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+# Runs each given spec file in a separate, isolated process -- equivalent to booting
+# `rspec <file>` once per file, but far cheaper: bundler and rspec-core are loaded only
+# once, in this parent process, and each spec file then runs in a `fork` of it.
+#
+# The parent never loads any ElasticGraph code or spec code, so each child starts from
+# the same clean slate as a freshly booted `rspec` process. That preserves what
+# file-by-file runs are meant to verify: that every spec file requires everything it
+# needs and can run in isolation.
+#
+# Unlike our previous approach (`bundle install --standalone` with binstubs, which skips
+# RubyGems gem activation entirely), children inherit a normally-activated bundle, so
+# gems that consult `Gem.loaded_specs` behave the same as they do in production. See
+# https://github.com/elastic/elastic-transport-ruby/pull/128 for an example of a gem
+# that breaks when loaded without activation.
+
+ENV["BUNDLE_GEMFILE"] ||= ::File.expand_path("../Gemfile", __dir__)
+require "bundler/setup"
+require "rspec/core"
+
+ARGV.each do |spec_file|
+  puts "Running #{spec_file}"
+
+  pid = fork do
+    exit ::RSpec::Core::Runner.run([spec_file, "-b", "--format", "progress", "--no-profile"])
+  end
+
+  _, status = ::Process.wait2(pid)
+  exit(status.exitstatus || 1) unless status.success?
+end


### PR DESCRIPTION
## Why

The `run_specs_file_by_file` CI part boots RSpec once per spec file (currently 288 files) to verify every spec file can run in isolation. To avoid paying bundler's boot cost 288 times, it used `bundle install --standalone` + binstubs, which loads gems from a static $LOAD_PATH file **without activating them through RubyGems** — so `Gem.loaded_specs` is empty at runtime.

That's a subtly nonstandard gem environment, and it recently bit us: elastic-transport 8.5.2+ consults `Gem.loaded_specs['multi_json']` on every request and crashed only in this CI part, forcing a version pin in #1290 (upstream fix: elastic/elastic-transport-ruby#128).

## What

A small runner script (`script/rspec_file_by_file`) boots bundler and rspec-core **once**, then runs each spec file in a `fork` of that parent:

- The parent never loads any ElasticGraph or spec code, so each child starts from the same clean slate as a freshly booted `rspec` process — the isolation guarantee this build part exists to check is preserved (verified: a missing-require failure and a deliberately failing spec file both still fail the run, and subsequent files don't run, matching today's fail-fast behavior).
- Children inherit a normally-activated bundle, so `Gem.loaded_specs` is populated and gems behave exactly as in production. No more standalone-only failure modes.
- The runner restores its invocation environment (both `ENV` and `Bundler::ORIGINAL_ENV`) after booting bundler, so children — and anything they shell out to via `Bundler.with_original_env` — observe the same environment a fresh `rspec` process would. (The first draft missed this and this build part correctly caught it, via schema_definition's `rake_tasks_spec`; all 7 env-sensitive spec files in the repo now pass under the runner locally.)

## Timing

**CI (the number that matters):** this PR's `run_specs_file_by_file` job ran in **20m49s**, vs the last four runs of the current approach on main: 23m17s, 25m55s, 26m18s, 26m29s (median ~26m). That's a **~5 minute / ~20% improvement**, faster than every recent baseline run.

Local measurements (M-series macOS, warm caches, ES 9.4.2, `NO_VCR=1`):

| Workload | standalone (current) | `bundle exec` per file | fork runner |
|---|---|---|---|
| elasticgraph-support — 19 files, all unit | 4.7s | 29.4s | **3.7s** |
| elasticgraph-admin — 7 files, mostly datastore integration (median of 3 alternating runs) | **23s** | ~27s | 33s |

The local admin regression is a macOS-specific fork penalty on socket I/O (raw `Net::HTTP` to local ES is ~40% slower in a forked child on macOS; pure-CPU and allocation-heavy benchmarks show zero fork penalty, and the same benchmark on Linux shows ~no penalty) — consistent with the CI job getting faster while local datastore-heavy gems get slower. Something to be aware of when running the file-by-file loop locally on a Mac, but CI is where this build part runs.