### PR TITLE
Handle deleted rollover index exclusions

### DIFF
--- a/elasticgraph-apollo/spec/integration/elastic_graph/apollo/graphql/entities_field_resolver_spec.rb
+++ b/elasticgraph-apollo/spec/integration/elastic_graph/apollo/graphql/entities_field_resolver_spec.rb
@@ -620,7 +620,7 @@ module ElasticGraph
         end
 
         def have_total_widget_searches(count)
-          eq([{"index" => "widgets_rollover__*"}] * count)
+          eq([{"index" => "widgets_rollover__*", "ignore_unavailable" => true}] * count)
         end
       end
     end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
@@ -239,7 +239,11 @@ module ElasticGraph
       end
 
       def to_datastore_msearch_header
-        @to_datastore_msearch_header ||= {index: search_index_expression, routing: shard_routing_values&.join(",")}.compact
+        @to_datastore_msearch_header ||= {
+          index: search_index_expression,
+          ignore_unavailable: excluding_indices? || nil,
+          routing: shard_routing_values&.join(",")
+        }.compact
       end
 
       # `DatastoreQuery` objects are used as keys in a hash. Computing `#hash` can be expensive (given how many fields

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
@@ -172,8 +172,13 @@ module ElasticGraph
         ).to_s
       end
 
-      def excluding_indices?
-        search_index_expression.split(",").any? { |expr| expr.start_with?("-") }
+      # Indicates if this query targets indices that our cached index state says exist. When true, a response
+      # reporting zero searched shards means those indices have been deleted since we cached them--not that the
+      # cluster was never configured.
+      def searches_only_deleted_indices?
+        !search_index_expression.empty? && narrowed_search_index_definitions.any? do |index_def|
+          index_def.rollover_index_template? && !index_def.known_related_query_rollover_indices.empty?
+        end
       end
 
       # Returns the name of the datastore cluster as a String where this query should be sent.
@@ -241,7 +246,7 @@ module ElasticGraph
       def to_datastore_msearch_header
         @to_datastore_msearch_header ||= {
           index: search_index_expression,
-          ignore_unavailable: excluding_indices? || nil,
+          ignore_unavailable: true,
           routing: shard_routing_values&.join(",")
         }.compact
       end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query.rb
@@ -172,8 +172,13 @@ module ElasticGraph
         ).to_s
       end
 
-      def excluding_indices?
-        search_index_expression.split(",").any? { |expr| expr.start_with?("-") }
+      # Indicates if this query only targets indices that our cached index state says exist. When true, a response
+      # reporting zero searched shards means those indices have been deleted since we cached them--not that the
+      # cluster was never configured.
+      def searches_only_deleted_indices?
+        !search_index_expression.empty? && narrowed_search_index_definitions.all? do |index_def|
+          index_def.rollover_index_template? && !index_def.known_related_query_rollover_indices.empty?
+        end
       end
 
       # Returns the name of the datastore cluster as a String where this query should be sent.
@@ -239,7 +244,11 @@ module ElasticGraph
       end
 
       def to_datastore_msearch_header
-        @to_datastore_msearch_header ||= {index: search_index_expression, routing: shard_routing_values&.join(",")}.compact
+        @to_datastore_msearch_header ||= {
+          index: search_index_expression,
+          ignore_unavailable: true,
+          routing: shard_routing_values&.join(",")
+        }.compact
       end
 
       # `DatastoreQuery` objects are used as keys in a hash. Computing `#hash` can be expensive (given how many fields

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_search_router.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_search_router.rb
@@ -98,7 +98,7 @@ module ElasticGraph
             outer_accum + queries_and_responses.reduce(0) do |inner_accum, (query, response)|
               shards_total = response.dig("_shards", "total")
 
-              if shards_total == 0 && !query.excluding_indices?
+              if shards_total == 0 && !query.searches_only_deleted_indices?
                 raise ::GraphQL::ExecutionError, INDICES_NOT_CONFIGURED_MESSAGE
               end
 

--- a/elasticgraph-graphql/spec/acceptance/aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/aggregations_spec.rb
@@ -20,29 +20,6 @@ module ElasticGraph
       let(:grouped_by) { case_correctly("grouped_by") }
       let(:approximate_distinct_value_count) { case_correctly("approximate_distinct_value_count") }
 
-      it "returns empty aggregation results when the indices have not been configured or no documents have been indexed" do
-        allow(GraphQL::DatastoreQuery).to receive(:perform).and_wrap_original do |original, queries, &block|
-          queries.each do |query|
-            original_to_datastore_msearch_header = query.to_datastore_msearch_header
-            to_datastore_msearch_header =
-              if original_to_datastore_msearch_header[:index].start_with?("widgets")
-                original_to_datastore_msearch_header.merge(index: "rollover_index_with_no_concrete_indexes__*")
-              else
-                original_to_datastore_msearch_header
-              end
-
-            allow(query).to receive(:to_datastore_msearch_header).and_return(to_datastore_msearch_header)
-          end
-
-          original.call(queries, &block)
-        end
-
-        # Test grouped_by
-        expect_indices_not_configured_error { group_widgets_by_tag(allow_errors: true) }
-        # Test aggregated_values
-        expect_indices_not_configured_error { list_widgets_with_aggregations(all_amount_aggregations, allow_errors: true) }
-      end
-
       it "returns aggregates (terms, date histogram) and nested aggregates" do
         # Test grouped_by before anything is indexed
         aggregations = group_widgets_by_tag
