### PR TITLE
Introduce QueryContext to replace magic GraphQL context keys

### DIFF
--- a/elasticgraph-apollo/apollo_tests_implementation/lib/product_resolver.rb
+++ b/elasticgraph-apollo/apollo_tests_implementation/lib/product_resolver.rb
@@ -23,7 +23,7 @@ class ProductResolver
   def resolve(field:, object:, args:, context:)
     query = @datastore_query_builder.new_query(
       initial_search_index_definitions: [@product_index_def],
-      monotonic_clock_deadline: context[:monotonic_clock_deadline],
+      monotonic_clock_deadline: context.monotonic_clock_deadline,
       client_filters: [{"id" => {"equalToAnyOf" => [args.fetch("id")]}}],
       individual_docs_needed: true,
       request_all_fields: true

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/entities_field_resolver.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/entities_field_resolver.rb
@@ -25,7 +25,7 @@ module ElasticGraph
         end
 
         def resolve(field:, object:, args:, context:, lookahead:)
-          schema = context.fetch(:elastic_graph_schema)
+          schema = context.elastic_graph_schema
 
           representations = args.fetch("representations").map.with_index do |rep, index|
             try_parse_representation(rep, schema) do |error_description|
@@ -40,7 +40,7 @@ module ElasticGraph
           query_attributes = ElasticGraph::GraphQL::QueryAdapter::RequestedFields
             .new(schema)
             .query_attributes_for(field: field, lookahead: lookahead)
-            .merge(monotonic_clock_deadline: context[:monotonic_clock_deadline])
+            .merge(monotonic_clock_deadline: context.monotonic_clock_deadline)
 
           # Build a separate query per adapter instance since each adapter instance is capable of building
           # a single query that handles all representations assigned to it.

--- a/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/service_field_resolver.rb
+++ b/elasticgraph-apollo/lib/elastic_graph/apollo/graphql/service_field_resolver.rb
@@ -18,7 +18,7 @@ module ElasticGraph
         end
 
         def resolve(field:, object:, args:, context:)
-          {"sdl" => service_sdl(context.fetch(:elastic_graph_schema))}
+          {"sdl" => service_sdl(context.elastic_graph_schema)}
         end
 
         private

--- a/elasticgraph-apollo/sig/elastic_graph/apollo/graphql/entities_field_resolver.rbs
+++ b/elasticgraph-apollo/sig/elastic_graph/apollo/graphql/entities_field_resolver.rbs
@@ -43,7 +43,7 @@ module ElasticGraph
           def identify_matching_hit: (
             I,
             R,
-            context: ::GraphQL::Query::Context,
+            context: ElasticGraph::GraphQL::QueryContext,
             index: ::Integer
           ) -> (ElasticGraph::GraphQL::DatastoreResponse::Document | ::Hash[::String, untyped])?
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_adapter.rb
@@ -43,7 +43,7 @@ module ElasticGraph
           def call(query:, lookahead:, args:, field:, context:)
             return query unless field.type.unwrap_fully.indexed_aggregation?
 
-            @build_adapter.call(context.fetch(:elastic_graph_schema)).call(
+            @build_adapter.call(context.elastic_graph_schema).call(
               query: query,
               lookahead: lookahead,
               args: args,

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/http_endpoint.rb
@@ -57,6 +57,7 @@ module ElasticGraph
             client: client_or_response,
             timeout_in_ms: parsed.timeout_in_ms,
             context: parsed.context,
+            http_request: request,
             start_time_in_ms: start_time_in_ms
           )
 
@@ -155,17 +156,18 @@ module ElasticGraph
         yield [max_timeout_in_ms, requested_timeout_in_ms].compact.min
       end
 
-      # Responsible for determining any `context` values to pass down into the `query_executor`,
-      # which in turn will make the values available to the GraphQL resolvers.
+      # Responsible for determining any extra `context` values to pass down into the `query_executor`,
+      # which in turn will make the values available to the GraphQL resolvers. (`http_request` itself is
+      # always passed down separately--see `process`--so it does not need to be added here.)
       #
-      # By default, our only context value is the HTTP request. This method exists to provide an extension
+      # By default we have no extra context values. This method exists to provide an extension
       # point so that ElasticGraph extensions can add `context` values based on the `request` as desired.
       #
       # Extensions can return an `HTTPResponse` with an error if the `request` is invalid according
       # to their requirements. Otherwise, they must call `super` (to delegate to this and any other
       # extensions) with a block. In the block, they must merge in their `context` values and then `yield`.
       def with_context(request)
-        yield({http_request: request})
+        yield({})
       end
 
       ParsedRequest = Data.define(:query_string, :variables, :operation_name, :timeout_in_ms, :context)

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/requested_fields.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_adapter/requested_fields.rb
@@ -21,7 +21,7 @@ module ElasticGraph
           def call(field:, query:, lookahead:, args:, context:)
             return query if field.type.unwrap_fully.indexed_aggregation?
 
-            RequestedFields.new(context.fetch(:elastic_graph_schema)).call(
+            RequestedFields.new(context.elastic_graph_schema).call(
               field: field,
               query: query,
               lookahead: lookahead,

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_context.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_context.rb
@@ -1,0 +1,78 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/graphql/client"
+require "elastic_graph/graphql/query_details_tracker"
+require "graphql"
+
+module ElasticGraph
+  class GraphQL
+    # `GraphQL::Query::Context` subclass used by ElasticGraph, providing typed accessors in
+    # place of untyped context hash keys. Registered as the `context_class` on the `GraphQL::Schema`
+    # built by `Schema`, via `new_class`, so that every query gets an instance closed over the
+    # `Schema` and `DatastoreSearchRouter` in use for that schema.
+    class QueryContext < ::GraphQL::Query::Context
+      def self.elastic_graph_schema
+        @elastic_graph_schema
+      end
+
+      def self.datastore_search_router
+        @datastore_search_router
+      end
+
+      # Builds a `QueryContext` subclass closed over the given `elastic_graph_schema` and
+      # `datastore_search_router`, suitable for registering as a `GraphQL::Schema#context_class`.
+      def self.new_class(elastic_graph_schema:, datastore_search_router:)
+        klass = ::Class.new(self) # : singleton(QueryContext)
+        klass.instance_variable_set(:@elastic_graph_schema, elastic_graph_schema)
+        klass.instance_variable_set(:@datastore_search_router, datastore_search_router)
+        klass
+      end
+
+      # `elastic_graph_schema` is only `nil` before `new_class` has closed over it, which never
+      # happens for a `QueryContext` actually used to execute a query (see `Schema#initialize`).
+      def elastic_graph_schema
+        self.class.elastic_graph_schema # : Schema
+      end
+
+      def datastore_search_router
+        self.class.datastore_search_router # : DatastoreSearchRouter
+      end
+
+      # @dynamic monotonic_clock_deadline, elastic_graph_client, http_request
+      attr_reader :monotonic_clock_deadline, :elastic_graph_client, :http_request
+
+      # Registers the given ElasticGraph-managed values on this context. Intended to be called
+      # exactly once, by `Schema#new_graphql_query` callers immediately after building a query and
+      # before making it available to resolvers or other user-facing code. Not for use elsewhere.
+      def register_elastic_graph_values(monotonic_clock_deadline: nil, elastic_graph_client: Client::ANONYMOUS, http_request: nil)
+        @monotonic_clock_deadline = monotonic_clock_deadline
+        @elastic_graph_client = elastic_graph_client
+        @http_request = http_request
+      end
+
+      # Lazily builds (and memoizes) the `QueryDetailsTracker` for this query.
+      def elastic_graph_query_tracker
+        @elastic_graph_query_tracker ||= QueryDetailsTracker.empty
+      end
+
+      # Caches the result of the given block (a built `DatastoreQuery`) under `cache_key`, scoped to
+      # this single query execution. See `Resolvers::QueryAdapter#build_query_from` for why this
+      # memoization is beneficial.
+      def cache_datastore_query(cache_key)
+        datastore_query_cache[cache_key] ||= yield
+      end
+
+      private
+
+      def datastore_query_cache
+        @datastore_query_cache ||= {}
+      end
+    end
+  end
+end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_context.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_context.rb
@@ -6,6 +6,7 @@
 #
 # frozen_string_literal: true
 
+require "elastic_graph/errors"
 require "elastic_graph/graphql/client"
 require "elastic_graph/graphql/query_details_tracker"
 require "graphql"
@@ -68,7 +69,36 @@ module ElasticGraph
         datastore_query_cache[cache_key] ||= yield
       end
 
+      # These context hash keys were replaced by typed accessors above. `[]`/`fetch` raise a
+      # helpful error here instead of silently returning `nil`, in case any custom resolver code
+      # still reads them as hash keys.
+      REMOVED_KEY_REPLACEMENTS = {
+        elastic_graph_schema: "elastic_graph_schema",
+        datastore_search_router: "datastore_search_router",
+        datastore_query_cache: "cache_datastore_query",
+        elastic_graph_query_tracker: "elastic_graph_query_tracker",
+        monotonic_clock_deadline: "monotonic_clock_deadline",
+        elastic_graph_client: "elastic_graph_client",
+        http_request: "http_request"
+      }
+
+      def [](key)
+        raise_if_removed_key(key)
+        super
+      end
+
+      def fetch(key, *args, &block)
+        raise_if_removed_key(key)
+        super
+      end
+
       private
+
+      def raise_if_removed_key(key)
+        if (replacement = REMOVED_KEY_REPLACEMENTS[key])
+          raise Errors::ConfigError, "`context[#{key.inspect}]` is no longer supported; use `context.#{replacement}` instead."
+        end
+      end
 
       def datastore_query_cache
         @datastore_query_cache ||= {}

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_executor.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_executor.rb
@@ -7,7 +7,6 @@
 # frozen_string_literal: true
 
 require "elastic_graph/graphql/client"
-require "elastic_graph/graphql/query_details_tracker"
 require "elastic_graph/support/hash_util"
 
 module ElasticGraph
@@ -40,6 +39,7 @@ module ElasticGraph
         timeout_in_ms: nil,
         operation_name: nil,
         context: {},
+        http_request: nil,
         start_time_in_ms: @monotonic_clock.now_in_ms
       )
         # Before executing the query, prune any null-valued variable fields. This means we
@@ -50,19 +50,17 @@ module ElasticGraph
         # due to a null-valued field referencing an undefined schema element.
         variables = ElasticGraph::Support::HashUtil.recursively_prune_nils_from(variables)
 
-        query_tracker = QueryDetailsTracker.empty
-
         query, result = build_and_execute_query(
           query_string: query_string,
           variables: variables,
           operation_name: operation_name,
           client: client,
-          context: context.merge({
-            monotonic_clock_deadline: timeout_in_ms&.+(start_time_in_ms),
-            elastic_graph_query_tracker: query_tracker,
-            elastic_graph_client: client
-          }.compact)
+          context: context,
+          monotonic_clock_deadline: timeout_in_ms&.+(start_time_in_ms),
+          http_request: http_request
         )
+
+        query_tracker = query.context.elastic_graph_query_tracker
 
         unless result.to_h.fetch("errors", []).empty?
           @logger.error <<~EOS
@@ -128,12 +126,17 @@ module ElasticGraph
 
       # Note: this is designed so that `elasticgraph-query_registry` can hook into this method. It needs to be able
       # to override how the query is built and executed.
-      def build_and_execute_query(query_string:, variables:, operation_name:, context:, client:)
+      def build_and_execute_query(query_string:, variables:, operation_name:, context:, client:, monotonic_clock_deadline:, http_request:)
         query = @schema.new_graphql_query(
           query_string,
           variables: variables,
           operation_name: operation_name,
           context: context
+        )
+        query.context.register_elastic_graph_values(
+          monotonic_clock_deadline: monotonic_clock_deadline,
+          elastic_graph_client: client,
+          http_request: http_request
         )
 
         [query, execute_query(query, client: client)]

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter_builder.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter_builder.rb
@@ -54,7 +54,7 @@ module ElasticGraph
                 resolver_lambda =
                   if resolver.method(:resolve).parameters.include?([:keyreq, :lookahead])
                     lambda do |object, args, context|
-                      schema_field = context.fetch(:elastic_graph_schema).field_named(type_name, field_name)
+                      schema_field = context.elastic_graph_schema.field_named(type_name, field_name)
 
                       # Extract the `:lookahead` extra that we have configured all fields to provide.
                       # See https://graphql-ruby.org/api-doc/1.10.8/GraphQL/Execution/Lookahead.html for more info.
@@ -80,7 +80,7 @@ module ElasticGraph
                     end
                   else
                     lambda do |object, args, context|
-                      schema_field = context.fetch(:elastic_graph_schema).field_named(type_name, field_name)
+                      schema_field = context.elastic_graph_schema.field_named(type_name, field_name)
                       # Convert args to the form they were defined in the schema, undoing the normalization
                       # the GraphQL gem does to convert them to Ruby keyword args form.
                       args = schema_field.args_to_schema_form(args)
@@ -109,7 +109,7 @@ module ElasticGraph
 
         # In order to support unions and interfaces, we must implement `resolve_type`.
         def resolve_type(supertype, object, context)
-          schema = context.fetch(:elastic_graph_schema)
+          schema = context.elastic_graph_schema
           # If `__typename` is available, use that to resolve. It will be present on embedded abstract
           # types, and also on root documents indexed in a shared interface/union index.
           # (See `Inventor` in `config/schema/widgets.rb` for an example of an embedded abstract type.)
@@ -124,7 +124,8 @@ module ElasticGraph
             # (See `Part` in `config/schema/widgets.rb` for an example of this kind of type union.)
             # This branch is only reached for individually-indexed types (no `__typename`
             # in the document), so the set always contains exactly one type.
-            schema.document_types_stored_in(object.index_definition_name).first.graphql_type
+            type = schema.document_types_stored_in(object.index_definition_name).first # : Schema::Type
+            type.graphql_type
           end
         end
       end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships_source.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/nested_relationships_source.rb
@@ -65,7 +65,7 @@ module ElasticGraph
           @join = join
           @filter_id_field_name_path = @join.filter_id_field_name.split(".")
           @context = context
-          elastic_graph_schema = context.fetch(:elastic_graph_schema)
+          elastic_graph_schema = context.elastic_graph_schema
           @schema_element_names = elastic_graph_schema.element_names
           @logger = elastic_graph_schema.logger
           @monotonic_clock = monotonic_clock

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/query_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/query_adapter.rb
@@ -18,7 +18,7 @@ module ElasticGraph
         end
 
         def build_query_from(field:, args:, lookahead:, context:)
-          monotonic_clock_deadline = context[:monotonic_clock_deadline]
+          monotonic_clock_deadline = context.monotonic_clock_deadline
 
           # Building an `DatastoreQuery` is not cheap; we do a lot of work to:
           #
@@ -53,9 +53,9 @@ module ElasticGraph
           # instance, so we can safely cache things in it and trust that it will not "leak" to another
           # query execution. We carefully build a cache key below to ensure that we only ever reuse
           # the same `DatastoreQuery` in a situation that would produce the exact same `DatastoreQuery`.
-          context[:datastore_query_cache] ||= {}
-          context[:datastore_query_cache][cache_key_for(field, args, lookahead)] ||=
+          context.cache_datastore_query(cache_key_for(field, args, lookahead)) do
             build_new_query_from(field, args, lookahead, context, monotonic_clock_deadline)
+          end
         end
 
         private

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/query_source.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/query_source.rb
@@ -36,8 +36,8 @@ module ElasticGraph
         end
 
         def self.execute_many(queries, for_context:)
-          datastore_router = for_context.fetch(:datastore_search_router)
-          query_tracker = for_context.fetch(:elastic_graph_query_tracker)
+          datastore_router = for_context.datastore_search_router
+          query_tracker = for_context.elastic_graph_query_tracker
           opaque_id_parts = datastore_opaque_id_parts_for(for_context)
           dataloader = for_context.dataloader
 
@@ -49,11 +49,11 @@ module ElasticGraph
           execute_many([query], for_context: for_context).fetch(query)
         end
 
-        # `QueryExecutor` adds `:elastic_graph_client` to the GraphQL context before
+        # `Schema#new_graphql_query` sets `elastic_graph_client` on the context before
         # resolver execution begins, so resolver-side datastore queries can reuse the
         # same client identity in their datastore `X-Opaque-Id` headers.
         private_class_method def self.datastore_opaque_id_parts_for(for_context)
-          client = for_context.fetch(:elastic_graph_client)
+          client = for_context.elastic_graph_client # : Client
           graphql_query = for_context.query
           [
             "elasticgraph-graphql",

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection.rb
@@ -20,7 +20,7 @@ module ElasticGraph
         def self.maybe_wrap(search_response, field:, context:, lookahead:, query:)
           return search_response unless field.type.relay_connection?
 
-          schema = context.fetch(:elastic_graph_schema)
+          schema = context.elastic_graph_schema
 
           unless field.type.unwrap_fully.indexed_aggregation?
             return SearchResponseAdapterBuilder.build_from(

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/array_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/array_adapter.rb
@@ -26,7 +26,7 @@ module ElasticGraph
           def_delegators :graphql_impl, :start_cursor, :end_cursor, :has_next_page, :has_previous_page
 
           def self.build(nodes, args, context)
-            schema = context.fetch(:elastic_graph_schema)
+            schema = context.elastic_graph_schema
             schema_element_names = schema.element_names
             nodes ||= [] # : ::Array[untyped]
 

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/schema.rb
@@ -9,6 +9,7 @@
 require "graphql"
 require "elastic_graph/constants"
 require "elastic_graph/errors"
+require "elastic_graph/graphql/query_context"
 require "elastic_graph/graphql/schema/field"
 require "elastic_graph/graphql/schema/type"
 
@@ -69,6 +70,11 @@ module ElasticGraph
           using: graphql_gem_plugins
         )
 
+        @graphql_schema.context_class(QueryContext.new_class(
+          elastic_graph_schema: self,
+          datastore_search_router: @datastore_search_router
+        ))
+
         # Pre-load all defined types so that all field extras can get configured as part
         # of loading the schema, before we execute the first query.
         @types_by_name = build_types_by_name
@@ -92,11 +98,7 @@ module ElasticGraph
           operation_name: operation_name,
           document: document,
           validate: validate,
-          context: context.merge({
-            datastore_search_router: @datastore_search_router,
-            elastic_graph_schema: self,
-            visibility_profile: VISIBILITY_PROFILE
-          })
+          context: context.merge({visibility_profile: VISIBILITY_PROFILE})
         )
       end
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/query_adapter/interface.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/query_adapter/interface.rbs
@@ -6,7 +6,7 @@ module ElasticGraph
         field: Schema::Field,
         args: ::Hash[::String, untyped],
         lookahead: ::GraphQL::Execution::Lookahead,
-        context: ::GraphQL::Query::Context
+        context: QueryContext
       ) -> DatastoreQuery
     end
   end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/query_context.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/query_context.rbs
@@ -27,7 +27,14 @@ module ElasticGraph
 
       def cache_datastore_query: (untyped cache_key) { () -> DatastoreQuery } -> DatastoreQuery
 
+      REMOVED_KEY_REPLACEMENTS: ::Hash[::Symbol, ::String]
+
+      def []: (untyped key) -> untyped
+      def fetch: (untyped key, *untyped args) ?{ (untyped) -> untyped } -> untyped
+
       private
+
+      def raise_if_removed_key: (untyped key) -> void
 
       @datastore_query_cache: ::Hash[untyped, DatastoreQuery]?
       def datastore_query_cache: () -> ::Hash[untyped, DatastoreQuery]

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/query_context.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/query_context.rbs
@@ -1,0 +1,36 @@
+module ElasticGraph
+  class GraphQL
+    class QueryContext < ::GraphQL::Query::Context
+      self.@elastic_graph_schema: Schema?
+      def self.elastic_graph_schema: () -> Schema?
+
+      self.@datastore_search_router: DatastoreSearchRouter?
+      def self.datastore_search_router: () -> DatastoreSearchRouter?
+
+      def self.new_class: (elastic_graph_schema: Schema, datastore_search_router: DatastoreSearchRouter) -> singleton(QueryContext)
+
+      def elastic_graph_schema: () -> Schema
+      def datastore_search_router: () -> DatastoreSearchRouter
+
+      attr_reader monotonic_clock_deadline: ::Integer?
+      attr_reader elastic_graph_client: Client?
+      attr_reader http_request: HTTPRequest?
+
+      def register_elastic_graph_values: (
+        ?monotonic_clock_deadline: ::Integer?,
+        ?elastic_graph_client: Client?,
+        ?http_request: HTTPRequest?
+      ) -> void
+
+      @elastic_graph_query_tracker: QueryDetailsTracker?
+      def elastic_graph_query_tracker: () -> QueryDetailsTracker
+
+      def cache_datastore_query: (untyped cache_key) { () -> DatastoreQuery } -> DatastoreQuery
+
+      private
+
+      @datastore_query_cache: ::Hash[untyped, DatastoreQuery]?
+      def datastore_query_cache: () -> ::Hash[untyped, DatastoreQuery]
+    end
+  end
+end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/query_executor.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/query_executor.rbs
@@ -15,6 +15,7 @@ module ElasticGraph
         ?timeout_in_ms: ::Integer?,
         ?operation_name: ::String?,
         ?context: ::Hash[::Symbol, untyped],
+        ?http_request: HTTPRequest?,
         ?start_time_in_ms: ::Integer
       ) -> ::GraphQL::Query::Result
 
@@ -32,7 +33,9 @@ module ElasticGraph
         variables: ::Hash[::String, untyped],
         operation_name: ::String?,
         context: ::Hash[::Symbol, untyped],
-        client: Client
+        client: Client,
+        monotonic_clock_deadline: ::Integer?,
+        http_request: HTTPRequest?
       ) -> [::GraphQL::Query, ::GraphQL::Query::Result]
 
       def execute_query: (::GraphQL::Query, client: Client) -> ::GraphQL::Query::Result

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/graphql_adapter_builder.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/graphql_adapter_builder.rbs
@@ -20,9 +20,9 @@ module ElasticGraph
 
         private
 
