### PR TITLE
Add approximatePercentile aggregated value function

### DIFF
--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -4034,7 +4034,7 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       approximate_percentile:
-        computation_function: percentiles
+        computation_function: percentile
         resolver:
           name: object_with_lookahead
       exact_max:
@@ -4072,7 +4072,7 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       approximate_percentile:
-        computation_function: percentiles
+        computation_function: percentile
         resolver:
           name: object_with_lookahead
       exact_max:
@@ -4422,7 +4422,7 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       approximate_percentile:
-        computation_function: percentiles
+        computation_function: percentile
         resolver:
           name: object_with_lookahead
       approximate_sum:
@@ -4686,7 +4686,7 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       approximate_percentile:
-        computation_function: percentiles
+        computation_function: percentile
         resolver:
           name: object_with_lookahead
       approximate_sum:
@@ -4843,7 +4843,7 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       approximate_percentile:
-        computation_function: percentiles
+        computation_function: percentile
         resolver:
           name: object_with_lookahead
       approximate_sum:
@@ -4879,7 +4879,7 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       approximate_percentile:
-        computation_function: percentiles
+        computation_function: percentile
         resolver:
           name: object_with_lookahead
       exact_max:
@@ -4911,7 +4911,7 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       approximate_percentile:
-        computation_function: percentiles
+        computation_function: percentile
         resolver:
           name: object_with_lookahead
       approximate_sum:

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -4033,6 +4033,10 @@ object_types_by_name:
         computation_function: cardinality
         resolver:
           name: object_with_lookahead
+      approximate_percentile:
+        computation_function: percentiles
+        resolver:
+          name: object_with_lookahead
       exact_max:
         computation_function: max
         resolver:
@@ -4065,6 +4069,10 @@ object_types_by_name:
           name: object_with_lookahead
       approximate_distinct_value_count:
         computation_function: cardinality
+        resolver:
+          name: object_with_lookahead
+      approximate_percentile:
+        computation_function: percentiles
         resolver:
           name: object_with_lookahead
       exact_max:
@@ -4413,6 +4421,10 @@ object_types_by_name:
         computation_function: cardinality
         resolver:
           name: object_with_lookahead
+      approximate_percentile:
+        computation_function: percentiles
+        resolver:
+          name: object_with_lookahead
       approximate_sum:
         computation_function: sum
         resolver:
@@ -4673,6 +4685,10 @@ object_types_by_name:
         computation_function: cardinality
         resolver:
           name: object_with_lookahead
+      approximate_percentile:
+        computation_function: percentiles
+        resolver:
+          name: object_with_lookahead
       approximate_sum:
         computation_function: sum
         resolver:
@@ -4826,6 +4842,10 @@ object_types_by_name:
         computation_function: cardinality
         resolver:
           name: object_with_lookahead
+      approximate_percentile:
+        computation_function: percentiles
+        resolver:
+          name: object_with_lookahead
       approximate_sum:
         computation_function: sum
         resolver:
@@ -4858,6 +4878,10 @@ object_types_by_name:
         computation_function: cardinality
         resolver:
           name: object_with_lookahead
+      approximate_percentile:
+        computation_function: percentiles
+        resolver:
+          name: object_with_lookahead
       exact_max:
         computation_function: max
         resolver:
@@ -4884,6 +4908,10 @@ object_types_by_name:
           name: object_with_lookahead
       approximate_min:
         computation_function: min
+        resolver:
+          name: object_with_lookahead
+      approximate_percentile:
+        computation_function: percentiles
         resolver:
           name: object_with_lookahead
       approximate_sum:

