### PR TITLE
Validate pagination cursors on array-backed relay connections

### DIFF
--- a/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/paginator.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/datastore_query/paginator.rb
@@ -6,7 +6,7 @@
 #
 # frozen_string_literal: true
 
-require "elastic_graph/errors"
+require "elastic_graph/graphql/decoded_cursor"
 require "elastic_graph/support/memoizable_data"
 require "graphql"
 
@@ -69,13 +69,13 @@ module ElasticGraph
         # @return [DecodedCursor, nil] the decoded after cursor
         def decoded_after
           return @decoded_after if defined?(@decoded_after)
-          @decoded_after = decode_cursor(after)
+          @decoded_after = DecodedCursor.decode_or_raise_execution_error(after)
         end
 
         # @return [DecodedCursor, nil] the decoded before cursor
         def decoded_before
           return @decoded_before if defined?(@decoded_before)
-          @decoded_before = decode_cursor(before)
+          @decoded_before = DecodedCursor.decode_or_raise_execution_error(before)
         end
 
         def requested_page_size
@@ -152,13 +152,6 @@ module ElasticGraph
         end
 
         private
-
-        def decode_cursor(cursor)
-          return nil if cursor.nil?
-          DecodedCursor.decode!(cursor)
-        rescue Errors::InvalidCursorError => e
-          raise ::GraphQL::ExecutionError, e.message
-        end
 
         def first_n
           @first_n ||= size_arg_value(:first, first)

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/decoded_cursor.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/decoded_cursor.rb
@@ -10,6 +10,7 @@ require "base64"
 require "elastic_graph/constants"
 require "elastic_graph/errors"
 require "elastic_graph/support/memoizable_data"
+require "graphql"
 require "json"
 
 module ElasticGraph
@@ -50,6 +51,18 @@ module ElasticGraph
         new(::JSON.parse(json))
       rescue ::ArgumentError, ::JSON::ParserError
         raise Errors::InvalidCursorError, "`#{string}` is an invalid cursor."
+      end
+
+      # Decodes the given string cursor, returning `nil` if it is `nil`, and raising a
+      # `GraphQL::ExecutionError` if it is invalid. Use this to decode a cursor that a GraphQL
+      # client provided, so that an invalid cursor produces a clean query error. The `Cursor`
+      # scalar cannot do this validation itself, because the `Cursor` type can be overridden to
+      # `String`, and in that case cursor arguments are not coerced by our `Cursor` scalar.
+      def self.decode_or_raise_execution_error(string)
+        return nil if string.nil?
+        decode!(string)
+      rescue Errors::InvalidCursorError => e
+        raise ::GraphQL::ExecutionError, e.message
       end
 
       # Encodes the cursor to a string using JSON and Base64 encoding.

--- a/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/array_adapter.rb
+++ b/elasticgraph-graphql/lib/elastic_graph/graphql/resolvers/relay_connection/array_adapter.rb
@@ -6,6 +6,7 @@
 #
 # frozen_string_literal: true
 
+require "elastic_graph/graphql/decoded_cursor"
 require "elastic_graph/graphql/resolvers/resolvable_value"
 require "forwardable"
 
@@ -35,12 +36,14 @@ module ElasticGraph
             # Here we map the args back to the canonical relay args so `ArrayConnection` can
             # understand them.
             #
-            # `after` and `before` are encoded to convert them to the string form required by `ArrayConnection`.
+            # `after` and `before` are decoded (and then re-encoded) so that an invalid cursor produces a
+            # clean query error. `ArrayConnection` itself decodes cursors leniently and would silently
+            # treat an invalid cursor as the start of the collection.
             relay_args = {
               first: args[schema_element_names.first],
-              after: args[schema_element_names.after]&.encode,
+              after: DecodedCursor.decode_or_raise_execution_error(args[schema_element_names.after])&.encode,
               last: args[schema_element_names.last],
-              before: args[schema_element_names.before]&.encode
+              before: DecodedCursor.decode_or_raise_execution_error(args[schema_element_names.before])&.encode
             }.compact
 
             graphql_impl = ::GraphQL::Pagination::ArrayConnection.new(nodes, context: context, **relay_args)

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/datastore_query/paginator.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/datastore_query/paginator.rbs
@@ -42,8 +42,6 @@ module ElasticGraph
 
         private
 
