### PR TITLE
Key aggregated value aggregations off the GraphQL alias

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/computation.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/computation.rb
@@ -6,8 +6,9 @@
 #
 # frozen_string_literal: true
 
-require "elastic_graph/graphql/aggregation/key"
 require "elastic_graph/graphql/aggregation/field_path_encoder"
+require "elastic_graph/graphql/aggregation/key"
+require "elastic_graph/graphql/aggregation/path_segment"
 
 module ElasticGraph
   class GraphQL
@@ -18,14 +19,14 @@ module ElasticGraph
       # https://www.elastic.co/guide/en/elasticsearch/reference/7.12/search-aggregations-metrics-max-aggregation.html
       # https://www.elastic.co/guide/en/elasticsearch/reference/7.12/search-aggregations-metrics-min-aggregation.html
       # https://www.elastic.co/guide/en/elasticsearch/reference/7.12/search-aggregations-metrics-sum-aggregation.html
-      Computation = ::Data.define(:source_field_path, :computed_index_field_name, :detail) do
+      Computation = ::Data.define(:source_field_path, :leaf, :detail) do
         # @implements Computation
 
         def key(aggregation_name:)
           Key::AggregatedValue.new(
             aggregation_name: aggregation_name,
             field_path: source_field_path.map(&:name_in_graphql_query),
-            function_name: computed_index_field_name
+            function_name: leaf.name_in_graphql_query
           ).encode
         end
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_adapter.rb
@@ -188,11 +188,11 @@ module ElasticGraph
 
               get_children_nodes(node).map do |fn_node|
                 computed_field = field_from_node(fn_node)
-                computation_detail = field_from_node(fn_node).computation_detail # : SchemaArtifacts::RuntimeMetadata::ComputationDetail
+                computation_detail = computed_field.computation_detail # : SchemaArtifacts::RuntimeMetadata::ComputationDetail
 
                 Aggregation::Computation.new(
                   source_field_path: field_path,
-                  computed_index_field_name: computed_field.name_in_index,
+                  leaf: PathSegment.for(field: computed_field, lookahead: fn_node),
                   detail: computation_detail
                 )
               end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rb
@@ -21,7 +21,7 @@ module ElasticGraph
             key = Key::AggregatedValue.new(
               aggregation_name: aggregation_name,
               field_path: field_path.map(&:name_in_graphql_query),
-              function_name: field.name_in_index
+              function_name: PathSegment.for(field: field, lookahead: lookahead).name_in_graphql_query
             )
 
             result = Support::HashUtil.verbose_fetch(bucket, key.encode)

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/computation.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/computation.rbs
@@ -3,7 +3,7 @@ module ElasticGraph
     module Aggregation
       class Computation
         attr_reader source_field_path: fieldPath
-        attr_reader computed_index_field_name: ::String
+        attr_reader leaf: PathSegment
         attr_reader detail: SchemaArtifacts::RuntimeMetadata::ComputationDetail
 
         def key: (aggregation_name: ::String) -> ::String
@@ -11,13 +11,13 @@ module ElasticGraph
 
         def initialize : (
           source_field_path: fieldPath,
-          computed_index_field_name: ::String,
+          leaf: PathSegment,
           detail: SchemaArtifacts::RuntimeMetadata::ComputationDetail
         ) -> void
 
         def with: (
           ?source_field_path: fieldPath,
-          ?computed_index_field_name: ::String,
+          ?leaf: PathSegment,
           ?detail: SchemaArtifacts::RuntimeMetadata::ComputationDetail
         ) -> instance
       end

--- a/elasticgraph-graphql/spec/acceptance/aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/aggregations_spec.rb
@@ -151,6 +151,21 @@ module ElasticGraph
         size_uniq_count = widget_ungrouped_aggregated_values_for("size { approximate_distinct_value_count }")
         expect(size_uniq_count).to eq({"size" => {case_correctly("approximate_distinct_value_count") => 2}})
 