--- a/config/schema/artifacts/schema.graphql
+++ b/config/schema/artifacts/schema.graphql
@@ -2170,6 +2170,22 @@ type DateAggregatedValues {
   approximate_distinct_value_count: JsonSafeLong
 
   """
+  An approximate percentile of the field values within this grouping.
+
+  Percentiles are computed using an approximate algorithm, so the returned value may not be
+  exact. Request a specific percentile via the `percentile` argument (e.g.
+  `percentile: 50` for the median). To request multiple percentiles in a single query,
+  use a GraphQL alias for each: `p50: approximate_percentile(percentile: 50)`.
+  """
+  approximate_percentile(
+    """
+    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
+    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    """
+    percentile: Float!
+  ): Date
+
+  """
   The maximum of the field values within this grouping.
 
   So long as the grouping contains at least one non-null value for the
@@ -2485,6 +2501,22 @@ type DateTimeAggregatedValues {
   it usually differs from the true distinct value count by less than 7%.
   """
   approximate_distinct_value_count: JsonSafeLong
+
+  """
+  An approximate percentile of the field values within this grouping.
+
+  Percentiles are computed using an approximate algorithm, so the returned value may not be
+  exact. Request a specific percentile via the `percentile` argument (e.g.
+  `percentile: 50` for the median). To request multiple percentiles in a single query,
+  use a GraphQL alias for each: `p50: approximate_percentile(percentile: 50)`.
+  """
+  approximate_percentile(
+    """
+    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
+    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    """
+    percentile: Float!
+  ): DateTime
 
   """
   The maximum of the field values within this grouping.
@@ -3779,6 +3811,22 @@ type FloatAggregatedValues {
   approximate_distinct_value_count: JsonSafeLong
 
   """
+  An approximate percentile of the field values within this grouping.
+
+  Percentiles are computed using an approximate algorithm, so the returned value may not be
+  exact. Request a specific percentile via the `percentile` argument (e.g.
+  `percentile: 50` for the median). To request multiple percentiles in a single query,
+  use a GraphQL alias for each: `p50: approximate_percentile(percentile: 50)`.
+  """
+  approximate_percentile(
+    """
+    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
+    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    """
+    percentile: Float!
+  ): Float
+
+  """
   The sum of the field values within this grouping.
 
   As with all double-precision `Float` values, operations are subject to floating-point loss
@@ -4578,6 +4626,22 @@ type IntAggregatedValues {
   approximate_distinct_value_count: JsonSafeLong
 
   """
+  An approximate percentile of the field values within this grouping.
+
+  Percentiles are computed using an approximate algorithm, so the returned value may not be
+  exact. Request a specific percentile via the `percentile` argument (e.g.
+  `percentile: 50` for the median). To request multiple percentiles in a single query,
+  use a GraphQL alias for each: `p50: approximate_percentile(percentile: 50)`.
+  """
+  approximate_percentile(
+    """
+    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
+    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    """
+    percentile: Float!
+  ): Float
+
+  """
   The (approximate) sum of the field values within this grouping.
 
   Sums of large `Int` values can result in overflow, where the exact sum cannot
@@ -5163,6 +5227,22 @@ type JsonSafeLongAggregatedValues {
   approximate_distinct_value_count: JsonSafeLong
 
   """
+  An approximate percentile of the field values within this grouping.
+
+  Percentiles are computed using an approximate algorithm, so the returned value may not be
+  exact. Request a specific percentile via the `percentile` argument (e.g.
+  `percentile: 50` for the median). To request multiple percentiles in a single query,
+  use a GraphQL alias for each: `p50: approximate_percentile(percentile: 50)`.
+  """
+  approximate_percentile(
+    """
+    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
+    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    """
+    percentile: Float!
+  ): Float
+
+  """
   The (approximate) sum of the field values within this grouping.
 
   Sums of large `JsonSafeLong` values can result in overflow, where the exact sum cannot
@@ -5414,6 +5494,22 @@ type LocalTimeAggregatedValues {
   approximate_distinct_value_count: JsonSafeLong
 
   """
+  An approximate percentile of the field values within this grouping.
+
+  Percentiles are computed using an approximate algorithm, so the returned value may not be
+  exact. Request a specific percentile via the `percentile` argument (e.g.
+  `percentile: 50` for the median). To request multiple percentiles in a single query,
+  use a GraphQL alias for each: `p50: approximate_percentile(percentile: 50)`.
+  """
+  approximate_percentile(
+    """
+    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
+    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    """
+    percentile: Float!
+  ): LocalTime
+
+  """
   The maximum of the field values within this grouping.
 
   So long as the grouping contains at least one non-null value for the
@@ -5622,6 +5718,22 @@ type LongStringAggregatedValues {
   a value which may be approximate.
   """
   approximate_min: LongString
+
+  """
+  An approximate percentile of the field values within this grouping.
+
+  Percentiles are computed using an approximate algorithm, so the returned value may not be
+  exact. Request a specific percentile via the `percentile` argument (e.g.
+  `percentile: 50` for the median). To request multiple percentiles in a single query,
+  use a GraphQL alias for each: `p50: approximate_percentile(percentile: 50)`.
+  """
+  approximate_percentile(
+    """
+    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
+    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    """
+    percentile: Float!
+  ): Float
 
   """
   The (approximate) sum of the field values within this grouping.

--- a/config/schema/artifacts/schema.graphql
+++ b/config/schema/artifacts/schema.graphql
@@ -2179,8 +2179,8 @@ type DateAggregatedValues {
   """
   approximate_percentile(
     """
-    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
-    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100`
+    for the max, `50` for the median, `99` for the 99th percentile).
     """
     percentile: Float!
   ): Date
@@ -2512,8 +2512,8 @@ type DateTimeAggregatedValues {
   """
   approximate_percentile(
     """
-    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
-    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100`
+    for the max, `50` for the median, `99` for the 99th percentile).
     """
     percentile: Float!
   ): DateTime
@@ -3820,8 +3820,8 @@ type FloatAggregatedValues {
   """
   approximate_percentile(
     """
-    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
-    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100`
+    for the max, `50` for the median, `99` for the 99th percentile).
     """
     percentile: Float!
   ): Float
@@ -4635,8 +4635,8 @@ type IntAggregatedValues {
   """
   approximate_percentile(
     """
-    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
-    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100`
+    for the max, `50` for the median, `99` for the 99th percentile).
     """
     percentile: Float!
   ): Float
@@ -5236,8 +5236,8 @@ type JsonSafeLongAggregatedValues {
   """
   approximate_percentile(
     """
-    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
-    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100`
+    for the max, `50` for the median, `99` for the 99th percentile).
     """
     percentile: Float!
   ): Float
@@ -5503,8 +5503,8 @@ type LocalTimeAggregatedValues {
   """
   approximate_percentile(
     """
-    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
-    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100`
+    for the max, `50` for the median, `99` for the 99th percentile).
     """
     percentile: Float!
   ): LocalTime
@@ -5729,8 +5729,8 @@ type LongStringAggregatedValues {
   """
   approximate_percentile(
     """
-    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
-    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100`
+    for the max, `50` for the median, `99` for the 99th percentile).
     """
     percentile: Float!
   ): Float

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -4136,7 +4136,7 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       approximate_percentile:
-        computation_function: percentiles
+        computation_function: percentile
         resolver:
           name: object_with_lookahead
       exact_max:
@@ -4174,7 +4174,7 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       approximate_percentile:
-        computation_function: percentiles
+        computation_function: percentile
         resolver:
           name: object_with_lookahead
       exact_max:
@@ -4524,7 +4524,7 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       approximate_percentile:
-        computation_function: percentiles
+        computation_function: percentile
         resolver:
           name: object_with_lookahead
       approximate_sum:
@@ -4788,7 +4788,7 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       approximate_percentile:
-        computation_function: percentiles
+        computation_function: percentile
         resolver:
           name: object_with_lookahead
       approximate_sum:
@@ -4945,7 +4945,7 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       approximate_percentile:
-        computation_function: percentiles
+        computation_function: percentile
         resolver:
           name: object_with_lookahead
       approximate_sum:
@@ -4981,7 +4981,7 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       approximate_percentile:
-        computation_function: percentiles
+        computation_function: percentile
         resolver:
           name: object_with_lookahead
       exact_max:
@@ -5013,7 +5013,7 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       approximate_percentile:
-        computation_function: percentiles
+        computation_function: percentile
         resolver:
           name: object_with_lookahead
       approximate_sum:

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -4135,6 +4135,10 @@ object_types_by_name:
         computation_function: cardinality
         resolver:
           name: object_with_lookahead
+      approximate_percentile:
+        computation_function: percentiles
+        resolver:
+          name: object_with_lookahead
       exact_max:
         computation_function: max
         resolver:
@@ -4167,6 +4171,10 @@ object_types_by_name:
           name: object_with_lookahead
       approximate_distinct_value_count:
         computation_function: cardinality
+        resolver:
+          name: object_with_lookahead
+      approximate_percentile:
+        computation_function: percentiles
         resolver:
           name: object_with_lookahead
       exact_max:
@@ -4515,6 +4523,10 @@ object_types_by_name:
         computation_function: cardinality
         resolver:
           name: object_with_lookahead
+      approximate_percentile:
+        computation_function: percentiles
+        resolver:
+          name: object_with_lookahead
       approximate_sum:
         computation_function: sum
         resolver:
@@ -4775,6 +4787,10 @@ object_types_by_name:
         computation_function: cardinality
         resolver:
           name: object_with_lookahead
+      approximate_percentile:
+        computation_function: percentiles
+        resolver:
+          name: object_with_lookahead
       approximate_sum:
         computation_function: sum
         resolver:
@@ -4928,6 +4944,10 @@ object_types_by_name:
         computation_function: cardinality
         resolver:
           name: object_with_lookahead
+      approximate_percentile:
+        computation_function: percentiles
+        resolver:
+          name: object_with_lookahead
       approximate_sum:
         computation_function: sum
         resolver:
@@ -4960,6 +4980,10 @@ object_types_by_name:
         computation_function: cardinality
         resolver:
           name: object_with_lookahead
+      approximate_percentile:
+        computation_function: percentiles
+        resolver:
+          name: object_with_lookahead
       exact_max:
         computation_function: max
         resolver:
@@ -4986,6 +5010,10 @@ object_types_by_name:
           name: object_with_lookahead
       approximate_min:
         computation_function: min
+        resolver:
+          name: object_with_lookahead
+      approximate_percentile:
+        computation_function: percentiles
         resolver:
           name: object_with_lookahead
       approximate_sum:

--- a/config/schema/artifacts_with_apollo/schema.graphql
+++ b/config/schema/artifacts_with_apollo/schema.graphql
@@ -2446,8 +2446,8 @@ type DateAggregatedValues @shareable {
   """
   approximate_percentile(
     """
-    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
-    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100`
+    for the max, `50` for the median, `99` for the 99th percentile).
     """
     percentile: Float!
   ): Date
@@ -2779,8 +2779,8 @@ type DateTimeAggregatedValues @shareable {
   """
   approximate_percentile(
     """
-    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
-    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100`
+    for the max, `50` for the median, `99` for the 99th percentile).
     """
     percentile: Float!
   ): DateTime
@@ -4102,8 +4102,8 @@ type FloatAggregatedValues @shareable {
   """
   approximate_percentile(
     """
-    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
-    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100`
+    for the max, `50` for the median, `99` for the 99th percentile).
     """
     percentile: Float!
   ): Float
@@ -4917,8 +4917,8 @@ type IntAggregatedValues @shareable {
   """
   approximate_percentile(
     """
-    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
-    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100`
+    for the max, `50` for the median, `99` for the 99th percentile).
     """
     percentile: Float!
   ): Float
@@ -5518,8 +5518,8 @@ type JsonSafeLongAggregatedValues @shareable {
   """
   approximate_percentile(
     """
-    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
-    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100`
+    for the max, `50` for the median, `99` for the 99th percentile).
     """
     percentile: Float!
   ): Float
@@ -5785,8 +5785,8 @@ type LocalTimeAggregatedValues @shareable {
   """
   approximate_percentile(
     """
-    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
-    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100`
+    for the max, `50` for the median, `99` for the 99th percentile).
     """
     percentile: Float!
   ): LocalTime
@@ -6011,8 +6011,8 @@ type LongStringAggregatedValues @shareable {
   """
   approximate_percentile(
     """
-    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
-    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100`
+    for the max, `50` for the median, `99` for the 99th percentile).
     """
     percentile: Float!
   ): Float

--- a/config/schema/artifacts_with_apollo/schema.graphql
+++ b/config/schema/artifacts_with_apollo/schema.graphql
@@ -2437,6 +2437,22 @@ type DateAggregatedValues @shareable {
   approximate_distinct_value_count: JsonSafeLong
 
   """
+  An approximate percentile of the field values within this grouping.
+
+  Percentiles are computed using an approximate algorithm, so the returned value may not be
+  exact. Request a specific percentile via the `percentile` argument (e.g.
+  `percentile: 50` for the median). To request multiple percentiles in a single query,
+  use a GraphQL alias for each: `p50: approximate_percentile(percentile: 50)`.
+  """
+  approximate_percentile(
+    """
+    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
+    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    """
+    percentile: Float!
+  ): Date
+
+  """
   The maximum of the field values within this grouping.
 
   So long as the grouping contains at least one non-null value for the
@@ -2752,6 +2768,22 @@ type DateTimeAggregatedValues @shareable {
   it usually differs from the true distinct value count by less than 7%.
   """
   approximate_distinct_value_count: JsonSafeLong
+
+  """
+  An approximate percentile of the field values within this grouping.
+
+  Percentiles are computed using an approximate algorithm, so the returned value may not be
+  exact. Request a specific percentile via the `percentile` argument (e.g.
+  `percentile: 50` for the median). To request multiple percentiles in a single query,
+  use a GraphQL alias for each: `p50: approximate_percentile(percentile: 50)`.
+  """
+  approximate_percentile(
+    """
+    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
+    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    """
+    percentile: Float!
+  ): DateTime
 
   """
   The maximum of the field values within this grouping.
@@ -4061,6 +4093,22 @@ type FloatAggregatedValues @shareable {
   approximate_distinct_value_count: JsonSafeLong
 
   """
+  An approximate percentile of the field values within this grouping.
+
+  Percentiles are computed using an approximate algorithm, so the returned value may not be
+  exact. Request a specific percentile via the `percentile` argument (e.g.
+  `percentile: 50` for the median). To request multiple percentiles in a single query,
+  use a GraphQL alias for each: `p50: approximate_percentile(percentile: 50)`.
+  """
+  approximate_percentile(
+    """
+    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
+    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    """
+    percentile: Float!
+  ): Float
+
+  """
   The sum of the field values within this grouping.
 
   As with all double-precision `Float` values, operations are subject to floating-point loss
@@ -4860,6 +4908,22 @@ type IntAggregatedValues @shareable {
   approximate_distinct_value_count: JsonSafeLong
 
   """
+  An approximate percentile of the field values within this grouping.
+
+  Percentiles are computed using an approximate algorithm, so the returned value may not be
+  exact. Request a specific percentile via the `percentile` argument (e.g.
+  `percentile: 50` for the median). To request multiple percentiles in a single query,
+  use a GraphQL alias for each: `p50: approximate_percentile(percentile: 50)`.
+  """
+  approximate_percentile(
+    """
+    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
+    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    """
+    percentile: Float!
+  ): Float
+
+  """
   The (approximate) sum of the field values within this grouping.
 
   Sums of large `Int` values can result in overflow, where the exact sum cannot
@@ -5445,6 +5509,22 @@ type JsonSafeLongAggregatedValues @shareable {
   approximate_distinct_value_count: JsonSafeLong
 
   """
+  An approximate percentile of the field values within this grouping.
+
+  Percentiles are computed using an approximate algorithm, so the returned value may not be
+  exact. Request a specific percentile via the `percentile` argument (e.g.
+  `percentile: 50` for the median). To request multiple percentiles in a single query,
+  use a GraphQL alias for each: `p50: approximate_percentile(percentile: 50)`.
+  """
+  approximate_percentile(
+    """
+    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
+    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    """
+    percentile: Float!
+  ): Float
+
+  """
   The (approximate) sum of the field values within this grouping.
 
   Sums of large `JsonSafeLong` values can result in overflow, where the exact sum cannot
@@ -5696,6 +5776,22 @@ type LocalTimeAggregatedValues @shareable {
   approximate_distinct_value_count: JsonSafeLong
 
   """
+  An approximate percentile of the field values within this grouping.
+
+  Percentiles are computed using an approximate algorithm, so the returned value may not be
+  exact. Request a specific percentile via the `percentile` argument (e.g.
+  `percentile: 50` for the median). To request multiple percentiles in a single query,
+  use a GraphQL alias for each: `p50: approximate_percentile(percentile: 50)`.
+  """
+  approximate_percentile(
+    """
+    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
+    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    """
+    percentile: Float!
+  ): LocalTime
+
+  """
   The maximum of the field values within this grouping.
 
   So long as the grouping contains at least one non-null value for the
@@ -5904,6 +6000,22 @@ type LongStringAggregatedValues @shareable {
   a value which may be approximate.
   """
   approximate_min: LongString
+
+  """
+  An approximate percentile of the field values within this grouping.
+
+  Percentiles are computed using an approximate algorithm, so the returned value may not be
+  exact. Request a specific percentile via the `percentile` argument (e.g.
+  `percentile: 50` for the median). To request multiple percentiles in a single query,
+  use a GraphQL alias for each: `p50: approximate_percentile(percentile: 50)`.
+  """
+  approximate_percentile(
+    """
+    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min,
+    `100` for the max, `50` for the median, `99` for the 99th percentile).
+    """
+    percentile: Float!
+  ): Float
 
   """
   The (approximate) sum of the field values within this grouping.

--- a/config/site/examples/music/queries/aggregations/BluegrassArtistLifetimeSales.graphql
+++ b/config/site/examples/music/queries/aggregations/BluegrassArtistLifetimeSales.graphql
@@ -16,6 +16,9 @@ query BluegrassArtistLifetimeSales {
           approximateSum
 
           approximateAvg
+
+          median: approximatePercentile(percentile: 50)
+          p90: approximatePercentile(percentile: 90)
         }
       }
     }

--- a/config/site/src/query-api/aggregations/aggregated-values.md
+++ b/config/site/src/query-api/aggregations/aggregated-values.md
@@ -10,7 +10,7 @@ Here's an example:
 
 {% include copyable_code_snippet.html language="graphql" data="music_queries.aggregations.BluegrassArtistLifetimeSales" %}
 
-This example query aggregates the values of the `Artist.lifetimeSales` field using all 4 of the standard numeric
+This example query aggregates the values of the `Artist.lifetimeSales` field using all 4 of the basic numeric
 aggregated values: `min`, `max`, `avg`, and `sum`. These are qualified with `approximate` or `exact` to indicate
 the level of precision they offer. The documentation for `approximateSum` and `exactSum` provides more detail:
 
@@ -28,7 +28,19 @@ the level of precision they offer. The documentation for `approximateSum` and `e
   fit in a `JsonSafeLong`. In that case, `null` will be returned, and `approximateSum`
   can be used to get an approximate value.
 
-Besides these standard numeric aggregated values, ElasticGraph offers one more:
+The same example also requests two percentiles of `lifetimeSales`, using aliases (`median`/`p90`) to request
+both in a single query:
+
+`approximatePercentile`
+: An approximate percentile of the field values within this grouping. The `percentile` argument specifies
+  the desired percentile rank, from `0` to `100` (e.g. `50` for the median, `90` for the 90th percentile).
+
+  Percentiles are computed using an approximate algorithm, so the returned value may not be exact--this is
+  true regardless of the field's type, so there is no `exactPercentile` counterpart the way there is for
+  `min`/`max`/`sum`. To request multiple percentiles in a single query, use a GraphQL alias for each
+  selection, as the example above does.
+
+Besides these basic numeric aggregated values, ElasticGraph offers one more:
 
 {% include copyable_code_snippet.html language="graphql" data="music_queries.aggregations.SkaArtistHomeCountries" %}
 

--- a/config/site/src/query-api/aggregations/aggregated-values.md
+++ b/config/site/src/query-api/aggregations/aggregated-values.md
@@ -33,7 +33,8 @@ both in a single query:
 
 `approximatePercentile`
 : An approximate percentile of the field values within this grouping. The `percentile` argument specifies
-  the desired percentile rank, from `0` to `100` (e.g. `50` for the median, `90` for the 90th percentile).
+  the desired percentile rank, from `0` to `100` (e.g. `0` for the min, `100` for the max, `50` for the
+  median, `90` for the 90th percentile).
 
   Percentiles are computed using an approximate algorithm, so the returned value may not be exact--this is
   true regardless of the field's type, so there is no `exactPercentile` counterpart the way there is for

--- a/config/site/src/query-api/aggregations/aggregated-values.md
+++ b/config/site/src/query-api/aggregations/aggregated-values.md
@@ -33,7 +33,7 @@ both in a single query:
 
 `approximatePercentile`
 : An approximate percentile of the field values within this grouping. The `percentile` argument specifies
-  the desired percentile rank, from `0` to `100` (e.g. `0` for the min, `100` for the max, `50` for the
+  the desired percentile, from `0` to `100` (e.g. `0` for the min, `100` for the max, `50` for the
   median, `90` for the 90th percentile).
 
   Percentiles are computed using an approximate algorithm, so the returned value may not be exact--this is

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/function_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/function_adapter.rb
@@ -82,7 +82,7 @@ module ElasticGraph
           cardinality: SimpleMetric.new(datastore_function_name: "cardinality", empty_bucket_value: 0),
           max: SimpleMetric.new(datastore_function_name: "max", empty_bucket_value: nil),
           min: SimpleMetric.new(datastore_function_name: "min", empty_bucket_value: nil),
-          percentiles: Percentile.new(datastore_function_name: "percentiles"),
+          percentile: Percentile.new(datastore_function_name: "percentiles"),
           sum: SimpleMetric.new(datastore_function_name: "sum", empty_bucket_value: 0)
         }.freeze
       end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/function_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/function_adapter.rb
@@ -6,6 +6,8 @@
 #
 # frozen_string_literal: true
 
+require "graphql"
+
 module ElasticGraph
   class GraphQL
     module Aggregation
@@ -39,12 +41,48 @@ module ElasticGraph
           end
         end
 
+        # Adapter for the `percentiles` aggregation, which takes a `percentile` argument and
+        # returns a nested `{"values" => [{"key" => ..., "value" => ...}]}` response rather than
+        # the flat `{"value" => ...}` shape `SimpleMetric` handles.
+        #
+        # @private
+        class Percentile < ::Data.define(:datastore_function_name)
+          def extract_args(args, element_names)
+            percentile = args.fetch(element_names.percentile)
+
+            unless percentile.is_a?(::Numeric) && percentile >= 0 && percentile <= 100
+              raise ::GraphQL::ExecutionError, "`#{element_names.percentile}` must be between 0 and 100, but is #{percentile.inspect}."
+            end
+
+            {percentile: percentile}
+          end
+
+          def clause_options(function_args)
+            # `keyed: false` gives us an array response (`"values" => [{"key" => ..., "value" => ...}]`)
+            # instead of a string-keyed hash (`"values" => {"50.0" => ...}`), which avoids having to
+            # reconstruct the datastore's float-formatted string key to look up our single requested value.
+            {"percents" => [function_args.fetch(:percentile)], "keyed" => false}
+          end
+
+          def extract_result(raw)
+            # We always request exactly one percentile per computation (multiple requested ranks are
+            # expressed as multiple aliased GraphQL field selections, each becoming its own computation),
+            # so the single entry in `values` is always the one we want.
+            raw.fetch("values").first
+          end
+
+          def empty_bucket_result
+            {"values" => [{"value" => nil}]}
+          end
+        end
+
         # The registered adapters, keyed by the function name used in runtime metadata.
         BY_NAME = {
           avg: SimpleMetric.new(datastore_function_name: "avg", empty_bucket_value: nil),
           cardinality: SimpleMetric.new(datastore_function_name: "cardinality", empty_bucket_value: 0),
           max: SimpleMetric.new(datastore_function_name: "max", empty_bucket_value: nil),
           min: SimpleMetric.new(datastore_function_name: "min", empty_bucket_value: nil),
+          percentiles: Percentile.new(datastore_function_name: "percentiles"),
           sum: SimpleMetric.new(datastore_function_name: "sum", empty_bucket_value: 0)
         }.freeze
       end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/function_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/function_adapter.rb
@@ -6,8 +6,6 @@
 #
 # frozen_string_literal: true
 
-require "graphql"
-
 module ElasticGraph
   class GraphQL
     module Aggregation
@@ -17,6 +15,11 @@ module ElasticGraph
       # locate its value in the datastore response, and what response to fabricate for a bucket
       # the datastore omitted.
       #
+      # When an adapter's `extract_args` is given args it considers invalid, it yields an error
+      # message instead of returning extracted args. Each caller passes a block that exits
+      # non-locally (the args of an invalid field are never used), which lets a field with invalid
+      # args be handled without disrupting the sibling fields being processed alongside it.
+      #
       # @private
       module FunctionAdapter
         # Adapter for metric aggregations that take no arguments and return a flat
@@ -24,6 +27,7 @@ module ElasticGraph
         #
         # @private
         class SimpleMetric < ::Data.define(:datastore_function_name, :empty_bucket_value)
+          # These functions take no args, so there's nothing to extract and nothing that can be invalid.
           def extract_args(args, element_names)
             {}
           end
@@ -51,7 +55,7 @@ module ElasticGraph
             percentile = args.fetch(element_names.percentile)
 
             unless percentile.is_a?(::Numeric) && percentile >= 0 && percentile <= 100
-              raise ::GraphQL::ExecutionError, "`#{element_names.percentile}` must be between 0 and 100, but is #{percentile.inspect}."
+              return yield "`#{element_names.percentile}` must be between 0 and 100, but is #{percentile.inspect}."
             end
 
             {percentile: percentile}

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_adapter.rb
@@ -186,29 +186,26 @@ module ElasticGraph
           build_clauses_from(aggregated_values_node) do |node, field, field_path|
             if field.aggregated?
               field_path = from_field_path + field_path
-
-              get_children_nodes(node).filter_map do |fn_node|
-                computed_field = field_from_node(fn_node)
-                function_adapter = computed_field.function_adapter # : FunctionAdapter::adapter
-
-                # An invalid argument (e.g. an out-of-range `percentile`) raises here. Skip building a
-                # `Computation` for it rather than letting that fail the whole aggregations field--the
-                # resolver re-runs `extract_args` at resolve time and attributes the error precisely.
-                begin
-                  function_args = function_adapter.extract_args(computed_field.args_to_schema_form(fn_node.arguments), element_names)
-                rescue ::GraphQL::ExecutionError
-                  next
-                end
-
-                Aggregation::Computation.new(
-                  source_field_path: field_path,
-                  leaf: PathSegment.for(field: computed_field, lookahead: fn_node),
-                  function_adapter: function_adapter,
-                  function_args: function_args
-                )
-              end
+              get_children_nodes(node).filter_map { |fn_node| computation_for(fn_node, field_path) }
             end
           end
+        end
+
+        # Builds the `Computation` for an aggregated value function node, or returns `nil` if the node
+        # has invalid args (e.g. an out-of-range `percentile`). We omit the computation rather than
+        # failing the whole aggregations field here: the resolver detects the same invalid args when it
+        # resolves this specific field, and can attribute the error to that field's precise path.
+        def computation_for(fn_node, field_path)
+          computed_field = field_from_node(fn_node)
+          function_adapter = computed_field.function_adapter # : FunctionAdapter::adapter
+          args = computed_field.args_to_schema_form(fn_node.arguments)
+
+          Aggregation::Computation.new(
+            source_field_path: field_path,
+            leaf: PathSegment.for(field: computed_field, lookahead: fn_node),
+            function_adapter: function_adapter,
+            function_args: function_adapter.extract_args(args, element_names) { return nil }
+          )
         end
 
         def build_groupings_from(node_node, aggregation_name, from_field_path: [])

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_adapter.rb
@@ -17,6 +17,7 @@ require "elastic_graph/graphql/aggregation/script_term_grouping"
 require "elastic_graph/graphql/schema/arguments"
 require "elastic_graph/support/hash_util"
 require "elastic_graph/support/memoizable_data"
+require "graphql"
 
 module ElasticGraph
   class GraphQL
@@ -186,15 +187,24 @@ module ElasticGraph
             if field.aggregated?
               field_path = from_field_path + field_path
 
-              get_children_nodes(node).map do |fn_node|
+              get_children_nodes(node).filter_map do |fn_node|
                 computed_field = field_from_node(fn_node)
                 function_adapter = computed_field.function_adapter # : FunctionAdapter::adapter
+
+                # An invalid argument (e.g. an out-of-range `percentile`) raises here. Skip building a
+                # `Computation` for it rather than letting that fail the whole aggregations field--the
+                # resolver re-runs `extract_args` at resolve time and attributes the error precisely.
+                begin
+                  function_args = function_adapter.extract_args(computed_field.args_to_schema_form(fn_node.arguments), element_names)
+                rescue ::GraphQL::ExecutionError
+                  next
+                end
 
                 Aggregation::Computation.new(
                   source_field_path: field_path,
                   leaf: PathSegment.for(field: computed_field, lookahead: fn_node),
                   function_adapter: function_adapter,
-                  function_args: function_adapter.extract_args(computed_field.args_to_schema_form(fn_node.arguments), element_names)
+                  function_args: function_args
                 )
               end
             end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rb
@@ -9,14 +9,40 @@
 require "elastic_graph/graphql/aggregation/key"
 require "elastic_graph/graphql/aggregation/path_segment"
 require "elastic_graph/support/hash_util"
+require "graphql"
 
 module ElasticGraph
   class GraphQL
     module Aggregation
       module Resolvers
-        class AggregatedValues < ::Data.define(:aggregation_name, :bucket, :field_path)
+        class AggregatedValues < ::Data.define(:schema, :aggregation_name, :bucket, :field_path)
           def resolve(field:, object:, args:, context:, lookahead:)
             return with(field_path: field_path + [PathSegment.for(field: field, lookahead: lookahead)]) if field.type.object?
+
+            function_adapter = field.function_adapter # : FunctionAdapter::adapter
+
+            # `QueryAdapter` already validated this field's args when the query was built, but it can't
+            # raise there without failing resolution of the entire aggregations field rather than just
+            # this one leaf--so it skips building a datastore clause for an invalid field instead. Here,
+            # at resolve time, we're actually resolving this specific field, so we re-run the same
+            # validation and can attribute an error to the correct, precise path when it fails.
+            #
+            # `args` is already in schema form here (`GraphQLAdapterBuilder` converts it before calling
+            # `resolve`), unlike at query-build time where `QueryAdapter` converts the raw AST arguments
+            # itself--so, unlike there, we pass `args` through as-is rather than re-converting it.
+            begin
+              function_adapter.extract_args(args, schema.element_names)
+            rescue ::GraphQL::ExecutionError => e
+              # Neither `context.add_error` nor `context.execution_errors.add` sets `path` for us--that
+              # only happens automatically when an `ExecutionError` is raised and returned as a field's
+              # own resolution result, which isn't the case here since we're continuing on to resolve
+              # sibling fields normally. So we set `path` ourselves from `context.current_path`, which
+              # is already the precise path to this field (e.g. `[..., "aggregatedValues", "amountCents",
+              # "p150"]`), so the error in the response is attributed to this specific field.
+              e.path ||= context.current_path
+              context.add_error(e)
+              return nil
+            end
 
             key = Key::AggregatedValue.new(
               aggregation_name: aggregation_name,
@@ -24,7 +50,6 @@ module ElasticGraph
               function_name: PathSegment.for(field: field, lookahead: lookahead).name_in_graphql_query
             )
 
-            function_adapter = field.function_adapter # : FunctionAdapter::adapter
             result = function_adapter.extract_result(Support::HashUtil.verbose_fetch(bucket, key.encode))
 
             # Aggregated value results always have a `value` key; in addition, for `date` field, they also have a `value_as_string`.

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rb
@@ -21,26 +21,26 @@ module ElasticGraph
 
             function_adapter = field.function_adapter # : FunctionAdapter::adapter
 
-            # `QueryAdapter` already validated this field's args when the query was built, but it can't
-            # raise there without failing resolution of the entire aggregations field rather than just
-            # this one leaf--so it skips building a datastore clause for an invalid field instead. Here,
-            # at resolve time, we're actually resolving this specific field, so we re-run the same
-            # validation and can attribute an error to the correct, precise path when it fails.
+            # `QueryAdapter` detected any invalid args when the query was built, but it can't report an
+            # error there without failing resolution of the entire aggregations field rather than just
+            # this one leaf--so it omits the datastore clause for an invalid field instead. Here, at
+            # resolve time, we're resolving this specific field, so we can report the error at the
+            # correct, precise path.
             #
             # `args` is already in schema form here (`GraphQLAdapterBuilder` converts it before calling
             # `resolve`), unlike at query-build time where `QueryAdapter` converts the raw AST arguments
             # itself--so, unlike there, we pass `args` through as-is rather than re-converting it.
-            begin
-              function_adapter.extract_args(args, schema.element_names)
-            rescue ::GraphQL::ExecutionError => e
+            function_adapter.extract_args(args, schema.element_names) do |message|
+              error = ::GraphQL::ExecutionError.new(message)
+
               # Neither `context.add_error` nor `context.execution_errors.add` sets `path` for us--that
               # only happens automatically when an `ExecutionError` is raised and returned as a field's
               # own resolution result, which isn't the case here since we're continuing on to resolve
               # sibling fields normally. So we set `path` ourselves from `context.current_path`, which
               # is already the precise path to this field (e.g. `[..., "aggregatedValues", "amountCents",
               # "p150"]`), so the error in the response is attributed to this specific field.
-              e.path ||= context.current_path
-              context.add_error(e)
+              error.path = context.current_path
+              context.add_error(error)
               return nil
             end
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/node.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/node.rb
@@ -24,7 +24,7 @@ module ElasticGraph
           end
 
           def aggregated_values
-            @aggregated_values ||= AggregatedValues.new(query.name, bucket, field_path)
+            @aggregated_values ||= AggregatedValues.new(schema, query.name, bucket, field_path)
           end
 
           def sub_aggregations

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/function_adapter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/function_adapter.rbs
@@ -25,7 +25,7 @@ module ElasticGraph
         end
 
         class SimpleMetric < SimpleMetricSupertype
-          def extract_args: (::Hash[::String, untyped], SchemaArtifacts::RuntimeMetadata::SchemaElementNames) -> functionArgs
+          def extract_args: (::Hash[::String, untyped], SchemaArtifacts::RuntimeMetadata::SchemaElementNames) { (::String) -> bot } -> functionArgs
           def clause_options: (functionArgs) -> ::Hash[::String, untyped]
           def extract_result: (::Hash[::String, untyped]) -> ::Hash[::String, untyped]
           def empty_bucket_result: () -> ::Hash[::String, untyped]
@@ -39,7 +39,7 @@ module ElasticGraph
         end
 
         class Percentile < PercentileSupertype
-          def extract_args: (::Hash[::String, untyped], SchemaArtifacts::RuntimeMetadata::SchemaElementNames) -> functionArgs
+          def extract_args: (::Hash[::String, untyped], SchemaArtifacts::RuntimeMetadata::SchemaElementNames) { (::String) -> bot } -> functionArgs
           def clause_options: (functionArgs) -> ::Hash[::String, untyped]
           def extract_result: (::Hash[::String, untyped]) -> ::Hash[::String, untyped]
           def empty_bucket_result: () -> ::Hash[::String, untyped]

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/function_adapter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/function_adapter.rbs
@@ -5,7 +5,7 @@ module ElasticGraph
         # Adapters need not all be data class instances. A function whose behavior is not a
         # parameterization of anything is registered as a singleton module instead, and joins
         # this union as a `singleton(...)` member.
-        type adapter = SimpleMetric
+        type adapter = SimpleMetric | Percentile
 
         type functionArgs = ::Hash[::Symbol, untyped]
 
@@ -25,6 +25,20 @@ module ElasticGraph
         end
 
         class SimpleMetric < SimpleMetricSupertype
+          def extract_args: (::Hash[::String, untyped], SchemaArtifacts::RuntimeMetadata::SchemaElementNames) -> functionArgs
+          def clause_options: (functionArgs) -> ::Hash[::String, untyped]
+          def extract_result: (::Hash[::String, untyped]) -> ::Hash[::String, untyped]
+          def empty_bucket_result: () -> ::Hash[::String, untyped]
+        end
+
+        class PercentileSupertype < Data
+          attr_reader datastore_function_name: ::String
+
+          def initialize: (datastore_function_name: ::String) -> void
+          def self.new: (datastore_function_name: ::String) -> Percentile
+        end
+
+        class Percentile < PercentileSupertype
           def extract_args: (::Hash[::String, untyped], SchemaArtifacts::RuntimeMetadata::SchemaElementNames) -> functionArgs
           def clause_options: (functionArgs) -> ::Hash[::String, untyped]
           def extract_result: (::Hash[::String, untyped]) -> ::Hash[::String, untyped]

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/query_adapter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/query_adapter.rbs
@@ -91,6 +91,11 @@ module ElasticGraph
           ?from_field_path: ::Array[PathSegment]
         ) -> ::Set[Computation]
 
+        def computation_for: (
+          ::GraphQL::Execution::Lookahead,
+          ::Array[PathSegment]
+        ) -> Computation?
+
         def build_groupings_from: (
           ::GraphQL::Execution::Lookahead,
           ::String,

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rbs
@@ -3,27 +3,32 @@ module ElasticGraph
     module Aggregation
       module Resolvers
         class AggregatedValuesSupertype
+          attr_reader schema: Schema
           attr_reader aggregation_name: ::String
           attr_reader bucket: ::Hash[::String, untyped]
           attr_reader field_path: ::Array[PathSegment]
 
           def initialize: (
+            schema: Schema,
             aggregation_name: ::String,
             bucket: ::Hash[::String, untyped],
             field_path: ::Array[PathSegment]
           ) -> void
 
           def self.new: (
+            schema: Schema,
             aggregation_name: ::String,
             bucket: ::Hash[::String, untyped],
             field_path: ::Array[PathSegment]
           ) -> instance | (
+            Schema,
             ::String,
             ::Hash[::String, untyped],
             ::Array[PathSegment]
           ) -> instance
 
           def with: (
+            ?schema: Schema,
             ?aggregation_name: ::String,
             ?bucket: ::Hash[::String, untyped],
             ?field_path: ::Array[PathSegment]

--- a/elasticgraph-graphql/sig/graphql_gem.rbs
+++ b/elasticgraph-graphql/sig/graphql_gem.rbs
@@ -36,6 +36,7 @@ module GraphQL
   end
 
   class ExecutionError < StandardError
+    attr_accessor path: ::Array[::String | ::Integer]?
   end
 
   module Language
@@ -127,6 +128,7 @@ module GraphQL
       def fetch: (untyped) -> untyped
       def add_error: (ExecutionError) -> void
       def dataloader: () -> Dataloader
+      def current_path: () -> ::Array[::String | ::Integer]?
     end
 
     class Result

--- a/elasticgraph-graphql/spec/acceptance/aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/aggregations_spec.rb
@@ -923,6 +923,10 @@ module ElasticGraph
         max = raw_values.max
         sum = raw_values.sum
         avg = raw_values.empty? ? nil : sum.to_f / raw_values.size
+        # Exact values for `percentile: 50`/`75`, verified against a real OpenSearch `percentiles`
+        # aggregation for each of this file's fixture shapes (empty, singletons, pairs, and the full
+        # triple)--every shape here lands on a clean value, not a t-digest approximation artifact.
+        median, p75 = percentile_50_and_75_of(raw_values)
 
         {
           case_correctly("approximate_sum") => float_of(sum),
@@ -932,9 +936,30 @@ module ElasticGraph
           # same expected values to verify `approximate_percentile` without needing separate fixture data.
           "p0" => float_of(min),
           "p100" => float_of(max),
+          # `p50`/`p75` (unlike p0/p100) can't be satisfied by an implementation that only supports
+          # min/max, so they're what actually proves full percentile support works.
+          "p50" => float_of(median),
+          "p75" => float_of(p75),
           case_correctly("exact_min") => int_of(min),
           case_correctly("exact_max") => int_of(max)
         }
+      end
+
+      # OpenSearch's percentile algorithm (t-digest) is generally approximate, but for these small,
+      # duplicate-free fixture sizes it always lands on one of the input values, so we can hardcode the
+      # expectation. Verified directly against a real OpenSearch `percentiles` aggregation, not derived
+      # by formula, since t-digest doesn't guarantee a standard percentile-interpolation formula's result.
+      def percentile_50_and_75_of(raw_values)
+        case raw_values.sort
+        when [] then [nil, nil]
+        when [100] then [100.0, 100.0]
+        when [200] then [200.0, 200.0]
+        when [300] then [300.0, 300.0]
+        when [100, 200] then [200.0, 200.0]
+        when [100, 300] then [300.0, 300.0]
+        when [100, 200, 300] then [200.0, 300.0]
+        else raise "No verified p50/p75 for #{raw_values.inspect}--verify against a real datastore and add it here."
+        end
       end
 
       def verify_all_timestamp_groupings_valid(widget_id, truncation_unit_type:, field:)
@@ -1824,6 +1849,8 @@ module ElasticGraph
                   exact_sum
                   approximate_avg
                   p0: approximate_percentile(percentile: 0)
+                  p50: approximate_percentile(percentile: 50)
+                  p75: approximate_percentile(percentile: 75)
                   p100: approximate_percentile(percentile: 100)
                   exact_min
                   exact_max
@@ -1835,6 +1862,8 @@ module ElasticGraph
                     exact_sum
                     approximate_avg
                     p0: approximate_percentile(percentile: 0)
+                    p50: approximate_percentile(percentile: 50)
+                    p75: approximate_percentile(percentile: 75)
                     p100: approximate_percentile(percentile: 100)
                     exact_min
                     exact_max
@@ -1860,6 +1889,8 @@ module ElasticGraph
                   exact_sum
                   approximate_avg
                   p0: approximate_percentile(percentile: 0)
+                  p50: approximate_percentile(percentile: 50)
+                  p75: approximate_percentile(percentile: 75)
                   p100: approximate_percentile(percentile: 100)
                   exact_min
                   exact_max
@@ -1871,6 +1902,8 @@ module ElasticGraph
                     exact_sum
                     approximate_avg
                     p0: approximate_percentile(percentile: 0)
+                    p50: approximate_percentile(percentile: 50)
+                    p75: approximate_percentile(percentile: 75)
                     p100: approximate_percentile(percentile: 100)
                     exact_min
                     exact_max

--- a/elasticgraph-graphql/spec/acceptance/aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/aggregations_spec.rb
@@ -923,10 +923,6 @@ module ElasticGraph
         max = raw_values.max
         sum = raw_values.sum
         avg = raw_values.empty? ? nil : sum.to_f / raw_values.size
-        # Exact values for `percentile: 50`/`75`, verified against a real OpenSearch `percentiles`
-        # aggregation for each of this file's fixture shapes (empty, singletons, pairs, and the full
-        # triple)--every shape here lands on a clean value, not a t-digest approximation artifact.
-        median, p75 = percentile_50_and_75_of(raw_values)
 
         {
           case_correctly("approximate_sum") => float_of(sum),
@@ -937,29 +933,20 @@ module ElasticGraph
           "p0" => float_of(min),
           "p100" => float_of(max),
           # `p50`/`p75` (unlike p0/p100) can't be satisfied by an implementation that only supports
-          # min/max, so they're what actually proves full percentile support works.
-          "p50" => float_of(median),
-          "p75" => float_of(p75),
+          # min/max, so they're what actually proves full percentile support works. We can't pin an
+          # exact expected value here: different datastore versions/backends use different (equally
+          # valid) interpolation conventions for a rank that doesn't land exactly on one data point, so
+          # we only assert it's a real number within [min, max] (a property every backend guarantees).
+          "p50" => percentile_of(min, max),
+          "p75" => percentile_of(min, max),
           case_correctly("exact_min") => int_of(min),
           case_correctly("exact_max") => int_of(max)
         }
       end
 
-      # OpenSearch's percentile algorithm (t-digest) is generally approximate, but for these small,
-      # duplicate-free fixture sizes it always lands on one of the input values, so we can hardcode the
-      # expectation. Verified directly against a real OpenSearch `percentiles` aggregation, not derived
-      # by formula, since t-digest doesn't guarantee a standard percentile-interpolation formula's result.
-      def percentile_50_and_75_of(raw_values)
-        case raw_values.sort
-        when [] then [nil, nil]
-        when [100] then [100.0, 100.0]
-        when [200] then [200.0, 200.0]
-        when [300] then [300.0, 300.0]
-        when [100, 200] then [200.0, 200.0]
-        when [100, 300] then [300.0, 300.0]
-        when [100, 200, 300] then [200.0, 300.0]
-        else raise "No verified p50/p75 for #{raw_values.inspect}--verify against a real datastore and add it here."
-        end
+      def percentile_of(min, max)
+        return nil if min.nil?
+        (be >= min).and(be <= max).and a_kind_of(::Float)
       end
 
       def verify_all_timestamp_groupings_valid(widget_id, truncation_unit_type:, field:)

--- a/elasticgraph-graphql/spec/acceptance/aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/aggregations_spec.rb
@@ -166,6 +166,55 @@ module ElasticGraph
           }
         })
 
+        # Verify that two aliased `approximate_percentile` selections under one field, each requesting a
+        # different rank, resolve independently rather than colliding on a single datastore aggregation.
+        aliased_percentiles = widget_ungrouped_aggregated_values_for(<<~QUERY)
+          #{amount_cents} {
+            p0: #{case_correctly("approximate_percentile")}(#{case_correctly("percentile")}: 0)
+            p100: #{case_correctly("approximate_percentile")}(#{case_correctly("percentile")}: 100)
+          }
+        QUERY
+        expect(aliased_percentiles).to eq({
+          amount_cents => {
+            "p0" => 100.0,
+            "p100" => 300.0
+          }
+        })
+
+        # Verify that an out-of-range `percentile` resolves to `null` (with a precisely-pathed error)
+        # rather than failing the entire `aggregated_values` subtree--sibling fields (including another,
+        # valid `approximate_percentile` alias) still resolve normally.
+        out_of_range_response = nil
+        expect {
+          out_of_range_response = call_graphql_query(<<~QUERY, allow_errors: true)
+            query {
+              #{case_correctly("widget_aggregations")} {
+                nodes {
+                  #{aggregated_values} {
+                    #{amount_cents} {
+                      #{case_correctly("exact_min")}
+                      good: #{case_correctly("approximate_percentile")}(#{case_correctly("percentile")}: 50)
+                      bad: #{case_correctly("approximate_percentile")}(#{case_correctly("percentile")}: 150)
+                    }
+                  }
+                }
+              }
+            }
+          QUERY
+        }.to log_warning(a_string_including("percentile` must be between 0 and 100"))
+
+        expect(out_of_range_response.dig("data", case_correctly("widget_aggregations"), "nodes", 0, aggregated_values, amount_cents)).to eq({
+          case_correctly("exact_min") => 100,
+          "good" => 200.0,
+          "bad" => nil
+        })
+        expect(out_of_range_response.fetch("errors")).to contain_exactly(
+          hash_including(
+            "message" => "`#{case_correctly("percentile")}` must be between 0 and 100, but is 150.0.",
+            "path" => [case_correctly("widget_aggregations"), "nodes", 0, aggregated_values, amount_cents, "bad"]
+          )
+        )
+
         aggregations = group_widget_currencies_by_widget_name
         expect(aggregations).to eq [
           {"count" => 1, case_correctly("grouped_by") => {case_correctly("widget_name") => "w100"}},
@@ -879,6 +928,10 @@ module ElasticGraph
           case_correctly("approximate_sum") => float_of(sum),
           case_correctly("exact_sum") => int_of(sum),
           case_correctly("approximate_avg") => float_of(avg),
+          # `percentile: 0`/`percentile: 100` are equivalent to min/max, so we reuse `float_of` with the
+          # same expected values to verify `approximate_percentile` without needing separate fixture data.
+          "p0" => float_of(min),
+          "p100" => float_of(max),
           case_correctly("exact_min") => int_of(min),
           case_correctly("exact_max") => int_of(max)
         }
