### PR TITLE
Memoize sourced_from update target resolution on Results

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/results.rb
@@ -55,6 +55,11 @@ module ElasticGraph
           .to_set
       end
 
+      # @private
+      def sourced_update_targets_by_source_type_name
+        @sourced_update_targets_by_source_type_name ||= Indexing::SourcedFromUpdateTargetsResolver.new(state).resolve
+      end
+
       private
 
       def after_initialize
@@ -89,7 +94,9 @@ module ElasticGraph
       end
 
       def build_runtime_metadata
-        sourced_update_targets_by_source_type_name = Indexing::SourcedFromUpdateTargetsResolver.new(state).resolve
+        # Resolve `sourced_from` update targets before touching `all_types` so that `sourced_from`
+        # validation errors take precedence over any errors raised while generating derived types.
+        sourced_update_targets_by_source_type_name = self.sourced_update_targets_by_source_type_name
 
         object_types_by_name = all_types
           .select { |t| t.respond_to?(:graphql_fields_by_name) }

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/results.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/results.rbs
@@ -12,6 +12,7 @@ module ElasticGraph
       def datastore_config: () -> ::Hash[::String, untyped]
       def runtime_metadata: () -> SchemaArtifacts::RuntimeMetadata::Schema
       def derived_indexing_type_names: () -> ::Set[::String]
+      def sourced_update_targets_by_source_type_name: () -> ::Hash[::String, ::Array[SchemaArtifacts::RuntimeMetadata::UpdateTarget]]
 
       @graphql_schema_string: ::String?
       @datastore_config: ::Hash[::String, untyped]
@@ -20,6 +21,7 @@ module ElasticGraph
       @no_circular_dependencies: bool?
       @field_path_resolver: SchemaElements::FieldPath::Resolver?
       @derived_indexing_type_names: ::Set[::String]?
+      @sourced_update_targets_by_source_type_name: ::Hash[::String, ::Array[SchemaArtifacts::RuntimeMetadata::UpdateTarget]]?
 
       STATIC_SCRIPT_REPO: Scripting::FileSystemRepository
 


### PR DESCRIPTION
## Summary

Pure refactor, no behavior change: extracts the inline `Indexing::SourcedFromUpdateTargetsResolver.new(state).resolve` call in `Results#build_runtime_metadata` into a memoized `Results#sourced_update_targets_by_source_type_name` method, following the existing `derived_indexing_type_names` pattern.

## Motivation
First step toward #1273. Supporting unindexed `sourced_from` source types requires the JSON schema event envelope (generated in `elasticgraph-json_ingestion`) to include source type names in its `type` enum — and that set is exactly the keys of this resolver's result. Memoizing it on `Results` lets a follow-up PR consume it from `ResultsExtension` (the same way `derived_indexing_type_names` is consumed today) without running a second resolver pass.
 
 ## Notes
 `build_runtime_metadata` still invokes the resolver eagerly before materializing `all_types` — the ordering matters so that `sourced_from` validation errors take precedence over errors raised during derived-type generation. A comment now documents this previously-implicit constraint; two existing specs guard it.