### PR TITLE
Stabilize nested relationship request assertions

### DIFF
--- a/elasticgraph-graphql/spec/acceptance/nested_relationships_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/nested_relationships_spec.rb
@@ -206,6 +206,8 @@ module ElasticGraph
           part_args = {order_by: [:id_DESC]} # ensure deterministic ordering of parts
           address_args = {order_by: [:full_address_ASC]} # ensure deterministic ordering of addresses
 
+          # Nested relationship levels can share an `_msearch` request depending on fiber scheduling, so assert
+          # the logical search count and routing below rather than the number of transport requests.
           [component_args_without_not, component_args_with_not].each do |component_args|
             expect {
               expect(query_all_relationship_levels_from_widgets(component_args: component_args, part_args: part_args)).to match edges_of(
@@ -226,7 +228,7 @@ module ElasticGraph
                   ))
                 ))
               )
-            }.to perform_datastore_msearch("main", 6).times.and perform_datastore_search("main", 6).times
+            }.to perform_datastore_search("main", 6).times
 
             expect_to_have_routed_to_shards_with("main",
               # Root `widgets` query isn't filtering on anything and uses no routing.
@@ -264,7 +266,7 @@ module ElasticGraph
                     ))
                   )))
               )
-            }.to perform_datastore_msearch("main", 6).times.and perform_datastore_search("main", 6).times
+            }.to perform_datastore_search("main", 6).times
 
             expect_to_have_routed_to_shards_with("main",
               # Root `addresses` query isn't filtering on anything and uses no routing.


### PR DESCRIPTION
## Why
Nested relationship acceptance tests assumed that each logical search would use a separate `_msearch` transport request. Fiber scheduling can batch the same six searches into five requests, causing unrelated changes such as #1316 to fail despite correct results and routing.

## What
- Stop asserting the transport request count in the bi-directional nested relationship test
- Continue asserting six logical datastore searches and their exact shard routing

## Risk Assessment
Low — this is a test-only change that preserves the result, query-count, and routing coverage.

## References
- Reproduced in the Ruby 3.4 and 4.0 `run_each_gem_spec` jobs on #1316
- `bundle exec rspec elasticgraph-graphql/spec/acceptance/nested_relationships_spec.rb`
- `script/lint`