### PR TITLE
Centralize protobuf scalar initialization

### DIFF
--- a/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/factory_extension.rb
+++ b/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/factory_extension.rb
@@ -18,23 +18,6 @@ module ElasticGraph
     module SchemaDefinition
       # Extension module applied to Factory to add proto support.
       module FactoryExtension
-        # Default protobuf types applied to ElasticGraph's built-in scalar types as they are constructed.
-        BUILT_IN_SCALAR_PROTO_TYPES_BY_NAME = {
-          "Boolean" => "bool",
-          "Cursor" => "string",
-          "Date" => "string",
-          "DateTime" => "string",
-          "Float" => "double",
-          "ID" => "string",
-          "Int" => "int32",
-          "JsonSafeLong" => "int64",
-          "LocalTime" => "string",
-          "LongString" => "int64",
-          "String" => "string",
-          "TimeZone" => "string",
-          "Untyped" => "string"
-        }.freeze
-
         # Creates a new enum type with proto extensions.
         #
         # @param name [String] enum type name
@@ -92,13 +75,9 @@ module ElasticGraph
         def new_scalar_type(name)
           super(name) do |type|
             extended_type = type.extend(SchemaElements::ScalarTypeExtension) # : ::ElasticGraph::SchemaDefinition::SchemaElements::ScalarType & SchemaElements::ScalarTypeExtension
-
-            if (proto_type = BUILT_IN_SCALAR_PROTO_TYPES_BY_NAME[name.to_s])
-              extended_type.protobuf type: proto_type
+            extended_type.initialize_proto_extension do
+              yield extended_type if block_given?
             end
-
-            yield extended_type if block_given?
-            extended_type.finalize_protobuf_configuration!
           end
         end
 

--- a/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/schema_elements/scalar_type_extension.rb
+++ b/elasticgraph-proto_ingestion/lib/elastic_graph/proto_ingestion/schema_definition/schema_elements/scalar_type_extension.rb
@@ -14,6 +14,23 @@ module ElasticGraph
       module SchemaElements
         # Extends ScalarType with proto field type conversion.
         module ScalarTypeExtension
+          # Default protobuf types applied to ElasticGraph's built-in scalar types as they are constructed.
+          BUILT_IN_SCALAR_PROTO_TYPES_BY_NAME = {
+            "Boolean" => "bool",
+            "Cursor" => "string",
+            "Date" => "string",
+            "DateTime" => "string",
+            "Float" => "double",
+            "ID" => "string",
+            "Int" => "int32",
+            "JsonSafeLong" => "int64",
+            "LocalTime" => "string",
+            "LongString" => "int64",
+            "String" => "string",
+            "TimeZone" => "string",
+            "Untyped" => "string"
+          }.freeze
+
           # Configured protobuf type (e.g. string, int64, bool).
           # @dynamic protobuf_type
           attr_reader :protobuf_type
@@ -26,13 +43,20 @@ module ElasticGraph
             @protobuf_type = type
           end
 
-          # Validates that a protobuf type has been configured on this scalar type. GraphQL-only
-          # scalar types are skipped because they are not part of ingestion.
+          # Applies any built-in protobuf type, yields for further configuration, and validates the result.
           #
+          # @yield additional scalar type configuration
           # @return [void]
-          # @raise [Errors::SchemaError] when missing
-          def finalize_protobuf_configuration!
+          # @raise [Errors::SchemaError] when a protobuf type is missing
+          def initialize_proto_extension
+            original_name = type_ref.with_reverted_override.name
+            if (proto_type = BUILT_IN_SCALAR_PROTO_TYPES_BY_NAME[original_name])
+              protobuf type: proto_type
+            end
+
+            yield
             return if graphql_only?
+
             proto_name
             nil
           end

--- a/elasticgraph-proto_ingestion/sig/elastic_graph/proto_ingestion/schema_definition/factory_extension.rbs
+++ b/elasticgraph-proto_ingestion/sig/elastic_graph/proto_ingestion/schema_definition/factory_extension.rbs
@@ -2,8 +2,6 @@ module ElasticGraph
   module ProtoIngestion
     module SchemaDefinition
       module FactoryExtension: ::ElasticGraph::SchemaDefinition::Factory