+        # Verify that two aliases of the same aggregated value function under one field each resolve correctly,
+        # rather than colliding on a single datastore aggregation.
+        aliased_mins = widget_ungrouped_aggregated_values_for(<<~QUERY)
+          #{amount_cents} {
+            #{case_correctly("exact_min")}
+            #{case_correctly("my_min")}: #{case_correctly("exact_min")}
+          }
+        QUERY
+        expect(aliased_mins).to eq({
+          amount_cents => {
+            case_correctly("exact_min") => 100,
+            case_correctly("my_min") => 100
+          }
+        })
+
         aggregations = group_widget_currencies_by_widget_name
         expect(aggregations).to eq [
           {"count" => 1, case_correctly("grouped_by") => {case_correctly("widget_name") => "w100"}},

--- a/elasticgraph-graphql/spec/support/aggregations_helpers.rb
+++ b/elasticgraph-graphql/spec/support/aggregations_helpers.rb
@@ -21,12 +21,12 @@ require "elastic_graph/schema_artifacts/runtime_metadata/schema_element_names"
 
 module ElasticGraph
   module AggregationsHelpers
-    def computation_of(*field_names_in_index, function, computed_field_name: function.to_s, field_names_in_graphql_query: field_names_in_index)
+    def computation_of(*field_names_in_index, function, computed_field_name: function.to_s, leaf_alias: computed_field_name, field_names_in_graphql_query: field_names_in_index)
       source_field_path = build_field_path(names_in_index: field_names_in_index, names_in_graphql_query: field_names_in_graphql_query)
 
       GraphQL::Aggregation::Computation.new(
         source_field_path: source_field_path,
-        computed_index_field_name: computed_field_name,
+        leaf: GraphQL::Aggregation::PathSegment.new(name_in_graphql_query: leaf_alias, name_in_index: computed_field_name),
         detail: SchemaArtifacts::RuntimeMetadata::ComputationDetail.new(
           function: function,
           empty_bucket_value: (function == :sum || function == :cardinality) ? 0 : nil

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/computation_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/computation_spec.rb
@@ -27,6 +27,20 @@ module ElasticGraph
 
             expect(computation.key(aggregation_name: "my_aggs")).to eq aggregated_value_key_of("oof", "rab", "average", aggregation_name: "my_aggs").encode
           end
+
+          it "uses the leaf's GraphQL query alias rather than its name in the index" do
+            computation = computation_of("foo", "bar", :min, computed_field_name: "exact_min", leaf_alias: "myMin")
+
+            expect(computation.key(aggregation_name: "my_aggs")).to eq aggregated_value_key_of("foo", "bar", "myMin", aggregation_name: "my_aggs").encode
+          end
+
+          it "differs between two aliases of the same function under the same field, so they don't collapse into one computation" do
+            computation = computation_of("foo", :min, computed_field_name: "exact_min", leaf_alias: "exactMin")
+            aliased_computation = computation_of("foo", :min, computed_field_name: "exact_min", leaf_alias: "myMin")
+
+            expect(computation).not_to eq(aliased_computation)
+            expect(computation.key(aggregation_name: "my_aggs")).not_to eq(aliased_computation.key(aggregation_name: "my_aggs"))
+          end
         end
 
         describe "#clause" do
@@ -46,6 +60,12 @@ module ElasticGraph
             computation = computation_of("foo.c", "bar.d", :avg, field_names_in_graphql_query: ["oof", "rab"])
 
             expect(computation.clause).to eq({"avg" => {"field" => "foo.c.bar.d"}})
+          end
+
+          it "is unaffected by an alias on the leaf" do
+            computation = computation_of("foo", "bar", :avg, computed_field_name: "approximate_avg", leaf_alias: "myAvg")
+
+            expect(computation.clause).to eq({"avg" => {"field" => "foo.bar"}})
           end
         end
       end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/query_adapter_spec.rb
@@ -1440,7 +1440,11 @@ module ElasticGraph
               name: "widget_aggregations",
               computations: [
                 computation_of("amount_cents", :avg, computed_field_name: "approximate_avg", field_names_in_graphql_query: ["ac1"]),
-                computation_of("amount_cents", :avg, computed_field_name: "approximate_avg", field_names_in_graphql_query: ["ac2"]),
+                # `aa1` and `aa2` are two aliases of the same function under the same field. Since the leaf key is
+                # derived from the alias, these produce two distinct computations (and, ultimately, two identical
+                # datastore aggregation clauses) rather than collapsing into one.
+                computation_of("amount_cents", :avg, computed_field_name: "approximate_avg", leaf_alias: "aa1", field_names_in_graphql_query: ["ac2"]),
+                computation_of("amount_cents", :avg, computed_field_name: "approximate_avg", leaf_alias: "aa2", field_names_in_graphql_query: ["ac2"]),
                 computation_of("amount_cents", :sum, computed_field_name: "exact_sum", field_names_in_graphql_query: ["ac2"])
               ]
             )])