@@ -1770,6 +1823,8 @@ module ElasticGraph
                   approximate_sum
                   exact_sum
                   approximate_avg
+                  p0: approximate_percentile(percentile: 0)
+                  p100: approximate_percentile(percentile: 100)
                   exact_min
                   exact_max
                 }
@@ -1779,6 +1834,8 @@ module ElasticGraph
                     approximate_sum
                     exact_sum
                     approximate_avg
+                    p0: approximate_percentile(percentile: 0)
+                    p100: approximate_percentile(percentile: 100)
                     exact_min
                     exact_max
                   }
@@ -1802,6 +1859,8 @@ module ElasticGraph
                   approximate_sum
                   exact_sum
                   approximate_avg
+                  p0: approximate_percentile(percentile: 0)
+                  p100: approximate_percentile(percentile: 100)
                   exact_min
                   exact_max
                 }
@@ -1811,6 +1870,8 @@ module ElasticGraph
                     approximate_sum
                     exact_sum
                     approximate_avg
+                    p0: approximate_percentile(percentile: 0)
+                    p100: approximate_percentile(percentile: 100)
                     exact_min
                     exact_max
                   }

--- a/elasticgraph-graphql/spec/acceptance/graphql_types_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/graphql_types_spec.rb
@@ -203,6 +203,11 @@ module ElasticGraph
         expect(value_at_path(aggregations.first, aggregated_values, "weight_in_ng_str", "exact_sum")).to be nil
         expect(value_at_path(aggregations.first, aggregated_values, "weight_in_ng", "approximate_avg")).to be_a(::Float).and be_approximately(weight_in_ngs.sum / weight_in_ngs.size)
         expect(value_at_path(aggregations.first, aggregated_values, "weight_in_ng_str", "approximate_avg")).to be_a(::Float).and be_approximately(weight_in_ng_strs.sum / weight_in_ng_strs.size)