-        BUILT_IN_SCALAR_PROTO_TYPES_BY_NAME: ::Hash[::String, ::String]
-
         def new_enum_type: (::String) ?{ (::ElasticGraph::SchemaDefinition::SchemaElements::EnumType & SchemaElements::EnumTypeExtension) -> void } -> (::ElasticGraph::SchemaDefinition::SchemaElements::EnumType & SchemaElements::EnumTypeExtension)
         def new_enum_value: (::String, ::String) ?{ (::ElasticGraph::SchemaDefinition::SchemaElements::EnumValue & SchemaElements::EnumValueExtension) -> void } -> (::ElasticGraph::SchemaDefinition::SchemaElements::EnumValue & SchemaElements::EnumValueExtension)
         def new_interface_type: (::String) ?{ (::ElasticGraph::SchemaDefinition::SchemaElements::InterfaceType & SchemaElements::ObjectInterfaceAndUnionExtension) -> void } -> (::ElasticGraph::SchemaDefinition::SchemaElements::InterfaceType & SchemaElements::ObjectInterfaceAndUnionExtension)

--- a/elasticgraph-proto_ingestion/sig/elastic_graph/proto_ingestion/schema_definition/schema_elements/scalar_type_extension.rbs
+++ b/elasticgraph-proto_ingestion/sig/elastic_graph/proto_ingestion/schema_definition/schema_elements/scalar_type_extension.rbs
@@ -3,10 +3,12 @@ module ElasticGraph
     module SchemaDefinition
       module SchemaElements
         module ScalarTypeExtension: ::ElasticGraph::SchemaDefinition::SchemaElements::ScalarType
+          BUILT_IN_SCALAR_PROTO_TYPES_BY_NAME: ::Hash[::String, ::String]
+
           attr_reader protobuf_type: ::String?
 
           def protobuf: (type: ::String) -> void
-          def finalize_protobuf_configuration!: () -> void
+          def initialize_proto_extension: () { () -> void } -> void
           def proto_name: () -> ::String
           def proto_type_reference: (::String package_name) -> ::String
           def to_proto: (::String package_name) -> nil

--- a/elasticgraph-proto_ingestion/spec/unit/elastic_graph/proto_ingestion/schema_definition/api_extension_spec.rb
+++ b/elasticgraph-proto_ingestion/spec/unit/elastic_graph/proto_ingestion/schema_definition/api_extension_spec.rb
@@ -35,7 +35,7 @@ module ElasticGraph
           field_types = []
           proto = define_proto_schema do |s|
             s.object_type "Widget" do |t|
-              FactoryExtension::BUILT_IN_SCALAR_PROTO_TYPES_BY_NAME.each_key do |type_name|
+              SchemaElements::ScalarTypeExtension::BUILT_IN_SCALAR_PROTO_TYPES_BY_NAME.each_key do |type_name|
                 t.field type_name.downcase, type_name
               end
               field_types = t.graphql_fields_by_name.values.map { |field| field.type.name }
@@ -43,8 +43,8 @@ module ElasticGraph
             end
           end
 
-          expect(field_types).to match_array(FactoryExtension::BUILT_IN_SCALAR_PROTO_TYPES_BY_NAME.keys)
-          FactoryExtension::BUILT_IN_SCALAR_PROTO_TYPES_BY_NAME.each.with_index(1) do |(type_name, proto_type), field_number|
+          expect(field_types).to match_array(SchemaElements::ScalarTypeExtension::BUILT_IN_SCALAR_PROTO_TYPES_BY_NAME.keys)
+          SchemaElements::ScalarTypeExtension::BUILT_IN_SCALAR_PROTO_TYPES_BY_NAME.each.with_index(1) do |(type_name, proto_type), field_number|
             expect(proto).to include("#{proto_type} #{type_name.downcase} = #{field_number};")
           end
         end


### PR DESCRIPTION
## Why

Built-in scalar defaults and final protobuf validation are split between the factory and scalar extension.

## What

- Centralize built-in protobuf mappings and initialization in `ScalarTypeExtension`.
- Keep the factory responsible only for extending the scalar and forwarding its configuration block.
- Preserve the existing default, user configuration, and validation order, including renamed built-in scalars.

## Validation

- `script/run_gem_specs elasticgraph-proto_ingestion`
- `script/lint elasticgraph-proto_ingestion`
- `script/type_check`

## Risk assessment

Low. This is a structural refactor that preserves existing scalar configuration behavior.

## References

- https://github.com/block/elasticgraph/pull/1080#discussion_r3610964291
- Follow-up to #1080