@@ -1840,8 +1817,8 @@ module ElasticGraph
       OPTS
     end
 
-    def group_widgets_by_tag(allow_errors: false)
-      response = call_graphql_query(<<~QUERY, allow_errors: allow_errors)
+    def group_widgets_by_tag
+      response = call_graphql_query(<<~QUERY)
         query {
           widget_aggregations {
             nodes {
@@ -1855,8 +1832,6 @@ module ElasticGraph
           }
         }
       QUERY
-
-      return response if allow_errors
 
       response.dig("data", case_correctly("widget_aggregations"), "nodes")
     end
@@ -1912,8 +1887,8 @@ module ElasticGraph
       QUERY
     end
 
-    def list_widgets_with_aggregations(widget_aggregation, allow_errors: false, **query_args)
-      response = call_graphql_query(<<~QUERY, allow_errors: allow_errors)
+    def list_widgets_with_aggregations(widget_aggregation, **query_args)
+      response = call_graphql_query(<<~QUERY)
         query {
           widgets#{graphql_args(query_args)} {
             edges {
@@ -1960,8 +1935,6 @@ module ElasticGraph
           }
         }
       QUERY
-
-      return response if allow_errors
 
       response.dig("data", case_correctly("widget_aggregations"), "edges").map { |edge| edge["node"] }
     end

--- a/elasticgraph-graphql/spec/acceptance/elasticgraph_graphql_acceptance_support.rb
+++ b/elasticgraph-graphql/spec/acceptance/elasticgraph_graphql_acceptance_support.rb
@@ -53,13 +53,6 @@ module ElasticGraph
       pre_cache_index_state(graphql)
     end
 
-    def expect_indices_not_configured_error
-      expect {
-        response = yield
-        expect(response.dig("errors").first).to include({"message" => GraphQL::DatastoreSearchRouter::INDICES_NOT_CONFIGURED_MESSAGE})
-      }.to log_warning(a_string_including(GraphQL::DatastoreSearchRouter::INDICES_NOT_CONFIGURED_MESSAGE))
-    end
-
     def self.with_both_casing_forms(&block)
       context "with a snake_case schema" do
         include SnakeCaseGraphQLAcceptanceAdapter

--- a/elasticgraph-graphql/spec/acceptance/sub_aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/sub_aggregations_spec.rb
@@ -16,14 +16,9 @@ module ElasticGraph
 
     with_both_casing_forms do
       shared_examples_for "sub-aggregation acceptance" do
-        it "returns the expected empty responses when the indices have not been configured or no documents have yet been indexed", :expect_search_routing do
+        it "returns the expected empty responses when no documents have yet been indexed", :expect_search_routing do
           main_datastore_client.delete_indices("team*")
-
-          expect_indices_not_configured_error { aggregate_teams_grouped_by_league(allow_errors: true) }
-          expect_indices_not_configured_error { aggregate_sibling_and_deeply_nested_counts(allow_errors: true) }
-          expect_indices_not_configured_error { aggregate_season_counts_grouped_by("year", "note", allow_errors: true) }
-
-          # Reconfigure the indices (but don't index any docs)
+          # Reconfigure the indices, but don't index any documents.
           admin.cluster_configurator.configure_cluster(StringIO.new)
 
           # Note: this is technically a "root" aggregations query (not sub-aggregations), but it's another case we need to
@@ -446,8 +441,8 @@ module ElasticGraph
         EOS
       end
 
-      def aggregate_sibling_and_deeply_nested_counts(allow_errors: false)
-        response = call_graphql_query(<<~EOS, allow_errors: allow_errors)
+      def aggregate_sibling_and_deeply_nested_counts
+        response = call_graphql_query(<<~EOS)
           query {
             team_aggregations {
               #{page_info_snippet}
@@ -503,8 +498,6 @@ module ElasticGraph
             upper_bound
           }
         EOS
-
-        return response if allow_errors
 
         team_node = get_single_aggregations_node_from(response, "team_aggregations", parent_field_name: "data")
         player_node = get_single_aggregations_node_from(team_node, "current_players_nested")
@@ -990,8 +983,8 @@ module ElasticGraph
         ]
       end
 
-      def aggregate_season_counts_grouped_by(*grouping_expressions, team_aggregations_args: {}, allow_errors: false, teams_has_next_page: false, seasons_has_next_page: false, **args)
-        response = call_graphql_query(<<~EOS, allow_errors: allow_errors)
+      def aggregate_season_counts_grouped_by(*grouping_expressions, team_aggregations_args: {}, teams_has_next_page: false, seasons_has_next_page: false, **args)
+        response = call_graphql_query(<<~EOS)
           query {
             team_aggregations#{graphql_args(team_aggregations_args)} {
               #{page_info_snippet}
@@ -1019,14 +1012,12 @@ module ElasticGraph
           }
         EOS
 
-        return response if allow_errors
-
         team_node = get_single_aggregations_node_from(response, "team_aggregations", parent_field_name: "data", has_next_page: teams_has_next_page)
         get_aggregations_nodes_from(team_node, "seasons_nested", has_next_page: seasons_has_next_page)
       end
 
-      def aggregate_teams_grouped_by_league(allow_errors: false)
-        response = call_graphql_query(<<~EOS, allow_errors: allow_errors)
+      def aggregate_teams_grouped_by_league
+        response = call_graphql_query(<<~EOS)
           query {
             team_aggregations {
               nodes {
@@ -1037,8 +1028,6 @@ module ElasticGraph
             }
           }
         EOS
-
-        return response if allow_errors
 
         response.dig("data", case_correctly("team_aggregations"), "nodes")
       end

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/misc_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/misc_spec.rb
@@ -118,7 +118,7 @@ module ElasticGraph
         end
       end
 
-      context "when indices have not yet been configured", :builds_admin do
+      context "with a unique monthly rollover index", :builds_admin do
         let(:graphql) do
           build_graphql(schema_definition: lambda do |schema|
             schema.object_type "Widget" do |t|
@@ -131,7 +131,82 @@ module ElasticGraph
           end)
         end
 
-        it "raises a `GraphQL::ExecutionError` indicating they need to be configured" do
+        it "continues searching after a cached rollover index has been manually deleted", :expect_index_exclusions do
+          build_admin(datastore_core: graphql.datastore_core).cluster_configurator.configure_cluster(StringIO.new)
+
+          index_into(
+            graphql,
+            january_widget = build(:widget, created_at: "2024-01-15T12:00:00Z"),
+            february_widget = build(:widget, created_at: "2024-02-15T12:00:00Z")
+          )
+
+          pre_cache_index_state(graphql)
+          index_def = graphql.datastore_core.index_definitions_by_name.fetch(unique_index_name)
+          january_index_name = index_def.index_name_for_writes({"created_at" => january_widget.fetch(:created_at)})
+          main_datastore_client.delete_indices(january_index_name)
+
+          results = search_datastore(
+            index_def_name: unique_index_name,
+            graphql: graphql,
+            client_filters: [{"created_at" => {"gte" => "2024-02-01T00:00:00Z"}}]
+          )
+
+          expect(ids_of(results.to_a)).to eq(ids_of(february_widget))
+          expect(performed_search_metadata("main").last).to include(
+            "index" => "#{index_def.index_expression_for_search},-#{january_index_name}",
+            "ignore_unavailable" => true
+          )
+          expect_to_have_excluded_indices("main", [january_index_name])
+        end
+
+        it "continues aggregating after the only cached rollover index a filter can match has been manually deleted" do
+          build_admin(datastore_core: graphql.datastore_core).cluster_configurator.configure_cluster(StringIO.new)
+
+          index_into(graphql, january_widget = build(:widget, created_at: "2024-01-15T12:00:00Z"))
+
+          pre_cache_index_state(graphql)
+          index_def = graphql.datastore_core.index_definitions_by_name.fetch(unique_index_name)
+          january_index_name = index_def.index_name_for_writes({"created_at" => january_widget.fetch(:created_at)})
+          main_datastore_client.delete_indices(january_index_name)
+
+          # This filter is impossible to satisfy, so the time set is empty. The aggregation requires an index to
+          # search, so `IndexExpressionBuilder` names the first cached index directly, with no wildcard and no
+          # exclusions. That index has been deleted, so the datastore has nothing to resolve the name against.
+          results = search_datastore(
+            index_def_name: unique_index_name,
+            graphql: graphql,
+            aggregations: [aggregation_query_of(name: "counts", groupings: [date_histogram_grouping_of("created_at", "month")])],
+            client_filters: [{"created_at" => {"gte" => "2025-02-01T00:00:00Z", "lt" => "2025-01-01T00:00:00Z"}}]
+          )
+
+          expect(performed_search_metadata("main").last).to include("index" => january_index_name)
+          expect(results.aggregations).to eq({})
+        end
+
+        it "continues searching after every cached rollover index has been manually deleted", :expect_index_exclusions do
+          build_admin(datastore_core: graphql.datastore_core).cluster_configurator.configure_cluster(StringIO.new)
+
+          index_into(graphql, january_widget = build(:widget, created_at: "2024-01-15T12:00:00Z"))
+
+          pre_cache_index_state(graphql)
+          index_def = graphql.datastore_core.index_definitions_by_name.fetch(unique_index_name)
+          january_index_name = index_def.index_name_for_writes({"created_at" => january_widget.fetch(:created_at)})
+          main_datastore_client.delete_indices(*index_def.known_related_query_rollover_indices.map(&:name))
+
+          # With every index gone, the rollover wildcard resolves to nothing at all. That alone is fine (the
+          # datastore allows a wildcard to match no indices by default), but the expression also excludes the
+          # now-missing January index by name, and resolving that name is what fails.
+          results = search_datastore(
+            index_def_name: unique_index_name,
+            graphql: graphql,
+            client_filters: [{"created_at" => {"gte" => "2024-02-01T00:00:00Z"}}]
+          )
+
+          expect(results.to_a).to eq []
+          expect_to_have_excluded_indices("main", [january_index_name])
+        end
+
+        it "raises a `GraphQL::ExecutionError` indicating they need to be configured if they have not yet been" do
           widgets_def = graphql.datastore_core.index_definitions_by_name.fetch(unique_index_name)
 
           query = graphql.datastore_query_builder.new_query(

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/misc_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/misc_spec.rb
@@ -118,7 +118,7 @@ module ElasticGraph
         end
       end
 
-      context "when indices have not yet been configured", :builds_admin do
+      context "with a unique monthly rollover index", :builds_admin do
         let(:graphql) do
           build_graphql(schema_definition: lambda do |schema|
             schema.object_type "Widget" do |t|
@@ -129,6 +129,34 @@ module ElasticGraph
               end
             end
           end)
+        end
+
+        it "continues searching after a cached rollover index has been manually deleted", :expect_index_exclusions, :no_vcr do
+          build_admin(datastore_core: graphql.datastore_core).cluster_configurator.configure_cluster(StringIO.new)
+
+          index_into(
+            graphql,
+            january_widget = build(:widget, created_at: "2024-01-15T12:00:00Z"),
+            february_widget = build(:widget, created_at: "2024-02-15T12:00:00Z")
+          )
+
+          pre_cache_index_state(graphql)
+          index_def = graphql.datastore_core.index_definitions_by_name.fetch(unique_index_name)
+          january_index_name = index_def.index_name_for_writes({"created_at" => january_widget.fetch(:created_at)})
+          main_datastore_client.delete_indices(january_index_name)
+
+          results = search_datastore(
+            index_def_name: unique_index_name,
+            graphql: graphql,
+            client_filters: [{"created_at" => {"gte" => "2024-02-01T00:00:00Z"}}]
+          )
+
+          expect(ids_of(results.to_a)).to eq(ids_of(february_widget))
+          expect(performed_search_metadata("main").last).to include(
+            "index" => "#{index_def.index_expression_for_search},-#{january_index_name}",
+            "ignore_unavailable" => true
+          )
+          expect_to_have_excluded_indices("main", [january_index_name])
         end
 
         it "raises a `GraphQL::ExecutionError` indicating they need to be configured" do

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/misc_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/misc_spec.rb
@@ -131,7 +131,7 @@ module ElasticGraph
           end)
         end
 
-        it "continues searching after a cached rollover index has been manually deleted", :expect_index_exclusions, :no_vcr do
+        it "continues searching after a cached rollover index has been manually deleted", :expect_index_exclusions do
           build_admin(datastore_core: graphql.datastore_core).cluster_configurator.configure_cluster(StringIO.new)
 
           index_into(
@@ -159,7 +159,54 @@ module ElasticGraph
           expect_to_have_excluded_indices("main", [january_index_name])
         end
 
-        it "raises a `GraphQL::ExecutionError` indicating they need to be configured" do
+        it "continues aggregating after the only cached rollover index a filter can match has been manually deleted" do
+          build_admin(datastore_core: graphql.datastore_core).cluster_configurator.configure_cluster(StringIO.new)
+
+          index_into(graphql, january_widget = build(:widget, created_at: "2024-01-15T12:00:00Z"))
+
+          pre_cache_index_state(graphql)
+          index_def = graphql.datastore_core.index_definitions_by_name.fetch(unique_index_name)
+          january_index_name = index_def.index_name_for_writes({"created_at" => january_widget.fetch(:created_at)})
+          main_datastore_client.delete_indices(january_index_name)
+
+          # This filter is impossible to satisfy, so the time set is empty. The aggregation requires an index to
+          # search, so `IndexExpressionBuilder` names the first cached index directly, with no wildcard and no
+          # exclusions. That index has been deleted, so the datastore has nothing to resolve the name against.
+          results = search_datastore(
+            index_def_name: unique_index_name,
+            graphql: graphql,
+            aggregations: [aggregation_query_of(name: "counts", groupings: [date_histogram_grouping_of("created_at", "month")])],
+            client_filters: [{"created_at" => {"gte" => "2025-02-01T00:00:00Z", "lt" => "2025-01-01T00:00:00Z"}}]
+          )
+
+          expect(performed_search_metadata("main").last).to include("index" => january_index_name)
+          expect(results.aggregations).to eq({})
+        end
+
+        it "continues searching after every cached rollover index has been manually deleted", :expect_index_exclusions do
+          build_admin(datastore_core: graphql.datastore_core).cluster_configurator.configure_cluster(StringIO.new)
+
+          index_into(graphql, january_widget = build(:widget, created_at: "2024-01-15T12:00:00Z"))
+
+          pre_cache_index_state(graphql)
+          index_def = graphql.datastore_core.index_definitions_by_name.fetch(unique_index_name)
+          january_index_name = index_def.index_name_for_writes({"created_at" => january_widget.fetch(:created_at)})
+          main_datastore_client.delete_indices(*index_def.known_related_query_rollover_indices.map(&:name))
+
+          # With every index gone, the rollover wildcard resolves to nothing at all. That alone is fine (the
+          # datastore allows a wildcard to match no indices by default), but the expression also excludes the
+          # now-missing January index by name, and resolving that name is what fails.
+          results = search_datastore(
+            index_def_name: unique_index_name,
+            graphql: graphql,
+            client_filters: [{"created_at" => {"gte" => "2024-02-01T00:00:00Z"}}]
+          )
+
+          expect(results.to_a).to eq []
+          expect_to_have_excluded_indices("main", [january_index_name])
+        end
+
+        it "raises a `GraphQL::ExecutionError` indicating they need to be configured if they have not yet been" do
           widgets_def = graphql.datastore_core.index_definitions_by_name.fetch(unique_index_name)
 
           query = graphql.datastore_query_builder.new_query(

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/misc_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/misc_spec.rb
@@ -23,7 +23,7 @@ module ElasticGraph
 
       it "inspects nicely, but redacts filters since they could contain PII" do
         expect(new_query(client_filters: [{"ssn" => {"equal_to_any_of" => ["123-45-6789"]}}], individual_docs_needed: true).inspect).to eq(<<~EOS.strip)
-          #<ElasticGraph::GraphQL::DatastoreQuery index="widgets_rollover__*" size=#{default_page_size + 1} sort=[{"id" => {"order" => "asc", "missing" => "_first"}}] track_total_hits=false query=<REDACTED> _source=false>
+          #<ElasticGraph::GraphQL::DatastoreQuery index="widgets_rollover__*" ignore_unavailable=true size=#{default_page_size + 1} sort=[{"id" => {"order" => "asc", "missing" => "_first"}}] track_total_hits=false query=<REDACTED> _source=false>
         EOS
       end
     end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/perform_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/perform_spec.rb
@@ -61,9 +61,9 @@ module ElasticGraph
         end
 
         expect(yielded_header_body_tuples_by_query).to match({
-          query0 => [{index: "widgets_rollover__*"}, a_hash_including(query: {bool: {filter: [{terms: {"age" => [0]}}]}})],
-          query1 => [{index: "widgets_rollover__*"}, a_hash_including(query: {bool: {filter: [{terms: {"age" => [10]}}]}})],
-          query2 => [{index: "components"}, a_hash_including(query: {bool: {filter: [{terms: {"age" => [20]}}]}})]
+          query0 => [{index: "widgets_rollover__*", ignore_unavailable: true}, a_hash_including(query: {bool: {filter: [{terms: {"age" => [0]}}]}})],
+          query1 => [{index: "widgets_rollover__*", ignore_unavailable: true}, a_hash_including(query: {bool: {filter: [{terms: {"age" => [10]}}]}})],
+          query2 => [{index: "components", ignore_unavailable: true}, a_hash_including(query: {bool: {filter: [{terms: {"age" => [20]}}]}})]
         })
 
         expect(responses.values).to all be_a DatastoreResponse::SearchResponse

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
@@ -33,6 +33,11 @@ module ElasticGraph
               i.rollover :yearly, "created_at"
             end
           end
+
+          schema.object_type "NonRolloverWidget" do |t|
+            t.field "id", "ID!"
+            t.index "non_rollover_widgets"
+          end
         end
       end
 
@@ -69,13 +74,13 @@ module ElasticGraph
         let(:query1) { new_widgets_query(default_page_size: 10, individual_docs_needed: true) }
         let(:query2) { new_widgets_query(default_page_size: 3, individual_docs_needed: true) }
 
-        it "passes a set of empty headers along with each search body to the datastore, since it requires that for msearch" do
+        it "passes index options along with each search body to the datastore" do
           router.msearch([query1, query2])
 
           expect(main_datastore_client).to have_received(:msearch).with(a_hash_including(body: [
-            {index: "widgets_rollover__*"},
+            {index: "widgets_rollover__*", ignore_unavailable: true},
             a_hash_including(sort: sort_list_with_missing_option_for(sort_list), size: a_value_within(1).of(10)),
-            {index: "widgets_rollover__*"},
+            {index: "widgets_rollover__*", ignore_unavailable: true},
             a_hash_including(sort: sort_list_with_missing_option_for(sort_list), size: a_value_within(1).of(3))
           ]))
         end
@@ -206,7 +211,7 @@ module ElasticGraph
           expect {
             router.msearch([query1, query2])
           }.to raise_error(Errors::SearchFailedError, a_string_including(
-            "2) ", '{"index":"widgets_rollover__*"}', '{"bad stuff" => "happened"}'
+            "2) ", '{"index":"widgets_rollover__*","ignore_unavailable":true}', '{"bad stuff" => "happened"}'
           ).and(excluding(
             # These are parts of the body of the request, which we don't want included because it could contain PII!
             "track_total_hits", "size",
@@ -241,7 +246,8 @@ module ElasticGraph
           )
         end
 
-        it "raises `::GraphQL::ExecutionError` if a search queries no shards without excluding any indices as that indicates the indices have not been configured" do
+        it "raises `::GraphQL::ExecutionError` if a search queries no shards from an unconfigured rollover index" do
+          allow(main_datastore_client).to receive(:list_indices_matching).with("widgets_rollover__*").and_return([])
           allow(main_datastore_client).to receive(:msearch).and_return("took" => 10, "responses" => [
             empty_response,
             no_shards_searched_response
@@ -252,6 +258,70 @@ module ElasticGraph
           }.to raise_error ::GraphQL::ExecutionError, a_string_including(
             "The datastore indices have not been configured. They must be configured before ElasticGraph can serve queries."
           )
+        end
+
+        it "raises `::GraphQL::ExecutionError` if a search queries no shards from an unconfigured non-rollover index" do
+          allow(main_datastore_client).to receive(:msearch).and_return("took" => 10, "responses" => [
+            no_shards_searched_response
+          ])
+
+          expect {
+            router.msearch([new_non_rollover_widgets_query])
+          }.to raise_error ::GraphQL::ExecutionError, a_string_including(
+            "The datastore indices have not been configured. They must be configured before ElasticGraph can serve queries."
+          )
+        end
+
+        it "uses `__typename`-narrowed index definitions to identify an unconfigured non-rollover index" do
+          allow(main_datastore_client).to receive(:msearch).and_return("took" => 10, "responses" => [
+            no_shards_searched_response
+          ])
+
+          widgets_def = graphql.datastore_core.index_definitions_by_name.fetch("widgets")
+          non_rollover_widgets_def = graphql.datastore_core.index_definitions_by_name.fetch("non_rollover_widgets")
+          narrowed_query = datastore_query_builder.new_query(
+            initial_search_index_definitions: [widgets_def, non_rollover_widgets_def],
+            client_filters: [{"__typename" => {"equal_to_any_of" => ["NonRolloverWidget"]}}],
+            requested_fields: ["id"]
+          )
+          expect(narrowed_query.search_index_expression).to eq("non_rollover_widgets")
+
+          expect {
+            router.msearch([narrowed_query])
+          }.to raise_error ::GraphQL::ExecutionError, a_string_including(
+            "The datastore indices have not been configured. They must be configured before ElasticGraph can serve queries."
+          )
+        end
+
+        it "raises `::GraphQL::ExecutionError` if a mixed search includes an unconfigured non-rollover index" do
+          allow(main_datastore_client).to receive(:msearch).and_return("took" => 10, "responses" => [
+            no_shards_searched_response
+          ])
+
+          widgets_def = graphql.datastore_core.index_definitions_by_name.fetch("widgets")
+          non_rollover_widgets_def = graphql.datastore_core.index_definitions_by_name.fetch("non_rollover_widgets")
+          mixed_query = datastore_query_builder.new_query(
+            initial_search_index_definitions: [widgets_def, non_rollover_widgets_def],
+            requested_fields: ["id"]
+          )
+          expect(mixed_query.search_index_expression).to eq("non_rollover_widgets,widgets_rollover__*")
+
+          expect {
+            router.msearch([mixed_query])
+          }.to raise_error ::GraphQL::ExecutionError, a_string_including(
+            "The datastore indices have not been configured. They must be configured before ElasticGraph can serve queries."
+          )
+        end
+
+        it "returns no results if no shards are searched after all cached rollover indices are deleted" do
+          allow(main_datastore_client).to receive(:msearch).and_return("took" => 10, "responses" => [
+            no_shards_searched_response
+          ])
+
+          expect(query1.search_index_expression).to eq("widgets_rollover__*")
+
+          responses_by_query = router.msearch([query1])
+          expect(responses_by_query.fetch(query1).documents).to eq([])
         end
 
         it "returns no results if a search queries no shards while excluding indices as that indicates the indices have been configured" do
@@ -265,6 +335,12 @@ module ElasticGraph
 
           responses_by_query = router.msearch([query1, query_excluding_indices])
           expect(responses_by_query.values.map(&:documents)).to eq [[], []]
+          expect(main_datastore_client).to have_received(:msearch).with(a_hash_including(body: [
+            {index: "widgets_rollover__*", ignore_unavailable: true},
+            anything,
+            {index: "widgets_rollover__*,-widgets_rollover__2024", ignore_unavailable: true},
+            anything
+          ]))
         end
 
         it "logs warning if a query has failed shards" do
@@ -399,6 +475,13 @@ module ElasticGraph
           }.merge(args)
 
           datastore_query_builder.with(default_page_size: default_page_size).new_query(**options)
+        end
+
+        def new_non_rollover_widgets_query
+          datastore_query_builder.new_query(
+            initial_search_index_definitions: [graphql.datastore_core.index_definitions_by_name.fetch("non_rollover_widgets")],
+            requested_fields: ["id"]
+          )
         end
       end
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
@@ -69,7 +69,7 @@ module ElasticGraph
         let(:query1) { new_widgets_query(default_page_size: 10, individual_docs_needed: true) }
         let(:query2) { new_widgets_query(default_page_size: 3, individual_docs_needed: true) }
 
-        it "passes a set of empty headers along with each search body to the datastore, since it requires that for msearch" do
+        it "passes index options along with each search body to the datastore" do
           router.msearch([query1, query2])
 
           expect(main_datastore_client).to have_received(:msearch).with(a_hash_including(body: [
@@ -265,6 +265,12 @@ module ElasticGraph
 
           responses_by_query = router.msearch([query1, query_excluding_indices])
           expect(responses_by_query.values.map(&:documents)).to eq [[], []]
+          expect(main_datastore_client).to have_received(:msearch).with(a_hash_including(body: [
+            {index: "widgets_rollover__*"},
+            anything,
+            {index: "widgets_rollover__*,-widgets_rollover__2024", ignore_unavailable: true},
+            anything
+          ]))
         end
 
         it "logs warning if a query has failed shards" do

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_search_router_spec.rb
@@ -33,6 +33,11 @@ module ElasticGraph
               i.rollover :yearly, "created_at"
             end
           end
+
+          schema.object_type "NonRolloverWidget" do |t|
+            t.field "id", "ID!"
+            t.index "non_rollover_widgets"
+          end
         end
       end
 
@@ -73,9 +78,9 @@ module ElasticGraph
           router.msearch([query1, query2])
 
           expect(main_datastore_client).to have_received(:msearch).with(a_hash_including(body: [
-            {index: "widgets_rollover__*"},
+            {index: "widgets_rollover__*", ignore_unavailable: true},
             a_hash_including(sort: sort_list_with_missing_option_for(sort_list), size: a_value_within(1).of(10)),
-            {index: "widgets_rollover__*"},
+            {index: "widgets_rollover__*", ignore_unavailable: true},
             a_hash_including(sort: sort_list_with_missing_option_for(sort_list), size: a_value_within(1).of(3))
           ]))
         end
@@ -206,7 +211,7 @@ module ElasticGraph
           expect {
             router.msearch([query1, query2])
           }.to raise_error(Errors::SearchFailedError, a_string_including(
-            "2) ", '{"index":"widgets_rollover__*"}', '{"bad stuff" => "happened"}'
+            "2) ", '{"index":"widgets_rollover__*","ignore_unavailable":true}', '{"bad stuff" => "happened"}'
           ).and(excluding(
             # These are parts of the body of the request, which we don't want included because it could contain PII!
             "track_total_hits", "size",
@@ -241,7 +246,8 @@ module ElasticGraph
           )
         end
 
-        it "raises `::GraphQL::ExecutionError` if a search queries no shards without excluding any indices as that indicates the indices have not been configured" do
+        it "raises `::GraphQL::ExecutionError` if a search queries no shards from an unconfigured rollover index" do
+          allow(main_datastore_client).to receive(:list_indices_matching).with("widgets_rollover__*").and_return([])
           allow(main_datastore_client).to receive(:msearch).and_return("took" => 10, "responses" => [
             empty_response,
             no_shards_searched_response
@@ -252,6 +258,50 @@ module ElasticGraph
           }.to raise_error ::GraphQL::ExecutionError, a_string_including(
             "The datastore indices have not been configured. They must be configured before ElasticGraph can serve queries."
           )
+        end
+
+        it "raises `::GraphQL::ExecutionError` if a search queries no shards from an unconfigured non-rollover index" do
+          allow(main_datastore_client).to receive(:msearch).and_return("took" => 10, "responses" => [
+            no_shards_searched_response
+          ])
+
+          expect {
+            router.msearch([new_non_rollover_widgets_query])
+          }.to raise_error ::GraphQL::ExecutionError, a_string_including(
+            "The datastore indices have not been configured. They must be configured before ElasticGraph can serve queries."
+          )
+        end
+
+        it "uses `__typename`-narrowed index definitions to identify an unconfigured non-rollover index" do
+          allow(main_datastore_client).to receive(:msearch).and_return("took" => 10, "responses" => [
+            no_shards_searched_response
+          ])
+
+          widgets_def = graphql.datastore_core.index_definitions_by_name.fetch("widgets")
+          non_rollover_widgets_def = graphql.datastore_core.index_definitions_by_name.fetch("non_rollover_widgets")
+          narrowed_query = datastore_query_builder.new_query(
+            initial_search_index_definitions: [widgets_def, non_rollover_widgets_def],
+            client_filters: [{"__typename" => {"equal_to_any_of" => ["NonRolloverWidget"]}}],
+            requested_fields: ["id"]
+          )
+          expect(narrowed_query.search_index_expression).to eq("non_rollover_widgets")
+
+          expect {
+            router.msearch([narrowed_query])
+          }.to raise_error ::GraphQL::ExecutionError, a_string_including(
+            "The datastore indices have not been configured. They must be configured before ElasticGraph can serve queries."
+          )
+        end
+
+        it "returns no results if no shards are searched after all cached rollover indices are deleted" do
+          allow(main_datastore_client).to receive(:msearch).and_return("took" => 10, "responses" => [
+            no_shards_searched_response
+          ])
+
+          expect(query1.search_index_expression).to eq("widgets_rollover__*")
+
+          responses_by_query = router.msearch([query1])
+          expect(responses_by_query.fetch(query1).documents).to eq([])
         end
 
         it "returns no results if a search queries no shards while excluding indices as that indicates the indices have been configured" do
@@ -266,7 +316,7 @@ module ElasticGraph
           responses_by_query = router.msearch([query1, query_excluding_indices])
           expect(responses_by_query.values.map(&:documents)).to eq [[], []]
           expect(main_datastore_client).to have_received(:msearch).with(a_hash_including(body: [
-            {index: "widgets_rollover__*"},
+            {index: "widgets_rollover__*", ignore_unavailable: true},
             anything,
             {index: "widgets_rollover__*,-widgets_rollover__2024", ignore_unavailable: true},
             anything
@@ -405,6 +455,13 @@ module ElasticGraph
           }.merge(args)
 
           datastore_query_builder.with(default_page_size: default_page_size).new_query(**options)
+        end
+
+        def new_non_rollover_widgets_query
+          datastore_query_builder.new_query(
+            initial_search_index_definitions: [graphql.datastore_core.index_definitions_by_name.fetch("non_rollover_widgets")],
+            requested_fields: ["id"]
+          )
         end
       end
 


### PR DESCRIPTION
## Why

ElasticGraph caches the concrete indices related to a rollover template. If
those indices are then deleted manually, a later search can still target a
cached concrete name or include it as an exclusion in its `_msearch` index
expression. OpenSearch rejects either request with
`index_not_found_exception`.

## What

- Always set `ignore_unavailable: true` on `_msearch` metadata headers. Unlike
  `allow_no_indices`, this handles both a missing concrete target and a deleted
  concrete name in an exclusion expression.
- Distinguish a zero-shard response caused by cached rollover indices being
  deleted from a genuinely unconfigured index. The router now requires every
  narrowed target to be a rollover definition with known cached indices before
  treating a zero-shard response as deleted-index state.
- Add live-datastore regressions for partial deletion, an empty time set with an
  aggregation, and deleting every cached rollover index. Unit coverage retains
  the configuration error for genuinely unconfigured rollover, non-rollover,
  narrowed, and mixed-index searches.

## Validation

- Current PR-base patch on OpenSearch 3.6.0: router specs 26 examples and the
  focused Apollo/GraphQL live-datastore suite 53 examples, all passing.
- The identical patch rebased onto current `main` (matching stable patch ID):
  full repository suite 5,341 examples, 0 failures, with 100% line and branch
  coverage; focused live-datastore suite 55 examples, 0 failures.
- GraphQL gem suite: 1,695 examples, 0 failures, 100% line and branch coverage.
- Apollo gem suite: 123 examples, 0 failures, 100% line and branch coverage.
- `script/lint`, `script/type_check`, `script/spellcheck`, schema artifact check,
  and `git diff --check` pass.
- Site generation and internal-link checks pass. The final external-link check
  is currently blocked by redirects/timeouts and changed anchors on existing
  Apollo documentation URLs; no documentation links are changed by this PR.

## Risk assessment

The change sends an officially supported `_msearch` metadata option on every
search. The router still raises its existing configuration error unless all
narrowed targets have cached rollover state, so a cached rollover definition
cannot hide a genuinely unconfigured non-rollover or second rollover target.
Index-expression construction, request bodies, query grouping, and public APIs
are unchanged.

## References

Closes #589.
