### PR TITLE
Extract shared casing helpers

### DIFF
--- a/elasticgraph-graphql/spec/acceptance/elasticgraph_graphql_acceptance_support.rb
+++ b/elasticgraph-graphql/spec/acceptance/elasticgraph_graphql_acceptance_support.rb
@@ -9,6 +9,7 @@
 require "elastic_graph/graphql/datastore_search_router"
 require "elastic_graph/schema_definition/schema_elements/type_namer"
 require "elastic_graph/spec_support/builds_admin"
+require "elastic_graph/support/casing"
 require "graphql"
 require "support/graphql"
 
@@ -155,7 +156,7 @@ module ElasticGraph
     end
 
     def case_correctly(word)
-      ::ElasticGraph::SchemaArtifacts::RuntimeMetadata::SchemaElementNamesDefinition::SnakeCaseConverter.normalize_case(word)
+      Support::Casing.to_snake(word)
     end
 
     def index_definition_name_for(snake_case_name)
@@ -410,12 +411,12 @@ module ElasticGraph
     end
 
     def word_to_camel_case(word)
-      ::ElasticGraph::SchemaArtifacts::RuntimeMetadata::SchemaElementNamesDefinition::CamelCaseConverter.normalize_case(word)
+      Support::Casing.to_camel(word)
     end
     alias_method :case_correctly, :word_to_camel_case
 
     def word_to_snake_case(word)
-      ::ElasticGraph::SchemaArtifacts::RuntimeMetadata::SchemaElementNamesDefinition::SnakeCaseConverter.normalize_case(word)
+      Support::Casing.to_snake(word)
     end
   end
 

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rb
@@ -8,6 +8,7 @@
 
 require "elastic_graph/constants"
 require "elastic_graph/errors"
+require "elastic_graph/support/casing"
 
 module ElasticGraph
   module SchemaArtifacts
@@ -37,7 +38,7 @@ module ElasticGraph
               exposed_name_by_canonical_name = element_names.each_with_object({}) do |element, names|
                 names[element] = overrides.fetch(element) do
                   overrides.fetch(element.to_s) do
-                    converter.normalize_case(element.to_s)
+                    converter.call(element.to_s)
                   end
                 end.to_s
               end.freeze
@@ -55,13 +56,13 @@ module ElasticGraph
 
             # standard:disable Lint/NestedMethodDefinition
             element_names.each do |element|
-              method_name = SnakeCaseConverter.normalize_case(element.to_s)
+              method_name = Support::Casing.to_snake(element.to_s)
               define_method(method_name) { exposed_name_by_canonical_name.fetch(element) }
             end
 
             # Converts a name to the configured case form (snake_case or camelCase).
             def normalize_case(name)
-              CONVERTERS.fetch(form.to_s).normalize_case(name)
+              CONVERTERS.fetch(form.to_s).call(name)
             end
 
             # Returns the _canonical_ name for the given _exposed name_. The canonical name
@@ -114,27 +115,9 @@ module ElasticGraph
         FORM = "form"
         OVERRIDES = "overrides"
 
-        # @private
-        module SnakeCaseConverter
-          extend self
-
-          def normalize_case(name)
-            name.gsub(/([[:upper:]])/) { "_#{$1.downcase}" }
-          end
-        end
-
-        # @private
-        module CamelCaseConverter
-          extend self
-
-          def normalize_case(name)
-            name.gsub(/(?<=\w)_(\w)/) { $1.upcase }
-          end
-        end
-
         CONVERTERS = {
-          "snake_case" => SnakeCaseConverter,
-          "camelCase" => CamelCaseConverter
+          "snake_case" => Support::Casing.method(:to_snake),
+          "camelCase" => Support::Casing.method(:to_camel)
         }
       end
 

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rbs
@@ -3,13 +3,6 @@ module ElasticGraph
     module RuntimeMetadata
       # Note: this is a partial signature definition (the ruby file is ignored in `Steepfile`)
       class SchemaElementNamesDefinition