-        def scalar_type_hash: () -> ::Hash[::String, ::Hash[::String, ^(untyped, ::GraphQL::Query::Context) -> untyped]]
-        def object_type_hash: () -> ::Hash[::String, ::Hash[::String, ^(untyped, ::Hash[::Symbol, untyped], ::GraphQL::Query::Context) -> untyped]]
-        def resolve_type: (::Module, untyped, ::GraphQL::Query::Context) -> untyped
+        def scalar_type_hash: () -> ::Hash[::String, ::Hash[::String, ^(untyped, QueryContext) -> untyped]]
+        def object_type_hash: () -> ::Hash[::String, ::Hash[::String, ^(untyped, ::Hash[::Symbol, untyped], QueryContext) -> untyped]]
+        def resolve_type: (::Module, untyped, QueryContext) -> untyped
       end
     end
   end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/nested_relationships_source.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/nested_relationships_source.rbs
@@ -8,14 +8,14 @@ module ElasticGraph
         def initialize: (
           query: DatastoreQuery,
           join: Schema::RelationJoin,
-          context: ::GraphQL::Query::Context,
+          context: QueryContext,
           monotonic_clock: Support::MonotonicClock
         ) -> void
 
         @query: DatastoreQuery
         @join: Schema::RelationJoin
         @filter_id_field_name_path: ::Array[::String]