+        # `approximate_percentile` returns `Float` even for these integral types, since the percentile
+        # computation interpolates between adjacent values and can produce a non-integer result. Using
+        # `percentile: 0` (equivalent to min) lets us assert an exact expected value here.
+        expect(value_at_path(aggregations.first, aggregated_values, "weight_in_ng", "approximate_percentile")).to be_a(::Float).and be_approximately(weight_in_ngs.min)
+        expect(value_at_path(aggregations.first, aggregated_values, "weight_in_ng_str", "approximate_percentile")).to be_a(::Float).and be_approximately(weight_in_ng_strs.min)
         expect(value_at_path(aggregations.first, aggregated_values, "weight_in_ng", "exact_min")).to be_a(::Integer).and eq(weight_in_ngs.min)
         expect(value_at_path(aggregations.first, aggregated_values, "weight_in_ng_str", "exact_min")).to be_a(::Integer).and eq(weight_in_ng_strs.min)
         expect(value_at_path(aggregations.first, aggregated_values, "weight_in_ng_str", "approximate_min")).to be_a(::String).and eq(weight_in_ng_strs.min.to_s)
@@ -228,6 +233,8 @@ module ElasticGraph
         expect(value_at_path(aggregations.first, aggregated_values, "weight_in_ng_str", "exact_sum")).to be_a(::Integer).and eq(weight_in_ng_strs.sum)
         expect(value_at_path(aggregations.first, aggregated_values, "weight_in_ng", "approximate_avg")).to be_a(::Float).and be_approximately(weight_in_ngs.sum / weight_in_ngs.size)
         expect(value_at_path(aggregations.first, aggregated_values, "weight_in_ng_str", "approximate_avg")).to be_a(::Float).and be_approximately(weight_in_ng_strs.sum / weight_in_ng_strs.size)
