### PR TITLE
Let a lookahead resolver record an error for a descendant field

### DIFF
--- a/benchmarks/graphql/lookahead_error_check.rb
+++ b/benchmarks/graphql/lookahead_error_check.rb
@@ -1,0 +1,165 @@
+#!/usr/bin/env ruby
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+# Benchmarks the per-field cost `QueryContext#matching_lookahead_error` (#1340) adds to every
+# field resolution, for the overwhelmingly common query that never records a lookahead error.
+#
+# `Resolvers::GraphQLAdapterBuilder` calls `context.matching_lookahead_error` at the top of both
+# resolver lambdas it builds, i.e. for effectively every field ElasticGraph resolves. This compares
+# three variants of that call:
+#
+# - "before" — no call at all, i.e. `main` prior to #1340.
+# - "unguarded" — #1340 as originally written: unconditionally builds `context.current_path`
+#   (which allocates) before checking the (empty, in the common case) recorded-errors array.
+# - "guarded" — the shipped fix: returns immediately, without building `current_path` or
+#   allocating a `LookaheadErrors` collector, when no error was ever recorded for this query.
+#
+# Each variant is exercised through real `GraphQL::Schema#execute`, not a microbenchmark of the
+# method in isolation, so the numbers reflect the added cost relative to total field-resolution
+# time (schema/query overhead, hash allocation for the response, etc.), not the method alone.
+#
+# Run with:
+#   bundle exec ruby benchmarks/graphql/lookahead_error_check.rb
+
+require "benchmark/ips"
+require "graphql"
+
+# A stand-in for `ElasticGraph::GraphQL::LookaheadErrors`: never has any records in this benchmark
+# (we're measuring the no-error-recorded path), but matches its real shape (`Array#find` over
+# `@records`) so the "unguarded" variant pays the same cost that path pays in production.
+class FakeLookaheadErrors
+  def initialize
+    @records = []
+  end
+
+  def matching_error_for(current_path)
+    @records.find { |r| r.matches?(current_path) }
+  end
+end
+
+class BeforeContext < ::GraphQL::Query::Context
+end
+
+class UnguardedContext < ::GraphQL::Query::Context
+  def matching_lookahead_error
+    current_path = self.current_path
+    lookahead_errors.matching_error_for(current_path)
+  end
+
+  def lookahead_errors
+    @lookahead_errors ||= FakeLookaheadErrors.new
+  end
+end
+
+class GuardedContext < ::GraphQL::Query::Context
+  def matching_lookahead_error
+    return nil unless (lookahead_errors = @lookahead_errors)
+    current_path = self.current_path
+    lookahead_errors.matching_error_for(current_path)
+  end
+end
+
+# Builds a schema with many leaf fields, whose resolvers call `context.matching_lookahead_error`
+# (for `context_class`es that define it) before returning a static value, mirroring exactly what
+# `GraphQLAdapterBuilder`'s resolver lambdas do around the actual resolver call.
+def build_schema(context_class:, num_fields:, check_lookahead_error:)
+  field_defs = (1..num_fields).map { |i| "f#{i}" }
+
+  leaf_type = Class.new(::GraphQL::Schema::Object) do
+    graphql_name "Leaf#{context_class}"
+    field_defs.each do |name|
+      field name, String, null: true
+      define_method(name) do
+        context.matching_lookahead_error if check_lookahead_error
+        "value"
+      end
+    end
+  end
+
+  container_type = Class.new(::GraphQL::Schema::Object) do
+    graphql_name "Container#{context_class}"
+    field :leaf, leaf_type, null: true
+    define_method(:leaf) do
+      context.matching_lookahead_error if check_lookahead_error
+      :leaf
+    end
+  end
+
+  query_type = Class.new(::GraphQL::Schema::Object) do
+    graphql_name "Query#{context_class}"
+    field :container, container_type, null: true
+    define_method(:container) do
+      context.matching_lookahead_error if check_lookahead_error
+      :container
+    end
+  end
+
+  Class.new(::GraphQL::Schema) do
+    query(query_type)
+    context_class(context_class)
+  end
+end
+
+# Builds a query selecting `num_leaves` leaf fields, aliasing repeatedly into the fixed
+# `leaf_field_names` pool once `num_leaves` exceeds it--this is what lets `num_leaves` scale into
+# the hundreds of thousands without needing a schema with that many distinct field definitions.
+def build_query(num_leaves:, leaf_field_names:)
+  selections = (0...num_leaves).map { |i| "  a#{i}: #{leaf_field_names[i % leaf_field_names.size]}" }.join("\n")
+  <<~GRAPHQL
+    query BenchQuery {
+      container {
+        leaf {
+    #{selections}
+        }
+      }
+    }
+  GRAPHQL
+end
+
+# `num_fields` is the size of the schema's actual field-definition pool (kept small--building the
+# schema itself, not just executing queries against it, has a real cost); `num_leaves` is how many
+# times the benchmark query selects (via aliases) into that pool.
+configs = [
+  {label: "small", num_fields: 10, num_leaves: 5},
+  {label: "medium", num_fields: 50, num_leaves: 25},
+  {label: "large", num_fields: 150, num_leaves: 100},
+  {label: "xlarge", num_fields: 500, num_leaves: 500},
+  {label: "5000 leaves", num_fields: 50, num_leaves: 5_000},
+  {label: "50000 leaves", num_fields: 50, num_leaves: 50_000},
+  {label: "500000 leaves", num_fields: 50, num_leaves: 500_000}
+]
+
+configs.each do |config|
+  leaf_field_names = (1..config[:num_fields]).map { |i| "f#{i}" }
+  query_string = build_query(num_leaves: config[:num_leaves], leaf_field_names: leaf_field_names)
+
+  before_schema = build_schema(context_class: BeforeContext, num_fields: config[:num_fields], check_lookahead_error: false)
+  unguarded_schema = build_schema(context_class: UnguardedContext, num_fields: config[:num_fields], check_lookahead_error: true)
+  guarded_schema = build_schema(context_class: GuardedContext, num_fields: config[:num_fields], check_lookahead_error: true)
+
+  [before_schema, unguarded_schema, guarded_schema].each do |schema|
+    result = schema.execute(query_string)
+    abort "query is not valid — check benchmark setup: #{result["errors"]}" if result["errors"]
+  end
+
+  puts
+  puts "=" * 70
+  puts "#{config[:label]} — #{config[:num_leaves]} leaf fields resolved per query"
+  puts "=" * 70
+
+  Benchmark.ips do |x|
+    x.config(time: 5, warmup: 2)
+
+    x.report("before (no check, main)") { before_schema.execute(query_string) }
+    x.report("unguarded (#1340 as written)") { unguarded_schema.execute(query_string) }
+    x.report("guarded (shipped fix)") { guarded_schema.execute(query_string) }
+
+    x.compare!
+  end
+end