-        @context: ::GraphQL::Query::Context
+        @context: QueryContext
         @schema_element_names: SchemaArtifacts::RuntimeMetadata::SchemaElementNames
         @logger: ::Logger
         @monotonic_clock: Support::MonotonicClock
@@ -26,7 +26,7 @@ module ElasticGraph
           ::Set[::String],
           query: DatastoreQuery,
           join: Schema::RelationJoin,
-          context: ::GraphQL::Query::Context,
+          context: QueryContext,
           monotonic_clock: Support::MonotonicClock
         ) -> DatastoreResponse::SearchResponse
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/query_adapter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/query_adapter.rbs
@@ -14,7 +14,7 @@ module ElasticGraph
           field: Schema::Field,
           args: ::Hash[::String, untyped],
           lookahead: ::GraphQL::Execution::Lookahead,
-          context: ::GraphQL::Query::Context
+          context: QueryContext
         ) -> DatastoreQuery
 
         private
@@ -29,8 +29,8 @@ module ElasticGraph
           Schema::Field,
           ::Hash[::String, untyped],
           ::GraphQL::Execution::Lookahead,
-          ::GraphQL::Query::Context,
-          ::Integer
+          QueryContext,
+          ::Integer?
         ) -> DatastoreQuery
       end
     end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/query_source.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/query_source.rbs
