### PR TITLE
Show schema definition order differences

### DIFF
--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/define_schema_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/graphql_schema/define_schema_spec.rb
@@ -93,7 +93,7 @@ module ElasticGraph
           )
         end
 
-        it "produces the same GraphQL output, regardless of the order the types are defined in" do
+        it "produces byte-identical GraphQL output, regardless of the order the types are defined in" do
           object_type_definitions = {
             "Component" => lambda do |t|
               t.field "id", "ID!"
@@ -129,18 +129,24 @@ module ElasticGraph
             %w[WidgetVersion Component Widget]
           ]
 
-          uniq_results_for_each_ordering = all_definition_orderings.map do |type_names_in_order|
-            define_schema do |schema|
+          results_by_definition_order = all_definition_orderings.to_h do |type_names_in_order|
+            result = define_schema do |schema|
               type_names_in_order.each do |type_name|
                 schema.object_type(type_name, &object_type_definitions.fetch(type_name))
               end
             end
-          end.uniq
 
-          expect(uniq_results_for_each_ordering.size).to eq 1
+            [type_names_in_order, result]
+          end
 
-          # Also compare the first and last, so that if there are multiple we get a diff showing how they differ.
-          expect(uniq_results_for_each_ordering.first).to eq uniq_results_for_each_ordering.last
+          reference_order, reference_result = results_by_definition_order.first
+
+          # Compare the raw generated SDL rather than normalizing it through graphql-ruby. Schema definition
+          # order must not affect field order or any other part of the generated schema artifact.
+          results_by_definition_order.drop(1).each do |definition_order, result|
+            expect(result).to eq(reference_result),
+              "Expected definition order #{definition_order.inspect} to match #{reference_order.inspect}"
+          end
         end
 
         it "returns reasonably-sized strings from `#inspect` and `#to_s` for all objects exposed to users so that the exception output if the user misspells a method name is readable" do


### PR DESCRIPTION
## Why

An intermittent JRuby failure proves that schema definition order can produce two different GraphQL outputs, but the current assertion stops after counting unique results and hides the actual SDL difference. Capture an actionable diff before choosing a production fix.

## What

- Compare every definition ordering directly against a reference ordering
- Label failures with both definition orders while retaining the unified raw-SDL diff
- Clarify that the invariant covers byte-identical schema artifacts, including field order

## Risk Assessment

Very low. This changes one test assertion and no production behavior; the same flake may recur, but its next failure will identify the divergent ordering and output.

## Validation

- Focused regression with seed 3570 on CRuby 4.0.0
- Focused regression with seed 3570 on JRuby 10.0.6.0
- `script/lint`

## Context

Observed while validating https://github.com/block/elasticgraph/pull/1305.