### PR TITLE
Provide `path_to_schema` to schema definition state

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/api.rb
@@ -59,6 +59,7 @@ module ElasticGraph
       def initialize(
         schema_elements,
         index_document_sizes,
+        path_to_schema: nil,
         extension_modules: [],
         derived_type_name_formats: {},
         type_name_overrides: {},
@@ -69,6 +70,7 @@ module ElasticGraph
           api: self,
           schema_elements: schema_elements,
           index_document_sizes: index_document_sizes,
+          path_to_schema: path_to_schema,
           derived_type_name_formats: derived_type_name_formats,
           type_name_overrides: type_name_overrides,
           enum_value_overrides_by_type: enum_value_overrides_by_type,

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/rake_tasks.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/rake_tasks.rb
@@ -168,6 +168,7 @@ module ElasticGraph
           API.new(
             @schema_element_names,
             @index_document_sizes,
+            path_to_schema: @path_to_schema.to_s,
             extension_modules: @extension_modules,
             derived_type_name_formats: @derived_type_name_formats,
             type_name_overrides: @type_name_overrides,

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/state.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/state.rb
@@ -26,6 +26,7 @@ module ElasticGraph
       :api,
       :schema_elements,
       :index_document_sizes,
+      :path_to_schema,
       :types_by_name,
       :object_types_by_name,
       :namespace_types_by_name,
@@ -65,6 +66,7 @@ module ElasticGraph
         derived_type_name_formats:,
         type_name_overrides:,
         enum_value_overrides_by_type:,
+        path_to_schema: nil,
         output: $stdout
       )
         # @type var types_by_name: SchemaElements::typesByNameHash
@@ -74,6 +76,7 @@ module ElasticGraph
           api: api,
           schema_elements: schema_elements,
           index_document_sizes: index_document_sizes,
+          path_to_schema: path_to_schema,
           types_by_name: types_by_name,
           object_types_by_name: {},
           namespace_types_by_name: {},

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/api.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/api.rbs
@@ -58,6 +58,7 @@ module ElasticGraph
       def initialize: (
         SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
         bool,
+        ?path_to_schema: ::String?,
         ?extension_modules: ::Array[::Module],
         ?derived_type_name_formats: ::Hash[::Symbol, ::String],
         ?type_name_overrides: ::Hash[::Symbol, ::String],

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/state.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/state.rbs
@@ -4,6 +4,7 @@ module ElasticGraph
       attr_reader api: API
       attr_reader schema_elements: SchemaArtifacts::RuntimeMetadata::SchemaElementNames
       attr_reader index_document_sizes: bool
+      attr_reader path_to_schema: ::String?
       attr_reader types_by_name: SchemaElements::typesByNameHash
       attr_reader object_types_by_name: ::Hash[::String, indexableType]
       attr_reader namespace_types_by_name: ::Hash[::String, SchemaElements::ObjectType]
@@ -38,6 +39,7 @@ module ElasticGraph
         api: API,
         schema_elements: SchemaArtifacts::RuntimeMetadata::SchemaElementNames,
         index_document_sizes: bool,
+        path_to_schema: ::String?,
         types_by_name: SchemaElements::typesByNameHash,
         object_types_by_name: ::Hash[::String, indexableType],
         namespace_types_by_name: ::Hash[::String, SchemaElements::ObjectType],
@@ -78,6 +80,7 @@ module ElasticGraph
         derived_type_name_formats: ::Hash[::Symbol, ::String],
         type_name_overrides: ::Hash[::String, ::String] | ::Hash[::Symbol, ::String],
         enum_value_overrides_by_type: ::Hash[::String | ::Symbol, ::Hash[::String | ::Symbol, ::String]],
+        ?path_to_schema: ::String?,
         ?output: io
       ) -> State
 

--- a/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
+++ b/elasticgraph-schema_definition/spec/integration/elastic_graph/schema_definition/rake_tasks_spec.rb
@@ -32,6 +32,20 @@ module ElasticGraph
       end
 
       describe "schema_artifacts:dump", :in_temp_dir do
+        it "exposes `path_to_schema` on schema definition state before applying extensions" do
+          write_elastic_graph_schema_def_code
+          observed_paths = []
+          extension_module = Module.new do
+            define_singleton_method(:extended) do |api|
+              observed_paths << api.state.path_to_schema
+            end
+          end
+
+          run_rake("schema_artifacts:dump", extension_modules: [extension_module])
+
+          expect(observed_paths).to eq(["schema.rb"])
+        end
+
         it "idempotently dumps all schema artifacts, and is able to check if they are current with `:check`" do
           write_elastic_graph_schema_def_code
           expect_all_artifacts_out_of_date_because_they_havent_been_dumped


### PR DESCRIPTION
Today, every schema artifact is a pure function of the schema definition: the schema artifacts directory can safely be deleted and regenerated at any time. In https://github.com/block/elasticgraph/pull/1304#discussion_r3635047247, @myronmarston pointed out that `proto_field_numbers.yaml` doesn't fit that model--it's an _input_ to `schema.proto` generation, not a pure output--and suggested treating it as part of the schema definition, stored as a sibling of `path_to_schema`, rather than as a schema artifact.

For an extension to maintain a file there, schema definition state needs to know where the schema definition lives. `RakeTasks` already knows (it's how the schema gets loaded) but never passed it into the API. This PR stores `path_to_schema` on `SchemaDefinition::State`, allowing extensions to access it without expanding `SchemaArtifactManager`'s dependencies.

Nothing in core uses the value yet, so there are no behavior changes to the core artifacts. #1304 builds on this to relocate `proto_field_numbers.yaml`.

## Update — 2026-07-29

After review, the path is carried by schema definition state rather than an extension-only `SchemaArtifactManager` instance variable. The manager continues to accept the narrower schema-definition results object.