### PR TITLE
Include non-indexed sourced_from source types in the event envelope type enum

### DIFF
--- a/elasticgraph-indexer/spec/unit/elastic_graph/indexer/operation/factory_spec.rb
+++ b/elasticgraph-indexer/spec/unit/elastic_graph/indexer/operation/factory_spec.rb
@@ -140,7 +140,7 @@ module ElasticGraph
             expect_failed_event_error(event, "/properties/type", expect_no_ops: true)
           end
 
-          it "notifies an error on non-indexed graphql type" do
+          it "notifies an error on a graphql type that is not ingestible" do
             event = {
               "op" => "upsert",
               "id" => "1",
@@ -152,7 +152,7 @@ module ElasticGraph
 
             expect(indexer.datastore_core.index_definitions_by_graphql_type.fetch(event.fetch("type"), [])).to be_empty
 
-            # We can't build any operations when the `type` isn't an indexed type. We don't know what index to target!
+            # We can't build any operations when the `type` isn't an ingestible type
             expect_failed_event_error(event, "/properties/type", expect_no_ops: true)
           end
 
@@ -389,6 +389,48 @@ module ElasticGraph
             expect(operations.map(&:event)).to all eq event
             expect(operations.map(&:destination_index_def)).to all eq index_def_named("components")
             expect(operations.map(&:doc_id)).to contain_exactly("c1", "c2", "c3")
+          end
+
+          context "for an event of a non-indexed `sourced_from` source type", :json_ingestion_schema_definition do
+            let(:indexer) do
+              build_indexer(schema_definition: lambda do |s|
+                s.object_type "Widget" do |t|
+                  t.field "id", "ID!"
+                  t.field "name", "String"
+                  t.field "component_ids", "[ID!]!"
+                end
+
+                s.object_type "Component" do |t|
+                  t.field "id", "ID!"
+                  t.relates_to_one "widget", "Widget", via: "component_ids", dir: :in, indexing_only: true
+
+                  t.field "widget_name", "String" do |f|
+                    f.sourced_from "widget", "name"
+                  end
+
+                  t.index "components" do |i|
+                    i.has_had_multiple_sources!
+                  end
+                end
+              end)
+            end
+
+            it "builds only the `sourced_from` update operations since the source type has no index of its own" do
+              event = {
+                "op" => "upsert",
+                "id" => "w1",
+                "type" => "Widget",
+                "version" => 1,
+                JSON_SCHEMA_VERSION_KEY => 1,
+                "record" => {"id" => "w1", "name" => "Widgy", "component_ids" => ["c1", "c2"]}
+              }
+
+              operations = build_expecting_success(event)
+
+              expect(operations.map { |op| op.update_target.type }).to all eq "Component"
+              expect(operations.map(&:destination_index_def)).to all eq index_def_named("components")
+              expect(operations.map(&:doc_id)).to contain_exactly("c1", "c2")
+            end
           end
 
           def expect_failed_event_error(event, *error_message_snippets, factory: indexer.operation_factory, expect_no_ops: false)

--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/indexing/event_envelope.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/indexing/event_envelope.rb
@@ -17,10 +17,11 @@ module ElasticGraph
         #
         # @api private
         module EventEnvelope
-          # @param indexed_type_names [Array<String>] names of the indexed types
+          # @param ingestible_type_names [Array<String>] names of the types events can be ingested for (indexed
+          #   document types plus non-indexed `sourced_from` source types)
           # @param json_schema_version [Integer] the version of the JSON schema
-          # @return [Hash<String, Object>] the JSON schema for the ElasticGraph event envelope for the given `indexed_type_names`.
-          def self.json_schema(indexed_type_names, json_schema_version)
+          # @return [Hash<String, Object>] the JSON schema for the ElasticGraph event envelope for the given `ingestible_type_names`.
+          def self.json_schema(ingestible_type_names, json_schema_version)
             {
               "type" => "object",
               "description" => "Required by ElasticGraph to wrap every data event.",
@@ -34,7 +35,7 @@ module ElasticGraph
                   "description" => "The type of object present in `record`.",
                   "type" => "string",
                   # Sorting doesn't really matter here, but it's nice for the output in the schema artifact to be consistent.
-                  "enum" => indexed_type_names.sort
+                  "enum" => ingestible_type_names.sort
                 },
                 "id" => {
                   "description" => "The unique identifier of the record.",

--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/json_schema_builder.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/json_schema_builder.rb
@@ -17,10 +17,11 @@ module ElasticGraph
       #
       # @private
       class JSONSchemaBuilder
-        def initialize(state:, all_types:, derived_indexing_type_names:)
+        def initialize(state:, all_types:, derived_indexing_type_names:, sourced_from_source_type_names:)
           @state = state
           @all_types = all_types
           @derived_indexing_type_names = derived_indexing_type_names
+          @sourced_from_source_type_names = sourced_from_source_type_names
         end
 
         def public_json_schema
@@ -33,7 +34,7 @@ module ElasticGraph
             "$schema" => JSON_META_SCHEMA,
             JSON_SCHEMA_VERSION_KEY => json_schema_version,
             "$defs" => {
-              "ElasticGraphEventEnvelope" => Indexing::EventEnvelope.json_schema(root_document_type_names, json_schema_version)
+              "ElasticGraphEventEnvelope" => Indexing::EventEnvelope.json_schema(ingestible_type_names, json_schema_version)
             }.merge(definitions_by_name)
           }
         end
@@ -44,10 +45,13 @@ module ElasticGraph
 
         private
 
-        def root_document_type_names
+        # The types the indexer can ingest events for: indexed document types plus `sourced_from` source types
+        # (which need not be indexed themselves). Derived indexing types are excluded because their documents
+        # are built from other types' events rather than ingested directly.
+        def ingestible_type_names
           @state.object_types_by_name.values
-            .select { |type| type.root_document_type? && !type.abstract? }
-            .reject { |type| @derived_indexing_type_names.include?(type.name) }
+            .select { |type| type.root_document_type? || @sourced_from_source_type_names.include?(type.name) }
+            .reject { |type| type.abstract? || @derived_indexing_type_names.include?(type.name) }
             .map(&:name)
         end
 

--- a/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/results_extension.rb
+++ b/elasticgraph-json_ingestion/lib/elastic_graph/json_ingestion/schema_definition/results_extension.rb
@@ -76,6 +76,10 @@ module ElasticGraph
 
         def json_ingestion_json_schema_builder
           @json_ingestion_json_schema_builder ||= begin
+            # Resolve `sourced_from` update targets before touching `all_types` so that `sourced_from`
+            # validation errors take precedence over any errors raised while generating derived types.
+            sourced_from_source_type_names = sourced_update_targets_by_source_type_name.keys.to_set
+
             # Force `all_types` to materialize before iterating `state.types_by_name`. Reading `all_types`
             # runs the `on_built_in_types` callbacks, including the GeoLocation JSON schema field
             # customizations registered by `APIExtension.extended`.
@@ -84,7 +88,8 @@ module ElasticGraph
             JSONSchemaBuilder.new(
               state: json_ingestion_state,
               all_types: materialized_all_types,
-              derived_indexing_type_names: derived_indexing_type_names
+              derived_indexing_type_names: derived_indexing_type_names,
+              sourced_from_source_type_names: sourced_from_source_type_names
             )
           end
         end

--- a/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/json_schema_builder.rbs
+++ b/elasticgraph-json_ingestion/sig/elastic_graph/json_ingestion/schema_definition/json_schema_builder.rbs
@@ -5,7 +5,8 @@ module ElasticGraph
         def initialize: (
           state: ::ElasticGraph::SchemaDefinition::State & StateExtension,
           all_types: ::Array[::ElasticGraph::SchemaDefinition::SchemaElements::graphQLType],
-          derived_indexing_type_names: ::Set[::String]
+          derived_indexing_type_names: ::Set[::String],
+          sourced_from_source_type_names: ::Set[::String]
         ) -> void
 
         def public_json_schema: () -> ::Hash[::String, untyped]
@@ -16,9 +17,10 @@ module ElasticGraph
         @state: ::ElasticGraph::SchemaDefinition::State & StateExtension
         @all_types: ::Array[::ElasticGraph::SchemaDefinition::SchemaElements::graphQLType]
         @derived_indexing_type_names: ::Set[::String]
+        @sourced_from_source_type_names: ::Set[::String]
         @indexing_field_types_by_name: ::Hash[::String, Indexing::_JSONFieldType]?
 
-        def root_document_type_names: () -> ::Array[::String]
+        def ingestible_type_names: () -> ::Array[::String]
         def definitions_by_name: () -> ::Hash[::String, untyped]
         def indexing_field_types_by_name: () -> ::Hash[::String, Indexing::_JSONFieldType]
       end

--- a/elasticgraph-json_ingestion/spec/unit/elastic_graph/json_ingestion/schema_definition/json_schema_spec.rb
+++ b/elasticgraph-json_ingestion/spec/unit/elastic_graph/json_ingestion/schema_definition/json_schema_spec.rb
@@ -548,6 +548,41 @@ module ElasticGraph
             expect(envelope_type_enum_values(schemas)).to eq %w[Component Widget]
             expect(schemas.fetch("Widget")).to include("properties" => hash_including("id", "name", "component_ids"))
           end
+
+          # Tagged `:dont_validate_graphql_schema` because this schema intentionally cannot generate a
+          # valid GraphQL schema: the derived type generation error is what the test is about.
+          it "raises `sourced_from` validation errors in preference to derived GraphQL type generation errors", :dont_validate_graphql_schema do
+            expect {
+              dump_schema do |s|
+                s.object_type "Widget" do |t|
+                  t.field "id", "ID!"
+
+                  # `workspace` is a plain field rather than a relationship, so the `sourced_from` below is
+                  # invalid. The schema is also broken in a second way: generating `Widget`'s derived sort
+                  # order enum fails because `workspace.name` and `workspace_name` both flatten to the same
+                  # `workspace_name_*` enum values.
+                  t.field "workspace", "WidgetWorkspace"
+
+                  t.field "workspace_name", "String" do |f|
+                    f.sourced_from "workspace", "name"
+                  end
+
+                  t.index "widgets" do |i|
+                    i.has_had_multiple_sources!
+                  end
+                end
+
+                s.object_type "WidgetWorkspace" do |t|
+                  t.field "id", "ID!"
+                  t.field "name", "String"
+                  t.field "widget_ids", "[ID!]!"
+                  t.index "widget_workspaces"
+                end
+              end
+            }.to raise_error Errors::SchemaError, a_string_including(
+              "`Widget.workspace` (referenced from `sourced_from` on field(s): `workspace_name`) is not a relationship"
+            )
+          end
         end
 
         %w[ID String].first(1).each do |graphql_type|

--- a/elasticgraph-json_ingestion/spec/unit/elastic_graph/json_ingestion/schema_definition/json_schema_spec.rb
+++ b/elasticgraph-json_ingestion/spec/unit/elastic_graph/json_ingestion/schema_definition/json_schema_spec.rb
@@ -456,6 +456,7 @@ module ElasticGraph
               s.object_type "Widget" do |t|
                 t.field "id", "ID!"
                 t.field "name", "String!"
+                t.field "component_ids", "[ID!]!"
 
                 t.index "widgets"
               end
@@ -464,7 +465,7 @@ module ElasticGraph
                 t.field "id", "ID!"
                 t.relates_to_one "widget", "Widget", via: "component_ids", dir: :in
 
-                t.field "widget_name", "String!" do |f|
+                t.field "widget_name", "String" do |f|
                   f.sourced_from "widget", "name"
                 end
 
@@ -490,6 +491,7 @@ module ElasticGraph
                   t.field "id", "ID!"
                   t.field "name", "String!"
                   t.field "size", "Int"
+                  t.field "component_ids", "[ID!]!"
 
                   t.index "widgets"
                 end
@@ -499,7 +501,7 @@ module ElasticGraph
                   t.relates_to_one "widget", "Widget", via: "component_ids", dir: :in
 
                   # Here we call `json_schema` after `sourced_from`...
-                  t.field "widget_name", "String!" do |f|
+                  t.field "widget_name", "String" do |f|
                     f.sourced_from "widget", "name"
                     f.json_schema minLength: 4
                   end
@@ -519,6 +521,32 @@ module ElasticGraph
               "Component` has 2 field(s) (`widget_name`, `widget_size`)",
               "also have JSON schema customizations"
             )