-        module SnakeCaseConverter
-          def self.normalize_case: (::String) -> ::String
-        end
-
-        module CamelCaseConverter
-          def self.normalize_case: (::String) -> ::String
-        end
       end
 
       class SchemaElementNames

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/mixins/has_indices.rb
@@ -10,6 +10,7 @@ require "elastic_graph/constants"
 require "elastic_graph/errors"
 require "elastic_graph/schema_artifacts/runtime_metadata/configured_graphql_resolver"
 require "elastic_graph/schema_definition/indexing/update_target_factory"
+require "elastic_graph/support/casing"
 
 module ElasticGraph
   module SchemaDefinition
@@ -543,8 +544,7 @@ module ElasticGraph
         end
 
         def to_field_name(type_name)
-          name_without_leading_uppercase = type_name.sub(/^([[:upper:]])/) { $1.downcase }
-          schema_def_state.schema_elements.normalize_case(name_without_leading_uppercase)
+          schema_def_state.schema_elements.normalize_case(Support::Casing.uncapitalize(type_name))
         end
       end
     end

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_reference.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_reference.rb
@@ -10,6 +10,7 @@ require "elastic_graph/errors"
 require "elastic_graph/schema_artifacts/runtime_metadata/schema_element_names"
 require "elastic_graph/schema_definition/mixins/verifies_graphql_name"
 require "elastic_graph/schema_definition/schema_elements/type_namer"
+require "elastic_graph/support/casing"
 require "elastic_graph/support/memoizable_data"
 require "forwardable"
 
@@ -175,8 +176,7 @@ module ElasticGraph
         # is source_type + suffix). This is a map of all of these.
         STATIC_FORMAT_NAME_BY_CATEGORY = TypeNamer::REQUIRED_PLACEHOLDERS.filter_map do |format_name, placeholders|
           if placeholders == [:base]
-            as_snake_case = SchemaArtifacts::RuntimeMetadata::SchemaElementNamesDefinition::SnakeCaseConverter
-              .normalize_case(format_name.to_s)
+            as_snake_case = Support::Casing.to_snake(format_name.to_s)
               .delete_prefix("_")
 
             [as_snake_case.to_sym, format_name]
@@ -326,10 +326,8 @@ module ElasticGraph
         end
 
         def to_title_case(name)
-          CamelCaseConverter.normalize_case(name).sub(/\A(\w)/, &:upcase)
+          Support::Casing.to_camel(name).sub(/\A(\w)/, &:upcase)
         end
-
-        CamelCaseConverter = SchemaArtifacts::RuntimeMetadata::SchemaElementNamesDefinition::CamelCaseConverter
       end
     end
   end

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_reference.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/type_reference.rb
@@ -176,8 +176,7 @@ module ElasticGraph
         # is source_type + suffix). This is a map of all of these.
         STATIC_FORMAT_NAME_BY_CATEGORY = TypeNamer::REQUIRED_PLACEHOLDERS.filter_map do |format_name, placeholders|
           if placeholders == [:base]
-            as_snake_case = Support::Casing.to_snake(format_name.to_s)
-              .delete_prefix("_")
+            as_snake_case = Support::Casing.to_snake(format_name.to_s).delete_prefix("_")
 
             [as_snake_case.to_sym, format_name]
           end
@@ -241,7 +240,7 @@ module ElasticGraph
         # what the parent doc types are (so that we can offer sub-aggregations of the parent doc types!)
         # and the field path (for the 2nd case).
         def as_aggregation_sub_aggregations(parent_doc_types: [fully_unwrapped.name], field_path: [])