+        expect(value_at_path(aggregations.first, aggregated_values, "weight_in_ng", "approximate_percentile")).to be_a(::Float).and be_approximately(weight_in_ngs.min)
+        expect(value_at_path(aggregations.first, aggregated_values, "weight_in_ng_str", "approximate_percentile")).to be_a(::Float).and be_approximately(weight_in_ng_strs.min)
         expect(value_at_path(aggregations.first, aggregated_values, "weight_in_ng", "exact_min")).to be_a(::Integer).and eq(weight_in_ngs.min)
         expect(value_at_path(aggregations.first, aggregated_values, "weight_in_ng_str", "exact_min")).to be_a(::Integer).and eq(weight_in_ng_strs.min)
         expect(value_at_path(aggregations.first, aggregated_values, "weight_in_ng_str", "approximate_min")).to be_a(::String).and eq(weight_in_ng_strs.min.to_s)
@@ -367,6 +374,7 @@ module ElasticGraph
                   approximate_sum
                   exact_sum
                   approximate_avg
+                  approximate_percentile(percentile: 0)
                   exact_min
                   exact_max
                 }
@@ -375,6 +383,7 @@ module ElasticGraph
                   approximate_sum
                   exact_sum
                   approximate_avg
+                  approximate_percentile(percentile: 0)
                   exact_min
                   approximate_min
                   exact_max

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/function_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/function_adapter_spec.rb
@@ -15,7 +15,7 @@ module ElasticGraph
       RSpec.describe FunctionAdapter do
         describe "BY_NAME" do
           it "registers an adapter for each supported aggregated value function" do
