### PR TITLE
Allow indexing_only relationships to reference non-indexed source types

### DIFF
--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/relationship_resolver.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/relationship_resolver.rb
@@ -36,8 +36,12 @@ module ElasticGraph
               end
 
             [nil, "#{relationship_error_prefix} #{issue}"]
-          elsif !related_type.root_document_type?
-            [nil, "#{relationship_error_prefix} references a type which is not a root document type: `#{related_type.name}`. Only root document types can be used in relations."]
+          elsif !related_type.root_document_type? && !relationship.indexing_only
+            [nil, "#{relationship_error_prefix} references a type which is not a root document type: `#{related_type.name}`. " \
+              "Only root document types can be used in relations exposed to GraphQL. To relate to a non-indexed source type " \
+              "purely for indexing purposes (e.g. `sourced_from`), declare the relationship with `indexing_only: true`."]
+          elsif (id_field_error = validate_non_indexed_related_type_id_field(related_type))
+            [nil, id_field_error]
           else
             relation_metadata = relationship.runtime_metadata # : SchemaArtifacts::RuntimeMetadata::Relation
             foreign_key_parent_type = (relation_metadata.direction == :in) ? related_type : object_type
@@ -65,6 +69,18 @@ module ElasticGraph
             end
 
           "`#{relationship_description}`#{sourced_fields_description}"
+        end
+
+        # A non-indexed related type never goes through the `id` validation that `t.index` performs on indexed
+        # types, but relationships join on `id`, so we must verify it here.
+        def validate_non_indexed_related_type_id_field(related_type)
+          return nil if related_type.root_document_type?
+
+          id_field = schema_def_state.field_path_resolver.resolve_public_path(related_type, "id") { true }
+          return nil if id_field
+
+          "#{relationship_error_prefix} references `#{related_type.name}`, which lacks an `id` field. Related types " \
+            "must define an `id` field since relationships join on it."
         end
 
         def validate_foreign_key(foreign_key_parent_type, relation_metadata)

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/relationship_resolver.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/relationship_resolver.rbs
@@ -19,6 +19,7 @@ module ElasticGraph
         attr_reader sourced_fields: ::Array[SchemaElements::Field]
 
         def relationship_error_prefix: () -> ::String
+        def validate_non_indexed_related_type_id_field: (indexableType) -> ::String?
         def validate_foreign_key: (
           indexableType,
           SchemaArtifacts::RuntimeMetadata::Relation

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/update_targets_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/runtime_metadata/object_types_by_name/update_targets_spec.rb
@@ -732,7 +732,7 @@ module ElasticGraph
               )
             end
 