@@ -10,15 +10,15 @@ module ElasticGraph
 
         def self.execute_many: (
           ::Array[DatastoreQuery],
-          for_context: ::GraphQL::Query::Context
+          for_context: QueryContext
         ) -> ::Hash[DatastoreQuery, DatastoreResponse::SearchResponse]
 
         def self.execute_one: (
           DatastoreQuery,
-          for_context: ::GraphQL::Query::Context
+          for_context: QueryContext
         ) -> DatastoreResponse::SearchResponse
 
-        def self.datastore_opaque_id_parts_for: (::GraphQL::Query::Context) -> ::Array[::String]
+        def self.datastore_opaque_id_parts_for: (QueryContext) -> ::Array[::String]
       end
     end
   end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/relay_connection.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/relay_connection.rbs
@@ -5,7 +5,7 @@ module ElasticGraph
         def self.maybe_wrap: (
           DatastoreResponse::SearchResponse,
           field: Schema::Field,
-          context: ::GraphQL::Query::Context,
+          context: QueryContext,
           lookahead: ::GraphQL::Execution::Lookahead,
           query: DatastoreQuery
         ) -> (DatastoreResponse::SearchResponse | GenericAdapter[DatastoreResponse::Document] | GenericAdapter[Aggregation::Resolvers::Node])

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/relay_connection/array_adapter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/resolvers/relay_connection/array_adapter.rbs
@@ -11,7 +11,7 @@ module ElasticGraph
 
           def initialize: (Schema, ::GraphQL::Pagination::ArrayConnection[N], ::Integer) -> void
 
