### PR TITLE
Support proto2 syntax and custom proto file headers

### DIFF
--- a/elasticgraph-proto_ingestion/README.md
+++ b/elasticgraph-proto_ingestion/README.md
@@ -1,7 +1,9 @@
 # ElasticGraph::ProtoIngestion
 
 An ElasticGraph extension that supports ingesting Protocol Buffer data into ElasticGraph.
-Currently it generates `proto3` Protocol Buffers schema artifacts from ElasticGraph schemas.
+Currently it generates Protocol Buffers schema artifacts from ElasticGraph schemas: it emits
+`proto3` by default and can emit `proto2`, and supports arbitrary file-level header lines (such
+as `option` declarations).
 
 ## Dependency Diagram
 
@@ -76,6 +78,62 @@ After running `bundle exec rake schema_artifacts:dump`, ElasticGraph will genera
 schema artifact, and will maintain a `proto_field_numbers.yaml` file alongside your schema definition.
 
 ## Schema Definition API
+
+### Protobuf Syntax (`proto2` / `proto3`)
+
+`proto_schema_artifacts` emits `proto3` by default. Pass `syntax: :proto2` to emit a proto2 file
+instead (every field is then labeled `optional` or `repeated`). This is useful when the generated
+messages need to reference proto2 types — for example, `protoc` forbids a `proto3` message from
+referencing a `proto2` enum:
+
+```ruby
+# in config/schema/protobuf.rb
+
+ElasticGraph.define_schema do |schema|
+  schema.proto_schema_artifacts package_name: "myapp.events.v1", syntax: :proto2
+end
+```
+
+Field numbers are unaffected by the syntax, so switching an existing schema between `proto2` and
+`proto3` preserves the meaning of every field. One encoding detail does differ: `proto3` packs
+repeated numeric fields by default, and `proto2` does not. ElasticGraph has no per-field option
+for this, and never emits the `[packed=true]` field option that turns packing on under `proto2`.
+Protobuf parsers accept both encodings for repeated numeric fields under either syntax, so data
+written before a switch still decodes correctly.
+
+### Custom Header Lines
+
+Pass `header_lines:` an array of strings to inject file-level lines (such as `option` declarations)
+verbatim, as a contiguous section immediately after the `package` declaration. This lets you set
+language-specific options without the gem baking in any particular convention. Each element
+renders as one line, so no element can contain a newline:
+
+```ruby
+# in config/schema/protobuf.rb
+
+ElasticGraph.define_schema do |schema|
+  schema.proto_schema_artifacts(
+    package_name: "myapp.events.v1",
+    header_lines: [
+      %(option java_package = "com.myapp.events";),
+      "option java_multiple_files = true;"
+    ]
+  )
+end
+```
+
+produces:
+
+```text
+syntax = "proto3";
+
+package myapp.events.v1;
+
+option java_package = "com.myapp.events";
+option java_multiple_files = true;
+
+// ...messages...
+```
 
 ### Custom Scalar Types
 

--- a/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/api_extension.rb
+++ b/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/api_extension.rb
@@ -34,14 +34,28 @@ module ElasticGraph
         # Configures protobuf artifact generation behavior.
         #
         # @param package_name [String] proto package name to emit
+        # @param syntax [Symbol, String] `:proto3` (default) or `:proto2`
+        # @param header_lines [Array<String>] file-level lines rendered verbatim after the package declaration
         # @return [void]
         #
         # @example Set the proto package name
         #   ElasticGraph.define_schema do |schema|
         #     schema.proto_schema_artifacts package_name: "myapp.events.v1"
         #   end
-        def proto_schema_artifacts(package_name:)
-          proto_ingestion_state.package_name = Identifier.validate_package_name(package_name)
+        #
+        # @example Emit proto2 with file-level options
+        #   ElasticGraph.define_schema do |schema|
+        #     schema.proto_schema_artifacts(
+        #       package_name: "myapp.events.v1",
+        #       syntax: :proto2,
+        #       header_lines: [%(option java_package = "com.myapp.events";)]
+        #     )
+        #   end
+        def proto_schema_artifacts(package_name:, syntax: Schema::DEFAULT_SYNTAX, header_lines: [])
+          ingestion_state = proto_ingestion_state
+          ingestion_state.package_name = Identifier.validate_package_name(package_name)
+          ingestion_state.syntax = Schema.validate_syntax(syntax)
+          ingestion_state.header_lines = Schema.validate_header_lines(header_lines)
           nil
         end
 

--- a/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/proto_ingestion_state.rb
+++ b/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/proto_ingestion_state.rb
@@ -12,7 +12,7 @@ module ElasticGraph
       # Holds the proto ingestion extension's schema definition state.
       #
       # @private