-            it "raises an error if the related type exists but is a non-indexed object type, regardless of whether there are any `sourced_from` fields or not" do
+            it "raises an error if the related type exists but is a non-indexed object type on a GraphQL-exposed relationship, regardless of whether there are any `sourced_from` fields or not" do
               expect {
                 update_targets_for("Widget", index_widget_workspaces: false) do |t|
                   t.relates_to_one "workspace", "WidgetWorkspace", via: "widget_ids", dir: :in
@@ -746,7 +746,7 @@ module ElasticGraph
                   end
                 end
               }.to raise_error_about_workspace_relationship(
-                "references a type which is not a root document type: `WidgetWorkspace`. Only root document types can be used in relations."
+                "references a type which is not a root document type: `WidgetWorkspace`. Only root document types can be used in relations exposed to GraphQL."
               )
 
               expect {
@@ -755,8 +755,46 @@ module ElasticGraph
                   expect(t.fields_with_sources).to be_empty
                 end
               }.to raise_error_about_workspace_relationship(
-                "references a type which is not a root document type: `WidgetWorkspace`. Only root document types can be used in relations.",
+                "references a type which is not a root document type: `WidgetWorkspace`. Only root document types can be used in relations exposed to GraphQL.",
                 sourced_fields: false
+              )
+            end
+
+            it "allows an `indexing_only: true` relationship to reference a non-indexed object type, so `sourced_from` source types need not be indexed" do
+              update_targets = update_targets_for("WidgetWorkspace", index_widget_workspaces: false) do |t|
+                t.relates_to_one "workspace", "WidgetWorkspace", via: "widget_ids", dir: :in, indexing_only: true
+
+                t.field "workspace_name", "String" do |f|
+                  f.sourced_from "workspace", "name"
+                end
+              end
+
+              expect_widget_update_target_with(
+                update_targets,
+                id_source: "widget_ids",
+                routing_value_source: nil,
+                relationship: "workspace",
+                top_level_fields_params: {
+                  "workspace_name" => dynamic_param_with(source_path: "name", cardinality: :one)
+                }
+              )
+            end
+
+            it "raises an error if a non-indexed related type lacks an `id` field, since relationships join on `id` and non-indexed types skip the `id` validation `t.index` performs" do
+              expect {
+                update_targets_for("Widget", index_widget_workspaces: false, define_widget_workspace_id: false) do |t|
+                  t.relates_to_one "workspace", "WidgetWorkspace", via: "widget_ids", dir: :in, indexing_only: true
+
+                  t.field "workspace_name", "String" do |f|
+                    f.sourced_from "workspace", "name"
+                  end
+
+                  t.field "workspace_created_at", "DateTime" do |f|
+                    f.sourced_from "workspace", "created_at"
+                  end
+                end
+              }.to raise_error_about_workspace_relationship(
+                "references `WidgetWorkspace`, which lacks an `id` field. Related types must define an `id` field since relationships join on it."
               )
             end
 
@@ -2039,6 +2077,7 @@ module ElasticGraph
           on_widgets_index: nil,
           on_widget_workspace_type: nil,
           index_widget_workspaces: true,
+          define_widget_workspace_id: true,
           type_name_overrides: {},
           &define_relation_and_sourced_from_fields
         )
@@ -2086,7 +2125,7 @@ module ElasticGraph
             end
 
             s.object_type "WidgetWorkspace" do |t|
-              t.field "id", "ID!"
+              t.field "id", "ID!" if define_widget_workspace_id
               t.field "workspace_owner_id", "ID!"
               t.field "name", widget_workspace_name, **widget_workspace_name_opts
               t.field "created_at", widget_workspace_created_at


### PR DESCRIPTION
## Summary

Second step toward #1273 (stacked on #1342). Allows an `indexing_only: true` relationship to reference a non-indexed object type, so that a `sourced_from` source type will no longer be required to have its own index.

Relationships serve two distinct jobs today:

1. GraphQL navigation (query time): the generated relationship field resolves by searching the related type's index. This genuinely requires the related type to be indexed.
2. `sourced_from` routing (indexing time): the relationship's foreign key metadata routes source events to the destination type's documents. The source type's own index is never touched.

The previous validation ("Only root document types can be used in relations") applied the job-1 requirement to both jobs. This PR scopes it to job 1: GraphQL-exposed relationships still require an indexed related type (with an updated error message that explains why), while `indexing_only: true` relationships may now reference a non-indexed type.

## New id validation

Allowing non-indexed related types opens a validation gap. "Indexed types must have an `id` field" is enforced as a side effect of `t.index` — so until now, source types (being necessarily indexed) always had `id` guaranteed transitively. A non-indexed source type skips that check entirely, but relationships join on `id` non-negotiably: the source event's `id` drives per-source-record version tracking on destination documents, and nested `sourced_from` matches list elements by `id`. Without a check, a missing `id` would surface as confusing ingestion-time failures far from the actual mistake.

This PR adds the corresponding schema-definition-time validation in `RelationshipResolver`: a non-indexed related type must define an `id` field, reported with the standard relationship error context. Indexed related types are unaffected (they're already validated via `t.index`).

## Note on scope

This PR makes such schemas _definable_, but events for a non-indexed source type are still rejected at ingestion: the event envelope's `type` enum in `json_schemas.yaml` only includes indexed types. Widening that to "ingestable types" (indexed types + `sourced_from` source types) is the next PR in the stack.