-          def self.build: [N] (::Array[N], ::Hash[::String, untyped], ::GraphQL::Query::Context) -> ArrayAdapter[N]
+          def self.build: [N] (::Array[N], ::Hash[::String, untyped], QueryContext) -> ArrayAdapter[N]
 
           @edges: ::Array[_RelayEdge[N]]?
           @nodes: ::Array[N]?

--- a/elasticgraph-graphql/sig/graphql_gem.rbs
+++ b/elasticgraph-graphql/sig/graphql_gem.rbs
@@ -117,6 +117,11 @@ module GraphQL
     attr_reader result: Result
     attr_reader query_string: ::String?
 
+    # Note: in reality this returns a `Query::Context`, but ElasticGraph always registers
+    # `ElasticGraph::GraphQL::QueryContext` as the schema's `context_class`, so every context
+    # ElasticGraph code encounters is actually one of those.
+    attr_reader context: ::ElasticGraph::GraphQL::QueryContext
+
     def selected_operation: () -> Language::Nodes::OperationDefinition?
     def selected_operation_name: () -> ::String?
     def static_errors: () -> ::Array[_ValidationError]
@@ -142,8 +147,10 @@ module GraphQL
     attr_reader static_validator: StaticValidation::Validator
 
     def execute: (::String, **untyped) -> ::Hash[::String, untyped]
+    def possible_types: (untyped, **untyped) -> ::Array[_Type]
     def self.from_definition: (::String) -> Schema
     def to_definition: () -> ::String
+    def context_class: (::Class) -> void
     def type_from_ast: (
       Language::Nodes::AbstractNode,
       ?context: Query::Context

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_source_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/resolvers/nested_relationships_source_spec.rb
@@ -6,7 +6,6 @@
 #
 # frozen_string_literal: true
 
-require "elastic_graph/graphql/query_details_tracker"
 require "elastic_graph/graphql/client"
 require "elastic_graph/graphql/resolvers/nested_relationships_source"
 require "graphql"
@@ -217,17 +216,12 @@ module ElasticGraph
           )
 
           ::GraphQL::Dataloader.with_dataloading do |dataloader|