-      class ProtoIngestionState < ::Struct.new(:package_name, :field_number_mappings)
+      class ProtoIngestionState < ::Struct.new(:package_name, :field_number_mappings, :syntax, :header_lines)
       end
     end
   end

--- a/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/results_extension.rb
+++ b/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/results_extension.rb
@@ -36,13 +36,11 @@ module ElasticGraph
             # The cast is needed because Steep can't see the `extend(StateExtension)` applied at
             # runtime in {APIExtension.extended}.
             extension_state = state # : ElasticGraph::SchemaDefinition::State & StateExtension
-            ingestion_state = extension_state.proto_ingestion_state
 
             Schema.new(
               state: extension_state,
               all_types: all_types,
-              package_name: ingestion_state.package_name,
-              proto_field_number_mappings: ingestion_state.field_number_mappings
+              ingestion_state: extension_state.proto_ingestion_state
             )
           end
         end

--- a/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/schema.rb
+++ b/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/schema.rb
@@ -16,27 +16,64 @@ require "forwardable"
 module ElasticGraph
   module ProtoIngestion
     module SchemaDefinition
-      # Builds a `proto3` schema string from an ElasticGraph schema definition.
+      # Builds a `proto2` or `proto3` schema string from an ElasticGraph schema definition.
       class Schema
         extend Forwardable
 
-        # @param state [ElasticGraph::SchemaDefinition::State]
-        # @param all_types [Array<ElasticGraph::SchemaDefinition::SchemaElements::graphQLType>]
-        # @param package_name [String]
-        # @param proto_field_number_mappings [Hash, nil] mappings in the `proto_field_numbers.yaml` artifact format
-        def initialize(
-          state:,
-          all_types:,
-          package_name:,
-          proto_field_number_mappings: {}
-        )
-          @state = state
-          @all_types = all_types
-          @package_name = package_name
-          @field_number_mappings = FieldNumberMappings.from_parsed_yaml(proto_field_number_mappings)
+        # Protobuf syntaxes this generator can emit.
+        SUPPORTED_SYNTAXES = %w[proto2 proto3].freeze
+
+        # The protobuf syntax emitted when the schema does not configure one.
+        DEFAULT_SYNTAX = "proto3"
+
+        # Normalizes a configured `syntax` to one of {SUPPORTED_SYNTAXES}.
+        #
+        # Both the `proto_schema_artifacts` API and this class validate through here so that a
+        # syntax is checked exactly once no matter which entry point supplies it.
+        #
+        # @param syntax [Symbol, String]
+        # @return [String]
+        def self.validate_syntax(syntax)
+          syntax.to_s.tap do |normalized|
+            unless SUPPORTED_SYNTAXES.include?(normalized)
+              raise Errors::SchemaError, "`syntax` must be one of #{SUPPORTED_SYNTAXES.inspect}, got: #{syntax.inspect}"
+            end
+          end
         end
 
-        # Renders the schema as a valid `proto3` file.
+        # Validates configured `header_lines`, as {.validate_syntax} does for a syntax.
+        #
+        # Each element renders as its own line, so a newline in one element would silently produce
+        # more lines than the schema asked for.
+        #
+        # @param header_lines [Array<String>]
+        # @return [Array<String>]
+        def self.validate_header_lines(header_lines)
+          unless header_lines.is_a?(::Array) && header_lines.all?(::String)
+            raise Errors::SchemaError, "`header_lines` must be an Array of Strings, got: #{header_lines.inspect}"
+          end
+
+          if (multi_line = header_lines.grep(/\n/)).any?
+            raise Errors::SchemaError, "`header_lines` must not contain newlines, but got: #{multi_line.inspect}. " \
+              "Pass one Array element per line."
+          end
+
+          header_lines
+        end
+
+        # @param state [ElasticGraph::SchemaDefinition::State]
+        # @param all_types [Array<ElasticGraph::SchemaDefinition::SchemaElements::graphQLType>]
+        # @param ingestion_state [ProtoIngestionState] this extension's configured schema definition state
+        def initialize(state:, all_types:, ingestion_state:)
+          @state = state
+          @all_types = all_types
+          @package_name = ingestion_state.package_name
+          @syntax = self.class.validate_syntax(ingestion_state.syntax)
+          @header_lines = self.class.validate_header_lines(ingestion_state.header_lines)
+          @field_number_mappings = FieldNumberMappings.from_parsed_yaml(ingestion_state.field_number_mappings)
+        end
+
+        # Renders the schema as a valid file in the configured syntax.
         #
         # @return [String]
         def to_proto
