### PR TITLE
Validate protobuf enum prefix collisions

### DIFF
--- a/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/schema.rb
+++ b/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/schema.rb
@@ -6,6 +6,7 @@
 #
 # frozen_string_literal: true
 
+require "elastic_graph/errors"
 require "elastic_graph/proto_ingestion/schema_definition/schema_elements/enum_type_extension"
 require "elastic_graph/proto_ingestion/schema_definition/schema_elements/object_interface_and_union_extension"
 require "elastic_graph/proto_ingestion/schema_definition/schema_elements/scalar_type_extension"
@@ -30,6 +31,8 @@ module ElasticGraph
         def to_proto
           types = proto_types
           return "" if types.empty?
+
+          validate_unique_enum_value_prefixes(types)
 
           sections = [
             %(syntax = "proto3";),
@@ -64,6 +67,21 @@ module ElasticGraph
             .sort_by(&:proto_name)
             .filter_map { |type| type.to_proto(@package_name) }
             .join("\n\n")
+        end
+
+        def validate_unique_enum_value_prefixes(types)
+          enum_type_by_prefix = {} # : ::Hash[::String, untyped]
+
+          types.each do |type|
+            next unless type.is_a?(SchemaElements::EnumTypeExtension)
+
+            if (existing_enum_type = enum_type_by_prefix[type.proto_enum_value_prefix])
+              raise Errors::SchemaError, "Enum types `#{existing_enum_type.name}` and `#{type.name}` map to " \
+                "duplicate protobuf enum value prefix `#{type.proto_enum_value_prefix}`."
+            end
+
+            enum_type_by_prefix[type.proto_enum_value_prefix] = type
+          end
         end
       end
     end

--- a/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/schema.rb
+++ b/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/schema.rb
@@ -73,7 +73,6 @@ module ElasticGraph
           enum_type_by_prefix = {} # : ::Hash[::String, untyped]
 
           types.grep(SchemaElements::EnumTypeExtension).each do |type|
-
             if (existing_enum_type = enum_type_by_prefix[type.proto_enum_value_prefix])
               raise Errors::SchemaError, "Enum types `#{existing_enum_type.name}` and `#{type.name}` map to " \
                 "duplicate protobuf enum value prefix `#{type.proto_enum_value_prefix}`."

--- a/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/schema.rb
+++ b/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/schema.rb
@@ -72,8 +72,7 @@ module ElasticGraph
         def validate_unique_enum_value_prefixes(types)
           enum_type_by_prefix = {} # : ::Hash[::String, untyped]
 
-          types.each do |type|
-            next unless type.is_a?(SchemaElements::EnumTypeExtension)
+          types.grep(SchemaElements::EnumTypeExtension).each do |type|
 
             if (existing_enum_type = enum_type_by_prefix[type.proto_enum_value_prefix])
               raise Errors::SchemaError, "Enum types `#{existing_enum_type.name}` and `#{type.name}` map to " \

--- a/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/schema_elements/enum_type_extension.rb
+++ b/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/schema_elements/enum_type_extension.rb
@@ -67,6 +67,13 @@ module ElasticGraph
             ".#{package_name}.#{proto_name}"
           end
 
+          # Returns the package-level prefix applied to this enum's protobuf values.
+          #
+          # @return [String]
+          def proto_enum_value_prefix
+            @proto_enum_value_prefix ||= Support::Casing.to_upper_snake(name)
+          end
+
           # @private
           def configure_derived_scalar_type(scalar_type)
             super
@@ -105,10 +112,6 @@ module ElasticGraph
 
           def proto_zero_value_name
             @proto_zero_value_name ||= "#{proto_enum_value_prefix}_UNSPECIFIED"
-          end
-
-          def proto_enum_value_prefix
-            @proto_enum_value_prefix ||= Support::Casing.to_upper_snake(name)
           end
 
           def values_by_proto_name

--- a/elasticgraph-proto_ingestion/sig/elastic_graph/proto_ingestion/schema_definition/schema.rbs
+++ b/elasticgraph-proto_ingestion/sig/elastic_graph/proto_ingestion/schema_definition/schema.rbs
@@ -18,6 +18,7 @@ module ElasticGraph
 
         def proto_types: () -> ::Array[untyped]
         def render_definitions: (::Array[untyped] types) -> ::String
+        def validate_unique_enum_value_prefixes: (::Array[untyped] types) -> void
       end
     end
   end

--- a/elasticgraph-proto_ingestion/sig/elastic_graph/proto_ingestion/schema_definition/schema_elements/enum_type_extension.rbs
+++ b/elasticgraph-proto_ingestion/sig/elastic_graph/proto_ingestion/schema_definition/schema_elements/enum_type_extension.rbs
@@ -11,6 +11,7 @@ module ElasticGraph
           def value: (::String) ?{ (::ElasticGraph::SchemaDefinition::SchemaElements::EnumValue & EnumValueExtension) -> void } -> void
           def proto_name: () -> ::String
           def proto_type_reference: (::String package_name) -> ::String
+          def proto_enum_value_prefix: () -> ::String
           def to_proto: (::String package_name) -> ::String
           def referenced_proto_types: () -> ::Array[::ElasticGraph::SchemaDefinition::SchemaElements::graphQLType]
           def configure_derived_scalar_type: (::ElasticGraph::SchemaDefinition::SchemaElements::ScalarType) -> void
@@ -20,7 +21,6 @@ module ElasticGraph
           def render_proto_enum: () -> ::String
           def proto_zero_value: () -> (::ElasticGraph::SchemaDefinition::SchemaElements::EnumValue & EnumValueExtension)
           def proto_zero_value_name: () -> ::String
-          def proto_enum_value_prefix: () -> ::String
           def values_by_proto_name: () -> ::Hash[::String, ::ElasticGraph::SchemaDefinition::SchemaElements::EnumValue & EnumValueExtension]
         end
       end

--- a/elasticgraph-proto_ingestion/spec/unit/elastic_graph/proto_ingestion/schema_definition/schema_edge_cases_spec.rb
+++ b/elasticgraph-proto_ingestion/spec/unit/elastic_graph/proto_ingestion/schema_definition/schema_edge_cases_spec.rb
@@ -49,6 +49,51 @@ module ElasticGraph
           ))
         end
 
