### PR TITLE
index_data.painless script cleanup

### DIFF
--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -2288,7 +2288,7 @@ scripts:
 
         // No timestamp values matched the params, so return `false`.
         return false;
-  update_index_data_52c5d011ab80b55684bf2f65af001803:
+  update_index_data_27fac9da6430f05440528c771880c7e6:
     context: update
     script:
       lang: painless
@@ -2343,13 +2343,14 @@ scripts:
             if (segment.containsKey("sourceField")) {
               parts.add(sourcedFromNestedPathIdentifiers[segment.sourceField]);
             } else {
-              parts.add(segment.get("field"));
+              parts.add(segment.field);
             }
           }
           return parts;
         }
 
-        // Finds the element of `elements` whose `id` equals `matchValue`, or null.
+        // Finds the first element of `elements` whose `id` equals `matchValue`, or null. Element ids are assumed unique
+        // within a collection, so we return the first match rather than scanning for duplicates.
         def findInList(List elements, String matchValue) {
           for (Map element : elements) {
             if (matchValue == element.id) {
@@ -2367,19 +2368,18 @@ scripts:
 
           for (int i = 0; i < pathSegments.size(); i++) {
             Map segment = (Map) pathSegments.get(i);
-            String field = (String) segment.get("field");
+            String field = (String) segment.field;
 
             def subField = current.get(field);
 
             if (subField instanceof List) {
               current = (Map) findInList((List) subField, (String) keyParts.get(i));
+              if (current == null) {
+                return null;
+              }
             } else if (subField instanceof Map) {
               current = (Map) subField;
             } else {
-              current = null;
-            }
-
-            if (current == null) {
               return null;
             }
           }
@@ -2486,7 +2486,7 @@ scripts:
             }
 
             // NOTE: orphaned buffer entries (a nested element removed from its parent) are never pruned, so
-            // `__nested_sourced_data` can grow unbounded for churning collections. Known limitation, will address in future PR.
+            // `__nested_sourced_data` can grow unbounded for churning collections. Known limitation--see #1270.
             Map target = (Map) extractNestedElement(doc, pathSegments, keyParts);
             if (target != null) {
               target.putAll((Map) entry.getValue());

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -3257,7 +3257,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         full_address:
           cardinality: one
@@ -3447,7 +3447,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -3536,7 +3536,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         annual_salary:
           cardinality: one
@@ -3564,7 +3564,7 @@ object_types_by_name:
       relationship: staff.coaches.profile
       rollover_timestamp_value_source: team_formed_on
       routing_value_source: team_league
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       sourced_from_nested_params:
         field_params:
           salary:
@@ -3721,7 +3721,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -3821,7 +3821,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         created_at:
           cardinality: one
@@ -4131,7 +4131,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -4304,7 +4304,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         created_at:
           cardinality: one
@@ -4518,7 +4518,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         annual_salary:
           cardinality: one
@@ -4544,7 +4544,7 @@ object_types_by_name:
       relationship: staff.general_manager.profile
       rollover_timestamp_value_source: team_formed_on
       routing_value_source: team_league
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       sourced_from_nested_params:
         field_params:
           salary:
@@ -5003,7 +5003,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         ceo:
           cardinality: one
@@ -5161,7 +5161,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         created_at:
           cardinality: one
@@ -6122,7 +6122,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -6321,7 +6321,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -6388,7 +6388,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         active:
           cardinality: one
@@ -6937,7 +6937,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         name:
           cardinality: one
@@ -7316,7 +7316,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: formed_on
       routing_value_source: league
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         country_code:
           cardinality: one
@@ -8455,7 +8455,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: created_at
       routing_value_source: workspace_id2
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         amount_cents:
           cardinality: one
@@ -8533,7 +8533,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: widget
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         widget_cost:
           cardinality: one
@@ -8763,7 +8763,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: introduced_on
       routing_value_source: primary_continent
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         details:
           cardinality: one
@@ -9808,7 +9808,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         name:
           cardinality: one
@@ -9830,7 +9830,7 @@ object_types_by_name:
       relationship: workspace
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         workspace_name:
           cardinality: one
@@ -10065,4 +10065,4 @@ static_script_ids_by_scoped_name:
   field/as_day_of_week: field_as_day_of_week_f2b5c7d9e8f75bf2457b52412bfb6537
   field/as_time_of_day: field_as_time_of_day_ed82aba44fc66bff5635bec4305c1c66
   filter/by_time_of_day: filter_by_time_of_day_ea12d0561b24961789ab68ed38435612
-  update/index_data: update_index_data_52c5d011ab80b55684bf2f65af001803
+  update/index_data: update_index_data_27fac9da6430f05440528c771880c7e6

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -2288,7 +2288,7 @@ scripts:
 
         // No timestamp values matched the params, so return `false`.
         return false;
-  update_index_data_52c5d011ab80b55684bf2f65af001803:
+  update_index_data_27fac9da6430f05440528c771880c7e6:
     context: update
     script:
       lang: painless
@@ -2343,13 +2343,14 @@ scripts:
             if (segment.containsKey("sourceField")) {
               parts.add(sourcedFromNestedPathIdentifiers[segment.sourceField]);
             } else {
-              parts.add(segment.get("field"));
+              parts.add(segment.field);
             }
           }
           return parts;
         }
 
-        // Finds the element of `elements` whose `id` equals `matchValue`, or null.
+        // Finds the first element of `elements` whose `id` equals `matchValue`, or null. Element ids are assumed unique
+        // within a collection, so we return the first match rather than scanning for duplicates.
         def findInList(List elements, String matchValue) {
           for (Map element : elements) {
             if (matchValue == element.id) {
@@ -2367,19 +2368,18 @@ scripts:
 
           for (int i = 0; i < pathSegments.size(); i++) {
             Map segment = (Map) pathSegments.get(i);
-            String field = (String) segment.get("field");
+            String field = (String) segment.field;
 
             def subField = current.get(field);
 
             if (subField instanceof List) {
               current = (Map) findInList((List) subField, (String) keyParts.get(i));
+              if (current == null) {
+                return null;
+              }
             } else if (subField instanceof Map) {
               current = (Map) subField;
             } else {
-              current = null;
-            }
-
-            if (current == null) {
               return null;
             }
           }
@@ -2486,7 +2486,7 @@ scripts:
             }
 
             // NOTE: orphaned buffer entries (a nested element removed from its parent) are never pruned, so
-            // `__nested_sourced_data` can grow unbounded for churning collections. Known limitation, will address in future PR.
+            // `__nested_sourced_data` can grow unbounded for churning collections. Known limitation--see #1270.
             Map target = (Map) extractNestedElement(doc, pathSegments, keyParts);
             if (target != null) {
               target.putAll((Map) entry.getValue());

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -3286,7 +3286,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         full_address:
           cardinality: one
@@ -3476,7 +3476,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -3565,7 +3565,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         annual_salary:
           cardinality: one
@@ -3593,7 +3593,7 @@ object_types_by_name:
       relationship: staff.coaches.profile
       rollover_timestamp_value_source: team_formed_on
       routing_value_source: team_league
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       sourced_from_nested_params:
         field_params:
           salary:
@@ -3750,7 +3750,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -3871,7 +3871,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         created_at:
           cardinality: one
@@ -4233,7 +4233,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -4406,7 +4406,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         created_at:
           cardinality: one
@@ -4620,7 +4620,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         annual_salary:
           cardinality: one
@@ -4646,7 +4646,7 @@ object_types_by_name:
       relationship: staff.general_manager.profile
       rollover_timestamp_value_source: team_formed_on
       routing_value_source: team_league
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       sourced_from_nested_params:
         field_params:
           salary:
@@ -5105,7 +5105,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         ceo:
           cardinality: one
@@ -5263,7 +5263,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         created_at:
           cardinality: one
@@ -6245,7 +6245,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -6444,7 +6444,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -6511,7 +6511,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         active:
           cardinality: one
@@ -7066,7 +7066,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         name:
           cardinality: one
@@ -7445,7 +7445,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: formed_on
       routing_value_source: league
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         country_code:
           cardinality: one
@@ -8584,7 +8584,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: created_at
       routing_value_source: workspace_id2
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         amount_cents:
           cardinality: one
@@ -8662,7 +8662,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: widget
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         widget_cost:
           cardinality: one
@@ -8892,7 +8892,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: introduced_on
       routing_value_source: primary_continent
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         details:
           cardinality: one
@@ -9937,7 +9937,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         name:
           cardinality: one
@@ -9959,7 +9959,7 @@ object_types_by_name:
       relationship: workspace
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
-      script_id: update_index_data_52c5d011ab80b55684bf2f65af001803
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
       top_level_fields_params:
         workspace_name:
           cardinality: one
@@ -10237,4 +10237,4 @@ static_script_ids_by_scoped_name:
   field/as_day_of_week: field_as_day_of_week_f2b5c7d9e8f75bf2457b52412bfb6537
   field/as_time_of_day: field_as_time_of_day_ed82aba44fc66bff5635bec4305c1c66
   filter/by_time_of_day: filter_by_time_of_day_ea12d0561b24961789ab68ed38435612
-  update/index_data: update_index_data_52c5d011ab80b55684bf2f65af001803
+  update/index_data: update_index_data_27fac9da6430f05440528c771880c7e6

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/scripts/update/index_data.painless
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/scripts/update/index_data.painless
@@ -48,13 +48,14 @@ List buildNestedElementKeyParts(String relationship, Map sourcedFromNestedPaths,
     if (segment.containsKey("sourceField")) {
       parts.add(sourcedFromNestedPathIdentifiers[segment.sourceField]);
     } else {
-      parts.add(segment.get("field"));
+      parts.add(segment.field);
     }
   }
   return parts;
 }
 
-// Finds the element of `elements` whose `id` equals `matchValue`, or null.
+// Finds the first element of `elements` whose `id` equals `matchValue`, or null. Element ids are assumed unique
+// within a collection, so we return the first match rather than scanning for duplicates.
 def findInList(List elements, String matchValue) {
   for (Map element : elements) {
     if (matchValue == element.id) {
@@ -72,19 +73,18 @@ def extractNestedElement(Map doc, List pathSegments, List keyParts) {
 
   for (int i = 0; i < pathSegments.size(); i++) {
     Map segment = (Map) pathSegments.get(i);
-    String field = (String) segment.get("field");
+    String field = (String) segment.field;
 
     def subField = current.get(field);
 
     if (subField instanceof List) {
       current = (Map) findInList((List) subField, (String) keyParts.get(i));
+      if (current == null) {
+        return null;
+      }
     } else if (subField instanceof Map) {
       current = (Map) subField;
     } else {
-      current = null;
-    }
-
-    if (current == null) {
       return null;
     }
   }
@@ -191,7 +191,7 @@ void applyNestedSourcedData(Map doc, Map sourcedFromNestedPaths) {
     }
 
     // NOTE: orphaned buffer entries (a nested element removed from its parent) are never pruned, so
-    // `__nested_sourced_data` can grow unbounded for churning collections. Known limitation, will address in future PR.
+    // `__nested_sourced_data` can grow unbounded for churning collections. Known limitation--see #1270.
     Map target = (Map) extractNestedElement(doc, pathSegments, keyParts);
     if (target != null) {
       target.putAll((Map) entry.getValue());

--- a/elasticgraph-support/lib/elastic_graph/constants.rb
+++ b/elasticgraph-support/lib/elastic_graph/constants.rb
@@ -152,7 +152,7 @@ module ElasticGraph
   #
   # Note: this constant is automatically kept up-to-date by our `schema_artifacts:dump` rake task.
   # @private
-  INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_52c5d011ab80b55684bf2f65af001803"
+  INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_27fac9da6430f05440528c771880c7e6"
 
   # When an update script has a no-op result we often want to communicate more information about
   # why it was a no-op back to ElasticGraph from the script. The only way to do that is to throw


### PR DESCRIPTION
Addresses the unresolved (non-blocking) review comments left on `index_data.painless` in #1252. 

Mechanical cleanups only — no behavior change; verified by the existing nested + top-level multi-source acceptance specs.

- Use `segment.field` map-access shorthand in `buildNestedElementKeyParts` and `extractNestedElement`
- More optimal null checking / returning in `extractNestedElement`
- Enhance the `findInList` comment (first-match-wins) and reword the unbounded-growth note to reference #1270

Schema artifacts regenerated (`INDEX_DATA_UPDATE_SCRIPT_ID` updated accordingly).