@@ -46,8 +83,9 @@ module ElasticGraph
           validate_unique_enum_value_prefixes(types)
 
           sections = [
-            %(syntax = "proto3";),
+            %(syntax = "#{@syntax}";),
             "package #{@package_name};",
+            *render_header_lines,
             *render_imports(types),
             render_definitions(types)
           ]
@@ -82,6 +120,27 @@ module ElasticGraph
           :next_enum_value_number_for,
           :reserved_enum_value_numbers_for
 
+        # Returns the label prefix (including its trailing space) that a field declaration needs
+        # under the configured syntax, or an empty string when the field takes no label.
+        #
+        # `proto2` requires an explicit label on every field, so non-repeated fields get
+        # `optional `; `proto3` labels repeated fields only. Note that `oneof` alternatives never
+        # get a label under either syntax -- protoc rejects one -- so the `oneof` renderer in
+        # `ObjectInterfaceAndUnionExtension` does not call this.
+        #
+        # @api private
+        def field_label_prefix(repeated:)
+          return "repeated " if repeated
+          proto2? ? "optional " : ""
+        end
+
+        # Indicates whether the generator emits `proto2` rather than `proto3`.
+        #
+        # @api private
+        def proto2?
+          @syntax == "proto2"
+        end
+
         private
 
         # Selects the indexed root types and every type transitively referenced by their protobuf
@@ -115,6 +174,10 @@ module ElasticGraph
           imports = types.filter_map(&:protobuf_import).uniq.sort
 
           imports.empty? ? [] : [imports.map { |import| %(import "#{import}";) }.join("\n")]
+        end
+
+        def render_header_lines
+          @header_lines.empty? ? [] : [@header_lines.join("\n")]
         end
 
         def validate_unique_enum_value_prefixes(types)

--- a/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/schema_elements/object_interface_and_union_extension.rb
+++ b/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/schema_elements/object_interface_and_union_extension.rb
@@ -100,7 +100,7 @@ module ElasticGraph
                 type_name: name,
                 public_field_name: schema_field.name
               )
-              label = "repeated " if repeated
+              label = schema.field_label_prefix(repeated: repeated)
               line = "  #{label}#{field_type} #{schema_field.name} = #{field_number};"
               comment_lines = field_comment_lines_for(schema_field.doc_comment, field_comment)
 

--- a/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/state_extension.rb
+++ b/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/state_extension.rb
@@ -9,6 +9,7 @@
 require "elastic_graph/proto_ingestion"
 require "elastic_graph/proto_ingestion/schema_definition/field_number_mappings"
 require "elastic_graph/proto_ingestion/schema_definition/proto_ingestion_state"
+require "elastic_graph/proto_ingestion/schema_definition/schema"
 
 module ElasticGraph
   module ProtoIngestion
@@ -30,7 +31,12 @@ module ElasticGraph
 
           state.instance_variable_set(
             :@proto_ingestion_state,
-            ProtoIngestionState.new(package_name: "elasticgraph", field_number_mappings: field_number_mappings)
+            ProtoIngestionState.new(
+              package_name: "elasticgraph",
+              field_number_mappings: field_number_mappings,
+              syntax: Schema::DEFAULT_SYNTAX,
+              header_lines: []
+            )
           )
         end
 

--- a/elasticgraph-proto_ingestion/sig/elastic_graph/proto_ingestion/schema_definition/api_extension.rbs
+++ b/elasticgraph-proto_ingestion/sig/elastic_graph/proto_ingestion/schema_definition/api_extension.rbs
@@ -3,7 +3,11 @@ module ElasticGraph
     module SchemaDefinition
       module APIExtension: ::ElasticGraph::SchemaDefinition::API
         def self.extended: (::ElasticGraph::SchemaDefinition::API & APIExtension) -> void
-        def proto_schema_artifacts: (package_name: ::String) -> void
+        def proto_schema_artifacts: (
+          package_name: ::String,
+          ?syntax: (::Symbol | ::String),
+          ?header_lines: ::Array[::String]
+        ) -> void
 
         private
 

--- a/elasticgraph-proto_ingestion/sig/elastic_graph/proto_ingestion/schema_definition/proto_ingestion_state.rbs
+++ b/elasticgraph-proto_ingestion/sig/elastic_graph/proto_ingestion/schema_definition/proto_ingestion_state.rbs
@@ -4,8 +4,15 @@ module ElasticGraph
       class ProtoIngestionStateSupertype
         attr_accessor package_name: ::String
         attr_accessor field_number_mappings: ::Hash[::String, untyped]