+          end
+
+          it "includes a non-indexed source type in the event envelope's `type` enum so that its events can be ingested" do
+            schemas = all_type_definitions_for do |s|
+              s.object_type "Widget" do |t|
+                t.field "id", "ID!"
+                t.field "name", "String!"
+                t.field "component_ids", "[ID!]!"
+              end
+
+              s.object_type "Component" do |t|
+                t.field "id", "ID!"
+                t.relates_to_one "widget", "Widget", via: "component_ids", dir: :in, indexing_only: true
+
+                t.field "widget_name", "String" do |f|
+                  f.sourced_from "widget", "name"
+                end
+
+                t.index "components" do |i|
+                  i.has_had_multiple_sources!
+                end
+              end
+            end
+
+            expect(envelope_type_enum_values(schemas)).to eq %w[Component Widget]
+            expect(schemas.fetch("Widget")).to include("properties" => hash_including("id", "name", "component_ids"))
           end
         end
 
@@ -2115,6 +2143,7 @@ module ElasticGraph
               json_schema = dump_schema do |s|
                 s.object_type "OtherType" do |t|
                   t.field "id", "ID!"
+                  t.index "other_type"
                 end
 
                 s.object_type "MyType" do |t|
@@ -2135,6 +2164,7 @@ module ElasticGraph
               json_schema = dump_schema do |s|
                 s.object_type "OtherType" do |t|
                   t.field "id", "ID!"
