### PR TITLE
Fix two local test-tooling issues that derailed coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,12 @@ bundle exec rake elasticsearch:test:boot
 bundle exec rake opensearch:test:boot
 ```
 
+#### Test runtime expectations (avoid waiting on a stuck run)
+
+- **Expected runtimes**: `script/run_gem_specs elasticgraph-graphql` ≈ 1-2 min; full `script/run_specs` ≈ 5-8 min. If a test run exceeds ~3x the expected time, do NOT keep waiting — the datastore is likely in a bad state.
+- **Diagnosing a stuck/slow run**: check `curl -s localhost:9234/_cluster/health` and look for a large `active_shards` count, and check `log/datastore_client.test.log` for repeated 429 `rejected_execution_exception` errors. Recover by killing the test run and re-booting the datastore (`bundle exec rake elasticsearch:test:boot` or `opensearch:test:boot`), then re-run.
+- **Always pipe long test runs to a file** (e.g. `> /tmp/specs.log 2>&1`) rather than through `tail`/`grep`, so you can observe incremental progress and distinguish "still working" from "hung".
+
 ### Build & Validation
 - `script/quick_build` - Run abridged CI build (recommended before opening PRs)
 - `script/lint` - Run linter (Standard Ruby)

--- a/spec_support/lib/elastic_graph/spec_support/enable_simplecov.rb
+++ b/spec_support/lib/elastic_graph/spec_support/enable_simplecov.rb
@@ -46,6 +46,31 @@ module ElasticGraph
     end
   end
 
+  # SimpleCov backfills `track_files`-matched files that a process never loaded with simulated
+  # coverage based on `Coverage.line_stub`. On CRuby 4.0.0 through 4.0.3 (fixed in 4.0.4),
+  # `Coverage.line_stub` classifies a few lines (e.g. continuation lines of multi-line hash
+  # literals, and `in` clauses of `case`/`in` expressions) as relevant-but-uncovered (`0`) even
+  # though the runtime `Coverage` API classifies them as not relevant (`nil`) when the file is
+  # actually loaded. When such a simulated result (e.g. from the flatware main process, which runs
+  # no tests) merges with a real result, SimpleCov 1.x treats "relevant on either side" as
+  # relevant, so the phantom `0` survives the merge and the file misleadingly reports < 100%
+  # coverage. On affected Ruby versions, we restore SimpleCov 0.22's merge semantics: an unexecuted
+  # (`0`) line only counts as relevant if BOTH sides agree it is relevant. Genuinely unloaded files
+  # are unaffected--all of their merged values are `0`-vs-`0`, which still merges to `0`--and
+  # executed lines are unaffected (`nil`-vs-positive still merges to the positive count).
+  #
+  # :nocov: -- which branch executes depends on the Ruby version.
+  if ::RUBY_ENGINE == "ruby" && ("4.0.0"..."4.0.4").cover?(::RUBY_VERSION)
+    module LinesCombinerPatch
+      def merge_line_coverage(first_val, second_val)
+        return nil if (first_val.nil? || second_val.nil?) && first_val.to_i + second_val.to_i == 0
+        super
+      end
+    end
+    ::SimpleCov::Combine::LinesCombiner.singleton_class.prepend LinesCombinerPatch
+  end
+  # :nocov:
+
   if defined?(::Flatware)
     module SimpleCovPatches
       attr_accessor :flatware_main_process_pid

--- a/spec_support/lib/elastic_graph/spec_support/uses_datastore.rb
+++ b/spec_support/lib/elastic_graph/spec_support/uses_datastore.rb
@@ -481,6 +481,17 @@ RSpec.configure do |config|
   end
   # :nocov:
 
+  # Our between-test cleanup strategy (a `/_delete_by_query` against all indices) opens one scroll
+  # context per shard. We intentionally keep the datastore (and its indices) running across many
+  # test runs, so shards accumulate over time (each parallel test worker gets its own `test_env_N_*`
+  # indices). If the shard count reaches the datastore's `search.max_open_scroll_context` limit
+  # (500 by default), every cleanup request fails with a 429 "Trying to create too many scroll
+  # contexts" error, poisoning the entire test run in a way that is slow and confusing to debug.
+  # Here we raise the limit to give us ample headroom. We do it here (rather than in the
+  # elasticgraph-local docker-compose configs) because the accumulation only happens from runs of
+  # this test suite--EG users booting the datastore locally don't need a raised limit.
+  `curl -s -X PUT '#{datastore_url}/_cluster/settings' -H 'Content-Type: application/json' -d '{"persistent": {"search.max_open_scroll_context": 10000}}'`
+
   version_info = JSON.parse(curl_output.sub(/\A[^{]+/, "")).fetch("version")
   version = version_info.fetch("number")
   backend = version_info.fetch("distribution") { "elasticsearch" }.to_sym


### PR DESCRIPTION
## Why

Coding-agent sessions in this repo repeatedly hit two local-only tooling failures, examined from session logs:

- A normally 2-3 minute `elasticgraph-graphql` suite ran 42+ minutes with the agent stuck waiting.
- Local coverage runs deterministically reported 4 uncovered lines that CI (which enforces 100%) said were covered, sending agents down rabbit trails.

## What

**1. Raise `search.max_open_scroll_context` to 10000 at test-suite startup** (`uses_datastore.rb`)

We intentionally keep the test datastore running across many test runs to avoid re-paying index creation costs, so shards accumulate over time (each parallel test worker gets its own `test_env_N_*` indices). Our between-test cleanup (`_delete_by_query` against all indices) opens one scroll context per shard; once active shards exceed the default limit of 500, every cleanup request fails with a 429 `rejected_execution_exception`, poisoning the run. The limit is raised in the test suite (not the elasticgraph-local docker-compose configs) because only this suite accumulates shards — EG users booting locally don't need it.

Verified by resetting the limit to 500 on a 617-shard datastore (guaranteed-poisoned state, reproduced the 429s directly) and running `script/run_gem_specs elasticgraph-graphql`: 1660 examples, 0 failures, normal runtime.

**2. Version-gated SimpleCov merge patch for CRuby 4.0.0-4.0.3** (`enable_simplecov.rb`)

`Coverage.line_stub` (used by SimpleCov 1.x to simulate coverage for tracked-but-unloaded files, e.g. the flatware main process which runs no tests) misclassifies some lines (continuation lines of multi-line hash literals, `in` clauses of `case`/`in`) as relevant-but-uncovered on CRuby 4.0.0-4.0.3; fixed in 4.0.4 (bisected via docker ruby-slim images). SimpleCov 1.x's merge lets the phantom `0`s survive merging with real results. On affected Ruby versions only, the patch restores SimpleCov 0.22's merge semantics; the version gate tells us exactly when it can be dropped.

Verified: same run that reported `99.85% -- 2752/2756` now reports `100.00% -- 2752/2752` on Ruby 4.0.0.

**3. AGENTS.md: test runtime expectations**

Documents expected suite runtimes, how to diagnose a stuck datastore (shard count via `_cluster/health`, 429s in `log/datastore_client.test.log`), and pipe-to-file guidance so agents can distinguish "still working" from "hung".

🤖 Generated with [Claude Code](https://claude.com/claude-code)