+        attr_accessor syntax: ::String
+        attr_accessor header_lines: ::Array[::String]
 
-        def initialize: (package_name: ::String, field_number_mappings: ::Hash[::String, untyped]) -> void
+        def initialize: (
+          package_name: ::String,
+          field_number_mappings: ::Hash[::String, untyped],
+          syntax: ::String,
+          header_lines: ::Array[::String]
+        ) -> void
       end
 
       class ProtoIngestionState < ProtoIngestionStateSupertype

--- a/elasticgraph-proto_ingestion/sig/elastic_graph/proto_ingestion/schema_definition/schema.rbs
+++ b/elasticgraph-proto_ingestion/sig/elastic_graph/proto_ingestion/schema_definition/schema.rbs
@@ -4,6 +4,14 @@ module ElasticGraph
       class Schema
         extend ::Forwardable
 
+        SUPPORTED_SYNTAXES: ::Array[::String]
+        DEFAULT_SYNTAX: ::String
+
+        def self.validate_syntax: ((::Symbol | ::String)) -> ::String
+        def self.validate_header_lines: (::Array[::String]) -> ::Array[::String]
+
+        @syntax: ::String
+        @header_lines: ::Array[::String]
         @state: ::ElasticGraph::SchemaDefinition::State
         @all_types: ::Array[::ElasticGraph::SchemaDefinition::SchemaElements::graphQLType]
         @package_name: ::String
@@ -13,8 +21,7 @@ module ElasticGraph
         def initialize: (
           state: ::ElasticGraph::SchemaDefinition::State,
           all_types: ::Array[::ElasticGraph::SchemaDefinition::SchemaElements::graphQLType],
-          package_name: ::String,
-          ?proto_field_number_mappings: ::Hash[::String, untyped]?
+          ingestion_state: ProtoIngestionState
         ) -> void
 
         def to_proto: () -> ::String
@@ -29,12 +36,15 @@ module ElasticGraph
         def enum_value_numbers_for: (::String, ::Array[::String]) -> ::Hash[::String, ::Integer]
         def next_enum_value_number_for: (::String) -> ::Integer
         def reserved_enum_value_numbers_for: (::String, ::Array[::String]) -> ::Hash[::String, ::Integer]
+        def field_label_prefix: (repeated: bool) -> ::String
+        def proto2?: () -> bool
 
         private
 
         def proto_types: () -> ::Array[untyped]
         def render_definitions: (::Array[untyped] types) -> ::String
         def render_imports: (::Array[untyped] types) -> ::Array[::String]
+        def render_header_lines: () -> ::Array[::String]
         def validate_unique_enum_value_prefixes: (::Array[untyped] types) -> void
         def previous_field_names_for: (::String, ::String) -> ::Array[::String]
         def previous_field_names_by_type_name_and_field_name: () -> ::Hash[::String, ::Hash[::String, ::Array[::String]]]

--- a/elasticgraph-proto_ingestion/spec/unit/elastic_graph/proto_ingestion/schema_definition/api_extension_spec.rb
+++ b/elasticgraph-proto_ingestion/spec/unit/elastic_graph/proto_ingestion/schema_definition/api_extension_spec.rb
@@ -55,6 +55,46 @@ module ElasticGraph
           end
         end
 