+                  t.index "other_type"
                 end
 
                 s.object_type "MyType" do |t|
@@ -2182,6 +2212,7 @@ module ElasticGraph
               json_schema = dump_schema do |s|
                 s.object_type "MyType" do |t|
                   t.relates_to_one "parent", "MyType!", via: "parent_id", dir: :out
+                  t.index "my_type"
                 end
               end
 
@@ -2274,6 +2305,7 @@ module ElasticGraph
             json_schema = dump_schema do |s|
               s.object_type "CardInferred" do |t|
                 t.relates_to_one "cloned_from_card", "CardInferred", via: "cloned_from_card_id", dir: :out
+                t.index "card_inferred"
               end
 
               s.object_type "CardExplicit" do |t|


### PR DESCRIPTION
## Summary

Third step toward #1273 (follows #1342 and #1343, which made these schemas definable). A non-indexed `sourced_from` source type could be declared but its events were still rejected at ingestion, because the event envelope's type enum in `json_schemas.yaml` only included indexed types. This PR widens that enum to "ingestible" types: non-abstract root document types (minus derived indexing types, as before) plus `sourced_from` source types.

The source-type set comes from `Results#sourced_update_targets_by_source_type_name` — the memoized resolver pass added in #1342 — so JSON schema generation and runtime metadata generation can't disagree about which types are sources. Derived indexing types and abstract types are excluded from the source-type side too, preserving the current enum for schemas where such a type happens to be a relationship target.

No change was needed on the ingestion side beyond the enum: the indexer's operation factory is already destination-keyed, so once an event passes envelope validation, its `sourced_from` update operations build normally (new `factory_spec` coverage proves this for a source type with no index of its own). `JSONSchemaWithMetadata`'s index-based filter also needed no change — it validates routing/rollover field paths per index, and a non-indexed type has neither.

## Note on a validation side effect

Computing the source-type set runs the `sourced_from` resolver, so generating JSON schemas now surfaces relationship/sourced_from validation errors it previously skipped (runtime metadata generation always raised them; `rake schema_artifacts:dump` behavior is unchanged). Six spec fixtures in `json_schema_spec.rb` had quietly-invalid schemas — missing inbound foreign keys, GraphQL-exposed relations to non-indexed types, non-nullable `sourced_from` fields — and are fixed here; only their setup changed, no assertions.

Schema artifacts are unchanged: every source type in the test schema is still indexed. The next PR in the stack drops `t.index` from `CoachProfile`/`GeneralManagerProfile` (resolving their TODO(#1273) markers) to prove the feature end-to-end.