-            context = ::GraphQL::Query::Context.new(
+            context = graphql.schema.graphql_schema.context_class.new(
               query: instance_double(::GraphQL::Query, fingerprint: "NestedRelationshipsSource/test"),
               schema: graphql.schema.graphql_schema,
-              values: {
-                elastic_graph_schema: graphql.schema,
-                dataloader: dataloader,
-                datastore_search_router: graphql.datastore_search_router,
-                elastic_graph_query_tracker: QueryDetailsTracker.empty,
-                elastic_graph_client: Client::ANONYMOUS
-              }
+              values: {dataloader: dataloader}
             )
+            context.register_elastic_graph_values
 
             dataloader.with(NestedRelationshipsSource, query:, join:, context:, monotonic_clock:).load_all(value_sets.map(&:to_set))
           end

--- a/elasticgraph-graphql/spec/support/resolver.rb
+++ b/elasticgraph-graphql/spec/support/resolver.rb
@@ -6,7 +6,6 @@
 #
 # frozen_string_literal: true
 
-require "elastic_graph/graphql/query_details_tracker"
 require "elastic_graph/graphql/client"
 require "elastic_graph/graphql/resolvers/query_adapter"
 require "elastic_graph/graphql/resolvers/query_source"
@@ -18,20 +17,14 @@ module ResolverHelperMethods
     query_overrides = options.fetch(:query_overrides) { {} }
     args = field.args_to_schema_form(options.except(:query_overrides, :lookahead))
     lookahead = options[:lookahead] || GraphQL::Execution::Lookahead::NULL_LOOKAHEAD
-    query_details_tracker = ElasticGraph::GraphQL::QueryDetailsTracker.empty
 
     ::GraphQL::Dataloader.with_dataloading do |dataloader|
-      context = ::GraphQL::Query::Context.new(
+      context = graphql.schema.graphql_schema.context_class.new(
         query: instance_double(::GraphQL::Query, fingerprint: "ResolverHelperQuery/test"),
         schema: graphql.schema.graphql_schema,
-        values: {
-          elastic_graph_schema: graphql.schema,
-          dataloader: dataloader,
-          elastic_graph_query_tracker: query_details_tracker,
-          datastore_search_router: graphql.datastore_search_router,
-          elastic_graph_client: ElasticGraph::GraphQL::Client::ANONYMOUS
-        }
+        values: {dataloader: dataloader}
       )
+      context.register_elastic_graph_values
 
       query = nil
       query_builder = -> {

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/http_endpoint_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/http_endpoint_spec.rb
@@ -59,7 +59,7 @@ module ElasticGraph
           let(:graphql) do
             adapter = Class.new do
               def call(query:, context:, **)
-                user_name = context.fetch(:http_request).normalized_headers["USER-NAME"]
+                user_name = context.http_request.normalized_headers["USER-NAME"]
                 query.merge_with(internal_filters: [{"user_name" => {"equal_to_any_of" => [user_name]}}])
               end
             end.new

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_context_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_context_spec.rb
@@ -1,0 +1,43 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/errors"
+require "elastic_graph/graphql/query_context"
+
+module ElasticGraph
+  class GraphQL
+    RSpec.describe QueryContext do
+      let(:context) do
+        described_class.new(
+          query: instance_double(::GraphQL::Query, fingerprint: "GetColors/abc123"),
+          schema: Class.new(::GraphQL::Schema),
+          values: {}
+        )
+      end
+
+      describe "#[] and #fetch" do
+        it "raises a helpful error for a removed magic context key, directing to the replacement accessor" do
+          expect {
+            context[:monotonic_clock_deadline]
+          }.to raise_error(Errors::ConfigError, a_string_including("context.monotonic_clock_deadline"))
+
+          expect {
+            context.fetch(:monotonic_clock_deadline)
+          }.to raise_error(Errors::ConfigError, a_string_including("context.monotonic_clock_deadline"))
+        end
+
+        it "still works normally for keys that were never replaced by a typed accessor" do
+          context[:visibility_profile] = "public"
+
+          expect(context[:visibility_profile]).to eq("public")
+          expect(context.fetch(:visibility_profile)).to eq("public")
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_executor_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/query_executor_spec.rb
@@ -337,9 +337,7 @@ module ElasticGraph
             }
           QUERY
 
-          expect(submitted_query_context_for(query, timeout_in_ms: 500)).to include(
-            monotonic_clock_deadline: monontonic_now_time + 500
-          )
+          expect(submitted_query_context_for(query, timeout_in_ms: 500).monotonic_clock_deadline).to eq(monontonic_now_time + 500)
         end
 
         it "passes no `monotonic_clock_deadline` in `context` when no `timeout_in_ms` is provided" do
@@ -351,7 +349,7 @@ module ElasticGraph
             }
           QUERY
 
-          expect(submitted_query_context_for(query)).not_to include(:monotonic_clock_deadline)
+          expect(submitted_query_context_for(query).monotonic_clock_deadline).to be_nil
         end
 
         it "allows full introspection on all built-in schema types" do
@@ -397,7 +395,7 @@ module ElasticGraph
           it "includes extension data in the logged duration message" do
             # Simulate an extension setting data in the query tracker
             allow(::GraphQL::Execution::Interpreter).to receive(:run_all).and_wrap_original do |original, schema, queries, context:|
-              query_tracker = context[:elastic_graph_query_tracker]
+              query_tracker = context.elastic_graph_query_tracker
               query_tracker["custom_field"] = "custom_value"
               query_tracker["another_field"] = "another_value"
               original.call(schema, queries, context: context)

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/query_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/query_adapter_spec.rb
@@ -145,7 +145,7 @@ module ElasticGraph
           end
 
           it "passes along the `monotonic_clock_deadline` from the `context` to the query" do
-            datastore_query = build_query_from({}, context: {monotonic_clock_deadline: 1234})
+            datastore_query = build_query_from({}, monotonic_clock_deadline: 1234)
             expect(datastore_query.monotonic_clock_deadline).to eq 1234
           end
 
@@ -207,12 +207,13 @@ module ElasticGraph
             expect(child_widget_queries.map(&:__id__).uniq.size).to eq 2
           end
 
-          def build_query_from(args, field: self.field, context: {})
-            context = ::GraphQL::Query::Context.new(
+          def build_query_from(args, field: self.field, monotonic_clock_deadline: nil)
+            context = graphql.schema.graphql_schema.context_class.new(
               query: nil,
               schema: graphql.schema.graphql_schema,
-              values: context.merge(elastic_graph_schema: graphql.schema)
+              values: {}
             )
+            context.register_elastic_graph_values(monotonic_clock_deadline: monotonic_clock_deadline)
 
             query_adapter.build_query_from(
               field: field,

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/query_source_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/query_source_spec.rb
@@ -7,6 +7,7 @@
 # frozen_string_literal: true
 
 require "elastic_graph/graphql/client"
+require "elastic_graph/graphql/query_context"
 require "elastic_graph/graphql/resolvers/query_source"
 
 module ElasticGraph
@@ -21,11 +22,12 @@ module ElasticGraph
               extra_opaque_id_parts: ["tenant=acme"]
             )
             graphql_query = instance_double(::GraphQL::Query, fingerprint: "GetColors/abc123")
-            for_context = ::GraphQL::Query::Context.new(
+            for_context = QueryContext.new(
               query: graphql_query,
               schema: Class.new(::GraphQL::Schema),
-              values: {elastic_graph_client: client}
+              values: {}
             )
+            for_context.register_elastic_graph_values(elastic_graph_client: client)
 
             parts = QuerySource.send(:datastore_opaque_id_parts_for, for_context)
 

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection_spec.rb
@@ -6,6 +6,7 @@
 #
 # frozen_string_literal: true
 
+require "elastic_graph/graphql/query_context"
 require "elastic_graph/graphql/resolvers/relay_connection"
 require "support/aggregations_helpers"
 
@@ -62,7 +63,7 @@ module ElasticGraph
 
             graphql = build_graphql(schema_artifacts: schema_artifacts)
             field = graphql.schema.field_named("Query", field_name)
-            context = {elastic_graph_schema: graphql.schema}
+            context = instance_double(QueryContext, elastic_graph_schema: graphql.schema)
 
             lookahead = ::GraphQL::Execution::Lookahead.new(
               query: nil,

--- a/elasticgraph-query_interceptor/lib/elastic_graph/query_interceptor/datastore_query_adapter.rb
+++ b/elasticgraph-query_interceptor/lib/elastic_graph/query_interceptor/datastore_query_adapter.rb
@@ -17,7 +17,9 @@ module ElasticGraph
       end
 
       def call(query:, args:, lookahead:, field:, context:)
-        http_request = context[:http_request]
+        # This extension is only usable in HTTP-serving deployments (per the `_Interceptor#intercept`
+        # interface, which requires `http_request:`), so `http_request` is always present here.
+        http_request = context.http_request # : GraphQL::HTTPRequest
 
         interceptors.reduce(query) do |accum, interceptor|
           interceptor.intercept(accum, field: field, args: args, http_request: http_request, context: context)

--- a/elasticgraph-query_interceptor/sig/elastic_graph/query_interceptor/config.rbs
+++ b/elasticgraph-query_interceptor/sig/elastic_graph/query_interceptor/config.rbs
@@ -47,7 +47,7 @@ module ElasticGraph
         field: GraphQL::Schema::Field,
         args: ::Hash[::String, untyped],
         http_request: GraphQL::HTTPRequest,
-        context: ::GraphQL::Query::Context
+        context: GraphQL::QueryContext
       ) -> GraphQL::DatastoreQuery
     end
   end

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/graphql_extension.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/graphql_extension.rb
@@ -59,16 +59,18 @@ module ElasticGraph
 
       private
 
-      def build_and_execute_query(query_string:, variables:, operation_name:, context:, client:)
+      def build_and_execute_query(query_string:, variables:, operation_name:, context:, client:, monotonic_clock_deadline:, http_request:)
         query, errors, registration_status = @registry.build_and_validate_query(
           query_string,
           variables: variables,
           operation_name: operation_name,
           context: context,
-          client: client
+          client: client,
+          monotonic_clock_deadline: monotonic_clock_deadline,
+          http_request: http_request
         )
 
-        context.fetch(:elastic_graph_query_tracker)["query_registration_status"] = registration_status
+        query.context.elastic_graph_query_tracker["query_registration_status"] = registration_status
 
         if errors.empty?
           [query, execute_query(query, client: client)]

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/query_validators/for_registered_client.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/query_validators/for_registered_client.rb
@@ -40,11 +40,19 @@ module ElasticGraph
           client_data_by_client_name.key?(client_name)
         end
 
-        def build_and_validate_query(query_string, client:, variables: {}, operation_name: nil, context: {})
+        def build_and_validate_query(query_string, client:, variables: {}, operation_name: nil, context: {}, monotonic_clock_deadline: nil, http_request: nil)
           client_data = client_data_for(client.name)
 
           if (cached_query = client_data.cached_query_for(query_string.to_s))
-            prepared_query = prepare_query_for_execution(cached_query, variables: variables, operation_name: operation_name, context: context)
+            prepared_query = prepare_query_for_execution(
+              cached_query,
+              client: client,
+              variables: variables,
+              operation_name: operation_name,
+              context: context,
+              monotonic_clock_deadline: monotonic_clock_deadline,
+              http_request: http_request
+            )
             return [prepared_query, [], RegistrationStatus::MATCHED_REGISTERED_QUERY]
           end
 
@@ -82,7 +90,7 @@ module ElasticGraph
           # to be in that alternate form every single time, so caching it can be a nice win.
           atomically_update_cached_client_data_for(client.name) do |cached_client_data|
             # We don't want the cached form of the query to persist the current variables, context, etc being used for this request.
-            cachable_query = prepare_query_for_execution(query, variables: {}, operation_name: nil, context: {})
+            cachable_query = prepare_query_for_execution(query, client: client, variables: {}, operation_name: nil, context: {})
 
             # We use `_` here because Steep believes `client_data` could be nil. In general, this is
             # true; it can be nil, but not at this callsite, because we are in a branch that is only
@@ -90,7 +98,15 @@ module ElasticGraph
             (_ = cached_client_data).with_updated_last_query(query_string, cachable_query)
           end
 
-          prepared_query = prepare_query_for_execution(query, variables: variables, operation_name: operation_name, context: context)
+          prepared_query = prepare_query_for_execution(
+            query,
+            client: client,
+            variables: variables,
+            operation_name: operation_name,
+            context: context,
+            monotonic_clock_deadline: monotonic_clock_deadline,
+            http_request: http_request
+          )
 
           [prepared_query, [], registration_status]
         end
@@ -122,8 +138,8 @@ module ElasticGraph
           end
         end
 
-        def prepare_query_for_execution(query, variables:, operation_name:, context:)
-          schema.new_graphql_query(
+        def prepare_query_for_execution(query, client:, variables:, operation_name:, context:, monotonic_clock_deadline: nil, http_request: nil)
+          new_query = schema.new_graphql_query(
             # Here we pass `document` instead of query string, so that we don't have to re-parse the query.
             # However, when the document is nil, we still need to pass the query string.
             query.document ? nil : query.query_string,
@@ -139,6 +155,12 @@ module ElasticGraph
             # are still reported as errors on every request.
             validate: false
           )
+          new_query.context.register_elastic_graph_values(
+            monotonic_clock_deadline: monotonic_clock_deadline,
+            elastic_graph_client: client,
+            http_request: http_request
+          )
+          new_query
         end
       end
     end

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/query_validators/for_unregistered_client.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/query_validators/for_unregistered_client.rb
@@ -14,7 +14,7 @@ module ElasticGraph
       # Query validator implementation used for unregistered or anonymous clients.
       ForUnregisteredClient = ::Data.define(:allow_unregistered_clients, :allow_any_query_for_clients) do
         # @implements ForUnregisteredClient
-        def build_and_validate_query(query_string, client:, variables: {}, operation_name: nil, context: {})
+        def build_and_validate_query(query_string, client:, variables: {}, operation_name: nil, context: {}, monotonic_clock_deadline: nil, http_request: nil)
           query = yield
 
           return [query, [], RegistrationStatus::UNREGISTERED_CLIENT] if allow_unregistered_clients

--- a/elasticgraph-query_registry/lib/elastic_graph/query_registry/registry.rb
+++ b/elasticgraph-query_registry/lib/elastic_graph/query_registry/registry.rb
@@ -59,7 +59,7 @@ module ElasticGraph
       # This is also tolerant of some minimal differences in the query string (such as comments
       # and whitespace). If the query differs in a significant way from a registered query, it
       # will not be recognized as registered.
-      def build_and_validate_query(query_string, client:, variables: {}, operation_name: nil, context: {})
+      def build_and_validate_query(query_string, client:, variables: {}, operation_name: nil, context: {}, monotonic_clock_deadline: nil, http_request: nil)
         validator =
           if @registered_client_validator.applies_to?(client)
             @registered_client_validator
@@ -67,13 +67,27 @@ module ElasticGraph
             @unregistered_client_validator
           end
 
-        validator.build_and_validate_query(query_string, client: client, variables: variables, operation_name: operation_name, context: context) do
-          @schema.new_graphql_query(
+        validator.build_and_validate_query(
+          query_string,
+          client: client,
+          variables: variables,
+          operation_name: operation_name,
+          context: context,
+          monotonic_clock_deadline: monotonic_clock_deadline,
+          http_request: http_request
+        ) do
+          query = @schema.new_graphql_query(
             query_string,
             variables: variables,
             operation_name: operation_name,
             context: context
           )
+          query.context.register_elastic_graph_values(
+            monotonic_clock_deadline: monotonic_clock_deadline,
+            elastic_graph_client: client,
+            http_request: http_request
+          )
+          query
         end
       end
 

--- a/elasticgraph-query_registry/sig/elastic_graph/query_registry/query_validators/for_registered_client.rbs
+++ b/elasticgraph-query_registry/sig/elastic_graph/query_registry/query_validators/for_registered_client.rbs
@@ -32,7 +32,9 @@ module ElasticGraph
           client: GraphQL::Client,
           ?variables: ::Hash[::String, untyped],
           ?operation_name: ::String?,
-          ?context: ::Hash[::Symbol, untyped]
+          ?context: ::Hash[::Symbol, untyped],
+          ?monotonic_clock_deadline: ::Integer?,
+          ?http_request: GraphQL::HTTPRequest?
         ) { () -> ::GraphQL::Query } -> [::GraphQL::Query, ::Array[::String], ::String]
 
         private
@@ -42,9 +44,12 @@ module ElasticGraph
 
         def prepare_query_for_execution: (
           ::GraphQL::Query,
+          client: GraphQL::Client,
           variables: ::Hash[::String, untyped],
           operation_name: ::String?,
-          context: ::Hash[::Symbol, untyped]
+          context: ::Hash[::Symbol, untyped],
+          ?monotonic_clock_deadline: ::Integer?,
+          ?http_request: GraphQL::HTTPRequest?
         ) -> ::GraphQL::Query
       end
     end

--- a/elasticgraph-query_registry/sig/elastic_graph/query_registry/query_validators/for_unregistered_client.rbs
+++ b/elasticgraph-query_registry/sig/elastic_graph/query_registry/query_validators/for_unregistered_client.rbs
@@ -15,7 +15,9 @@ module ElasticGraph
           client: GraphQL::Client,
           ?variables: ::Hash[::String, untyped],
           ?operation_name: ::String?,
-          ?context: ::Hash[::Symbol, untyped]
+          ?context: ::Hash[::Symbol, untyped],
+          ?monotonic_clock_deadline: ::Integer?,
+          ?http_request: GraphQL::HTTPRequest?
         ) { () -> ::GraphQL::Query } -> [::GraphQL::Query, ::Array[::String], ::String]
       end
     end

--- a/elasticgraph-query_registry/sig/elastic_graph/query_registry/registry.rbs
+++ b/elasticgraph-query_registry/sig/elastic_graph/query_registry/registry.rbs
@@ -21,7 +21,9 @@ module ElasticGraph
         client: GraphQL::Client,
         ?variables: ::Hash[::String, untyped],
         ?operation_name: ::String?,
-        ?context: ::Hash[::Symbol, untyped]
+        ?context: ::Hash[::Symbol, untyped],
+        ?monotonic_clock_deadline: ::Integer?,
+        ?http_request: GraphQL::HTTPRequest?
       ) -> [::GraphQL::Query, ::Array[::String], ::String]
 
       private

--- a/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/graphql_resolver.rbs
+++ b/elasticgraph-schema_artifacts/sig/elastic_graph/schema_artifacts/runtime_metadata/graphql_resolver.rbs
@@ -49,7 +49,7 @@ module ElasticGraph
     def resolve: (
       field: ElasticGraph::GraphQL::Schema::Field,
       object: untyped,
-      context: ::GraphQL::Query::Context,
+      context: ElasticGraph::GraphQL::QueryContext,
       args: ::Hash[::String, untyped],
       lookahead: ::GraphQL::Execution::Lookahead
     ) { () -> ElasticGraph::GraphQL::DatastoreQuery } -> untyped
@@ -59,7 +59,7 @@ module ElasticGraph
     def resolve: (
       field: ElasticGraph::GraphQL::Schema::Field,
       object: untyped,
-      context: ::GraphQL::Query::Context,
+      context: ElasticGraph::GraphQL::QueryContext,
       args: ::Hash[::String, untyped]
     ) -> untyped
   end


### PR DESCRIPTION
## Summary
- Replaces untyped GraphQL context hash keys (`:elastic_graph_schema`, `:datastore_search_router`, `:datastore_query_cache`, `:elastic_graph_query_tracker`, `:monotonic_clock_deadline`, `:elastic_graph_client`, `:http_request`) with typed accessors on a new `ElasticGraph::GraphQL::QueryContext < GraphQL::Query::Context`.
- `QueryContext.new_class` closes an anonymous subclass over `elastic_graph_schema`/`datastore_search_router`, registered as the schema's `context_class`.
- `monotonic_clock_deadline`/`elastic_graph_client`/`http_request` are read-only attrs set once via `QueryContext#register_elastic_graph_values` (defaults: `elastic_graph_client: Client::ANONYMOUS`, others `nil`), called by each query-building call site immediately after building the query.
- `:visibility_profile` stays in the context hash since it's needed at schema-boot time, before a `QueryContext` exists.
- No behavior change; no dedicated unit spec (existing seam-level specs already give 100% coverage).

Closes #1339

## Test plan
- [x] `script/lint`
- [x] `script/type_check`
- [x] `script/run_gem_specs elasticgraph-graphql` (100% coverage)
- [x] `script/run_gem_specs elasticgraph-apollo` (100% coverage)
- [x] `script/run_gem_specs elasticgraph-query_registry` (100% coverage)
- [x] `script/run_gem_specs elasticgraph-query_interceptor` (100% coverage)
- [x] `script/quick_build`