### PR TITLE
Apply SimpleCov line_stub merge patch on affected CRuby 3.4.x versions too

### DIFF
--- a/spec_support/lib/elastic_graph/spec_support/enable_simplecov.rb
+++ b/spec_support/lib/elastic_graph/spec_support/enable_simplecov.rb
@@ -47,7 +47,7 @@ module ElasticGraph
   end
 
   # SimpleCov backfills `track_files`-matched files that a process never loaded with simulated
-  # coverage based on `Coverage.line_stub`. On CRuby 4.0.0 through 4.0.3 (fixed in 4.0.4),
+  # coverage based on `Coverage.line_stub`. On affected CRuby versions (see below),
   # `Coverage.line_stub` classifies a few lines (e.g. continuation lines of multi-line hash
   # literals, and `in` clauses of `case`/`in` expressions) as relevant-but-uncovered (`0`) even
   # though the runtime `Coverage` API classifies them as not relevant (`nil`) when the file is
@@ -59,8 +59,18 @@ module ElasticGraph
   # are unaffected--all of their merged values are `0`-vs-`0`, which still merges to `0`--and
   # executed lines are unaffected (`nil`-vs-positive still merges to the positive count).
   #
+  # Affected versions (verified with a `Coverage.line_stub`-vs-runtime probe against docker
+  # ruby-slim images): 3.4.1 through 4.0.3; 3.4.0 and 4.0.4 are clean, and no 3.4.x has the fix
+  # backported as of 3.4.7. On 3.4.x the mismatch shows up for multi-line all-static hash literals
+  # in files with a `# frozen_string_literal: true` magic comment (i.e. every file in this repo):
+  # the literal is compile-time folded so its continuation lines fire no runtime line events, but
+  # `Coverage.line_stub` still marks them relevant. On 4.0.0-4.0.3 the same happens without the
+  # magic comment. If a future 3.4.x release ships the backported fix, this range will over-apply
+  # to it, which is harmless; tighten the range at that point to keep the gate meaningful.
+  #
   # :nocov: -- which branch executes depends on the Ruby version.
-  if ::RUBY_ENGINE == "ruby" && ("4.0.0"..."4.0.4").cover?(::RUBY_VERSION)
+  affected_versions = ::Gem::Version.new("3.4.1")...::Gem::Version.new("4.0.4")
+  if ::RUBY_ENGINE == "ruby" && affected_versions.cover?(::Gem::Version.new(::RUBY_VERSION))
     module LinesCombinerPatch
       def merge_line_coverage(first_val, second_val)
         return nil if (first_val.nil? || second_val.nil?) && first_val.to_i + second_val.to_i == 0


### PR DESCRIPTION
## Why

`script/quick_build` deterministically fails on CRuby 3.4.4 with ~72 phantom "uncovered" lines (all continuation lines of multi-line hash literals), while CI stays green. This is the same `Coverage.line_stub` bug that #1334 patched, but that patch's version gate (`"4.0.0"..."4.0.4"`) excludes the 3.4 series.

The bisect fixture in #1334 missed the 3.4 variant because it lacked a `# frozen_string_literal: true` magic comment. With the magic comment (present in every file in this repo), CRuby folds all-static multi-line hash literals at compile time, so their continuation lines fire no runtime line events (`nil`) — yet `Coverage.line_stub` (used by SimpleCov 1.x to backfill tracked-but-unloaded files, e.g. from the flatware main process, which runs no tests) still marks them relevant (`0`). SimpleCov 1.x's merge lets the phantom `0` beat the real `nil`.

The raw `.resultset.json` from a failing run shows the mechanism directly: the one worker that actually ran `meta_schema_validator_spec.rb` recorded line 17 as `nil` (not relevant), while the flatware main process and the other three workers all stubbed it as `0` (relevant-but-uncovered). Merged: `0` — reported as a miss for a line that cannot be executed.

Re-probing with a `Coverage.line_stub`-vs-runtime script against docker `ruby-slim` images, using a fixture *with* the magic comment: **3.4.1 through 4.0.3 are all affected**. 3.4.0 and 4.0.4 are clean, and no 3.4.x release has the fix backported as of 3.4.7. (On 4.0.0–4.0.3 the folding happens even without the magic comment, which is why #1334 caught that range.)

## What

Widens the existing patch's version gate in `enable_simplecov.rb` to `Gem::Version.new("3.4.1")...Gem::Version.new("4.0.4")`, and updates the comment to document the affected range, the probe method, and the magic-comment variant.

Using `Gem::Version` also fixes a latent issue with the previous gate's lexicographic string comparison (e.g. `"4.0.10" < "4.0.4"` as strings).

The merge patch itself is unchanged, and remains harmless anywhere it applies unnecessarily: it only converts `nil`-vs-`0` merges to `nil`, which never hides a genuinely uncovered line — a real uncovered line is `0` on every side, and `0`-vs-`0` still merges to `0`.

## Verification

`COVERAGE=1 script/run_specs` (what `script/quick_build` runs) on this branch: 5223 examples, 0 failures, **100.00%** line and branch coverage (45057/45057 lines, 3152/3152 branches in 760 files). The same run on unpatched main reports 72 phantom uncovered lines and exits non-zero.