+        it "requires `syntax` to be a supported protobuf syntax" do
+          expect {
+            define_proto_schema do |s|
+              s.proto_schema_artifacts package_name: "elasticgraph", syntax: :proto1
+            end
+          }.to raise_error(Errors::SchemaError, a_string_including("`syntax` must be one of"))
+        end
+
+        it "requires `header_lines` to be an Array of Strings" do
+          invalid_header_lines = [
+            %(option java_package = "com.example";), # a bare String rather than an Array
+            [:not_a_string],
+            ["valid", :not_a_string]
+          ]
+
+          aggregate_failures do
+            invalid_header_lines.each do |header_lines|
+              expect {
+                define_proto_schema do |s|
+                  s.proto_schema_artifacts package_name: "elasticgraph", header_lines: header_lines
+                end
+              }.to raise_error(Errors::SchemaError, a_string_including("`header_lines` must be an Array of Strings"))
+            end
+          end
+        end
+
+        it "rejects a `header_lines` element containing a newline, which would render as extra lines" do
+          expect {
+            define_proto_schema do |s|
+              s.proto_schema_artifacts(
+                package_name: "elasticgraph",
+                header_lines: ["option java_multiple_files = true;\noption optimize_for = SPEED;"]
+              )
+            end
+          }.to raise_error(Errors::SchemaError, a_string_including(
+            "`header_lines` must not contain newlines",
+            "Pass one Array element per line."
+          ))
+        end
+
         it "rejects invalid package names when they are configured" do
           invalid_package_names = [
             "",

--- a/elasticgraph-proto_ingestion/spec/unit/elastic_graph/proto_ingestion/schema_definition/schema_spec.rb
+++ b/elasticgraph-proto_ingestion/spec/unit/elastic_graph/proto_ingestion/schema_definition/schema_spec.rb
@@ -102,6 +102,91 @@ module ElasticGraph
           expect(proto.scan(/^(?:enum|message) (\w+) \{/).flatten).to eq(%w[Alpha Beta Yak Zulu])
         end
 
+        it "emits proto2 syntax with an explicit label on every field when `syntax: :proto2`" do
+          proto = define_proto_schema do |s|
+            s.proto_schema_artifacts package_name: "elasticgraph", syntax: :proto2
+
+            s.enum_type "Status" do |t|
+              t.values "ACTIVE", "INACTIVE"
+            end
+
+            s.object_type "Account" do |t|
+              t.field "id", "ID"
+              t.field "status", "Status"
+              t.field "tags", "[String!]!"
+              t.index "accounts"
+            end
+          end
+
+          expect(proto).to start_with(%(syntax = "proto2";))
+          expect(proto_type_def_from(proto, "Account")).to include(
+            "optional string id = 1;",
+            "optional .elasticgraph.Status status = 2;",
+            "repeated string tags = 3;"
+          )
+        end
+
+        it "omits the field label on `oneof` alternatives under `proto2`, which protoc forbids from carrying one" do
+          proto = define_proto_schema do |s|
+            s.proto_schema_artifacts package_name: "elasticgraph", syntax: :proto2
+
+            s.object_type "Car" do |t|
+              t.implements "Vehicle"
+              t.field "id", "ID"
+            end
+
+            s.object_type "Bike" do |t|
+              t.implements "Vehicle"
+              t.field "id", "ID"
+            end
+
+            s.interface_type "Vehicle" do |t|
+              t.field "id", "ID"
+              t.index "vehicles"
+            end
+          end
+
+          # The alternatives carry no `optional`, unlike the `optional string id` fields on the
+          # concrete messages below, which do get a label under proto2.
+          expect(proto_type_def_from(proto, "Vehicle")).to eq(<<~PROTO.strip)
+            message Vehicle {
+              oneof value {
+                .elasticgraph.Car car = 1;
+                .elasticgraph.Bike bike = 2;
+              }
+              // Next field number: 3
+            }
+          PROTO
+
+          expect(proto_type_def_from(proto, "Car")).to include("optional string id = 1;")
+        end
+
+        it "renders custom `header_lines` verbatim after the package declaration" do
+          proto = define_proto_schema do |s|
+            s.proto_schema_artifacts(
+              package_name: "myapp.events.v1",
+              header_lines: [
+                %(option java_package = "com.myapp.events";),
+                "option java_multiple_files = true;"
+              ]
+            )
+
+            s.object_type "Account" do |t|
+              t.field "id", "ID"
+              t.index "accounts"
+            end
+          end
+
+          expect(proto).to include(<<~PROTO)
+            package myapp.events.v1;
+
+            option java_package = "com.myapp.events";
+            option java_multiple_files = true;
+
+            message Account {
+          PROTO
+        end
+
         it "generates oneof wrappers for indexed interface and union types" do
           proto = define_proto_schema do |s|
             s.object_type "Car" do |t|
@@ -563,7 +648,7 @@ module ElasticGraph
           generator = Schema.new(
             state: results.state,
             all_types: results.send(:all_types),
-            package_name: "elasticgraph"
+            ingestion_state: results.state.proto_ingestion_state
           )
 
           first_generation = generator.to_proto


### PR DESCRIPTION
## Why
Some consumers need the generated messages to reference proto2 types — `protoc` forbids a proto3 message from referencing a proto2 enum — and language-specific file options (like `java_package`) shouldn't require baking any convention into the gem.

## What
`proto_schema_artifacts` gains two options:
- `syntax: :proto2` emits a proto2 file instead of the default proto3, labeling every field `optional` or `repeated`
- `headers:` injects file-level lines (such as `option` declarations) verbatim as a contiguous section after the `package` declaration

## Risk Assessment
Low — only affects the unreleased `elasticgraph-proto_ingestion` extension; both options are opt-in.

## References
- Stacked on #1304 (which is stacked on #1080)

## Update — 2026-07-10
This PR is stacked directly on #1306 (→ #1304 → #1080).