+        it "raises when emitted enums map to the same protobuf enum value prefix" do
+          expect {
+            define_proto_schema do |s|
+              s.enum_type "HttpStatus" do |t|
+                t.value "AVAILABLE"
+              end
+
+              s.enum_type "HTTPStatus" do |t|
+                t.value "UNAVAILABLE"
+              end
+
+              s.object_type "Endpoint" do |t|
+                t.field "id", "ID"
+                t.field "externalStatus", "HttpStatus"
+                t.field "internalStatus", "HTTPStatus"
+                t.index "endpoints"
+              end
+            end
+          }.to raise_error(Errors::SchemaError, a_string_including(
+            "Enum types `HttpStatus` and `HTTPStatus`",
+            "duplicate protobuf enum value prefix `HTTP_STATUS`"
+          ))
+        end
+
+        it "allows colliding enum value prefixes when only one enum is emitted" do
+          proto = define_proto_schema do |s|
+            s.enum_type "HttpStatus" do |t|
+              t.value "AVAILABLE"
+            end
+
+            s.enum_type "HTTPStatus" do |t|
+              t.value "UNAVAILABLE"
+            end
+
+            s.object_type "Endpoint" do |t|
+              t.field "id", "ID"
+              t.field "status", "HttpStatus"
+              t.index "endpoints"
+            end
+          end
+
+          expect(proto).to include("enum HttpStatus {")
+          expect(proto).not_to include("enum HTTPStatus {")
+        end
+
         it "fully qualifies local type references so they do not conflict with contextual protobuf keywords" do
           proto = define_proto_schema do |s|
             s.enum_type "option" do |t|


### PR DESCRIPTION
## Why

Distinct GraphQL enum names can normalize to the same protobuf enum-value prefix, producing duplicate package-level symbols in `schema.proto`.

## What

- Validate enum-value prefixes across the enum types actually emitted in `schema.proto`.
- Raise an actionable schema error naming both enum types and their shared prefix.
- Preserve reachability behavior by allowing collisions with enum types that are not emitted.

## Validation

- `script/run_gem_specs elasticgraph-proto_ingestion`
- `script/lint elasticgraph-proto_ingestion`
- `script/type_check`

## Risk assessment

Low. This adds validation only for schemas that would otherwise emit invalid protobuf definitions.

## References

- https://github.com/block/elasticgraph/pull/1080#discussion_r3611424698
- Follow-up to #1080