-            expect(FunctionAdapter::BY_NAME.keys).to contain_exactly(:avg, :cardinality, :max, :min, :percentiles, :sum)
+            expect(FunctionAdapter::BY_NAME.keys).to contain_exactly(:avg, :cardinality, :max, :min, :percentile, :sum)
           end
 
           it "maps each function to its datastore aggregation name" do
@@ -24,7 +24,7 @@ module ElasticGraph
               cardinality: "cardinality",
               max: "max",
               min: "min",
-              percentiles: "percentiles",
+              percentile: "percentiles",
               sum: "sum"
             )
           end
@@ -35,7 +35,7 @@ module ElasticGraph
               cardinality: {"value" => 0},
               max: {"value" => nil},
               min: {"value" => nil},
-              percentiles: {"values" => [{"value" => nil}]},
+              percentile: {"values" => [{"value" => nil}]},
               sum: {"value" => 0}
             )
           end
@@ -50,7 +50,7 @@ module ElasticGraph
           end
 
           it "extracts no args, since these functions take none" do
-            expect(adapter.extract_args({"some_arg" => 3}, element_names)).to eq({})
+            expect(adapter.extract_args({"some_arg" => 3}, element_names) { |msg| raise msg }).to eq({})
           end
 
           it "contributes no extra clause options beyond the `field` the clause builder provides" do
@@ -75,25 +75,22 @@ module ElasticGraph
             expect(adapter.datastore_function_name).to eq "percentiles"
           end
 
-          it "extracts the requested percentile rank from the args" do
-            expect(adapter.extract_args({"percentile" => 50.0}, element_names)).to eq({percentile: 50.0})
+          it "extracts the requested percentile from the args" do
+            expect(extract_args({"percentile" => 50.0})).to eq({percentile: 50.0})
           end
 
           it "accepts the boundary values 0 and 100" do
-            expect(adapter.extract_args({"percentile" => 0}, element_names)).to eq({percentile: 0})
-            expect(adapter.extract_args({"percentile" => 100}, element_names)).to eq({percentile: 100})
+            expect(extract_args({"percentile" => 0})).to eq({percentile: 0})
+            expect(extract_args({"percentile" => 100})).to eq({percentile: 100})
           end
 
-          it "raises a GraphQL::ExecutionError when the requested percentile is below 0" do
-            expect {
-              adapter.extract_args({"percentile" => -1}, element_names)
-            }.to raise_error(::GraphQL::ExecutionError, "`percentile` must be between 0 and 100, but is -1.")
+          it "yields an error message--rather than raising--when the requested percentile is outside 0 to 100" do
+            expect(extract_args({"percentile" => -1})).to eq "`percentile` must be between 0 and 100, but is -1."
+            expect(extract_args({"percentile" => 150})).to eq "`percentile` must be between 0 and 100, but is 150."
           end
 
-          it "raises a GraphQL::ExecutionError when the requested percentile is above 100" do
-            expect {
-              adapter.extract_args({"percentile" => 150}, element_names)
-            }.to raise_error(::GraphQL::ExecutionError, "`percentile` must be between 0 and 100, but is 150.")
+          it "yields an error message when the requested percentile is not numeric" do
+            expect(extract_args({"percentile" => "50"})).to eq '`percentile` must be between 0 and 100, but is "50".'
           end
 
           it "requests a single unkeyed percentile in the clause options" do
@@ -106,6 +103,12 @@ module ElasticGraph
 
           it "fabricates an empty bucket response with a nil value" do
             expect(adapter.empty_bucket_result).to eq({"values" => [{"value" => nil}]})
+          end
+
+          # Returns the extracted args, or--when the args are invalid--the yielded error message,
+          # so that a single expectation can cover either outcome.
+          def extract_args(args)
+            adapter.extract_args(args, element_names) { |message| return message }
           end
         end
       end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/function_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/function_adapter_spec.rb
@@ -15,7 +15,7 @@ module ElasticGraph
       RSpec.describe FunctionAdapter do
         describe "BY_NAME" do
           it "registers an adapter for each supported aggregated value function" do
-            expect(FunctionAdapter::BY_NAME.keys).to contain_exactly(:avg, :cardinality, :max, :min, :sum)
+            expect(FunctionAdapter::BY_NAME.keys).to contain_exactly(:avg, :cardinality, :max, :min, :percentiles, :sum)
           end
 
           it "maps each function to its datastore aggregation name" do
@@ -24,6 +24,7 @@ module ElasticGraph
               cardinality: "cardinality",
               max: "max",
               min: "min",
+              percentiles: "percentiles",
               sum: "sum"
             )
           end
@@ -34,6 +35,7 @@ module ElasticGraph
               cardinality: {"value" => 0},
               max: {"value" => nil},
               min: {"value" => nil},
+              percentiles: {"values" => [{"value" => nil}]},
               sum: {"value" => 0}
             )
           end
@@ -62,6 +64,48 @@ module ElasticGraph
           it "fabricates an empty bucket response using the configured empty bucket value" do
             expect(adapter.empty_bucket_result).to eq({"value" => nil})
             expect(FunctionAdapter::SimpleMetric.new(datastore_function_name: "sum", empty_bucket_value: 0).empty_bucket_result).to eq({"value" => 0})
+          end
+        end
+
+        describe FunctionAdapter::Percentile do
+          let(:element_names) { SchemaArtifacts::RuntimeMetadata::SchemaElementNames.new(form: :snake_case, overrides: {}) }
+          let(:adapter) { FunctionAdapter::Percentile.new(datastore_function_name: "percentiles") }
+
+          it "exposes the datastore function name it was configured with" do
+            expect(adapter.datastore_function_name).to eq "percentiles"
+          end
+
+          it "extracts the requested percentile rank from the args" do
+            expect(adapter.extract_args({"percentile" => 50.0}, element_names)).to eq({percentile: 50.0})
+          end
+
+          it "accepts the boundary values 0 and 100" do
+            expect(adapter.extract_args({"percentile" => 0}, element_names)).to eq({percentile: 0})
+            expect(adapter.extract_args({"percentile" => 100}, element_names)).to eq({percentile: 100})
+          end
+
+          it "raises a GraphQL::ExecutionError when the requested percentile is below 0" do
+            expect {
+              adapter.extract_args({"percentile" => -1}, element_names)
+            }.to raise_error(::GraphQL::ExecutionError, "`percentile` must be between 0 and 100, but is -1.")
+          end
+
+          it "raises a GraphQL::ExecutionError when the requested percentile is above 100" do
+            expect {
+              adapter.extract_args({"percentile" => 150}, element_names)
+            }.to raise_error(::GraphQL::ExecutionError, "`percentile` must be between 0 and 100, but is 150.")
+          end
+
+          it "requests a single unkeyed percentile in the clause options" do
+            expect(adapter.clause_options({percentile: 99.9})).to eq({"percents" => [99.9], "keyed" => false})
+          end
+
+          it "extracts the single value from the datastore's array-shaped response" do
+            expect(adapter.extract_result({"values" => [{"key" => 50.0, "value" => 3.7}]})).to eq({"key" => 50.0, "value" => 3.7})
+          end
+
+          it "fabricates an empty bucket response with a nil value" do
+            expect(adapter.empty_bucket_result).to eq({"values" => [{"value" => nil}]})
           end
         end
       end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/aggregation_resolver_support.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/aggregation_resolver_support.rb