--- a/benchmarks/graphql/lookahead_error_check.results.txt
+++ b/benchmarks/graphql/lookahead_error_check.results.txt
@@ -1,0 +1,133 @@
+
+======================================================================
+small — 5 leaf fields resolved per query
+======================================================================
+ruby 4.0.0 (2025-12-25 revision 553f1675f3) +PRISM [arm64-darwin25]
+Warming up --------------------------------------
+     before (no check, main)   653.000 i/100ms
+unguarded (#1340 as written)   636.000 i/100ms
+       guarded (shipped fix)   658.000 i/100ms
+Calculating -------------------------------------
+     before (no check, main)      6.350k (± 5.5%) i/s  (157.49 μs/i) -     31.997k in   5.039166s
+unguarded (#1340 as written)      6.039k (± 5.7%) i/s  (165.59 μs/i) -     30.528k in   5.055148s
+       guarded (shipped fix)      6.325k (± 4.3%) i/s  (158.11 μs/i) -     32.242k in   5.097622s
+
+Comparison:
+     before (no check, main):     6349.7 i/s
+       guarded (shipped fix):     6324.9 i/s - same-ish: difference falls within error
+unguarded (#1340 as written):     6039.0 i/s - same-ish: difference falls within error
+
+
+======================================================================
+medium — 25 leaf fields resolved per query
+======================================================================
+ruby 4.0.0 (2025-12-25 revision 553f1675f3) +PRISM [arm64-darwin25]
+Warming up --------------------------------------
+     before (no check, main)   341.000 i/100ms
+unguarded (#1340 as written)   330.000 i/100ms
+       guarded (shipped fix)   276.000 i/100ms
+Calculating -------------------------------------
+     before (no check, main)      3.396k (± 3.7%) i/s  (294.44 μs/i) -     17.050k in   5.020214s
+unguarded (#1340 as written)      3.233k (± 3.3%) i/s  (309.26 μs/i) -     16.170k in   5.000779s
+       guarded (shipped fix)      3.332k (± 4.5%) i/s  (300.08 μs/i) -     16.836k in   5.052123s
+
+Comparison:
+     before (no check, main):     3396.3 i/s
+       guarded (shipped fix):     3332.5 i/s - same-ish: difference falls within error
+unguarded (#1340 as written):     3233.5 i/s - same-ish: difference falls within error
+
+
+======================================================================
+large — 100 leaf fields resolved per query
+======================================================================
+ruby 4.0.0 (2025-12-25 revision 553f1675f3) +PRISM [arm64-darwin25]
+Warming up --------------------------------------
+     before (no check, main)   129.000 i/100ms
+unguarded (#1340 as written)   124.000 i/100ms
+       guarded (shipped fix)   128.000 i/100ms
+Calculating -------------------------------------
+     before (no check, main)      1.277k (± 3.2%) i/s  (782.87 μs/i) -      6.450k in   5.049535s
+unguarded (#1340 as written)      1.220k (± 2.9%) i/s  (819.39 μs/i) -      6.200k in   5.080219s
+       guarded (shipped fix)      1.220k (± 3.8%) i/s  (820.00 μs/i) -      6.144k in   5.038067s
+
+Comparison:
+     before (no check, main):     1277.3 i/s
+unguarded (#1340 as written):     1220.4 i/s - same-ish: difference falls within error
+       guarded (shipped fix):     1219.5 i/s - same-ish: difference falls within error
+
+
+======================================================================
+xlarge — 500 leaf fields resolved per query
+======================================================================
+ruby 4.0.0 (2025-12-25 revision 553f1675f3) +PRISM [arm64-darwin25]
+Warming up --------------------------------------
+     before (no check, main)    21.000 i/100ms
+unguarded (#1340 as written)     8.000 i/100ms
+       guarded (shipped fix)    23.000 i/100ms
+Calculating -------------------------------------
+     before (no check, main)    256.320 (± 2.3%) i/s    (3.90 ms/i) -      1.302k in   5.079591s
+unguarded (#1340 as written)    250.039 (± 3.6%) i/s    (4.00 ms/i) -      1.256k in   5.023210s
+       guarded (shipped fix)    267.284 (± 3.4%) i/s    (3.74 ms/i) -      1.357k in   5.077001s
+
+Comparison:
+       guarded (shipped fix):      267.3 i/s
+     before (no check, main):      256.3 i/s - same-ish: difference falls within error
+unguarded (#1340 as written):      250.0 i/s - same-ish: difference falls within error
+
+
+======================================================================
+5000 leaves — 5000 leaf fields resolved per query
+======================================================================
+ruby 4.0.0 (2025-12-25 revision 553f1675f3) +PRISM [arm64-darwin25]
+Warming up --------------------------------------
+     before (no check, main)     3.000 i/100ms
+unguarded (#1340 as written)     2.000 i/100ms
+       guarded (shipped fix)     3.000 i/100ms
+Calculating -------------------------------------
+     before (no check, main)     30.697 (± 3.3%) i/s   (32.58 ms/i) -    156.000 in   5.081942s
+unguarded (#1340 as written)     28.986 (± 3.4%) i/s   (34.50 ms/i) -    146.000 in   5.036878s
+       guarded (shipped fix)     30.702 (± 3.3%) i/s   (32.57 ms/i) -    156.000 in   5.081034s
+
+Comparison:
+       guarded (shipped fix):       30.7 i/s
+     before (no check, main):       30.7 i/s - same-ish: difference falls within error
+unguarded (#1340 as written):       29.0 i/s - same-ish: difference falls within error
+
+
+======================================================================
+50000 leaves — 50000 leaf fields resolved per query
+======================================================================
+ruby 4.0.0 (2025-12-25 revision 553f1675f3) +PRISM [arm64-darwin25]
+Warming up --------------------------------------
+     before (no check, main)     1.000 i/100ms
+unguarded (#1340 as written)     1.000 i/100ms
+       guarded (shipped fix)     1.000 i/100ms
+Calculating -------------------------------------
+     before (no check, main)      3.115 (± 0.0%) i/s  (321.01 ms/i) -     16.000 in   5.136164s
+unguarded (#1340 as written)      2.919 (± 0.0%) i/s  (342.63 ms/i) -     15.000 in   5.139388s
+       guarded (shipped fix)      2.959 (± 0.0%) i/s  (338.00 ms/i) -     15.000 in   5.069968s
+
+Comparison:
+     before (no check, main):        3.1 i/s
+       guarded (shipped fix):        3.0 i/s - 1.05x  slower
+unguarded (#1340 as written):        2.9 i/s - 1.07x  slower
+
+
+======================================================================
+500000 leaves — 500000 leaf fields resolved per query
+======================================================================
+ruby 4.0.0 (2025-12-25 revision 553f1675f3) +PRISM [arm64-darwin25]
+Warming up --------------------------------------
+     before (no check, main)     1.000 i/100ms
+unguarded (#1340 as written)     1.000 i/100ms
+       guarded (shipped fix)     1.000 i/100ms
+Calculating -------------------------------------
+     before (no check, main)      0.271 (± 0.0%) i/s     (3.69 s/i) -      2.000 in   7.374854s
+unguarded (#1340 as written)      0.264 (± 0.0%) i/s     (3.79 s/i) -      2.000 in   7.570256s
+       guarded (shipped fix)      0.274 (± 0.0%) i/s     (3.65 s/i) -      2.000 in   7.293748s
+
+Comparison:
+       guarded (shipped fix):        0.3 i/s
+     before (no check, main):        0.3 i/s - 1.01x  slower
+unguarded (#1340 as written):        0.3 i/s - 1.04x  slower
+

--- a/docs/adr/0001-lookahead-error-record-key.md
+++ b/docs/adr/0001-lookahead-error-record-key.md
@@ -1,0 +1,55 @@
+# Identify lookahead errors by response path, not by field or AST node
+
+A resolver that builds its datastore query from a lookahead can discover that a *descendant* field is
+invalid (e.g. `approximatePercentile(percentile: 150)`). It cannot raise `GraphQL::ExecutionError` for
+that descendant — the raise would fail the recording field's entire subtree instead of the one bad
+leaf. So the recording field records a **lookahead error** and ElasticGraph fails the flagged field
+when it is resolved. This ADR records how a recorded error is matched to the field it is about.
+
+Terms used here:
+
+- **Recording field** — the field whose resolver holds the lookahead and observes the problem.
+- **Flagged node** — the lookahead node, at any depth beneath the recording field, that the recording
+  field identified as erroneous.
+- **Lookahead error** — an error about a flagged node, discovered by a recording field rather than by
+  the flagged node's own resolver.
+
+**Decision**: a record is keyed by the flagged node's **absolute, index-free response path**, found by
+walking down from the query's root lookahead (`context.query.lookahead`) to the flagged node's AST
+nodes. At resolve time a field matches if its `context.current_path`, with list indices dropped, equals
+that path.
+
+## Considered Options
+
+| Option | Why rejected |
+|---|---|
+| `[schema field, args]` | A schema field is static, so it cannot distinguish an invalid selection from a valid one of the same field elsewhere in the query. |
+| AST node identity | Would require the `:ast_node` extra on every field ElasticGraph resolves — a cost paid by every query for a rare feature. |
+| Recording field's exact path (indices included) + relative path | Expresses a per-list-element distinction that cannot arise (see below), at the cost of the recording field having to bind its records to a path, which datastore query memoization then has to participate in. |
+
+## Consequences
+
+- **The caller passes only the flagged node**, and the path is derived from `context.current_path`, so
+  there is no way to misidentify the recording field. A node that isn't selected at or beneath
+  `current_path` — a typo'd `Lookahead#selection` name, or a node from an unrelated part of the query —
+  raises `Errors::ConfigError` at the point of misuse. That leaves nothing to detect after the fact.
+- **A record may match several response positions.** A list *between* the query root and the flagged
+  node collapses its indices, so one record can match every bucket of an aggregation. Each match
+  produces its own error with its own path, which is what the [GraphQL
+  spec](https://spec.graphql.org/October2021/#sec-Errors) requires: an execution error occurs at a
+  specific response position, and its `path` is what lets clients tell an errored `null` from a real
+  one. Nothing is lost, because a lookahead error is a property of the query, not of the data — a
+  recording field cannot legitimately mean "bucket 1 only." `Resolvers::QueryAdapter` enforces as much
+  for datastore query adapters, which must be pure functions of `(field, args, lookahead)`.
+- **A record may match nothing**, legitimately, when execution never reaches the flagged position
+  (e.g. the recording field resolved to an empty list). Nothing to report: unlike a raised error, an
+  unreached lookahead error is simply inert.
+- **A node can flag itself, not just a descendant**, since its own path matches. This lets any
+  `:lookahead`-accepting resolver report its own invalid args through the same mechanism it would use
+  for a descendant (by returning `QueryContext#matching_lookahead_error`) rather than raising — handy
+  when the resolver wants one consistent way to fail a field.
+- **Datastore query memoization needs no involvement.** Queries are memoized on
+  `(field, args, lookahead)`, so on a cache hit the build — and its recording — is skipped. That's
+  correct precisely because the key is index-free: a cache hit implies identical `lookahead.ast_nodes`
+  (which hash by identity), hence the same document position, hence the same index-free path as the
+  record made on the miss.

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/function_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/function_adapter.rb
@@ -16,9 +16,10 @@ module ElasticGraph
       # the datastore omitted.
       #
       # When an adapter's `extract_args` is given args it considers invalid, it yields an error
-      # message instead of returning extracted args. Each caller passes a block that exits
-      # non-locally (the args of an invalid field are never used), which lets a field with invalid
-      # args be handled without disrupting the sibling fields being processed alongside it.
+      # message instead of returning extracted args. The caller (`QueryAdapter#computation_for`)
+      # passes a block that exits non-locally (the args of an invalid field are never used), which
+      # lets a field with invalid args be handled without disrupting the sibling fields being
+      # processed alongside it.
       #
       # @private
       module FunctionAdapter

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/query_adapter.rb
@@ -63,6 +63,7 @@ module ElasticGraph
           aggregation_query = build_aggregation_query_for(
             aggregations_node,
             field: field,
+            context: context,
             grouping_adapter: CompositeGroupingAdapter,
             # Filters on root aggregations applied to the search query body itself instead of
             # using a filter aggregation, like sub-aggregations do, so we don't want a filter
@@ -95,7 +96,7 @@ module ElasticGraph
           )
         end
 
-        def build_aggregation_query_for(aggregations_node, field:, grouping_adapter:, nested_path: [], unfiltered: false)
+        def build_aggregation_query_for(aggregations_node, field:, context:, grouping_adapter:, nested_path: [], unfiltered: false)
           aggregation_name = name_of(_ = aggregations_node.ast_nodes.first)
 
           # Get the AST node for the `nodes` subfield (e.g. from `fooAggregations { nodes { ... } }`)
@@ -130,8 +131,8 @@ module ElasticGraph
           Query.new(
             name: aggregation_name,
             groupings: build_groupings_from(node_node, aggregation_name, from_field_path: nested_path),
-            computations: build_computations_from(node_node, from_field_path: nested_path),
-            sub_aggregations: build_sub_aggregations_from(node_node, parent_nested_path: nested_path),
+            computations: build_computations_from(node_node, context: context, from_field_path: nested_path),
+            sub_aggregations: build_sub_aggregations_from(node_node, context: context, parent_nested_path: nested_path),
             needs_doc_count: count_detail_node.selected? || node_node.selects?(element_names.count),
             needs_doc_count_error: needs_doc_count_error,
             paginator: build_paginator_for(aggregations_node),
@@ -179,22 +180,22 @@ module ElasticGraph
           end
         end
 
-        def build_computations_from(node_node, from_field_path: [])
+        def build_computations_from(node_node, context:, from_field_path: [])
           aggregated_values_node = node_node.selection(element_names.aggregated_values)
 
           build_clauses_from(aggregated_values_node) do |node, field, field_path|
             if field.aggregated?
               field_path = from_field_path + field_path
-              get_children_nodes(node).filter_map { |fn_node| computation_for(fn_node, field_path) }
+              get_children_nodes(node).filter_map { |fn_node| computation_for(fn_node, field_path, context: context) }
             end
           end
         end
 
         # Builds the `Computation` for an aggregated value function node, or returns `nil` if the node
-        # has invalid args (e.g. an out-of-range `percentile`). We omit the computation rather than
-        # failing the whole aggregations field here: the resolver detects the same invalid args when it
-        # resolves this specific field, and can attribute the error to that field's precise path.
-        def computation_for(fn_node, field_path)
+        # has invalid args (e.g. an out-of-range `percentile`). We record a lookahead error (rather
+        # than failing the whole aggregations field here) and omit the computation; ElasticGraph fails
+        # just this one leaf, at its precise path, when GraphQL execution reaches it.
+        def computation_for(fn_node, field_path, context:)
           computed_field = field_from_node(fn_node)
           function_adapter = computed_field.function_adapter # : FunctionAdapter::adapter
           args = computed_field.args_to_schema_form(fn_node.arguments)
@@ -203,7 +204,10 @@ module ElasticGraph
             source_field_path: field_path,
             leaf: PathSegment.for(field: computed_field, lookahead: fn_node),
             function_adapter: function_adapter,
-            function_args: function_adapter.extract_args(args, element_names) { return nil }
+            function_args: function_adapter.extract_args(args, element_names) do |message|
+              context.record_lookahead_error(fn_node, message)
+              return nil
+            end
           )
         end
 
@@ -306,7 +310,7 @@ module ElasticGraph
           ast_node.alias || ast_node.name
         end
 
-        def build_sub_aggregations_from(node_node, parent_nested_path: [])
+        def build_sub_aggregations_from(node_node, context:, parent_nested_path: [])
           key_sub_agg_pairs =
             build_clauses_from(node_node.selection(element_names.sub_aggregations)) do |node, field, field_path|
               if field.type.elasticgraph_category == :nested_sub_aggregation_connection
@@ -316,6 +320,7 @@ module ElasticGraph
                   query: build_aggregation_query_for(
                     node,
                     field: field,
+                    context: context,
                     grouping_adapter: sub_aggregation_grouping_adapter,
                     nested_path: nested_path
                   )

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/aggregation/resolvers/aggregated_values.rb
@@ -9,7 +9,6 @@
 require "elastic_graph/graphql/aggregation/key"
 require "elastic_graph/graphql/aggregation/path_segment"
 require "elastic_graph/support/hash_util"
-require "graphql"
 
 module ElasticGraph
   class GraphQL
@@ -20,29 +19,6 @@ module ElasticGraph
             return with(field_path: field_path + [PathSegment.for(field: field, lookahead: lookahead)]) if field.type.object?
 
             function_adapter = field.function_adapter # : FunctionAdapter::adapter
-
-            # `QueryAdapter` detected any invalid args when the query was built, but it can't report an
-            # error there without failing resolution of the entire aggregations field rather than just
-            # this one leaf--so it omits the datastore clause for an invalid field instead. Here, at
-            # resolve time, we're resolving this specific field, so we can report the error at the
-            # correct, precise path.
-            #
-            # `args` is already in schema form here (`GraphQLAdapterBuilder` converts it before calling
-            # `resolve`), unlike at query-build time where `QueryAdapter` converts the raw AST arguments
-            # itself--so, unlike there, we pass `args` through as-is rather than re-converting it.
-            function_adapter.extract_args(args, schema.element_names) do |message|
-              error = ::GraphQL::ExecutionError.new(message)
-
-              # Neither `context.add_error` nor `context.execution_errors.add` sets `path` for us--that
-              # only happens automatically when an `ExecutionError` is raised and returned as a field's
-              # own resolution result, which isn't the case here since we're continuing on to resolve
-              # sibling fields normally. So we set `path` ourselves from `context.current_path`, which
-              # is already the precise path to this field (e.g. `[..., "aggregatedValues", "amountCents",
-              # "p150"]`), so the error in the response is attributed to this specific field.
-              error.path = context.current_path
-              context.add_error(error)
-              return nil
-            end
 
             key = Key::AggregatedValue.new(
               aggregation_name: aggregation_name,

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/lookahead_errors.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/lookahead_errors.rb
@@ -1,0 +1,89 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/errors"
+require "graphql"
+
+module ElasticGraph
+  class GraphQL
+    # Tracks "lookahead errors": errors that an ancestor resolver discovers about a *descendant*
+    # field while walking its lookahead to build a datastore query, but cannot raise for (raising
+    # there would fail the ancestor's entire subtree instead of just the one bad descendant).
+    #
+    # See `docs/adr/0001-lookahead-error-record-key.md` for the design rationale behind the
+    # record key used here.
+    class LookaheadErrors
+      # A recorded error about the field selected at `path`--an absolute response path from the root
+      # of the query, with no list indices.
+      Record = ::Data.define(:path, :message, :extensions) do
+        # @implements Record
+
+        # Indices are skipped rather than compared because the flagged node's list positions don't
+        # exist yet when it is recorded, so one record can match many response positions (e.g. every
+        # bucket of an aggregation).
+        def matches?(current_path)
+          current_path.grep_v(::Integer) == path
+        end
+      end
+
+      def initialize
+        @records = [] # : Array[Record]
+      end
+
+      # Records that `node` (a lookahead node at or beneath the field being resolved at
+      # `recording_path`) is invalid, with the given `message`, making it matchable via
+      # `#matching_error_for`. `root_lookahead` is the lookahead of the query as a whole, which we
+      # walk to resolve `node` to its absolute path.
+      def record(node, message, root_lookahead:, recording_path:, extensions: nil)
+        # A node reached through a fragment spread that's used in multiple places has multiple paths;
+        # only the one(s) under the field being resolved are ours to flag.
+        prefix = recording_path.grep_v(::Integer)
+        target_ast_nodes = node.selected? ? node.ast_nodes.to_set : ::Set.new # : ::Set[::GraphQL::Language::Nodes::Field]
+        paths = find_paths(root_lookahead, target_ast_nodes, []).select { |path| path.first(prefix.size) == prefix }
+
+        if paths.empty?
+          raise Errors::ConfigError, "`record_lookahead_error` was given a lookahead node that is not " \
+            "selected at or beneath #{prefix.inspect}, the field being resolved. Note that " \
+            "`Lookahead#selection` returns a null object for an unselected (or misspelled) field."
+        end
+
+        @records.concat(paths.map { |path| Record.new(path: path, message: message, extensions: extensions) })
+      end
+
+      # Returns a `GraphQL::ExecutionError` for the first recorded error matching `current_path` (the
+      # path of the field about to be resolved), or `nil` if none match. Cheap (an `Array#find` over
+      # `@records`, empty for the overwhelmingly common query that never records a lookahead error)
+      # with no separate guard needed at call sites. A record legitimately matches nothing at all when
+      # execution never reaches the flagged position (e.g. its parent resolved to an empty list).
+      def matching_error_for(current_path)
+        record = @records.find { |r| r.matches?(current_path) }
+        return nil unless record
+
+        ::GraphQL::ExecutionError.new(record.message, extensions: record.extensions)
+      end
+
+      private
+
+      # Finds the index-free response-key path(s) from `current` down to a node whose `ast_nodes`
+      # intersect `target_ast_nodes`, including `current` itself (so a node can flag its own
+      # recording field, yielding that field's own path).
+      def find_paths(current, target_ast_nodes, path_so_far)
+        return [path_so_far] if current.ast_nodes.to_set.intersect?(target_ast_nodes)
+
+        current.selections.flat_map do |child|
+          # `Lookahead#name` returns the field's method name, not its response key, so aliased
+          # selections would collide under it. `#selections` already groups by response key
+          # (`alias || name`), so pull the response key straight off the underlying AST node.
+          first_ast_node = child.ast_nodes.first
+          response_key = first_ast_node.alias || first_ast_node.name
+          find_paths(child, target_ast_nodes, path_so_far + [response_key])
+        end
+      end
+    end
+  end
+end

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/lookahead_errors.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/lookahead_errors.rb
@@ -56,10 +56,9 @@ module ElasticGraph
       end
 
       # Returns a `GraphQL::ExecutionError` for the first recorded error matching `current_path` (the
-      # path of the field about to be resolved), or `nil` if none match. Cheap (an `Array#find` over
-      # `@records`, empty for the overwhelmingly common query that never records a lookahead error)
-      # with no separate guard needed at call sites. A record legitimately matches nothing at all when
-      # execution never reaches the flagged position (e.g. its parent resolved to an empty list).
+      # path of the field about to be resolved), or `nil` if none match. A record legitimately matches
+      # nothing at all when execution never reaches the flagged position (e.g. its parent resolved to
+      # an empty list).
       def matching_error_for(current_path)
         record = @records.find { |r| r.matches?(current_path) }
         return nil unless record

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_context.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_context.rb
@@ -8,6 +8,7 @@
 
 require "elastic_graph/errors"
 require "elastic_graph/graphql/client"
+require "elastic_graph/graphql/lookahead_errors"
 require "elastic_graph/graphql/query_details_tracker"
 require "graphql"
 
@@ -90,6 +91,37 @@ module ElasticGraph
       def fetch(key, *args, &block)
         raise_if_removed_key(key)
         super
+      end
+
+      # Records that `node`, a `GraphQL::Execution::Lookahead` node at or beneath the field currently
+      # being resolved, is invalid, with the given `message`. Intended for a custom lookahead-driven
+      # resolver that discovers a problem with itself or a *descendant* field while building its
+      # datastore query, and cannot raise a `GraphQL::ExecutionError` for it there (doing so would
+      # fail this resolver's entire subtree instead of just the one bad field).
+      #
+      # `extensions`, if provided, is included verbatim under the `"extensions"` key of the error
+      # in the GraphQL response; when omitted, no `"extensions"` key is added.
+      #
+      # `node` is resolved into a matching field the next time GraphQL execution reaches it: instead
+      # of running the registered resolver, ElasticGraph fails that field with a
+      # `GraphQL::ExecutionError` built from `message`/`extensions`, without disrupting sibling
+      # fields. A resolver that flags *itself* can report the error by returning
+      # `#matching_lookahead_error`, giving it one consistent way to fail a field regardless of
+      # whether the problem is with itself or a descendant.
+      #
+      # Must be called while the recording field is being resolved, since `node` is resolved to a
+      # response path relative to `#current_path`. Raises `Errors::ConfigError` if `node` is not
+      # selected at or beneath that path.
+      def record_lookahead_error(node, message, extensions: nil)
+        current_path = self.current_path # : Array[String | Integer]
+        (@lookahead_errors ||= LookaheadErrors.new).record(node, message, root_lookahead: query.lookahead, recording_path: current_path, extensions: extensions)
+      end
+
+      # Returns a `GraphQL::ExecutionError` for the field about to be resolved (at `#current_path`)
+      # if an ancestor resolver recorded a lookahead error matching it, or `nil` otherwise.
+      def matching_lookahead_error
+        current_path = self.current_path # : Array[String | Integer]
+        (@lookahead_errors ||= LookaheadErrors.new).matching_error_for(current_path)
       end
 
       private

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/query_context.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/query_context.rb
@@ -120,8 +120,13 @@ module ElasticGraph
       # Returns a `GraphQL::ExecutionError` for the field about to be resolved (at `#current_path`)
       # if an ancestor resolver recorded a lookahead error matching it, or `nil` otherwise.
       def matching_lookahead_error
+        # Checked on every field resolution, so the overwhelmingly common case--no lookahead error
+        # ever recorded for this query--must stay cheap: return before building `#current_path`
+        # (which allocates) or a `LookaheadErrors` (which `#record_lookahead_error` never got called
+        # to create).
+        return nil unless (lookahead_errors = @lookahead_errors)
         current_path = self.current_path # : Array[String | Integer]
-        (@lookahead_errors ||= LookaheadErrors.new).matching_error_for(current_path)
+        lookahead_errors.matching_error_for(current_path)
       end
 
       private

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter_builder.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/graphql_adapter_builder.rb
@@ -54,6 +54,10 @@ module ElasticGraph
                 resolver_lambda =
                   if resolver.method(:resolve).parameters.include?([:keyreq, :lookahead])
                     lambda do |object, args, context|
+                      if (error = context.matching_lookahead_error)
+                        return error
+                      end
+
                       schema_field = context.elastic_graph_schema.field_named(type_name, field_name)
 
                       # Extract the `:lookahead` extra that we have configured all fields to provide.
@@ -80,6 +84,10 @@ module ElasticGraph
                     end
                   else
                     lambda do |object, args, context|
+                      if (error = context.matching_lookahead_error)
+                        return error
+                      end
+
                       schema_field = context.elastic_graph_schema.field_named(type_name, field_name)
                       # Convert args to the form they were defined in the schema, undoing the normalization
                       # the GraphQL gem does to convert them to Ruby keyword args form.

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/query_adapter.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/aggregation/query_adapter.rbs
@@ -54,6 +54,7 @@ module ElasticGraph
         def build_aggregation_query_for: (
           ::GraphQL::Execution::Lookahead,
           field: Schema::Field,
+          context: QueryContext,
           grouping_adapter: groupingAdapter,
           ?nested_path: ::Array[PathSegment],
           ?unfiltered: bool
@@ -88,12 +89,14 @@ module ElasticGraph
 
         def build_computations_from: (
           ::GraphQL::Execution::Lookahead,
+          context: QueryContext,
           ?from_field_path: ::Array[PathSegment]
         ) -> ::Set[Computation]
 
         def computation_for: (
           ::GraphQL::Execution::Lookahead,
-          ::Array[PathSegment]
+          ::Array[PathSegment],
+          context: QueryContext
         ) -> Computation?
 
         def build_groupings_from: (
@@ -135,6 +138,7 @@ module ElasticGraph
 
         def build_sub_aggregations_from: (
           ::GraphQL::Execution::Lookahead,
+          context: QueryContext,
           ?parent_nested_path: ::Array[PathSegment]
         ) -> ::Hash[::String, NestedSubAggregation]
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/lookahead_errors.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/lookahead_errors.rbs
@@ -1,0 +1,33 @@
+module ElasticGraph
+  class GraphQL
+    class LookaheadErrors
+      class Record
+        attr_reader path: ::Array[::String]
+        attr_reader message: ::String
+        attr_reader extensions: ::Hash[::String, untyped]?
+
+        def initialize: (path: ::Array[::String], message: ::String, extensions: ::Hash[::String, untyped]?) -> void
+
+        def matches?: (::Array[::String | ::Integer] current_path) -> bool
+      end
+
+      @records: ::Array[Record]
+
+      def initialize: () -> void
+
+      def record: (
+        ::GraphQL::Execution::Lookahead node,
+        ::String message,
+        root_lookahead: ::GraphQL::Execution::Lookahead,
+        recording_path: ::Array[::String | ::Integer],
+        ?extensions: ::Hash[::String, untyped]?
+      ) -> void
+
+      def matching_error_for: (::Array[::String | ::Integer] current_path) -> ::GraphQL::ExecutionError?
+
+      private
+
+      def find_paths: (::GraphQL::Execution::Lookahead current, ::Set[::GraphQL::Language::Nodes::Field] target_ast_nodes, ::Array[::String] path_so_far) -> ::Array[::Array[::String]]
+    end
+  end
+end

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/query_context.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/query_context.rbs
@@ -32,6 +32,11 @@ module ElasticGraph
       def []: (untyped key) -> untyped
       def fetch: (untyped key, *untyped args) ?{ (untyped) -> untyped } -> untyped
 
+      def record_lookahead_error: (::GraphQL::Execution::Lookahead node, ::String message, ?extensions: ::Hash[::String, untyped]?) -> void
+      def matching_lookahead_error: () -> ::GraphQL::ExecutionError?
+
+      @lookahead_errors: LookaheadErrors?
+
       private
 
       def raise_if_removed_key: (untyped key) -> void

--- a/elasticgraph-graphql/sig/graphql_gem.rbs
+++ b/elasticgraph-graphql/sig/graphql_gem.rbs
@@ -37,6 +37,8 @@ module GraphQL
 
   class ExecutionError < StandardError
     attr_accessor path: ::Array[::String | ::Integer]?
+
+    def initialize: (::String message, ?extensions: ::Hash[::String, untyped]?) -> void
   end
 
   module Language
@@ -122,6 +124,7 @@ module GraphQL
     # ElasticGraph code encounters is actually one of those.
     attr_reader context: ::ElasticGraph::GraphQL::QueryContext
 
+    def lookahead: () -> Execution::Lookahead
     def selected_operation: () -> Language::Nodes::OperationDefinition?
     def selected_operation_name: () -> ::String?
     def static_errors: () -> ::Array[_ValidationError]

--- a/elasticgraph-graphql/spec/acceptance/aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/aggregations_spec.rb
@@ -183,13 +183,16 @@ module ElasticGraph
 
         # Verify that an out-of-range `percentile` resolves to `null` (with a precisely-pathed error)
         # rather than failing the entire `aggregated_values` subtree--sibling fields (including another,
-        # valid `approximate_percentile` alias) still resolve normally.
+        # valid `approximate_percentile` alias) still resolve normally. Grouping (rather than querying
+        # ungrouped) also proves the same recorded error independently flags the invalid field in
+        # *every* bucket, not just the first.
         out_of_range_response = nil
         expect {
           out_of_range_response = call_graphql_query(<<~QUERY, allow_errors: true)
             query {
               #{case_correctly("widget_aggregations")} {
                 nodes {
+                  #{grouped_by} { options { size } }
                   #{aggregated_values} {
                     #{amount_cents} {
                       #{case_correctly("exact_min")}
@@ -203,17 +206,26 @@ module ElasticGraph
           QUERY
         }.to log_warning(a_string_including("percentile` must be between 0 and 100"))
 
-        expect(out_of_range_response.dig("data", case_correctly("widget_aggregations"), "nodes", 0, aggregated_values, amount_cents)).to eq({
-          case_correctly("exact_min") => 100,
-          "good" => 200.0,
+        nodes = out_of_range_response.dig("data", case_correctly("widget_aggregations"), "nodes")
+        expect(nodes.size).to eq 2 # one bucket for size SMALL (w100, w200), one for size MEDIUM (w300)
+        nodes.each { |node| expect(node.dig(aggregated_values, amount_cents, "bad")).to eq nil }
+
+        # `w300` is the only widget in the MEDIUM bucket, so `good` (p50) is unambiguously its own
+        # `amount_cents`, regardless of the datastore's percentile interpolation method.
+        medium_node = nodes.find { |node| node.dig(grouped_by, "options", "size") == enum_value("MEDIUM") }
+        expect(medium_node.dig(aggregated_values, amount_cents)).to eq({
+          case_correctly("exact_min") => 300,
+          "good" => 300.0,
           "bad" => nil
         })
-        expect(out_of_range_response.fetch("errors")).to contain_exactly(
+
+        expected_errors = nodes.each_index.map do |index|
           hash_including(
             "message" => "`#{case_correctly("percentile")}` must be between 0 and 100, but is 150.0.",
-            "path" => [case_correctly("widget_aggregations"), "nodes", 0, aggregated_values, amount_cents, "bad"]
+            "path" => [case_correctly("widget_aggregations"), "nodes", index, aggregated_values, amount_cents, "bad"]
           )
-        )
+        end
+        expect(out_of_range_response.fetch("errors")).to contain_exactly(*expected_errors)
 
         aggregations = group_widget_currencies_by_widget_name
         expect(aggregations).to eq [
@@ -915,6 +927,28 @@ module ElasticGraph
 
         verify_all_timestamp_groupings_valid(widget1.fetch(:id), truncation_unit_type: "DateTimeGroupingTruncationUnitInput", field: "created_at")
         verify_all_datetime_offset_units_valid(widget1.fetch(:id))
+      end
+
+      it "does not error or warn about an out-of-range percentile when the aggregation has no buckets" do
+        # An *ungrouped* aggregation always has exactly one (possibly empty) bucket, but a *grouped*
+        # one has zero buckets when there's no matching data--which is the case we want here.
+        response = call_graphql_query(<<~QUERY)
+          query {
+            #{case_correctly("widget_aggregations")} {
+              nodes {
+                #{grouped_by} { tag }
+                #{aggregated_values} {
+                  #{amount_cents} {
+                    bad: #{case_correctly("approximate_percentile")}(#{case_correctly("percentile")}: 150)
+                  }
+                }
+              }
+            }
+          }
+        QUERY
+
+        expect(response.dig("data", case_correctly("widget_aggregations"), "nodes")).to eq []
+        expect(response).not_to have_key("errors")
       end
 
       def expected_aggregated_amounts_of(*raw_values)

--- a/elasticgraph-graphql/spec/acceptance/sub_aggregations_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/sub_aggregations_spec.rb
@@ -578,38 +578,49 @@ module ElasticGraph
       end
 
       def verify_aggregate_sibling_and_deeply_nested_grouped_counts_and_aggregated_values
-        team_aggs = call_graphql_query(<<~EOS).dig("data", case_correctly("team_aggregations"))
-          query {
-            team_aggregations {
-              nodes {
-                sub_aggregations {
-                  current_players_nested {
-                    nodes {
-                      grouped_by { name }
-                      count_detail { approximate_value }
-                      aggregated_values { name { approximate_distinct_value_count } }
+        response = nil
+        expect {
+          response = call_graphql_query(<<~EOS, allow_errors: true)
+            query {
+              team_aggregations {
+                nodes {
+                  sub_aggregations {
+                    current_players_nested {
+                      nodes {
+                        grouped_by { name }
+                        count_detail { approximate_value }
+                        aggregated_values { name { approximate_distinct_value_count } }
+                      }
                     }
-                  }
 
-                  seasons_nested {
-                    nodes {
-                      grouped_by { year }
-                      count_detail { approximate_value }
-                      aggregated_values { record { wins { approximate_avg, exact_max } } }
+                    seasons_nested {
+                      nodes {
+                        grouped_by { year }
+                        count_detail { approximate_value }
+                        aggregated_values {
+                          record {
+                            wins {
+                              approximate_avg
+                              exact_max
+                              bad: approximate_percentile(percentile: 150)
+                            }
+                          }
+                        }
 
-                      sub_aggregations {
-                        players_nested {
-                          nodes {
-                            grouped_by { name }
-                            count_detail { approximate_value }
-                            aggregated_values { name { approximate_distinct_value_count } }
+                        sub_aggregations {
+                          players_nested {
+                            nodes {
+                              grouped_by { name }
+                              count_detail { approximate_value }
+                              aggregated_values { name { approximate_distinct_value_count } }
 
-                            sub_aggregations {
-                              seasons_nested {
-                                nodes {
-                                  grouped_by { year }
-                                  count_detail { approximate_value }
-                                  aggregated_values { games_played { exact_max } }
+                              sub_aggregations {
+                                seasons_nested {
+                                  nodes {
+                                    grouped_by { year }
+                                    count_detail { approximate_value }
+                                    aggregated_values { games_played { exact_max } }
+                                  }
                                 }
                               }
                             }
@@ -621,8 +632,27 @@ module ElasticGraph
                 }
               }
             }
-          }
-        EOS
+          EOS
+        }.to log_warning(a_string_including("percentile` must be between 0 and 100"))
+
+        team_aggs = response.dig("data", case_correctly("team_aggregations"))
+
+        # Verify that the out-of-range `bad` percentile--recorded at sub-aggregation depth, on a field
+        # nested two layers under `seasons_nested`--resolves to `null` (with a precisely-pathed error) in
+        # every `seasons_nested` bucket, without disrupting any sibling field, including the `2021` bucket
+        # where `wins` itself is `nil` (proving the recorded error doesn't depend on the field's data).
+        season_nodes = team_aggs.dig(case_correctly("nodes"), 0, case_correctly("sub_aggregations"), case_correctly("seasons_nested"), case_correctly("nodes"))
+        expected_bad_errors = season_nodes.each_index.map do |index|
+          hash_including(
+            "message" => "`#{case_correctly("percentile")}` must be between 0 and 100, but is 150.0.",
+            "path" => [
+              case_correctly("team_aggregations"), "nodes", 0, case_correctly("sub_aggregations"),
+              case_correctly("seasons_nested"), "nodes", index, case_correctly("aggregated_values"),
+              "record", "wins", "bad"
+            ]
+          )
+        end
+        expect(response.fetch("errors")).to contain_exactly(*expected_bad_errors)
 
         expect(team_aggs).to eq({
           case_correctly("nodes") => [
@@ -665,7 +695,8 @@ module ElasticGraph
                       case_correctly("aggregated_values") => {
                         "record" => {"wins" => {
                           case_correctly("approximate_avg") => 40.0,
-                          case_correctly("exact_max") => 50
+                          case_correctly("exact_max") => 50,
+                          "bad" => nil
                         }}
                       },
                       case_correctly("sub_aggregations") => {
@@ -713,7 +744,8 @@ module ElasticGraph
                       case_correctly("aggregated_values") => {
                         "record" => {"wins" => {
                           case_correctly("approximate_avg") => 40.0,
-                          case_correctly("exact_max") => 40
+                          case_correctly("exact_max") => 40,
+                          "bad" => nil
                         }}
                       },
                       case_correctly("sub_aggregations") => {case_correctly("players_nested") => {case_correctly("nodes") => []}}
@@ -724,7 +756,8 @@ module ElasticGraph
                       case_correctly("aggregated_values") => {
                         "record" => {"wins" => {
                           case_correctly("approximate_avg") => nil,
-                          case_correctly("exact_max") => nil
+                          case_correctly("exact_max") => nil,
+                          "bad" => nil
                         }}
                       },
                       case_correctly("sub_aggregations") => {case_correctly("players_nested") => {case_correctly("nodes") => []}}
@@ -735,7 +768,8 @@ module ElasticGraph
                       case_correctly("aggregated_values") => {
                         "record" => {"wins" => {
                           case_correctly("approximate_avg") => 40.0,
-                          case_correctly("exact_max") => 40
+                          case_correctly("exact_max") => 40,
+                          "bad" => nil
                         }}
                       },
                       case_correctly("sub_aggregations") => {case_correctly("players_nested") => {case_correctly("nodes") => []}}
@@ -746,7 +780,8 @@ module ElasticGraph
                       case_correctly("aggregated_values") => {
                         "record" => {"wins" => {
                           case_correctly("approximate_avg") => 50.0,
-                          case_correctly("exact_max") => 50
+                          case_correctly("exact_max") => 50,
+                          "bad" => nil
                         }}
                       },
                       case_correctly("sub_aggregations") => {case_correctly("players_nested") => {case_correctly("nodes") => []}}

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/lookahead_error_recording_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/lookahead_error_recording_spec.rb
@@ -1,0 +1,279 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require "elastic_graph/graphql/query_executor"
+require "elastic_graph/graphql/schema"
+
+module ElasticGraph
+  class GraphQL
+    # Exercises `QueryContext#record_lookahead_error` (see `docs/adr/0001-lookahead-error-record-key.md`)
+    # purely through GraphQL query execution against custom resolvers backed by static data--no
+    # datastore, indexer, or admin component needed--so this covers the same ground as a
+    # `LookaheadErrors`-internals unit spec would, but through the same test seam
+    # (`register_graphql_resolver` + `graphql_query_executor.execute`) as our other resolver specs,
+    # rather than by calling `LookaheadErrors` directly.
+    RSpec.describe "lookahead error recording", :capture_logs do
+      attr_accessor :schema_artifacts
+
+      # Registered under these constant names (via `::Object.const_set` below) so
+      # `register_graphql_resolver`'s `defined_at: __FILE__` has a real, nameable class to point
+      # at. Built once, in `before(:context)`, since `generate_schema_artifacts` is expensive and
+      # nothing here varies per example.
+      before(:context) do
+        static_value_resolver_class = Class.new do
+          def initialize(elasticgraph_graphql:, config:)
+          end
+
+          def resolve(field:, object:, args:, context:)
+            # :nocov: -- the whole point of this resolver is that it never runs once flagged.
+            "should never be resolved once flagged"
+            # :nocov:
+          end
+        end
+
+        # Flags the `flagged`/`details` subfields of its own `widgets` list (whenever selected) and
+        # returns static data, exactly as `Aggregation::QueryAdapter#computation_for` flags an
+        # out-of-range `approximatePercentile` selection--except this is a plain resolver, not a
+        # datastore query adapter, proving `record_lookahead_error` is usable directly by one.
+        # `emptyList:` lets a test simulate the recording field itself resolving to no elements.
+        widgets_resolver_class = Class.new do
+          def initialize(elasticgraph_graphql:, config:)
+          end
+
+          def resolve(field:, object:, args:, context:, lookahead:)
+            flagged_node = lookahead.selection("flagged")
+            context.record_lookahead_error(flagged_node, "flagged field is invalid") if flagged_node.selected?
+
+            details_node = lookahead.selection("details")
+            context.record_lookahead_error(details_node, "details field is invalid") if details_node.selected?
+
+            args["emptyList"] ? [] : [{"id" => "1"}, {"id" => "2"}]
+          end
+        end
+
+        # A scalar-returning resolver that flags *itself* (rather than a descendant) when invalid,
+        # then reuses `matching_lookahead_error` to report it--the same mechanism a descendant flag
+        # would use--instead of raising directly.
+        risky_value_resolver_class = Class.new do
+          def initialize(elasticgraph_graphql:, config:)
+          end
+
+          def resolve(field:, object:, args:, context:, lookahead:)
+            context.record_lookahead_error(lookahead, "threshold too high") if args.fetch("threshold") > 100
+
+            context.matching_lookahead_error || args.fetch("threshold")
+          end
+        end
+
+        # Simulates a caller bug: flags a node that isn't at or beneath the field being resolved
+        # (here, an unrelated sibling top-level field).
+        misrooted_recording_resolver_class = Class.new do
+          def initialize(elasticgraph_graphql:, config:)
+          end
+
+          # No return value: the `record_lookahead_error` call raises.
+          def resolve(field:, object:, args:, context:, lookahead:)
+            context.record_lookahead_error(context.query.lookahead.selection("riskyValue"), "misrooted")
+          end
+        end
+
+        # Simulates a caller bug: flags a descendant field the client did not select (which is what a
+        # typo'd `selection` name looks like, since `Lookahead#selection` returns a null object).
+        unselected_flagging_resolver_class = Class.new do
+          def initialize(elasticgraph_graphql:, config:)
+          end
+
+          # No return value: the `record_lookahead_error` call raises.
+          def resolve(field:, object:, args:, context:, lookahead:)
+            context.record_lookahead_error(lookahead.selection("flagged"), "unselected")
+          end
+        end
+
+        ::Object.const_set(:StaticValueResolver, static_value_resolver_class)
+        ::Object.const_set(:WidgetsResolver, widgets_resolver_class)
+        ::Object.const_set(:RiskyValueResolver, risky_value_resolver_class)
+        ::Object.const_set(:MisrootedRecordingResolver, misrooted_recording_resolver_class)
+        ::Object.const_set(:UnselectedFlaggingResolver, unselected_flagging_resolver_class)
+
+        self.schema_artifacts = generate_schema_artifacts do |schema|
+          schema.register_graphql_resolver :static_value, StaticValueResolver, defined_at: __FILE__
+          schema.register_graphql_resolver :widgets, WidgetsResolver, defined_at: __FILE__
+          schema.register_graphql_resolver :risky_value, RiskyValueResolver, defined_at: __FILE__
+          schema.register_graphql_resolver :misrooted_recording, MisrootedRecordingResolver, defined_at: __FILE__
+          schema.register_graphql_resolver :unselected_flagging, UnselectedFlaggingResolver, defined_at: __FILE__
+
+          schema.object_type "WidgetDetails" do |t|
+            t.field "value", "String"
+          end
+
+          schema.object_type "Widget" do |t|
+            t.field "id", "ID"
+            t.field "flagged", "String", graphql_only: true do |f|
+              f.resolve_with :static_value
+            end
+            t.field "details", "WidgetDetails", graphql_only: true do |f|
+              f.resolve_with :static_value
+            end
+          end
+
+          schema.on_root_query_type do |t|
+            t.field "widgets", "[Widget]" do |f|
+              f.argument "emptyList", "Boolean" do |a|
+                a.default false
+              end
+              f.resolve_with :widgets
+            end
+
+            t.field "riskyValue", "Int" do |f|
+              f.argument "threshold", "Int"
+              f.resolve_with :risky_value
+            end
+
+            t.field "misrootedRecording", "[Widget]" do |f|
+              f.resolve_with :misrooted_recording
+            end
+
+            t.field "unselectedFlagging", "[Widget]" do |f|
+              f.resolve_with :unselected_flagging
+            end
+          end
+        end
+      end
+
+      after(:context) do
+        # standard:disable RSpec/RemoveConst
+        ::Object.send(:remove_const, :StaticValueResolver)
+        ::Object.send(:remove_const, :WidgetsResolver)
+        ::Object.send(:remove_const, :RiskyValueResolver)
+        ::Object.send(:remove_const, :MisrootedRecordingResolver)
+        ::Object.send(:remove_const, :UnselectedFlaggingResolver)
+        # standard:enable RSpec/RemoveConst
+      end
+
+      before do
+        # Stub the `require` call `register_graphql_resolver` triggers for `defined_at:`. If we allow
+        # it to load this spec file it'll mess with our reported code coverage (as done elsewhere in
+        # the codebase for the same reason, e.g. `query_executor_spec.rb`).
+        allow(SchemaArtifacts::RuntimeMetadata::GraphQLResolver.without_lookahead_loader).to receive(:require)
+        allow(SchemaArtifacts::RuntimeMetadata::GraphQLResolver.with_lookahead_loader).to receive(:require)
+      end
+
+      let(:graphql) { build_graphql(schema_artifacts: schema_artifacts) }
+
+      it "halts just the flagged field's subtree, resolving it to `null` with a precisely-pathed error, while sibling fields, other list items, and an unrelated top-level field resolve normally--including when the flagged field is selected under multiple aliases" do
+        response = nil
+        expect {
+          response = graphql.graphql_query_executor.execute(<<~QUERY).to_h
+            query {
+              widgets {
+                id
+                a: flagged
+                b: flagged
+              }
+              riskyValue(threshold: 10)
+            }
+          QUERY
+        }.to log_warning(a_string_including("flagged field is invalid"))
+
+        expect(response.dig("data", "widgets")).to contain_exactly(
+          {"id" => "1", "a" => nil, "b" => nil},
+          {"id" => "2", "a" => nil, "b" => nil}
+        )
+        # `riskyValue` has nothing to do with `widgets`' recorded errors--proves a resolved path
+        # with an entirely different prefix than any recorded path just doesn't match.
+        expect(response.dig("data", "riskyValue")).to eq 10
+
+        expect(response.fetch("errors")).to contain_exactly(
+          hash_including("message" => "flagged field is invalid", "path" => ["widgets", 0, "a"]),
+          hash_including("message" => "flagged field is invalid", "path" => ["widgets", 0, "b"]),
+          hash_including("message" => "flagged field is invalid", "path" => ["widgets", 1, "a"]),
+          hash_including("message" => "flagged field is invalid", "path" => ["widgets", 1, "b"])
+        )
+      end
+
+      it "halts an entire object subtree, not just a leaf, when the flagged node is a non-leaf (object) field" do
+        response = nil
+        expect {
+          response = graphql.graphql_query_executor.execute(<<~QUERY).to_h
+            query {
+              widgets {
+                id
+                details {
+                  value
+                }
+              }
+            }
+          QUERY
+        }.to log_warning(a_string_including("details field is invalid"))
+
+        expect(response.dig("data", "widgets")).to eq [
+          {"id" => "1", "details" => nil},
+          {"id" => "2", "details" => nil}
+        ]
+        expect(response.fetch("errors")).to contain_exactly(
+          hash_including("message" => "details field is invalid", "path" => ["widgets", 0, "details"]),
+          hash_including("message" => "details field is invalid", "path" => ["widgets", 1, "details"])
+        )
+      end
+
+      it "does not flag (or halt) the field when it is not even selected" do
+        response = graphql.graphql_query_executor.execute(<<~QUERY).to_h
+          query {
+            widgets {
+              id
+            }
+          }
+        QUERY
+
+        expect(response.dig("data", "widgets")).to eq [{"id" => "1"}, {"id" => "2"}]
+        expect(response).not_to have_key("errors")
+      end
+
+      it "silently ignores a recorded error GraphQL execution never reaches, such as when the recording field itself resolves to an empty list" do
+        response = graphql.graphql_query_executor.execute(<<~QUERY).to_h
+          query {
+            widgets(emptyList: true) {
+              id
+              flagged
+            }
+          }
+        QUERY
+
+        expect(response.dig("data", "widgets")).to eq []
+        expect(response).not_to have_key("errors")
+      end
+
+      it "lets a resolver flag itself (rather than a descendant) and report the error via `matching_lookahead_error`" do
+        invalid = nil
+        expect {
+          invalid = graphql.graphql_query_executor.execute("query { riskyValue(threshold: 150) }").to_h
+        }.to log_warning(a_string_including("threshold too high"))
+
+        expect(invalid.dig("data", "riskyValue")).to eq nil
+        expect(invalid.fetch("errors")).to contain_exactly(
+          hash_including("message" => "threshold too high", "path" => ["riskyValue"])
+        )
+
+        valid = graphql.graphql_query_executor.execute("query { riskyValue(threshold: 50) }").to_h
+        expect(valid.to_h).to eq({"data" => {"riskyValue" => 50}})
+      end
+
+      it "raises when the flagged node is not at or beneath the field being resolved", :expect_warning_logging do
+        expect {
+          graphql.graphql_query_executor.execute("query { misrootedRecording { id } riskyValue(threshold: 10) }")
+        }.to raise_error(Errors::ConfigError, a_string_including("misrootedRecording", "not selected at or beneath"))
+      end
+
+      it "raises when the flagged node is not selected at all", :expect_warning_logging do
+        expect {
+          graphql.graphql_query_executor.execute("query { unselectedFlagging { id } }")
+        }.to raise_error(Errors::ConfigError, a_string_including("unselectedFlagging", "not selected at or beneath"))
+      end
+    end
+  end
+end

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/lookahead_error_recording_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/lookahead_error_recording_spec.rb
@@ -47,7 +47,7 @@ module ElasticGraph
 
           def resolve(field:, object:, args:, context:, lookahead:)
             flagged_node = lookahead.selection("flagged")
-            context.record_lookahead_error(flagged_node, "flagged field is invalid") if flagged_node.selected?
+            context.record_lookahead_error(flagged_node, "flagged field is invalid", extensions: {"code" => "FLAGGED"}) if flagged_node.selected?
 
             details_node = lookahead.selection("details")
             context.record_lookahead_error(details_node, "details field is invalid") if details_node.selected?
@@ -189,10 +189,10 @@ module ElasticGraph
         expect(response.dig("data", "riskyValue")).to eq 10
 
         expect(response.fetch("errors")).to contain_exactly(
-          hash_including("message" => "flagged field is invalid", "path" => ["widgets", 0, "a"]),
-          hash_including("message" => "flagged field is invalid", "path" => ["widgets", 0, "b"]),
-          hash_including("message" => "flagged field is invalid", "path" => ["widgets", 1, "a"]),
-          hash_including("message" => "flagged field is invalid", "path" => ["widgets", 1, "b"])
+          hash_including("message" => "flagged field is invalid", "path" => ["widgets", 0, "a"], "extensions" => {"code" => "FLAGGED"}),
+          hash_including("message" => "flagged field is invalid", "path" => ["widgets", 0, "b"], "extensions" => {"code" => "FLAGGED"}),
+          hash_including("message" => "flagged field is invalid", "path" => ["widgets", 1, "a"], "extensions" => {"code" => "FLAGGED"}),
+          hash_including("message" => "flagged field is invalid", "path" => ["widgets", 1, "b"], "extensions" => {"code" => "FLAGGED"})
         )
       end
 


### PR DESCRIPTION
Closes #1340. Stacked on #1341.

A resolver that builds its datastore query from a lookahead can discover that a *descendant* field is invalid — `approximatePercentile(percentile: 150)`, say. It can't raise `GraphQL::ExecutionError` there: that fails the recording field's entire subtree instead of the one bad leaf.

So it records a **lookahead error**, and ElasticGraph fails the flagged field when execution reaches it.

## The API

```ruby
# From any resolver, while it is being resolved:
context.record_lookahead_error(node, message, extensions: nil)

# For a resolver flagging *itself*, to report it the same way a descendant would be reported:
context.matching_lookahead_error
```

That's the whole surface. `Resolvers::GraphQLAdapterBuilder`'s resolver lambdas check for a matching record before resolving, and return a `GraphQL::ExecutionError` built from the record instead of running the registered resolver — halting just that field or subtree, leaving siblings and other list elements alone.

## How a record is matched

Each record is keyed by the flagged node's **absolute, index-free response path**, found by walking down from `context.query.lookahead` to the node's AST nodes. A field matches when its `context.current_path`, with list indices dropped, equals that path. `docs/adr/0001-lookahead-error-record-key.md` records the rationale and the alternatives considered.

Two consequences worth calling out:

- **One record can match many response positions** — every bucket of an aggregation, for instance — each producing its own error at its own path. That's what the GraphQL spec asks for, and it's what lets a client tell an errored `null` from a real one. Nothing is lost: a lookahead error is a property of the query, not of the data.
- **Datastore query memoization needs no involvement.** A cache hit implies identical `lookahead.ast_nodes` (which hash by identity), hence the same document position, hence the same index-free path as the record made on the miss.

## Misuse is caught at the call site

`record_lookahead_error` raises `Errors::ConfigError` if the node isn't selected at or beneath the field being resolved. That covers a node from an unrelated part of the query and a typo'd `Lookahead#selection` name (which returns a null object) alike, so there's no after-the-fact bug detection to maintain.

## Replaces the `approximatePercentile` workaround

`Aggregation::QueryAdapter#computation_for` records the error rather than silently omitting the computation, and `Aggregation::Resolvers::AggregatedValues#resolve` no longer needs its own parallel validation and error-path logic.

## Testing

- `spec/unit/elastic_graph/graphql/lookahead_error_recording_spec.rb` exercises the mechanism end-to-end through `register_graphql_resolver` + `graphql_query_executor.execute` against static data (no datastore), covering: multi-alias leaf halting, object-subtree halting, self-flagging, a record execution never reaches, and both misuse cases.
- `spec/acceptance/aggregations_spec.rb` covers the real `approximatePercentile` path against a live datastore, grouped so that multiple buckets each get their own error.
- `script/run_specs`, `script/type_check`, `script/lint`, `script/spellcheck` all clean; 100% line and branch coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
