### PR TITLE
Fix sibling `should`-producing filters collapsing into one OR group

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/boolean_query.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/boolean_query.rb
@@ -47,7 +47,18 @@ module ElasticGraph
         end
 
         def merge_into(bool_node)
-          bool_node[occurrence].concat(clauses)
+          if occurrence == :should && bool_node.key?(:should)
+            # `minimum_should_match: 1` applies to the entire `should` array of a bool node, so a
+            # node can hold only one group of `should` clauses. `bool_node` already has such a group,
+            # and our clauses are a separate group which must be ANDed with it--not ORed into it.
+            # (Merging them into one array would turn `(A OR B) AND (C OR D)` into `A OR B OR C OR D`.)
+            #
+            # So, we nest our clauses in their own bool query and add that as a `filter` clause, where
+            # it is required on its own.
+            BooleanQuery.filter({bool: {minimum_should_match: 1, should: clauses}}).merge_into(bool_node)
+          else
+            bool_node[occurrence].concat(clauses)
+          end
         end
 
         ALWAYS_FALSE_FILTER = filter({match_none: {}})

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_interpreter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_interpreter.rb
@@ -183,12 +183,16 @@ module ElasticGraph
             raise ::GraphQL::ExecutionError, "`#{formatted_filter}` is not supported because it produces " \
               "multiple filtering clauses under `#{schema_names.any_satisfy}`, which doesn't work as expected. " \
               "Remove one or more of your `#{schema_names.any_satisfy}` predicates and try again."
-          elsif (should_clauses = processed_bool_query.fetch(:should, nil))
+          elsif processed_bool_query.key?(:should)
             # Our sub-filter is a group of `should` clauses (from an `any_of`), and only one of them
             # must match. We merge it with `BooleanQuery#merge_into` rather than merging the clauses
             # directly, so that it does not get ORed into a `should` group that a sibling filter has
             # already put on `bool_node`.
-            BooleanQuery.should(*should_clauses).merge_into(bool_node)
+            #
+            # Note: `build_bool_hash` gives `processed_bool_query` a default proc that assigns `[]`, so
+            # `key?` is required here. `processed_bool_query[:should]` would return a truthy `[]` for
+            # every sub-filter and would also add the key.
+            BooleanQuery.should(*processed_bool_query.fetch(:should)).merge_into(bool_node)
           else
             bool_node.update(processed_bool_query) do |_, existing_clauses, any_satisfy_clauses|
               existing_clauses + any_satisfy_clauses

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_interpreter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_interpreter.rb
@@ -183,6 +183,12 @@ module ElasticGraph
             raise ::GraphQL::ExecutionError, "`#{formatted_filter}` is not supported because it produces " \
               "multiple filtering clauses under `#{schema_names.any_satisfy}`, which doesn't work as expected. " \
               "Remove one or more of your `#{schema_names.any_satisfy}` predicates and try again."
+          elsif (should_clauses = processed_bool_query.fetch(:should, nil))
+            # Our sub-filter is a group of `should` clauses (from an `any_of`), and only one of them
+            # must match. We merge it with `BooleanQuery#merge_into` rather than merging the clauses
+            # directly, so that it does not get ORed into a `should` group that a sibling filter has
+            # already put on `bool_node`.
+            BooleanQuery.should(*should_clauses).merge_into(bool_node)
           else
             bool_node.update(processed_bool_query) do |_, existing_clauses, any_satisfy_clauses|
               existing_clauses + any_satisfy_clauses