@@ -23,13 +23,19 @@ module ElasticGraph
           hit_count: nil,
           aggs: {"target" => {"buckets" => target_buckets}},
           path: ["data", "target", "nodes"],
-          allow_errors: false
+          expect_errors: false
         )
           allow(datastore_client).to receive(:msearch).and_return({"responses" => [datastore_response_payload_with_aggs(aggs, hit_count)]})
 
           response = graphql.graphql_query_executor.execute("query { #{inner_query} }")
-          return response if allow_errors
-          expect(response["errors"]).to eq([]).or eq(nil)
+
+          if expect_errors
+            expect(response["errors"]).not_to be_empty
+          else
+            expect(response["errors"]).to eq([]).or eq(nil)
+          end
+
+          return response if expect_errors
           response.dig(*path)
         end
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/aggregation_resolver_support.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/aggregation_resolver_support.rb
@@ -22,11 +22,13 @@ module ElasticGraph
           target_buckets: [],
           hit_count: nil,
           aggs: {"target" => {"buckets" => target_buckets}},
-          path: ["data", "target", "nodes"]
+          path: ["data", "target", "nodes"],
+          allow_errors: false
         )
           allow(datastore_client).to receive(:msearch).and_return({"responses" => [datastore_response_payload_with_aggs(aggs, hit_count)]})
 
           response = graphql.graphql_query_executor.execute("query { #{inner_query} }")
+          return response if allow_errors
           expect(response["errors"]).to eq([]).or eq(nil)
           response.dig(*path)
         end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/aggregations_spec.rb
@@ -412,6 +412,46 @@ module ElasticGraph
           ]
         end
 
+        it "resolves sibling aggregated value fields normally and returns `null` (with a precisely-pathed error) for an out-of-range `approximate_percentile`, rather than failing the whole query" do
+          aggs = {
+            aggregated_value_key_of("amount_cents", "exact_sum") => {"value" => 900.0},
+            aggregated_value_key_of("amount_cents", "good") => {"values" => [{"value" => 500.0}]}
+          }
+
+          response = resolve_target_nodes(<<~QUERY, aggs: aggs, allow_errors: true)
+            target: widget_aggregations {
+              nodes {
+                aggregated_values {
+                  amount_cents {
+                    exact_sum
+                    good: approximate_percentile(percentile: 50)
+                    bad: approximate_percentile(percentile: 150)
+                  }
+                }
+              }
+            }
+          QUERY
+
+          expect(response.dig("data", "target", "nodes")).to eq [
+            {
+              "aggregated_values" => {
+                "amount_cents" => {
+                  "exact_sum" => 900,
+                  "good" => 500,
+                  "bad" => nil
+                }
+              }
+            }
+          ]
+
+          expect(response.fetch("errors")).to contain_exactly(
+            hash_including(
+              "message" => "`percentile` must be between 0 and 100, but is 150.0.",
+              "path" => ["target", "nodes", 0, "aggregated_values", "amount_cents", "bad"]
+            )
+          )
+        end
+
         def aggregated_value_key_of(*field_path, function_name, aggregation_name: "target")
           super(*field_path, function_name, aggregation_name: "target").encode
         end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/aggregations_spec.rb
@@ -418,7 +418,7 @@ module ElasticGraph
             aggregated_value_key_of("amount_cents", "good") => {"values" => [{"value" => 500.0}]}
           }
 
-          response = resolve_target_nodes(<<~QUERY, aggs: aggs, allow_errors: true)
+          response = resolve_target_nodes(<<~QUERY, aggs: aggs, expect_errors: true)
             target: widget_aggregations {
               nodes {
                 aggregated_values {

--- a/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rb
+++ b/elasticgraph-schema_artifacts/lib/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rb
@@ -151,7 +151,7 @@ module ElasticGraph
         :query, :phrase, :query_with_prefix, :allowed_edits_per_term, :require_all_terms,
         # Aggregated values field names:
         :exact_min, :exact_max, :approximate_min, :approximate_max, :approximate_avg, :approximate_sum, :exact_sum,
-        :approximate_distinct_value_count
+        :approximate_distinct_value_count, :approximate_percentile, :percentile
       )
     end
   end

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/schema_element_names.rbs
@@ -96,6 +96,8 @@ module ElasticGraph
         attr_reader approximate_sum: ::String
         attr_reader exact_sum: ::String
         attr_reader approximate_distinct_value_count: ::String
+        attr_reader approximate_percentile: ::String
+        attr_reader percentile: ::String
 
         def normalize_case: (::String) -> ::String
         def self.from_hash: (::Hash[::String, untyped]) -> SchemaElementNames

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
@@ -1602,7 +1602,7 @@ module ElasticGraph
             f.computes :percentiles
 
             f.argument names.percentile, "Float!" do |a|
-              a.documentation "The percentile rank to compute, from `0` to `100` (e.g. `0` for the min, `100` for the max, `50` for the median, `99` for the 99th percentile)."
+              a.documentation "The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100` for the max, `50` for the median, `99` for the 99th percentile)."
             end
 
             f.documentation <<~EOS

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
@@ -1599,7 +1599,7 @@ module ElasticGraph
 
         def define_approximate_percentile_on_aggregated_values(aggregated_values_type, scalar_type)
           aggregated_values_type.field names.approximate_percentile, scalar_type, graphql_only: true do |f|
-            f.computes :percentiles
+            f.computes :percentile
 
             f.argument names.percentile, "Float!" do |a|
               a.documentation "The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100` for the max, `50` for the median, `99` for the 99th percentile)."

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/schema_elements/built_in_types.rb
@@ -711,6 +711,8 @@ module ElasticGraph
                   outside the `JsonSafeLong` range (#{format_number(JSON_SAFE_LONG_MIN)} to #{format_number(JSON_SAFE_LONG_MAX)}).
                 EOS
               end
+
+              define_approximate_percentile_on_aggregated_values(avt, "Float")
             end
           end
 
@@ -791,7 +793,7 @@ module ElasticGraph
             EOS
 
             t.customize_aggregated_values_type do |avt|
-              define_exact_min_max_and_approx_avg_on_aggregated_values(avt, "Date") do |adjective:, full_name:|
+              define_temporal_aggregated_values(avt, "Date") do |adjective:, full_name:|
                 <<~EOS
                   So long as the grouping contains at least one non-null value for the
                   underlying indexed field, this will return an exact non-null value.
@@ -827,7 +829,7 @@ module ElasticGraph
             end
 
             t.customize_aggregated_values_type do |avt|
-              define_exact_min_max_and_approx_avg_on_aggregated_values(avt, "DateTime") do |adjective:, full_name:|
+              define_temporal_aggregated_values(avt, "DateTime") do |adjective:, full_name:|
                 <<~EOS
                   So long as the grouping contains at least one non-null value for the
                   underlying indexed field, this will return an exact non-null value.
@@ -893,7 +895,7 @@ module ElasticGraph
             t.mapping type: "date", format: "HH:mm:ss||HH:mm:ss.S||HH:mm:ss.SS||HH:mm:ss.SSS"
 
             t.customize_aggregated_values_type do |avt|
-              define_exact_min_max_and_approx_avg_on_aggregated_values(avt, "LocalTime") do |adjective:, full_name:|
+              define_temporal_aggregated_values(avt, "LocalTime") do |adjective:, full_name:|
                 <<~EOS
                   So long as the grouping contains at least one non-null value for the
                   underlying indexed field, this will return an exact non-null value.
@@ -1070,6 +1072,8 @@ module ElasticGraph
                   to #{format_number(JSON_SAFE_LONG_MAX)}).
                 EOS
               end
+
+              define_approximate_percentile_on_aggregated_values(avt, "Float")
             end
           end
         end
@@ -1573,10 +1577,12 @@ module ElasticGraph
                 to #{format_number(JSON_SAFE_LONG_MAX)}).
               EOS
             end
+
+            define_approximate_percentile_on_aggregated_values(t, "Float")
           end
         end
 
-        def define_exact_min_max_and_approx_avg_on_aggregated_values(aggregated_values_type, scalar_type, &block)
+        def define_temporal_aggregated_values(aggregated_values_type, scalar_type, &block)
           define_exact_min_and_max_on_aggregated_values(aggregated_values_type, scalar_type, &block)
 
           aggregated_values_type.field names.approximate_avg, scalar_type, graphql_only: true do |f|
@@ -1585,6 +1591,27 @@ module ElasticGraph
             f.documentation <<~EOS
               The average (mean) of the field values within this grouping.
               The returned value will be rounded to the nearest `#{scalar_type}` value.
+            EOS
+          end
+
+          define_approximate_percentile_on_aggregated_values(aggregated_values_type, scalar_type)
+        end
+
+        def define_approximate_percentile_on_aggregated_values(aggregated_values_type, scalar_type)
+          aggregated_values_type.field names.approximate_percentile, scalar_type, graphql_only: true do |f|
+            f.computes :percentiles
+
+            f.argument names.percentile, "Float!" do |a|
+              a.documentation "The percentile rank to compute, from `0` to `100` (e.g. `0` for the min, `100` for the max, `50` for the median, `99` for the 99th percentile)."
+            end
+
+            f.documentation <<~EOS
+              An approximate percentile of the field values within this grouping.
+
+              Percentiles are computed using an approximate algorithm, so the returned value may not be
+              exact. Request a specific percentile via the `#{names.percentile}` argument (e.g.
+              `#{names.percentile}: 50` for the median). To request multiple percentiles in a single query,
+              use a GraphQL alias for each: `p50: #{names.approximate_percentile}(#{names.percentile}: 50)`.
             EOS
           end
         end

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/built_in_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/built_in_types_spec.rb
@@ -1134,6 +1134,19 @@ module ElasticGraph
                 outside the `JsonSafeLong` range (-9,007,199,254,740,991 to 9,007,199,254,740,991).
                 """
                 #{schema_elements.approximate_avg}: Float
+                """
+                An approximate percentile of the field values within this grouping.
+
+                Percentiles are computed using an approximate algorithm, so the returned value may not be
+                exact. Request a specific percentile via the `#{schema_elements.percentile}` argument (e.g.
+                `#{schema_elements.percentile}: 50` for the median). To request multiple percentiles in a single query,
+                use a GraphQL alias for each: `p50: #{schema_elements.approximate_percentile}(#{schema_elements.percentile}: 50)`.
+                """
+                #{schema_elements.approximate_percentile}(
+                  """
+                  The percentile rank to compute, from `0` to `100` (e.g. `0` for the min, `100` for the max, `50` for the median, `99` for the 99th percentile).
+                  """
+                  #{schema_elements.percentile}: Float!): Float
               }
             EOS
           end
@@ -1173,6 +1186,19 @@ module ElasticGraph
                 The returned value will be rounded to the nearest `#{scalar_type}` value.
                 """
                 #{schema_elements.approximate_avg}: #{scalar_type}
+                """
+                An approximate percentile of the field values within this grouping.
+
+                Percentiles are computed using an approximate algorithm, so the returned value may not be
+                exact. Request a specific percentile via the `#{schema_elements.percentile}` argument (e.g.
+                `#{schema_elements.percentile}: 50` for the median). To request multiple percentiles in a single query,
+                use a GraphQL alias for each: `p50: #{schema_elements.approximate_percentile}(#{schema_elements.percentile}: 50)`.
+                """
+                #{schema_elements.approximate_percentile}(
+                  """
+                  The percentile rank to compute, from `0` to `100` (e.g. `0` for the min, `100` for the max, `50` for the median, `99` for the 99th percentile).
+                  """
+                  #{schema_elements.percentile}: Float!): #{scalar_type}
               }
             EOS
           end
@@ -1290,6 +1316,19 @@ module ElasticGraph
                   to 9,007,199,254,740,991).
                   """
                   #{schema_elements.approximate_avg}: Float
+                  """
+                  An approximate percentile of the field values within this grouping.
+
+                  Percentiles are computed using an approximate algorithm, so the returned value may not be
+                  exact. Request a specific percentile via the `#{schema_elements.percentile}` argument (e.g.
+                  `#{schema_elements.percentile}: 50` for the median). To request multiple percentiles in a single query,
+                  use a GraphQL alias for each: `p50: #{schema_elements.approximate_percentile}(#{schema_elements.percentile}: 50)`.
+                  """
+                  #{schema_elements.approximate_percentile}(
+                    """
+                    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min, `100` for the max, `50` for the median, `99` for the 99th percentile).
+                    """
+                    #{schema_elements.percentile}: Float!): Float
                 }
               EOS
             end
@@ -1377,6 +1416,19 @@ module ElasticGraph
                 to 9,007,199,254,740,991).
                 """
                 #{schema_elements.approximate_avg}: Float