@@ -1793,8 +1797,8 @@ module ElasticGraph
             expect(aggregations).to eq([aggregation_query_of(
               name: "wa",
               computations: [
-                computation_of("amount_cents", :avg, computed_field_name: "approximate_avg", field_names_in_graphql_query: ["ac"]),
-                computation_of("amount_cents", :max, computed_field_name: "exact_max", field_names_in_graphql_query: ["ac"])
+                computation_of("amount_cents", :avg, computed_field_name: "approximate_avg", leaf_alias: "aa", field_names_in_graphql_query: ["ac"]),
+                computation_of("amount_cents", :max, computed_field_name: "exact_max", leaf_alias: "em", field_names_in_graphql_query: ["ac"])
               ],
               groupings: [
                 field_term_grouping_of("size", field_names_in_graphql_query: ["s"]),
@@ -1900,8 +1904,8 @@ module ElasticGraph
             expect(aggregations).to eq([aggregation_query_of(
               name: "wa",
               computations: [
-                computation_of("amount_cents", :avg, computed_field_name: "approximate_avg", field_names_in_graphql_query: ["ac"]),
-                computation_of("amount_cents", :max, computed_field_name: "exact_max", field_names_in_graphql_query: ["ac"])
+                computation_of("amount_cents", :avg, computed_field_name: "approximate_avg", leaf_alias: "aa", field_names_in_graphql_query: ["ac"]),
+                computation_of("amount_cents", :max, computed_field_name: "exact_max", leaf_alias: "em", field_names_in_graphql_query: ["ac"])
               ],
               groupings: [
                 field_term_grouping_of("size", field_names_in_graphql_query: ["s"]),

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/aggregation/resolvers/aggregations_spec.rb
@@ -284,6 +284,39 @@ module ElasticGraph
           ]
         end
 
+        it "uses GraphQL field aliases when resolving the aggregation function leaf fields, allowing the same function to be requested multiple times under one field" do
+          aggs = {
+            aggregated_value_key_of("amount_cents", "es") => {"value" => 900.0},
+            aggregated_value_key_of("amount_cents", "exact_sum") => {"value" => 900.0},
+            aggregated_value_key_of("cost", "amount_cents", "mx") => {"value" => 400.0}
+          }
+
+          response = resolve_target_nodes(<<~QUERY, aggs: aggs)
+            target: widget_aggregations {
+              nodes {
+                aggregated_values {
+                  amount_cents {
+                    es: exact_sum
+                    exact_sum
+                  }
+                  cost {
+                    amount_cents { mx: exact_max }
+                  }
+                }
+              }
+            }
+          QUERY
+
+          expect(response).to eq [
+            {
+              "aggregated_values" => {
+                "amount_cents" => {"es" => 900, "exact_sum" => 900},
+                "cost" => {"amount_cents" => {"mx" => 400}}
+              }
+            }
+          ]
+        end
+
         it "resolves aggregated Date/DateTime/LocalTime values" do
           aggs = {
             aggregated_value_key_of("created_at", "exact_min") => {"value" => 1696854612000.0, "value_as_string" => "2023-10-09T12:30:12.000Z"},


### PR DESCRIPTION
## Summary

Prep refactor #1 of 2 for PR #1327 (`approximatePercentile`). The percentile function itself is not added here.

An aggregated value function field that is aliased in a GraphQL query now resolves through a datastore aggregation key derived from that alias, rather than from the field's `name_in_index`.

Previously, the leaf segment of an aggregated value key was the only path segment keyed off `name_in_index` -- every parent segment already used the alias-aware `name_in_graphql_query`. That inconsistency would have forced an argument-bearing function (like the upcoming `approximatePercentile`) to invent a synthetic leaf name (e.g. `approximate_percentile(50.0)`), built independently in the query-building code and the resolver, which would then have to agree byte-for-byte. Making the leaf alias-derived removes the need for synthetic key naming entirely.

- `Computation` replaces its `computed_index_field_name` string attribute with a `leaf` attribute holding a `PathSegment`. Its `name_in_index` is intentionally unused -- the function name isn't part of the datastore index path, which `clause` derives entirely from `source_field_path`.
- Both the query-building side (`QueryAdapter`) and the resolver side (`Resolvers::AggregatedValues`) now derive the leaf name through the same `PathSegment.for` factory, so there's one rule instead of two implementations that must agree.
- `computed_index_field_name` is deleted (not left unused), since the datastore clause already derives its index path from `source_field_path`.

## Behavior change

This is **not** a pure refactor. Two aliases of the same function under one field used to collapse into a single computation (the value objects were equal, held in a `Set`, with an identical key). After this change their leaf segments differ, so two identical datastore aggregations are sent:

```graphql
aggregatedValues { amount { exactMin, myMin: exactMin } }
# before: ONE agg clause; both fields read it
# after:  TWO identical agg clauses, keyed by `exactMin` and `myMin`
```

Correct in both cases -- each field resolves via its own alias. Accepted deliberately:

- The redundancy only occurs when a client asks for the same value twice under two names, which is pathological, and the cost is a duplicate metric aggregation on an already-loaded shard.
- Deduplicating by clause content would require threading an alias-to-canonical-key map from query building into the resolver, reintroducing the coupling this ticket exists to delete.
- Rejecting aliases outright is a non-starter: the percentile function requires aliases to request multiple ranks.

## Test plan

- [x] Unit test: an aliased aggregated value function field produces a key built from the alias
- [x] Unit test: two aliases of the same function under one field produce two distinct keys
- [x] Unit test: the datastore clause's index field path is unaffected by leaf aliasing
- [x] Query-building unit test covering an aliased function field
- [x] Acceptance test issuing a GraphQL query with an aliased aggregated value function and asserting the resolved value
- [x] RBS signatures updated; `script/type_check` passes
- [x] `script/run_gem_specs elasticgraph-graphql` passes (100% line/branch coverage maintained)
- [x] `script/quick_build` passes

Closes #1329

🤖 Generated with [Claude Code](https://claude.com/claude-code)