-        def decode_cursor: (::String?) -> DecodedCursor?
-
         @first_n: ::Integer?
         def first_n: () -> ::Integer?
 

--- a/elasticgraph-graphql/sig/elastic_graph/graphql/decoded_cursor.rbs
+++ b/elasticgraph-graphql/sig/elastic_graph/graphql/decoded_cursor.rbs
@@ -8,6 +8,7 @@ module ElasticGraph
       def encode: () -> ::String
       def self.try_decode: (::String) -> DecodedCursor?
       def self.decode!: (::String) -> DecodedCursor
+      def self.decode_or_raise_execution_error: (::String?) -> DecodedCursor?
       @encode: ::String?
 
       SINGLETON: DecodedCursor

--- a/elasticgraph-graphql/spec/acceptance/search_spec.rb
+++ b/elasticgraph-graphql/spec/acceptance/search_spec.rb
@@ -109,6 +109,14 @@ module ElasticGraph
           case_correctly("widget_fee_currencies") => ["CAD", "USD"]
         }])
 
+        # Demonstrate that a broken cursor on an array-backed connection is rejected, just like it
+        # is on a datastore-backed connection.
+        broken_cursor = "not-a-cursor"
+        expect {
+          response = list_widget_currencies(widget_names_args: {first: 1, after: broken_cursor}, expect_errors: true)
+          expect(response["errors"]).to contain_exactly(a_hash_including("message" => "`#{broken_cursor}` is an invalid cursor."))
+        }.to log_warning a_string_including("`#{broken_cursor}` is an invalid cursor.")
+
         unfiltered_widget_currencies = list_widget_currencies
         expect(unfiltered_widget_currencies).to match([{
           "id" => "USD",
@@ -1941,8 +1949,8 @@ module ElasticGraph
         QUERY
       end
 
-      def list_widget_currencies(widget_names_args: {}, **query_args)
-        call_graphql_query(<<~QUERY).dig("data", case_correctly("widget_currencies"), "edges").map { |we| we.fetch("node") }
+      def list_widget_currencies(widget_names_args: {}, expect_errors: false, **query_args)
+        response = call_graphql_query(<<~QUERY, allow_errors: expect_errors)
           query {
             widget_currencies#{graphql_args(query_args)} {
               edges {
@@ -1974,6 +1982,9 @@ module ElasticGraph
             }
           }
         QUERY
+
+        return response if expect_errors
+        response.dig("data", case_correctly("widget_currencies"), "edges").map { |we| we.fetch("node") }
       end
 
       def list_widget_currencies_by_nodes(**query_args)

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/decoded_cursor_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/decoded_cursor_spec.rb
@@ -112,6 +112,27 @@ module ElasticGraph
         end
       end
 
+      describe ".decode_or_raise_execution_error" do
+        it "returns a decoded cursor value" do
+          cursor = DecodedCursor.new(sort_values).encode
+          decoded = DecodedCursor.decode_or_raise_execution_error(cursor)
+
+          expect(decoded.sort_values).to eq sort_values
+        end
+
+        it "returns `nil` when given `nil`" do
+          expect(DecodedCursor.decode_or_raise_execution_error(nil)).to eq nil
+        end
+
+        it "raises a `GraphQL::ExecutionError` when given an invalid cursor" do
+          bad_cursor = DecodedCursor.new(sort_values).encode + ' $1!!@#(#@'
+
+          expect {
+            DecodedCursor.decode_or_raise_execution_error(bad_cursor)
+          }.to raise_error(::GraphQL::ExecutionError, a_string_including(bad_cursor))
+        end
+      end
+
       describe ".factory_from_sort_list" do
         let(:amount) { ::Faker::Number.between(from: 100, to: 900) }
         let(:sort_fields) { %w[created_at amount id] }

--- a/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection/array_adapter_spec.rb
+++ b/elasticgraph-graphql/spec/unit/elastic_graph/graphql/resolvers/relay_connection/array_adapter_spec.rb
@@ -112,6 +112,18 @@ module ElasticGraph
             expect(response.nodes).to eq([])
           end
 
+          it "rejects an invalid `after` cursor with a clear error instead of silently returning the first page" do
+            expect {
+              resolve_nums(11, first: 2, after: "not-a-cursor")
+            }.to raise_error ::GraphQL::ExecutionError, "`not-a-cursor` is an invalid cursor."
+          end
+
+          it "rejects an invalid `before` cursor with a clear error instead of silently returning an empty page" do
+            expect {
+              resolve_nums(11, last: 2, before: "not-a-cursor")
+            }.to raise_error ::GraphQL::ExecutionError, "`not-a-cursor` is an invalid cursor."
+          end
+
           context "with `max_page_size` configured" do
             let(:graphql) { build_graphql(max_page_size: 10) }
 
@@ -151,16 +163,6 @@ module ElasticGraph
           end
 
           def resolve_nums(count, **args)
-            # Parse cursors in the same way the GraphQL runtime does.
-            args = args.to_h do |name, value|
-              case name
-              when :after, :aftr, :before, :bfr
-                [name, DecodedCursor.try_decode(value)]
-              else
-                [name, value]
-              end
-            end
-
             natural_numbers = count.is_a?(::Integer) ? 1.upto(count).to_a : count
             resolve("Widget", "natural_numbers", {"natural_numbers" => natural_numbers}, **args)
           end


### PR DESCRIPTION
## Problem

`widgetNames(first: 2, after: "not-a-cursor")` silently returns the first page with `hasPreviousPage: false`. The same invalid cursor on a datastore-backed field returns a validation error, so the two paths disagree.

Before ac2c10ea, `Cursor.coerce_input` decoded each cursor and returned `nil` for an invalid one, and GraphQL-Ruby rejected it at argument coercion time. That commit moved decoding into `Paginator` so decoding still runs when a project overrides the `Cursor` type to `String` (GraphQL only coerces at the scalar level, so a `String`-typed cursor argument never reaches our `Cursor` scalar).

Array-backed relay connections never reach `Paginator`. `GetRecordFieldValue` and `ApolloEntityRefResolver` pass their args straight to `ArrayAdapter.build`. `GraphQL::Pagination::ArrayConnection` then decodes with `Base64.decode64`, which is lenient — `Base64.decode64("not-a-cursor").to_i` is `0`, i.e. the start of the collection. `before: "garbage"` yields an empty page with `hasNextPage: true`.

## Fix

`ArrayAdapter.build` now decodes `after` and `before` before handing them to `ArrayConnection`, raising the same `GraphQL::ExecutionError` that `Paginator` raises. Both paths share a new `DecodedCursor.decode_or_raise_execution_error`, so they produce an identical message.

This keeps ac2c10ea's design — validation lives in the consumer rather than the scalar — so it still works under the `Cursor: "String"` override.

Also included:

- Removed the `&.encode` calls in `ArrayAdapter.build`. They became no-ops when cursor args became strings, and the comment above them was no longer true.
- Stopped `array_adapter_spec.rb` from decoding cursor args itself. That emulated the pre-ac2c10ea runtime and hid the bug.
- Added an acceptance expectation for a broken cursor on `widget_names`, covering both the `Cursor` scalar and the `String` cursor override.

## Verification

I confirmed the acceptance test is a real regression test: with `array_adapter.rb` reverted it fails in both the snake_case and camelCase contexts, and passes with the fix.

Valid cursors are unaffected. `ArrayConnection` cursors round-trip through `DecodedCursor` unchanged (index `1` → `"MQ"` → `"MQ"` → `1`).

`script/quick_build` passes: 5259 examples, 0 failures, 100% line and branch coverage, no standardrb offenses, no steep type errors.

## Note

`DecodedCursor.try_decode` is now unused within `lib` — it went dead in ac2c10ea. It is public, documented API, so I left it in place rather than widening this change.