+                """
+                An approximate percentile of the field values within this grouping.
+
+                Percentiles are computed using an approximate algorithm, so the returned value may not be
+                exact. Request a specific percentile via the `#{schema_elements.percentile}` argument (e.g.
+                `#{schema_elements.percentile}: 50` for the median). To request multiple percentiles in a single query,
+                use a GraphQL alias for each: `p50: #{schema_elements.approximate_percentile}(#{schema_elements.percentile}: 50)`.
+                """
+                #{schema_elements.approximate_percentile}(
+                  """
+                  The percentile rank to compute, from `0` to `100` (e.g. `0` for the min, `100` for the max, `50` for the median, `99` for the 99th percentile).
+                  """
+                  #{schema_elements.percentile}: Float!): Float
               }
             EOS
           end

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/built_in_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/built_in_types_spec.rb
@@ -1144,7 +1144,7 @@ module ElasticGraph
                 """
                 #{schema_elements.approximate_percentile}(
                   """
-                  The percentile rank to compute, from `0` to `100` (e.g. `0` for the min, `100` for the max, `50` for the median, `99` for the 99th percentile).
+                  The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100` for the max, `50` for the median, `99` for the 99th percentile).
                   """
                   #{schema_elements.percentile}: Float!): Float
               }
@@ -1196,7 +1196,7 @@ module ElasticGraph
                 """
                 #{schema_elements.approximate_percentile}(
                   """
-                  The percentile rank to compute, from `0` to `100` (e.g. `0` for the min, `100` for the max, `50` for the median, `99` for the 99th percentile).
+                  The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100` for the max, `50` for the median, `99` for the 99th percentile).
                   """
                   #{schema_elements.percentile}: Float!): #{scalar_type}
               }
@@ -1326,7 +1326,7 @@ module ElasticGraph
                   """
                   #{schema_elements.approximate_percentile}(
                     """
-                    The percentile rank to compute, from `0` to `100` (e.g. `0` for the min, `100` for the max, `50` for the median, `99` for the 99th percentile).
+                    The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100` for the max, `50` for the median, `99` for the 99th percentile).
                     """
                     #{schema_elements.percentile}: Float!): Float
                 }
@@ -1426,7 +1426,7 @@ module ElasticGraph
                 """
                 #{schema_elements.approximate_percentile}(
                   """
-                  The percentile rank to compute, from `0` to `100` (e.g. `0` for the min, `100` for the max, `50` for the median, `99` for the 99th percentile).
+                  The percentile to compute, from `0` to `100` (e.g. `0` for the min, `100` for the max, `50` for the median, `99` for the 99th percentile).
                   """
                   #{schema_elements.percentile}: Float!): Float
               }

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/for_built_in_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/for_built_in_types_spec.rb
@@ -30,7 +30,8 @@ module ElasticGraph
             "exact_sum" => :sum,
             "exact_max" => :max,
             "exact_min" => :min,
-            "approximate_distinct_value_count" => :cardinality
+            "approximate_distinct_value_count" => :cardinality,
+            "approximate_percentile" => :percentiles
           )
         end
 
@@ -49,7 +50,8 @@ module ElasticGraph
             "approximate_sum" => :sum,
             "exact_max" => :max,
             "exact_min" => :min,
-            "approximate_distinct_value_count" => :cardinality
+            "approximate_distinct_value_count" => :cardinality,
+            "approximate_percentile" => :percentiles
           )
         end
 
@@ -69,7 +71,8 @@ module ElasticGraph
             "exact_sum" => :sum,
             "exact_max" => :max,
             "exact_min" => :min,
-            "approximate_distinct_value_count" => :cardinality
+            "approximate_distinct_value_count" => :cardinality,
+            "approximate_percentile" => :percentiles
           )
         end
 
@@ -91,7 +94,8 @@ module ElasticGraph
             "exact_max" => :max,
             "approximate_min" => :min,
             "exact_min" => :min,
-            "approximate_distinct_value_count" => :cardinality
+            "approximate_distinct_value_count" => :cardinality,
+            "approximate_percentile" => :percentiles
           )
         end
       end

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/for_built_in_types_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/for_built_in_types_spec.rb
@@ -31,7 +31,7 @@ module ElasticGraph
             "exact_max" => :max,
             "exact_min" => :min,
             "approximate_distinct_value_count" => :cardinality,
-            "approximate_percentile" => :percentiles
+            "approximate_percentile" => :percentile
           )
         end
 
@@ -51,7 +51,7 @@ module ElasticGraph
             "exact_max" => :max,
             "exact_min" => :min,
             "approximate_distinct_value_count" => :cardinality,
-            "approximate_percentile" => :percentiles
+            "approximate_percentile" => :percentile
           )
         end
 
@@ -72,7 +72,7 @@ module ElasticGraph
             "exact_max" => :max,
             "exact_min" => :min,
             "approximate_distinct_value_count" => :cardinality,
-            "approximate_percentile" => :percentiles
+            "approximate_percentile" => :percentile
           )
         end
 
@@ -95,7 +95,7 @@ module ElasticGraph
             "approximate_min" => :min,
             "exact_min" => :min,
             "approximate_distinct_value_count" => :cardinality,
-            "approximate_percentile" => :percentiles
+            "approximate_percentile" => :percentile
           )
         end
       end


### PR DESCRIPTION
## Summary

Adds an `approximatePercentile` field to the `aggregatedValues` API for `Float`, `Int`, `JsonSafeLong`, `LongString`, `Date`, `DateTime`, and `LocalTime` fields, backed by the datastore's `percentiles` aggregation.

```graphql
type FloatAggregatedValues {
  approximateAvg: Float
  approximateSum: Float!
  exactMin: Float
  exactMax: Float
  approximatePercentile(percentile: Float!): Float
}
```

Callers request a specific percentile rank via the `percentile` argument (e.g. `percentile: 50` for the median), and can request multiple ranks in a single query by aliasing the field selection:

```graphql
{
  amountCents {
    p50: approximatePercentile(percentile: 50)
    p99: approximatePercentile(percentile: 99)
  }
}
```

This shape (as opposed to a list-return shape accepting an array of percentiles) keeps query validity statically verifiable: each aliased selection independently validates its own rank and always returns exactly one value, avoiding the ambiguity a list-argument API would have around duplicate or out-of-range requests. Percentiles are computed using an approximate algorithm (t-digest) regardless of field type, so there's no `exactPercentile` counterpart the way there is for `min`/`max`/`sum`.

@myronmarston and I discussed and agreed on this API shape beforehand.

## Implementation notes

- `ComputationDetail` gains an optional `function_arg_name`, and `Computation` gains a `function_arg_value`, so a function that needs a query-time argument (like `percentile`) can fold the resolved value into both the emitted datastore clause and the aggregation key. This avoids key collisions between multiple aliased selections of the same field with different argument values.
- The datastore's `percentiles` aggregation is requested with `keyed: false` and a single-element `percents` array per `Computation`, so the response is a small array (`"values" => [{"key" => ..., "value" => ...}]`) rather than a string-keyed hash — this avoids reconstructing the datastore's float-formatted string key to look up the single requested value.
- Verified end-to-end against a running datastore (both a `Float`/`Int` field and a `DateTime` field, confirming `value_as_string` formatting carries through the same as the other aggregated value functions) before writing the automated tests.

## Test plan
- [x] Unit tests: `Computation#key`/`#clause` for the `percentiles` function; `QueryAdapter` builds distinct computations for aliased selections with different percentile args; resolver tests including empty-bucket (`null`) and `DateTime` formatting
- [x] Integration test against a real datastore: median/p99 over a small dataset, plus the empty-result-set case
- [x] Acceptance tests: aliased multi-percentile query, and percentile alongside `groupedBy`
- [x] Extended existing `built_in_types_spec.rb`/`for_built_in_types_spec.rb` SDL and runtime-metadata assertions for the new field on all 7 supported types
- [x] `script/quick_build` passes (spellcheck, lint, type_check, schema_artifacts:check, full spec suite at 100% line/branch coverage, site validation)
- [x] Added a validated example query (`config/site/examples/music`) and doc-site prose in `query-api/aggregations/aggregated-values.md`