-          field_part = field_path.map { |f| to_title_case(f.name) }.join
+          field_part = field_path.map { |f| Support::Casing.to_title(f.name) }.join
 
           renamed_with_same_wrappings(type_namer.generate_name_for(
             :SubAggregations,
@@ -323,10 +322,6 @@ module ElasticGraph
             return :enum if ENUM_FORMATS.any? { |f| type_namer.matches_format?(as_output_enum_name, f) }
             :enum if as_output_enum_name != self.name && schema_def_state.type_ref(as_output_enum_name).enum? { false }
           end
-        end
-
-        def to_title_case(name)
-          Support::Casing.to_camel(name).sub(/\A(\w)/, &:upcase)
         end
       end
     end

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/type_reference.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/type_reference.rbs
@@ -64,8 +64,6 @@ module ElasticGraph
         ENUM_FORMATS: ::Set[::Symbol]
         OBJECT_FORMATS: ::Set[::Symbol]
         def schema_kind_implied_by_name: () -> (:enum | :object)?
-
-        def to_title_case: (::String) -> ::String
       end
     end
   end

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/type_reference.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/schema_elements/type_reference.rbs
@@ -66,7 +66,6 @@ module ElasticGraph
         def schema_kind_implied_by_name: () -> (:enum | :object)?
 
         def to_title_case: (::String) -> ::String
-        CamelCaseConverter: singleton(SchemaArtifacts::RuntimeMetadata::SchemaElementNamesDefinition::CamelCaseConverter)
       end
     end
   end

--- a/elasticgraph-support/lib/elastic_graph/support/casing.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/casing.rb
@@ -17,41 +17,43 @@ module ElasticGraph
       # uppercase letter produces a leading underscore (`"HTTPResponse"` becomes
       # `"_h_t_t_p_response"`). Contrast with {.to_upper_snake}, which keeps acronyms intact.
       #
-      # @param name [String] identifier to convert
+      # @param identifier [String] identifier to convert
       # @return [String] converted identifier
-      def self.to_snake(name)
-        name.gsub(/([[:upper:]])/) do
+      def self.to_snake(identifier)
+        identifier.gsub(/([[:upper:]])/) do
           uppercase_letter = $1 # : ::String
           "_#{uppercase_letter.downcase}"
         end
       end
 
-      # Converts an identifier to camelCase.
+      # Converts an identifier to camelCase. Each single underscore between two letters or digits
+      # is removed, and the following character is uppercased. Leading and consecutive underscores
+      # are left intact (`"__typename"` remains `"__typename"`).
       #
-      # @param name [String] identifier to convert
+      # @param identifier [String] identifier to convert
       # @return [String] converted identifier
-      def self.to_camel(name)
-        name.gsub(/(?<=\w)_(\w)/) do
-          letter_after_underscore = $1 # : ::String
-          letter_after_underscore.upcase
+      def self.to_camel(identifier)
+        identifier.gsub(/(?<=[[:alnum:]])_([[:alnum:]])/) do
+          character_after_underscore = $1 # : ::String
+          character_after_underscore.upcase
         end
       end
 
       # Converts an identifier to TitleCase.
       #
-      # @param name [String] identifier to convert
+      # @param identifier [String] identifier to convert
       # @return [String] converted identifier
-      def self.to_title(name)
-        to_camel(name).sub(/\A(\w)/, &:upcase)
+      def self.to_title(identifier)
+        to_camel(identifier).sub(/\A([[:alpha:]])/, &:upcase)
       end
 
       # Downcases the first letter of an identifier, leaving the rest unchanged
       # (`"WidgetCurrency"` becomes `"widgetCurrency"`).
       #
-      # @param name [String] identifier to convert
+      # @param identifier [String] identifier to convert
       # @return [String] converted identifier
-      def self.uncapitalize(name)
-        name.sub(/\A(\w)/, &:downcase)
+      def self.uncapitalize(identifier)
+        identifier.sub(/\A([[:upper:]])/, &:downcase)
       end
 
       # Converts an identifier to UPPER_SNAKE_CASE. In contrast to {.to_snake}, a multi-letter
@@ -59,10 +61,10 @@ module ElasticGraph
       # a leading underscore (`"HTTPResponse"` becomes `"HTTP_RESPONSE"`). A digit is treated as
       # part of the word that precedes it (`"Sha256Hash"` becomes `"SHA256_HASH"`).
       #
-      # @param name [String] identifier to convert
+      # @param identifier [String] identifier to convert
       # @return [String] converted identifier
-      def self.to_upper_snake(name)
-        name
+      def self.to_upper_snake(identifier)
+        identifier
           .gsub(/([[:upper:]]+)([[:upper:]][[:lower:]])/, "\\1_\\2")
           .gsub(/([[:lower:]\d])([[:upper:]])/, "\\1_\\2")
           .upcase

--- a/elasticgraph-support/lib/elastic_graph/support/casing.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/casing.rb
@@ -9,8 +9,13 @@
 module ElasticGraph
   module Support
     # Provides shared identifier casing conversions.
+    #
+    # @private
     class Casing
-      # Converts an identifier to snake_case.
+      # Converts an identifier to snake_case. Treats every uppercase letter as the start of a
+      # new word: a multi-letter acronym gets split into one "word" per letter, and a leading
+      # uppercase letter produces a leading underscore (`"HTTPResponse"` becomes
+      # `"_h_t_t_p_response"`). Contrast with {.to_upper_snake}, which keeps acronyms intact.
       #
       # @param name [String] identifier to convert
       # @return [String] converted identifier
@@ -32,7 +37,18 @@ module ElasticGraph
         end
       end
 
-      # Converts an identifier to UPPER_SNAKE_CASE, preserving acronym boundaries.
+      # Converts an identifier to TitleCase.
+      #
+      # @param name [String] identifier to convert
+      # @return [String] converted identifier
+      def self.to_title(name)
+        to_camel(name).sub(/\A(\w)/, &:upcase)
+      end
+
+      # Converts an identifier to UPPER_SNAKE_CASE. In contrast to {.to_snake}, a multi-letter
+      # acronym is kept intact as a single word, and a leading uppercase letter does not produce
+      # a leading underscore (`"HTTPResponse"` becomes `"HTTP_RESPONSE"`). A digit is treated as
+      # part of the word that precedes it (`"Sha256Hash"` becomes `"SHA256_HASH"`).
       #
       # @param name [String] identifier to convert
       # @return [String] converted identifier

--- a/elasticgraph-support/lib/elastic_graph/support/casing.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/casing.rb
@@ -1,0 +1,47 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+module ElasticGraph
+  module Support
+    # Provides shared identifier casing conversions.
+    class Casing
+      # Converts an identifier to snake_case.
+      #
+      # @param name [String] identifier to convert
+      # @return [String] converted identifier
+      def self.to_snake(name)
+        name.gsub(/([[:upper:]])/) do
+          uppercase_letter = $1 # : ::String
+          "_#{uppercase_letter.downcase}"
+        end
+      end
+
+      # Converts an identifier to camelCase.
+      #
+      # @param name [String] identifier to convert
+      # @return [String] converted identifier
+      def self.to_camel(name)
+        name.gsub(/(?<=\w)_(\w)/) do
+          letter_after_underscore = $1 # : ::String
+          letter_after_underscore.upcase
+        end
+      end
+
+      # Converts an identifier to UPPER_SNAKE_CASE, preserving acronym boundaries.
+      #
+      # @param name [String] identifier to convert
+      # @return [String] converted identifier
+      def self.to_upper_snake(name)
+        name
+          .gsub(/([[:upper:]]+)([[:upper:]][[:lower:]])/, "\\1_\\2")
+          .gsub(/([[:lower:]\d])([[:upper:]])/, "\\1_\\2")
+          .upcase
+      end
+    end
+  end
+end

--- a/elasticgraph-support/lib/elastic_graph/support/casing.rb
+++ b/elasticgraph-support/lib/elastic_graph/support/casing.rb
@@ -45,6 +45,15 @@ module ElasticGraph
         to_camel(name).sub(/\A(\w)/, &:upcase)
       end
 
+      # Downcases the first letter of an identifier, leaving the rest unchanged
+      # (`"WidgetCurrency"` becomes `"widgetCurrency"`).
+      #
+      # @param name [String] identifier to convert
+      # @return [String] converted identifier
+      def self.uncapitalize(name)
+        name.sub(/\A(\w)/, &:downcase)
+      end
+
       # Converts an identifier to UPPER_SNAKE_CASE. In contrast to {.to_snake}, a multi-letter
       # acronym is kept intact as a single word, and a leading uppercase letter does not produce
       # a leading underscore (`"HTTPResponse"` becomes `"HTTP_RESPONSE"`). A digit is treated as

--- a/elasticgraph-support/sig/elastic_graph/support/casing.rbs
+++ b/elasticgraph-support/sig/elastic_graph/support/casing.rbs
@@ -4,6 +4,7 @@ module ElasticGraph
       def self.to_snake: (::String) -> ::String
       def self.to_camel: (::String) -> ::String
       def self.to_title: (::String) -> ::String
+      def self.uncapitalize: (::String) -> ::String
       def self.to_upper_snake: (::String) -> ::String
     end
   end

--- a/elasticgraph-support/sig/elastic_graph/support/casing.rbs
+++ b/elasticgraph-support/sig/elastic_graph/support/casing.rbs
@@ -1,0 +1,9 @@
+module ElasticGraph
+  module Support
+    class Casing
+      def self.to_snake: (::String) -> ::String
+      def self.to_camel: (::String) -> ::String
+      def self.to_upper_snake: (::String) -> ::String
+    end
+  end
+end

--- a/elasticgraph-support/sig/elastic_graph/support/casing.rbs
+++ b/elasticgraph-support/sig/elastic_graph/support/casing.rbs
@@ -3,6 +3,7 @@ module ElasticGraph
     class Casing
       def self.to_snake: (::String) -> ::String
       def self.to_camel: (::String) -> ::String
+      def self.to_title: (::String) -> ::String
       def self.to_upper_snake: (::String) -> ::String
     end
   end

--- a/elasticgraph-support/spec/unit/elastic_graph/support/casing_spec.rb
+++ b/elasticgraph-support/spec/unit/elastic_graph/support/casing_spec.rb
@@ -1,0 +1,39 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/support/casing"
+
+module ElasticGraph
+  module Support
+    RSpec.describe Casing do
+      describe ".to_snake" do
+        it "converts camelCase to snake_case while preserving existing behavior" do
+          expect(Casing.to_snake("someWord")).to eq("some_word")
+          expect(Casing.to_snake("FooBar")).to eq("_foo_bar")
+          expect(Casing.to_snake("already_snake")).to eq("already_snake")
+        end
+      end
+
+      describe ".to_camel" do
+        it "converts snake_case to camelCase" do
+          expect(Casing.to_camel("some_word")).to eq("someWord")
+          expect(Casing.to_camel("alreadyCamel")).to eq("alreadyCamel")
+          expect(Casing.to_camel("_typename")).to eq("_typename")
+        end
+      end
+
+      describe ".to_upper_snake" do
+        it "converts mixed casing to UPPER_SNAKE_CASE while preserving acronym boundaries" do
+          expect(Casing.to_upper_snake("someWord")).to eq("SOME_WORD")
+          expect(Casing.to_upper_snake("HTTPResponseCode")).to eq("HTTP_RESPONSE_CODE")
+          expect(Casing.to_upper_snake("already_snake")).to eq("ALREADY_SNAKE")
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-support/spec/unit/elastic_graph/support/casing_spec.rb
+++ b/elasticgraph-support/spec/unit/elastic_graph/support/casing_spec.rb
@@ -32,6 +32,10 @@ module ElasticGraph
         it "prefixes an underscore before each letter of an UPPER_SNAKE_CASE string" do
           expect(Casing.to_snake("UPPER_SNAKE_CASE")).to eq("_u_p_p_e_r__s_n_a_k_e__c_a_s_e")
         end
+
+        it "treats a non-ASCII uppercase letter as a word start" do
+          expect(Casing.to_snake("ÉtudeBar")).to eq("_étude_bar")
+        end
       end
 
       describe ".to_camel" do
@@ -46,6 +50,19 @@ module ElasticGraph
 
         it "strips the underscores from an UPPER_SNAKE_CASE string" do
           expect(Casing.to_camel("UPPER_SNAKE_CASE")).to eq("UPPERSNAKECASE")
+        end
+
+        it "treats a digit as a word character both before and after an underscore" do
+          expect(Casing.to_camel("sha_256_hash")).to eq("sha256Hash")
+        end
+
+        it "preserves consecutive underscores" do
+          expect(Casing.to_camel("__typename")).to eq("__typename")
+          expect(Casing.to_camel("foo__bar")).to eq("foo__bar")
+        end
+
+        it "treats non-ASCII letters as word characters" do
+          expect(Casing.to_camel("café_word")).to eq("caféWord")
         end
       end
 
@@ -63,6 +80,14 @@ module ElasticGraph
         it "strips the underscores from an UPPER_SNAKE_CASE string" do
           expect(Casing.to_title("UPPER_SNAKE_CASE")).to eq("UPPERSNAKECASE")
         end
+
+        it "capitalizes a non-ASCII leading letter" do
+          expect(Casing.to_title("étude_word")).to eq("ÉtudeWord")
+        end
+
+        it "only capitalizes at the start of the identifier, not after an embedded newline" do
+          expect(Casing.to_title("\nfoo")).to eq("\nfoo")
+        end
       end
 
       describe ".uncapitalize" do
@@ -77,6 +102,16 @@ module ElasticGraph
 
         it "downcases only the first letter of an UPPER_SNAKE_CASE string" do
           expect(Casing.uncapitalize("UPPER_SNAKE_CASE")).to eq("uPPER_SNAKE_CASE")
+        end
+
+        it "downcases non-ASCII uppercase letters" do
+          expect(Casing.uncapitalize("Étude")).to eq("étude")
+          expect(Casing.uncapitalize("ⅠFoo")).to eq("ⅰFoo")
+          expect(Casing.uncapitalize("ⒶFoo")).to eq("ⓐFoo")
+        end
+
+        it "only downcases at the start of the identifier, not after an embedded newline" do
+          expect(Casing.uncapitalize("\nFoo")).to eq("\nFoo")
         end
       end
 
@@ -100,6 +135,11 @@ module ElasticGraph
 
         it "leaves an UPPER_SNAKE_CASE string unchanged" do
           expect(Casing.to_upper_snake("UPPER_SNAKE_CASE")).to eq("UPPER_SNAKE_CASE")
+        end
+
+        it "treats non-ASCII letters as word boundaries" do
+          expect(Casing.to_upper_snake("fooÉtude")).to eq("FOO_ÉTUDE")
+          expect(Casing.to_upper_snake("CAFÉCode")).to eq("CAFÉ_CODE")
         end
       end
     end

--- a/elasticgraph-support/spec/unit/elastic_graph/support/casing_spec.rb
+++ b/elasticgraph-support/spec/unit/elastic_graph/support/casing_spec.rb
@@ -12,10 +12,25 @@ module ElasticGraph
   module Support
     RSpec.describe Casing do
       describe ".to_snake" do
-        it "converts camelCase to snake_case while preserving existing behavior" do
+        it "converts camelCase to snake_case" do
           expect(Casing.to_snake("someWord")).to eq("some_word")
-          expect(Casing.to_snake("FooBar")).to eq("_foo_bar")
           expect(Casing.to_snake("already_snake")).to eq("already_snake")
+        end
+
+        it "prefixes an underscore for a leading uppercase letter, unlike `.to_upper_snake`" do
+          expect(Casing.to_snake("FooBar")).to eq("_foo_bar")
+        end
+
+        it "treats each letter of a multi-letter acronym as a separate word, unlike `.to_upper_snake`" do
+          expect(Casing.to_snake("HTTPResponseCode")).to eq("_h_t_t_p_response_code")
+        end
+
+        it "treats a digit as part of the word that precedes it" do
+          expect(Casing.to_snake("Sha256Hash")).to eq("_sha256_hash")
+        end
+
+        it "prefixes an underscore before each letter of an UPPER_SNAKE_CASE string" do
+          expect(Casing.to_snake("UPPER_SNAKE_CASE")).to eq("_u_p_p_e_r__s_n_a_k_e__c_a_s_e")
         end
       end
 
@@ -23,15 +38,53 @@ module ElasticGraph
         it "converts snake_case to camelCase" do
           expect(Casing.to_camel("some_word")).to eq("someWord")
           expect(Casing.to_camel("alreadyCamel")).to eq("alreadyCamel")
+        end
+
+        it "leaves a leading underscore intact" do
           expect(Casing.to_camel("_typename")).to eq("_typename")
+        end
+
+        it "strips the underscores from an UPPER_SNAKE_CASE string" do
+          expect(Casing.to_camel("UPPER_SNAKE_CASE")).to eq("UPPERSNAKECASE")
+        end
+      end
+
+      describe ".to_title" do
+        it "converts snake_case or camelCase to TitleCase" do
+          expect(Casing.to_title("some_word")).to eq("SomeWord")
+          expect(Casing.to_title("alreadyCamel")).to eq("AlreadyCamel")
+          expect(Casing.to_title("AlreadyTitle")).to eq("AlreadyTitle")
+        end
+
+        it "leaves a leading underscore intact" do
+          expect(Casing.to_title("_typename")).to eq("_typename")
+        end
+
+        it "strips the underscores from an UPPER_SNAKE_CASE string" do
+          expect(Casing.to_title("UPPER_SNAKE_CASE")).to eq("UPPERSNAKECASE")
         end
       end
 
       describe ".to_upper_snake" do
-        it "converts mixed casing to UPPER_SNAKE_CASE while preserving acronym boundaries" do
+        it "converts camelCase or snake_case to UPPER_SNAKE_CASE" do
           expect(Casing.to_upper_snake("someWord")).to eq("SOME_WORD")
-          expect(Casing.to_upper_snake("HTTPResponseCode")).to eq("HTTP_RESPONSE_CODE")
           expect(Casing.to_upper_snake("already_snake")).to eq("ALREADY_SNAKE")
+        end
+
+        it "adds no leading underscore for a leading uppercase letter, unlike `.to_snake`" do
+          expect(Casing.to_upper_snake("FooBar")).to eq("FOO_BAR")
+        end
+
+        it "keeps a multi-letter acronym intact as a single word, unlike `.to_snake`" do
+          expect(Casing.to_upper_snake("HTTPResponseCode")).to eq("HTTP_RESPONSE_CODE")
+        end
+
+        it "treats a digit as part of the word that precedes it" do
+          expect(Casing.to_upper_snake("Sha256Hash")).to eq("SHA256_HASH")
+        end
+
+        it "leaves an UPPER_SNAKE_CASE string unchanged" do
+          expect(Casing.to_upper_snake("UPPER_SNAKE_CASE")).to eq("UPPER_SNAKE_CASE")
         end
       end
     end

--- a/elasticgraph-support/spec/unit/elastic_graph/support/casing_spec.rb
+++ b/elasticgraph-support/spec/unit/elastic_graph/support/casing_spec.rb
@@ -65,6 +65,21 @@ module ElasticGraph
         end
       end
 
+      describe ".uncapitalize" do
+        it "downcases the first letter, leaving the rest unchanged" do
+          expect(Casing.uncapitalize("WidgetCurrency")).to eq("widgetCurrency")
+          expect(Casing.uncapitalize("alreadyLower")).to eq("alreadyLower")
+        end
+
+        it "leaves a leading underscore intact" do
+          expect(Casing.uncapitalize("_typename")).to eq("_typename")
+        end
+
+        it "downcases only the first letter of an UPPER_SNAKE_CASE string" do
+          expect(Casing.uncapitalize("UPPER_SNAKE_CASE")).to eq("uPPER_SNAKE_CASE")
+        end
+      end
+
       describe ".to_upper_snake" do
         it "converts camelCase or snake_case to UPPER_SNAKE_CASE" do
           expect(Casing.to_upper_snake("someWord")).to eq("SOME_WORD")


### PR DESCRIPTION
## Why
Casing conversions currently live behind private schema-artifact helpers, while protobuf generation needs the same shared behavior.

## What
- Add `ElasticGraph::Support::Casing` with snake, camel, and upper-snake conversions
- Replace existing private converter usages with the shared helper
- Preserve existing snake/camel semantics and cover acronym-aware upper-snake conversion

## Risk Assessment
Low — existing behavior is preserved, and the affected gem suites retain 100% line and branch coverage.

## References
- https://github.com/block/elasticgraph/pull/1080#discussion_r3583683182

---
**Update Jul 15, 15:54 CDT:** Addressed casing review feedback
- Made camel, title, and uncapitalize conversions Unicode-aware while preserving consecutive underscores.
- Added coverage for anchoring, digit boundaries, Unicode casing, and GraphQL `__typename`.
- Mutation-checked every previously surviving case; support and schema-definition suites retain 100% coverage.
- Risk remains low: the shared helper now has more explicit behavior and broader regression coverage.