--- a/elasticgraph-graphql/spec/acceptance/search_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/search_spec.rb
@@ -1020,6 +1020,7 @@ module ElasticGraph
             build(
               :team,
               id: "t1",
+              current_name: "Aces",
               details: build(:team_details, count: 5),
               past_names: ["Pilots", "Pink Sox"],
               won_championships_at: [],
@@ -1035,6 +1036,7 @@ module ElasticGraph
             build(
               :team,
               id: "t2",
+              current_name: "Bees",
               details: build(:team_details, count: 15),
               past_names: ["Pink Sox", "Ace Piloteers"],
               won_championships_at: ["2013-11-27T02:30:00Z", "2013-11-27T22:30:00Z"],
@@ -1053,6 +1055,7 @@ module ElasticGraph
             build(
               :team,
               id: "t3",
+              current_name: "Cyclones",
               details: build(:team_details, count: 4),
               past_names: ["Pilots"],
               won_championships_at: ["2003-10-27T19:30:00Z"],
@@ -1072,6 +1075,7 @@ module ElasticGraph
               :team,
               details: build(:team_details, count: 12),
               id: "t4",
+              current_name: "Dukes",
               past_names: ["Pill Bugs"],
               won_championships_at: ["2005-10-27T12:30:00Z"],
               forbes_valuations: [42],
@@ -1133,6 +1137,18 @@ module ElasticGraph
           results = query_teams_with(filter: {forbes_valuations: {any_satisfy: {any_of: [{gt: 150_000_000}, {lt: 5}]}}})
           # t1 has 200_000_000; t3 has 0
           expect(results).to eq [{"id" => "t1"}, {"id" => "t3"}]
+
+          # Verify `any_of: [...]` next to a sibling `any_satisfy: {any_of: [...]}`. Each filter produces its own
+          # group of `should` clauses, and the two groups must both be true of a document.
+          results = query_teams_with(filter: {
+            any_of: [
+              {current_name: {equal_to_any_of: ["Aces"]}},
+              {current_name: {equal_to_any_of: ["Bees"]}}
+            ],
+            forbes_valuations: {any_satisfy: {any_of: [{gt: 150_000_000}, {lt: 5}]}}
+          })
+          # t1 and t2 match the `any_of`; t1 and t3 match the `any_satisfy`. Only t1 matches both.
+          expect(results).to eq [{"id" => "t1"}]
 
           # Verify we can use the `any_satisfy` filter operator on a list-of-nested objects correctly.
           # Also, verify that the sub-objects are considered independently. Team t3 has a player with the name

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/filtering_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/filtering_spec.rb
@@ -545,9 +545,9 @@ module ElasticGraph
       end
 
       # Both filters below have two sibling parts that must be ANDed together, and each part produces
-      # `should` clauses. The parts share one `bool` node, so their `should` clauses land in one array
-      # under a single `minimum_should_match: 1`, and `(A OR B) AND (C OR D)` becomes `A OR B OR C OR D`.
-      # These examples show the extra documents that the datastore then returns.
+      # `should` clauses. `minimum_should_match: 1` applies to the entire `should` array of a bool
+      # node, so the two groups must not share one array. If they did, `(A OR B) AND (C OR D)` would
+      # become `A OR B OR C OR D`, and t2 and t3 would also match here.
       describe "sibling filters that each produce `should` clauses" do
         it "requires a document to satisfy both an `any_of` filter and a sibling `any_satisfy: {any_of: ...}` filter" do
           index_into(
@@ -567,7 +567,6 @@ module ElasticGraph
             "forbes_valuations" => {"any_satisfy" => {"any_of" => [{"gt" => 3_000_000}, {"lt" => 100_000}]}}
           }
 
-          pending "known bug: t2 and t3 also match, because the two `should` groups collapse into one flat `should` array"
           expect(search_with_freeform_filter(filter)).to match_array(ids_of(t1))
         end
 
@@ -591,7 +590,6 @@ module ElasticGraph
             sort: []
           ).to_a)
 
-          pending "known bug: the internal filter no longer restricts the results, so t2 and t3 also match"
           expect(results).to match_array(ids_of(t1))
         end
 

--- a/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/filtering_spec.rb
+++ b/elasticgraph-graphql/spec/integration/elastic_graph/graphql/datastore_query/filtering_spec.rb
@@ -544,6 +544,62 @@ module ElasticGraph
         end
       end
 
+      # Both filters below have two sibling parts that must be ANDed together, and each part produces
+      # `should` clauses. The parts share one `bool` node, so their `should` clauses land in one array
+      # under a single `minimum_should_match: 1`, and `(A OR B) AND (C OR D)` becomes `A OR B OR C OR D`.
+      # These examples show the extra documents that the datastore then returns.
+      describe "sibling filters that each produce `should` clauses" do
+        it "requires a document to satisfy both an `any_of` filter and a sibling `any_satisfy: {any_of: ...}` filter" do
+          index_into(
+            graphql,
+            t1 = build(:team, id: "t1", current_name: "Yankees", forbes_valuations: [5_000_000]),
+            build(:team, id: "t2", current_name: "Cardinals", forbes_valuations: [5_000_000]),
+            build(:team, id: "t3", current_name: "Dodgers", forbes_valuations: [1_000_000]),
+            build(:team, id: "t4", current_name: "Cardinals", forbes_valuations: [1_000_000])
+          )
+
+          # `(name = Yankees OR name = Dodgers) AND (valuation > 3M OR valuation < 100K)`
+          filter = {
+            "any_of" => [
+              {"current_name" => {"equal_to_any_of" => ["Yankees"]}},
+              {"current_name" => {"equal_to_any_of" => ["Dodgers"]}}
+            ],
+            "forbes_valuations" => {"any_satisfy" => {"any_of" => [{"gt" => 3_000_000}, {"lt" => 100_000}]}}
+          }
+
+          pending "known bug: t2 and t3 also match, because the two `should` groups collapse into one flat `should` array"
+          expect(search_with_freeform_filter(filter)).to match_array(ids_of(t1))
+        end
+
+        it "requires a document to satisfy both a client filter and an internal filter that each produce `should` clauses" do
+          index_into(
+            graphql,
+            t1 = build(:team, id: "t1", current_name: "Yankees", forbes_valuations: [5_000_000]),
+            build(:team, id: "t2", current_name: "Cardinals", forbes_valuations: [5_000_000]),
+            build(:team, id: "t3", current_name: "Dodgers", forbes_valuations: [1_000_000]),
+            build(:team, id: "t4", current_name: "Cardinals", forbes_valuations: [1_000_000])
+          )
+
+          # An internal filter (such as a relationship `additional_filter`) must restrict the client's
+          # results, so this is the same `(name = ...) AND (valuation ...)` filter as above.
+          results = ids_of(search_datastore(
+            client_filters: [{"forbes_valuations" => {"any_satisfy" => {"any_of" => [{"gt" => 3_000_000}, {"lt" => 100_000}]}}}],
+            internal_filters: [{"any_of" => [
+              {"current_name" => {"equal_to_any_of" => ["Yankees"]}},
+              {"current_name" => {"equal_to_any_of" => ["Dodgers"]}}
+            ]}],
+            sort: []
+          ).to_a)
+
+          pending "known bug: the internal filter no longer restricts the results, so t2 and t3 also match"
+          expect(results).to match_array(ids_of(t1))
+        end
+
+        def search_datastore(**options, &before_msearch)
+          super(index_def_name: "teams", **options, &before_msearch)
+        end
+      end
+
       # Note: a `count` filter gets translated into `__counts` (to distinguish it from a schema field named `count`),
       # and that translation happens as the query is being built, so we use `__counts` in our example filters here.
       describe "`count` filtering on a list" do

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/filtering_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/filtering_spec.rb
@@ -1039,6 +1039,134 @@ module ElasticGraph
         end
       end
 
+      # Each filter below has two sibling parts that must be ANDed together, and each part produces
+      # `should` clauses. The parts land in the same `bool` node, so their `should` clauses go into
+      # one shared array under a single `minimum_should_match: 1`. That turns `(A OR B) AND (C OR D)`
+      # into `A OR B OR C OR D`, which matches documents the filter excludes.
+      #
+      # The `required_matching_clause_count > 1` guard in `FilterInterpreter` only inspects one
+      # `any_satisfy` sub-filter at a time, so it cannot detect a collision with a sibling filter.
+      describe "sibling filters that each produce `should` clauses" do
+        it "does not merge `any_satisfy: {any_of: ...}` into a sibling `any_of` filter" do
+          pending "known bug: the two `should` groups collapse into one flat `should` array"
+
+          query = new_query(client_filter: {
+            "any_of" => [
+              {"name" => {"equal_to_any_of" => ["x"]}},
+              {"name" => {"equal_to_any_of" => ["y"]}}
+            ],
+            "ages" => {"any_satisfy" => {"any_of" => [{"gt" => 30}, {"lt" => 5}]}}
+          })
+
+          # `(name = x OR name = y) AND (age > 30 OR age < 5)`
+          expect(datastore_body_of(query)).to query_datastore_with({bool: {filter: [
+            {bool: {minimum_should_match: 1, should: [
+              {bool: {filter: [{terms: {"name" => ["x"]}}]}},
+              {bool: {filter: [{terms: {"name" => ["y"]}}]}}
+            ]}},
+            {bool: {minimum_should_match: 1, should: [
+              {bool: {filter: [{range: {"ages" => {gt: 30}}}]}},
+              {bool: {filter: [{range: {"ages" => {lt: 5}}}]}}
+            ]}}
+          ]}})
+        end
+
+        it "does not merge two sibling `any_satisfy: {any_of: ...}` filters on different fields" do
+          pending "known bug: the two `should` groups collapse into one flat `should` array"
+
+          query = new_query(client_filter: {
+            "tags" => {"any_satisfy" => {"any_of" => [{"equal_to_any_of" => ["a"]}, {"equal_to_any_of" => ["b"]}]}},
+            "ages" => {"any_satisfy" => {"any_of" => [{"gt" => 30}, {"lt" => 5}]}}
+          })
+
+          # `(tag = a OR tag = b) AND (age > 30 OR age < 5)`
+          expect(datastore_body_of(query)).to query_datastore_with({bool: {filter: [
+            {bool: {minimum_should_match: 1, should: [
+              {bool: {filter: [{terms: {"tags" => ["a"]}}]}},
+              {bool: {filter: [{terms: {"tags" => ["b"]}}]}}
+            ]}},
+            {bool: {minimum_should_match: 1, should: [
+              {bool: {filter: [{range: {"ages" => {gt: 30}}}]}},
+              {bool: {filter: [{range: {"ages" => {lt: 5}}}]}}
+            ]}}
+          ]}})
+        end
+
+        it "does not merge an `any_satisfy: {any_of: ...}` client filter into an `any_of` internal filter" do
+          pending "known bug: the two `should` groups collapse into one flat `should` array"
+
+          query = new_query(
+            client_filter: {"ages" => {"any_satisfy" => {"any_of" => [{"gt" => 30}, {"lt" => 5}]}}},
+            internal_filters: [{"any_of" => [
+              {"name" => {"equal_to_any_of" => ["x"]}},
+              {"name" => {"equal_to_any_of" => ["y"]}}
+            ]}]
+          )
+
+          # `(age > 30 OR age < 5) AND (name = x OR name = y)`
+          expect(datastore_body_of(query)).to query_datastore_with({bool: {filter: [
+            {bool: {minimum_should_match: 1, should: [
+              {bool: {filter: [{range: {"ages" => {gt: 30}}}]}},
+              {bool: {filter: [{range: {"ages" => {lt: 5}}}]}}
+            ]}},
+            {bool: {minimum_should_match: 1, should: [
+              {bool: {filter: [{terms: {"name" => ["x"]}}]}},
+              {bool: {filter: [{terms: {"name" => ["y"]}}]}}
+            ]}}
+          ]}})
+        end
+
+        it "does not merge an `any_of` client filter into an `any_of` internal filter" do
+          pending "known bug: the two `should` groups collapse into one flat `should` array"
+
+          query = new_query(
+            client_filter: {"any_of" => [
+              {"name" => {"equal_to_any_of" => ["x"]}},
+              {"name" => {"equal_to_any_of" => ["y"]}}
+            ]},
+            internal_filters: [{"any_of" => [
+              {"name" => {"equal_to_any_of" => ["y"]}},
+              {"name" => {"equal_to_any_of" => ["z"]}}
+            ]}]
+          )
+
+          # `(name = x OR name = y) AND (name = y OR name = z)`
+          expect(datastore_body_of(query)).to query_datastore_with({bool: {filter: [
+            {bool: {minimum_should_match: 1, should: [
+              {bool: {filter: [{terms: {"name" => ["x"]}}]}},
+              {bool: {filter: [{terms: {"name" => ["y"]}}]}}
+            ]}},
+            {bool: {minimum_should_match: 1, should: [
+              {bool: {filter: [{terms: {"name" => ["y"]}}]}},
+              {bool: {filter: [{terms: {"name" => ["z"]}}]}}
+            ]}}
+          ]}})
+        end
+
+        it "produces the correct query for the equivalent `all_of` filter, showing what the sibling form must produce" do
+          query = new_query(client_filter: {
+            "all_of" => [
+              {"any_of" => [
+                {"name" => {"equal_to_any_of" => ["x"]}},
+                {"name" => {"equal_to_any_of" => ["y"]}}
+              ]},
+              {"ages" => {"any_satisfy" => {"any_of" => [{"gt" => 30}, {"lt" => 5}]}}}
+            ]
+          })
+
+          expect(datastore_body_of(query)).to query_datastore_with({bool: {filter: [
+            {bool: {minimum_should_match: 1, should: [
+              {bool: {filter: [{terms: {"name" => ["x"]}}]}},
+              {bool: {filter: [{terms: {"name" => ["y"]}}]}}
+            ]}},
+            {bool: {minimum_should_match: 1, should: [
+              {bool: {filter: [{range: {"ages" => {gt: 30}}}]}},
+              {bool: {filter: [{range: {"ages" => {lt: 5}}}]}}
+            ]}}
+          ]}})
+        end
+      end
+
       # Note: a `count` filter gets translated into `__counts` (to distinguish it from a schema field named `count`),
       # and that translation happens as the query is being built, so we use `__counts` in our example filters here.
       describe "`count` operator on a list" do

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/filtering_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/datastore_query/filtering_spec.rb
@@ -1039,17 +1039,14 @@ module ElasticGraph
         end
       end
 
-      # Each filter below has two sibling parts that must be ANDed together, and each part produces
-      # `should` clauses. The parts land in the same `bool` node, so their `should` clauses go into
-      # one shared array under a single `minimum_should_match: 1`. That turns `(A OR B) AND (C OR D)`
-      # into `A OR B OR C OR D`, which matches documents the filter excludes.
-      #
-      # The `required_matching_clause_count > 1` guard in `FilterInterpreter` only inspects one
-      # `any_satisfy` sub-filter at a time, so it cannot detect a collision with a sibling filter.
+      # `minimum_should_match: 1` applies to the entire `should` array of a bool node, so a node can
+      # hold only one group of `should` clauses. Each filter below has two sibling parts that must be
+      # ANDed together, and each part produces such a group. The first group stays on the shared bool
+      # node, and each later group gets nested in its own bool query under `filter`, where it is
+      # required on its own. Without that nesting, `(A OR B) AND (C OR D)` would become
+      # `A OR B OR C OR D`, which matches documents the filter excludes.
       describe "sibling filters that each produce `should` clauses" do
-        it "does not merge `any_satisfy: {any_of: ...}` into a sibling `any_of` filter" do
-          pending "known bug: the two `should` groups collapse into one flat `should` array"
-
+        it "ANDs an `any_satisfy: {any_of: ...}` filter with a sibling `any_of` filter" do
           query = new_query(client_filter: {
             "any_of" => [
               {"name" => {"equal_to_any_of" => ["x"]}},
@@ -1059,42 +1056,44 @@ module ElasticGraph
           })
 
           # `(name = x OR name = y) AND (age > 30 OR age < 5)`
-          expect(datastore_body_of(query)).to query_datastore_with({bool: {filter: [
-            {bool: {minimum_should_match: 1, should: [
+          expect(datastore_body_of(query)).to query_datastore_with({bool: {
+            minimum_should_match: 1,
+            should: [
               {bool: {filter: [{terms: {"name" => ["x"]}}]}},
               {bool: {filter: [{terms: {"name" => ["y"]}}]}}
-            ]}},
-            {bool: {minimum_should_match: 1, should: [
-              {bool: {filter: [{range: {"ages" => {gt: 30}}}]}},
-              {bool: {filter: [{range: {"ages" => {lt: 5}}}]}}
-            ]}}
-          ]}})
+            ],
+            filter: [
+              {bool: {minimum_should_match: 1, should: [
+                {bool: {filter: [{range: {"ages" => {gt: 30}}}]}},
+                {bool: {filter: [{range: {"ages" => {lt: 5}}}]}}
+              ]}}
+            ]
+          }})
         end
 
-        it "does not merge two sibling `any_satisfy: {any_of: ...}` filters on different fields" do
-          pending "known bug: the two `should` groups collapse into one flat `should` array"
-
+        it "ANDs two sibling `any_satisfy: {any_of: ...}` filters on different fields" do
           query = new_query(client_filter: {
             "tags" => {"any_satisfy" => {"any_of" => [{"equal_to_any_of" => ["a"]}, {"equal_to_any_of" => ["b"]}]}},
             "ages" => {"any_satisfy" => {"any_of" => [{"gt" => 30}, {"lt" => 5}]}}
           })
 
           # `(tag = a OR tag = b) AND (age > 30 OR age < 5)`
-          expect(datastore_body_of(query)).to query_datastore_with({bool: {filter: [
-            {bool: {minimum_should_match: 1, should: [
+          expect(datastore_body_of(query)).to query_datastore_with({bool: {
+            minimum_should_match: 1,
+            should: [
               {bool: {filter: [{terms: {"tags" => ["a"]}}]}},
               {bool: {filter: [{terms: {"tags" => ["b"]}}]}}
-            ]}},
-            {bool: {minimum_should_match: 1, should: [
-              {bool: {filter: [{range: {"ages" => {gt: 30}}}]}},
-              {bool: {filter: [{range: {"ages" => {lt: 5}}}]}}
-            ]}}
-          ]}})
+            ],
+            filter: [
+              {bool: {minimum_should_match: 1, should: [
+                {bool: {filter: [{range: {"ages" => {gt: 30}}}]}},
+                {bool: {filter: [{range: {"ages" => {lt: 5}}}]}}
+              ]}}
+            ]
+          }})
         end
 
-        it "does not merge an `any_satisfy: {any_of: ...}` client filter into an `any_of` internal filter" do
-          pending "known bug: the two `should` groups collapse into one flat `should` array"
-
+        it "ANDs an `any_satisfy: {any_of: ...}` client filter with an `any_of` internal filter" do
           query = new_query(
             client_filter: {"ages" => {"any_satisfy" => {"any_of" => [{"gt" => 30}, {"lt" => 5}]}}},
             internal_filters: [{"any_of" => [
@@ -1104,21 +1103,22 @@ module ElasticGraph
           )
 
           # `(age > 30 OR age < 5) AND (name = x OR name = y)`
-          expect(datastore_body_of(query)).to query_datastore_with({bool: {filter: [
-            {bool: {minimum_should_match: 1, should: [
+          expect(datastore_body_of(query)).to query_datastore_with({bool: {
+            minimum_should_match: 1,
+            should: [
               {bool: {filter: [{range: {"ages" => {gt: 30}}}]}},
               {bool: {filter: [{range: {"ages" => {lt: 5}}}]}}
-            ]}},
-            {bool: {minimum_should_match: 1, should: [
-              {bool: {filter: [{terms: {"name" => ["x"]}}]}},
-              {bool: {filter: [{terms: {"name" => ["y"]}}]}}
-            ]}}
-          ]}})
+            ],
+            filter: [
+              {bool: {minimum_should_match: 1, should: [
+                {bool: {filter: [{terms: {"name" => ["x"]}}]}},
+                {bool: {filter: [{terms: {"name" => ["y"]}}]}}
+              ]}}
+            ]
+          }})
         end
 
-        it "does not merge an `any_of` client filter into an `any_of` internal filter" do
-          pending "known bug: the two `should` groups collapse into one flat `should` array"
-
+        it "ANDs an `any_of` client filter with an `any_of` internal filter" do
           query = new_query(
             client_filter: {"any_of" => [
               {"name" => {"equal_to_any_of" => ["x"]}},
@@ -1131,19 +1131,76 @@ module ElasticGraph
           )
 
           # `(name = x OR name = y) AND (name = y OR name = z)`
-          expect(datastore_body_of(query)).to query_datastore_with({bool: {filter: [
-            {bool: {minimum_should_match: 1, should: [
+          expect(datastore_body_of(query)).to query_datastore_with({bool: {
+            minimum_should_match: 1,
+            should: [
               {bool: {filter: [{terms: {"name" => ["x"]}}]}},
               {bool: {filter: [{terms: {"name" => ["y"]}}]}}
-            ]}},
-            {bool: {minimum_should_match: 1, should: [
-              {bool: {filter: [{terms: {"name" => ["y"]}}]}},
-              {bool: {filter: [{terms: {"name" => ["z"]}}]}}
-            ]}}
-          ]}})
+            ],
+            filter: [
+              {bool: {minimum_should_match: 1, should: [
+                {bool: {filter: [{terms: {"name" => ["y"]}}]}},
+                {bool: {filter: [{terms: {"name" => ["z"]}}]}}
+              ]}}
+            ]
+          }})
         end
 
-        it "produces the correct query for the equivalent `all_of` filter, showing what the sibling form must produce" do
+        it "unwraps a nested group that has a single `should` clause, so that the datastore can cache it" do
+          query = new_query(
+            client_filter: {"any_of" => [
+              {"name" => {"equal_to_any_of" => ["x"]}},
+              {"name" => {"equal_to_any_of" => ["y"]}}
+            ]},
+            internal_filters: [{"any_of" => [{"name" => {"equal_to_any_of" => ["y"]}}]}]
+          )
+
+          # `(name = x OR name = y) AND name = y`
+          expect(datastore_body_of(query)).to query_datastore_with({bool: {
+            minimum_should_match: 1,
+            should: [
+              {bool: {filter: [{terms: {"name" => ["x"]}}]}},
+              {bool: {filter: [{terms: {"name" => ["y"]}}]}}
+            ],
+            filter: [
+              {bool: {filter: [{terms: {"name" => ["y"]}}]}}
+            ]
+          }})
+        end
+
+        it "ANDs three sibling filters that each produce `should` clauses" do
+          query = new_query(
+            client_filter: {
+              "any_of" => [
+                {"name" => {"equal_to_any_of" => ["x"]}},
+                {"name" => {"equal_to_any_of" => ["y"]}}
+              ],
+              "ages" => {"any_satisfy" => {"any_of" => [{"gt" => 30}, {"lt" => 5}]}}
+            },
+            internal_filters: [{"tags" => {"any_satisfy" => {"any_of" => [{"equal_to_any_of" => ["a"]}, {"equal_to_any_of" => ["b"]}]}}}]
+          )
+
+          # `(name = x OR name = y) AND (age > 30 OR age < 5) AND (tag = a OR tag = b)`
+          expect(datastore_body_of(query)).to query_datastore_with({bool: {
+            minimum_should_match: 1,
+            should: [
+              {bool: {filter: [{terms: {"name" => ["x"]}}]}},
+              {bool: {filter: [{terms: {"name" => ["y"]}}]}}
+            ],
+            filter: [
+              {bool: {minimum_should_match: 1, should: [
+                {bool: {filter: [{range: {"ages" => {gt: 30}}}]}},
+                {bool: {filter: [{range: {"ages" => {lt: 5}}}]}}
+              ]}},
+              {bool: {minimum_should_match: 1, should: [
+                {bool: {filter: [{terms: {"tags" => ["a"]}}]}},
+                {bool: {filter: [{terms: {"tags" => ["b"]}}]}}
+              ]}}
+            ]
+          }})
+        end
+
+        it "produces the same results for the equivalent `all_of` filter" do
           query = new_query(client_filter: {
             "all_of" => [
               {"any_of" => [


### PR DESCRIPTION
## Problem

`minimum_should_match: 1` applies to the entire `should` array of a bool node, so a node can hold only one group of `should` clauses. Two sibling filters that must be ANDed together can each produce such a group, and both groups went into the same array. `(A OR B) AND (C OR D)` became `A OR B OR C OR D`.

`FilterInterpreter` merged the clauses of an `any_satisfy` sub-filter into the shared parent node ([`filter_interpreter.rb:187`](https://github.com/block/elasticgraph/blob/0fbeffff/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_interpreter.rb#L187)), and [`build_bool_hash`](https://github.com/block/elasticgraph/blob/0fbeffff/elasticgraph-graphql/lib/elastic_graph/graphql/filtering/filter_interpreter.rb#L353) then stamped one `minimum_should_match: 1` over the combined node. `BooleanQuery#merge_into` did the same for `any_of`.

This filter:

```ruby
{
  "any_of" => [
    {"name" => {"equal_to_any_of" => ["x"]}},
    {"name" => {"equal_to_any_of" => ["y"]}}
  ],
  "ages" => {"any_satisfy" => {"any_of" => [{"gt" => 30}, {"lt" => 5}]}}
}
```

must mean `(name = x OR name = y) AND (age > 30 OR age < 5)`. It generated one flat `should` array with all four clauses, so a document with `name = "z"` and `ages = [40]` was a search hit. There was no error and no log entry.

The `required_matching_clause_count > 1` guard in `process_any_satisfy_filter_expression_on_scalar_list` inspects one `any_satisfy` sub-filter alone, so it cannot detect a collision with a sibling filter.

Four legal, public filter forms collapsed:

1. `any_of` next to `any_satisfy: {any_of: ...}` — the case above.
2. Two `any_satisfy: {any_of: ...}` filters on different scalar list fields.
3. An `any_satisfy: {any_of: ...}` client filter next to an `any_of` internal filter.
4. An `any_of` client filter next to an `any_of` internal filter.

Cases 3 and 4 need no `any_satisfy`. `DatastoreQuery` passes `client_filters + internal_filters` to one `build_query` call, so the clauses share one bool node. An internal filter must restrict the client's results, and a relationship `additional_filter` or a `query_interceptor` filter can contain `any_of`. When it did, the restriction became one more OR branch.

## Fix

`BooleanQuery#merge_into` now nests a `should` group in its own bool query under `filter` when the target node already has a group:

```ruby
def merge_into(bool_node)
  if occurrence == :should && bool_node.key?(:should)
    BooleanQuery.filter({bool: {minimum_should_match: 1, should: clauses}}).merge_into(bool_node)
  else
    bool_node[occurrence].concat(clauses)
  end
end
```

The nested group is required on its own, which restores the AND. It routes through `BooleanQuery.filter`, so the existing unwrap keeps a single-clause group cacheable.

`process_any_satisfy_filter_expression_on_scalar_list` merged its clauses directly into the parent node and bypassed `merge_into`, so it now routes a `should` group through `merge_into`. The `required_matching_clause_count > 1` guard is unchanged: when the guard passes and the sub-filter has `should` clauses, that group is the whole sub-filter, because any other clause would raise the count above 1.

The first group stays on the shared node and each later group nests, so a query without a collision keeps its current shape and stays flat. No existing spec expectation changed.

For the filter above, the query is now:

```json
{"bool": {
  "minimum_should_match": 1,
  "should": [
    {"bool": {"filter": [{"terms": {"name": ["x"]}}]}},
    {"bool": {"filter": [{"terms": {"name": ["y"]}}]}}
  ],
  "filter": [
    {"bool": {"minimum_should_match": 1, "should": [
      {"bool": {"filter": [{"range": {"ages": {"gt": 30}}}]}},
      {"bool": {"filter": [{"range": {"ages": {"lt": 5}}}]}}
    ]}}
  ]
}}
```

## Specs

The specs came first and failed before the fix.

- `spec/unit/.../datastore_query/filtering_spec.rb` — the generated query for each of the four cases, plus three clauses in one filter, the single-clause unwrap, and the equivalent `all_of` form.
- `spec/integration/.../datastore_query/filtering_spec.rb` — the documents the datastore returns for cases 1 and 3. Before the fix, both returned `["t1", "t2", "t3"]` where only `t1` matches the filter.

## Verification

- `script/run_specs` — 5263 examples, 0 failures.
- `script/type_check` — no type error.
- `script/lint` — 894 files, no offenses.
