### PR TITLE
Update test schema with a pure-source (non-indexed) type feeding a top-level sourced_from field

### DIFF
--- a/config/schema/artifacts/data_warehouse.yaml
+++ b/config/schema/artifacts/data_warehouse.yaml
@@ -27,6 +27,7 @@ tables:
         widget_workspace_id3 STRING,
         widget_size STRING,
         widget_cost STRUCT<currency STRING, amount_cents INT>,
+        designer_name STRING,
         part_ids ARRAY<STRING>,
         owner_ids ARRAY<STRING>,
         owner_id STRING

--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -1610,6 +1610,8 @@ indices:
               type: keyword
             amount_cents:
               type: integer
+        designer_name:
+          type: keyword
         part_ids:
           type: keyword
         owner_ids:

--- a/config/schema/artifacts/json_schemas.yaml
+++ b/config/schema/artifacts/json_schemas.yaml
@@ -27,6 +27,7 @@ json_schema_version: 1
         - CoachProfile
         - Company
         - Component
+        - ComponentDesign
         - DirectWholesaler
         - ElectricalPart
         - GeneralManagerProfile
@@ -332,6 +333,33 @@ json_schema_version: 1
     - part_ids
     - owner_ids
     - owner_id
+  ComponentDesign:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+      component_id:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/ID"
+          - maxLength: 8191
+        - type: 'null'
+      designer_name:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+      __typename:
+        type: string
+        const: ComponentDesign
+        default: ComponentDesign
+    required:
+    - id
+    - component_id
+    - designer_name
   Date:
     type: string
     format: date

--- a/config/schema/artifacts/json_schemas_by_version/v1.yaml
+++ b/config/schema/artifacts/json_schemas_by_version/v1.yaml
@@ -27,6 +27,7 @@ json_schema_version: 1
         - CoachProfile
         - Company
         - Component
+        - ComponentDesign
         - DirectWholesaler
         - ElectricalPart
         - GeneralManagerProfile
@@ -422,6 +423,42 @@ json_schema_version: 1
     - part_ids
     - owner_ids
     - owner_id
+  ComponentDesign:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+        ElasticGraph:
+          type: ID!
+          nameInIndex: id
+      component_id:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/ID"
+          - maxLength: 8191
+        - type: 'null'
+        ElasticGraph:
+          type: ID
+          nameInIndex: component_id
+      designer_name:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+        ElasticGraph:
+          type: String
+          nameInIndex: designer_name
+      __typename:
+        type: string
+        const: ComponentDesign
+        default: ComponentDesign
+    required:
+    - id
+    - component_id
+    - designer_name
   Date:
     type: string
     format: date

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -31,6 +31,14 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: created_at
+      designer_name_ASC:
+        sort_field:
+          direction: asc
+          field_path: designer_name
+      designer_name_DESC:
+        sort_field:
+          direction: desc
+          field_path: designer_name
       id_ASC:
         sort_field:
           direction: asc
@@ -515,6 +523,14 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: created_on
+      designer_name_ASC:
+        sort_field:
+          direction: asc
+          field_path: designer_name
+      designer_name_DESC:
+        sort_field:
+          direction: desc
+          field_path: designer_name
       id_ASC:
         sort_field:
           direction: asc
@@ -1860,6 +1876,7 @@ index_definitions_by_name:
   components:
     current_sources:
     - __self
+    - design
     - widget
     default_sort_fields:
     - direction: desc
@@ -1875,6 +1892,8 @@ index_definitions_by_name:
         source: widget
       created_at:
         source: __self
+      designer_name:
+        source: design
       id:
         source: __self
       name:
@@ -3467,6 +3486,9 @@ object_types_by_name:
       created_at:
         resolver:
           name: get_record_field_value
+      designer_name:
+        resolver:
+          name: get_record_field_value
       dollar_widget:
         relation:
           additional_filter:
@@ -3575,6 +3597,9 @@ object_types_by_name:
       created_at:
         resolver:
           name: object_with_lookahead
+      designer_name:
+        resolver:
+          name: object_with_lookahead
       id:
         resolver:
           name: object_with_lookahead
@@ -3652,6 +3677,36 @@ object_types_by_name:
       total_edge_count:
         resolver:
           name: object_without_lookahead
+  ComponentDesign:
+    graphql_fields_by_name:
+      component_id:
+        resolver:
+          name: get_record_field_value
+      designer_name:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+    update_targets:
+    - id_source: component_id
+      metadata_params:
+        relationship:
+          value: design
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: design
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      top_level_fields_params:
+        designer_name:
+          cardinality: one
+      type: Component
   ComponentEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
@@ -3676,6 +3731,9 @@ object_types_by_name:
       created_at:
         resolver:
           name: object_with_lookahead
+      designer_name:
+        resolver:
+          name: object_with_lookahead
       name:
         resolver:
           name: object_with_lookahead
@@ -3697,6 +3755,9 @@ object_types_by_name:
           name: object_with_lookahead
   ComponentHighlights:
     graphql_fields_by_name:
+      designer_name:
+        resolver:
+          name: get_record_field_value
       id:
         resolver:
           name: get_record_field_value
@@ -4952,6 +5013,9 @@ object_types_by_name:
       description:
         resolver:
           name: get_record_field_value
+      designer_name:
+        resolver:
+          name: get_record_field_value
       dollar_widget:
         relation:
           additional_filter:
@@ -5146,6 +5210,9 @@ object_types_by_name:
         resolver:
           name: object_with_lookahead
       created_on:
+        resolver:
+          name: object_with_lookahead
+      designer_name:
         resolver:
           name: object_with_lookahead
       fees:
@@ -5359,6 +5426,9 @@ object_types_by_name:
       created_on:
         resolver:
           name: object_with_lookahead
+      designer_name:
+        resolver:
+          name: object_with_lookahead
       fees:
         resolver:
           name: object_with_lookahead
@@ -5465,6 +5535,9 @@ object_types_by_name:
         resolver:
           name: get_record_field_value
       description:
+        resolver:
+          name: get_record_field_value
+      designer_name:
         resolver:
           name: get_record_field_value
       fees:

--- a/config/schema/artifacts/schema.graphql
+++ b/config/schema/artifacts/schema.graphql
@@ -995,6 +995,7 @@ type Company implements NamedInventor {
 
 type Component implements NamedEntity {
   created_at: DateTime!
+  designer_name: String
   dollar_widget: Widget
   id: ID!
   name: String
@@ -1212,6 +1213,11 @@ type ComponentAggregatedValues {
   created_at: DateTimeAggregatedValues
 
   """
+  Computed aggregate values for the `designer_name` field.
+  """
+  designer_name: NonNumericAggregatedValues
+
+  """
   Computed aggregate values for the `id` field.
   """
   id: NonNumericAggregatedValues
@@ -1413,6 +1419,13 @@ input ComponentFilterInput {
   created_at: DateTimeFilterInput
 
   """
+  Used to filter on the `designer_name` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  designer_name: StringFilterInput
+
+  """
   Used to filter on the `id` field.
 
   When `null` or an empty object is passed, matches all documents.
@@ -1494,6 +1507,11 @@ type ComponentGroupedBy {
   created_at: DateTimeGroupedBy
 
   """
+  The `designer_name` field value for this group.
+  """
+  designer_name: String
+
+  """
   The `name` field value for this group.
   """
   name: String
@@ -1528,6 +1546,11 @@ type ComponentGroupedBy {
 Type used to request desired `Component` search highlight fields.
 """
 type ComponentHighlights {
+  """
+  Search highlights for the `designer_name`, providing snippets of the matching text.
+  """
+  designer_name: [String!]!
+
   """
   Search highlights for the `id`, providing snippets of the matching text.
   """
@@ -1582,6 +1605,16 @@ enum ComponentSortOrderInput {
   Sorts descending by the `created_at` field.
   """
   created_at_DESC
+
+  """
+  Sorts ascending by the `designer_name` field.
+  """
+  designer_name_ASC
+
+  """
+  Sorts descending by the `designer_name` field.
+  """
+  designer_name_DESC
 
   """
   Sorts ascending by the `id` field.
@@ -6402,6 +6435,11 @@ type NamedEntityAggregatedValues {
   created_on: DateAggregatedValues
 
   """
+  Computed aggregate values for the `designer_name` field.
+  """
+  designer_name: NonNumericAggregatedValues
+
+  """
   Computed aggregate values for the `fees` field.
   """
   fees: MoneyAggregatedValues
@@ -6804,6 +6842,13 @@ input NamedEntityFilterInput {
   description: TextFilterInput
 
   """
+  Used to filter on the `designer_name` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  designer_name: StringFilterInput
+
+  """
   Used to filter on the `fees` field.
 
   When `null` or an empty object is passed, matches all documents.
@@ -7085,6 +7130,11 @@ type NamedEntityGroupedBy {
   created_on: DateGroupedBy
 
   """
+  The `designer_name` field value for this group.
+  """
+  designer_name: String
+
+  """
   The `fees` field value for this group.
 
   Note: `fees` is a collection field, but selecting this field will group on
@@ -7279,6 +7329,11 @@ type NamedEntityHighlights {
   Search highlights for the `description`, providing snippets of the matching text.
   """
   description: [String!]!
+
+  """
+  Search highlights for the `designer_name`, providing snippets of the matching text.
+  """
+  designer_name: [String!]!
 
   """
   Search highlights for the `fees`, providing snippets of the matching text.
@@ -7549,6 +7604,16 @@ enum NamedEntitySortOrderInput {
   Sorts descending by the `created_on` field.
   """
   created_on_DESC
+
+  """
+  Sorts ascending by the `designer_name` field.
+  """
+  designer_name_ASC
+
+  """
+  Sorts descending by the `designer_name` field.
+  """
+  designer_name_DESC
 
   """
   Sorts ascending by the `id` field.

--- a/config/schema/artifacts_with_apollo/data_warehouse.yaml
+++ b/config/schema/artifacts_with_apollo/data_warehouse.yaml
@@ -27,6 +27,7 @@ tables:
         widget_workspace_id3 STRING,
         widget_size STRING,
         widget_cost STRUCT<currency STRING, amount_cents INT>,
+        designer_name STRING,
         part_ids ARRAY<STRING>,
         owner_ids ARRAY<STRING>,
         owner_id STRING

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -1610,6 +1610,8 @@ indices:
               type: keyword
             amount_cents:
               type: integer
+        designer_name:
+          type: keyword
         part_ids:
           type: keyword
         owner_ids:

--- a/config/schema/artifacts_with_apollo/json_schemas.yaml
+++ b/config/schema/artifacts_with_apollo/json_schemas.yaml
@@ -27,6 +27,7 @@ json_schema_version: 1
         - CoachProfile
         - Company
         - Component
+        - ComponentDesign
         - DirectWholesaler
         - ElectricalPart
         - GeneralManagerProfile
@@ -332,6 +333,33 @@ json_schema_version: 1
     - part_ids
     - owner_ids
     - owner_id
+  ComponentDesign:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+      component_id:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/ID"
+          - maxLength: 8191
+        - type: 'null'
+      designer_name:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+      __typename:
+        type: string
+        const: ComponentDesign
+        default: ComponentDesign
+    required:
+    - id
+    - component_id
+    - designer_name
   Date:
     type: string
     format: date

--- a/config/schema/artifacts_with_apollo/json_schemas_by_version/v1.yaml
+++ b/config/schema/artifacts_with_apollo/json_schemas_by_version/v1.yaml
@@ -27,6 +27,7 @@ json_schema_version: 1
         - CoachProfile
         - Company
         - Component
+        - ComponentDesign
         - DirectWholesaler
         - ElectricalPart
         - GeneralManagerProfile
@@ -422,6 +423,42 @@ json_schema_version: 1
     - part_ids
     - owner_ids
     - owner_id
+  ComponentDesign:
+    type: object
+    properties:
+      id:
+        allOf:
+        - "$ref": "#/$defs/ID"
+        - maxLength: 8191
+        ElasticGraph:
+          type: ID!
+          nameInIndex: id
+      component_id:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/ID"
+          - maxLength: 8191
+        - type: 'null'
+        ElasticGraph:
+          type: ID
+          nameInIndex: component_id
+      designer_name:
+        anyOf:
+        - allOf:
+          - "$ref": "#/$defs/String"
+          - maxLength: 8191
+        - type: 'null'
+        ElasticGraph:
+          type: String
+          nameInIndex: designer_name
+      __typename:
+        type: string
+        const: ComponentDesign
+        default: ComponentDesign
+    required:
+    - id
+    - component_id
+    - designer_name
   Date:
     type: string
     format: date

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -31,6 +31,14 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: created_at
+      designer_name_ASC:
+        sort_field:
+          direction: asc
+          field_path: designer_name
+      designer_name_DESC:
+        sort_field:
+          direction: desc
+          field_path: designer_name
       id_ASC:
         sort_field:
           direction: asc
@@ -515,6 +523,14 @@ enum_types_by_name:
         sort_field:
           direction: desc
           field_path: created_on
+      designer_name_ASC:
+        sort_field:
+          direction: asc
+          field_path: designer_name
+      designer_name_DESC:
+        sort_field:
+          direction: desc
+          field_path: designer_name
       id_ASC:
         sort_field:
           direction: asc
@@ -1889,6 +1905,7 @@ index_definitions_by_name:
   components:
     current_sources:
     - __self
+    - design
     - widget
     default_sort_fields:
     - direction: desc
@@ -1904,6 +1921,8 @@ index_definitions_by_name:
         source: widget
       created_at:
         source: __self
+      designer_name:
+        source: design
       id:
         source: __self
       name:
@@ -3496,6 +3515,9 @@ object_types_by_name:
       created_at:
         resolver:
           name: get_record_field_value
+      designer_name:
+        resolver:
+          name: get_record_field_value
       dollar_widget:
         relation:
           additional_filter:
@@ -3625,6 +3647,9 @@ object_types_by_name:
       created_at:
         resolver:
           name: object_with_lookahead
+      designer_name:
+        resolver:
+          name: object_with_lookahead
       id:
         resolver:
           name: object_with_lookahead
@@ -3702,6 +3727,36 @@ object_types_by_name:
       total_edge_count:
         resolver:
           name: object_without_lookahead
+  ComponentDesign:
+    graphql_fields_by_name:
+      component_id:
+        resolver:
+          name: get_record_field_value
+      designer_name:
+        resolver:
+          name: get_record_field_value
+      id:
+        resolver:
+          name: get_record_field_value
+    update_targets:
+    - id_source: component_id
+      metadata_params:
+        relationship:
+          value: design
+        sourceId:
+          cardinality: one
+          source_path: id
+        sourceType:
+          cardinality: one
+          source_path: type
+        version:
+          cardinality: one
+      relationship: design
+      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      top_level_fields_params:
+        designer_name:
+          cardinality: one
+      type: Component
   ComponentEdge:
     elasticgraph_category: relay_edge
     graphql_fields_by_name:
@@ -3726,6 +3781,9 @@ object_types_by_name:
       created_at:
         resolver:
           name: object_with_lookahead
+      designer_name:
+        resolver:
+          name: object_with_lookahead
       name:
         resolver:
           name: object_with_lookahead
@@ -3747,6 +3805,9 @@ object_types_by_name:
           name: object_with_lookahead
   ComponentHighlights:
     graphql_fields_by_name:
+      designer_name:
+        resolver:
+          name: get_record_field_value
       id:
         resolver:
           name: get_record_field_value
@@ -5054,6 +5115,9 @@ object_types_by_name:
       description:
         resolver:
           name: get_record_field_value
+      designer_name:
+        resolver:
+          name: get_record_field_value
       dollar_widget:
         relation:
           additional_filter:
@@ -5271,6 +5335,9 @@ object_types_by_name:
       created_on:
         resolver:
           name: object_with_lookahead
+      designer_name:
+        resolver:
+          name: object_with_lookahead
       fees:
         resolver:
           name: object_with_lookahead
@@ -5482,6 +5549,9 @@ object_types_by_name:
       created_on:
         resolver:
           name: object_with_lookahead
+      designer_name:
+        resolver:
+          name: object_with_lookahead
       fees:
         resolver:
           name: object_with_lookahead
@@ -5588,6 +5658,9 @@ object_types_by_name:
         resolver:
           name: get_record_field_value
       description:
+        resolver:
+          name: get_record_field_value
+      designer_name:
         resolver:
           name: get_record_field_value
       fees:

--- a/config/schema/artifacts_with_apollo/schema.graphql
+++ b/config/schema/artifacts_with_apollo/schema.graphql
@@ -1028,6 +1028,7 @@ type Company implements NamedInventor @key(fields: "id") {
 
 type Component implements NamedEntity @key(fields: "id") {
   created_at: DateTime!
+  designer_name: String
   dollar_widget: Widget
   id: ID!
   name: String
@@ -1286,6 +1287,11 @@ type ComponentAggregatedValues {
   created_at: DateTimeAggregatedValues
 
   """
+  Computed aggregate values for the `designer_name` field.
+  """
+  designer_name: NonNumericAggregatedValues
+
+  """
   Computed aggregate values for the `id` field.
   """
   id: NonNumericAggregatedValues
@@ -1487,6 +1493,13 @@ input ComponentFilterInput {
   created_at: DateTimeFilterInput
 
   """
+  Used to filter on the `designer_name` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  designer_name: StringFilterInput
+
+  """
   Used to filter on the `id` field.
 
   When `null` or an empty object is passed, matches all documents.
@@ -1568,6 +1581,11 @@ type ComponentGroupedBy {
   created_at: DateTimeGroupedBy
 
   """
+  The `designer_name` field value for this group.
+  """
+  designer_name: String
+
+  """
   The `name` field value for this group.
   """
   name: String
@@ -1602,6 +1620,11 @@ type ComponentGroupedBy {
 Type used to request desired `Component` search highlight fields.
 """
 type ComponentHighlights {
+  """
+  Search highlights for the `designer_name`, providing snippets of the matching text.
+  """
+  designer_name: [String!]!
+
   """
   Search highlights for the `id`, providing snippets of the matching text.
   """
@@ -1708,6 +1731,16 @@ enum ComponentSortOrderInput {
   Sorts descending by the `created_at` field.
   """
   created_at_DESC
+
+  """
+  Sorts ascending by the `designer_name` field.
+  """
+  designer_name_ASC
+
+  """
+  Sorts descending by the `designer_name` field.
+  """
+  designer_name_DESC
 
   """
   Sorts ascending by the `id` field.
@@ -6684,6 +6717,11 @@ type NamedEntityAggregatedValues {
   created_on: DateAggregatedValues
 
   """
+  Computed aggregate values for the `designer_name` field.
+  """
+  designer_name: NonNumericAggregatedValues
+
+  """
   Computed aggregate values for the `fees` field.
   """
   fees: MoneyAggregatedValues
@@ -7086,6 +7124,13 @@ input NamedEntityFilterInput {
   description: TextFilterInput
 
   """
+  Used to filter on the `designer_name` field.
+
+  When `null` or an empty object is passed, matches all documents.
+  """
+  designer_name: StringFilterInput
+
+  """
   Used to filter on the `fees` field.
 
   When `null` or an empty object is passed, matches all documents.
@@ -7367,6 +7412,11 @@ type NamedEntityGroupedBy {
   created_on: DateGroupedBy
 
   """
+  The `designer_name` field value for this group.
+  """
+  designer_name: String
+
+  """
   The `fees` field value for this group.
 
   Note: `fees` is a collection field, but selecting this field will group on
@@ -7561,6 +7611,11 @@ type NamedEntityHighlights {
   Search highlights for the `description`, providing snippets of the matching text.
   """
   description: [String!]!
+
+  """
+  Search highlights for the `designer_name`, providing snippets of the matching text.
+  """
+  designer_name: [String!]!
 
   """
   Search highlights for the `fees`, providing snippets of the matching text.
@@ -7831,6 +7886,16 @@ enum NamedEntitySortOrderInput {
   Sorts descending by the `created_on` field.
   """
   created_on_DESC
+
+  """
+  Sorts ascending by the `designer_name` field.
+  """
+  designer_name_ASC
+
+  """
+  Sorts descending by the `designer_name` field.
+  """
+  designer_name_DESC
 
   """
   Sorts ascending by the `id` field.

--- a/config/schema/widgets.rb
+++ b/config/schema/widgets.rb
@@ -279,6 +279,14 @@ ElasticGraph.define_schema do |schema|
       f.sourced_from "widget", "cost"
     end
 
+    # `designer_name` is fed by `ComponentDesign`, a pure-source type, demonstrating that a top-level
+    # `sourced_from` field can be sourced from a type that has no index of its own.
+    t.field "designer_name", "String" do |f|
+      f.sourced_from "design", "designer_name"
+    end
+
+    t.relates_to_one "design", "ComponentDesign", via: "component_id", dir: :in, indexing_only: true
+
     t.relates_to_one "widget", "Widget", via: "component_ids", dir: :in
     t.relates_to_one "dollar_widget", "Widget", via: "component_ids", dir: :in do |rel|
       rel.additional_filter "cost" => {"amount_cents" => {"equal_to_any_of" => [100]}}
@@ -309,6 +317,15 @@ ElasticGraph.define_schema do |schema|
       i.default_sort "created_at", :desc
       i.has_had_multiple_sources!
     end
+  end
+
+  # A pure-source type (no `t.index`): its events only update `Component` documents (via the
+  # `design` relationship backing `Component.designer_name`) and are not written to any index
+  # of their own.
+  schema.object_type "ComponentDesign" do |t|
+    t.field "id", "ID!"
+    t.field "component_id", "ID"
+    t.field "designer_name", "String"
   end
 
   schema.object_type "MechanicalPart" do |t|

--- a/elasticgraph-indexer/spec/acceptance/top_level_multi_source_indexing_spec.rb
+++ b/elasticgraph-indexer/spec/acceptance/top_level_multi_source_indexing_spec.rb
@@ -148,6 +148,50 @@ module ElasticGraph
       )
     end
 
+    it "fills in a top-level sourced field from a pure-source (non-indexed) type, regardless of ingestion order" do
+      design1 = build_upsert_event(:component_design, id: "d1", component_id: "c1", designer_name: "Alice", __version: 1)
+      design2 = build_upsert_event(:component_design, id: "d2", component_id: "c2", designer_name: "Bob", __version: 1)
+      component1 = build_upsert_event(:component, id: "c1", name: "C1", __version: 1)
+      component2 = build_upsert_event(:component, id: "c2", name: "C2", __version: 1)
+
+      # `design1` arrives BEFORE its component exists, materializing an incomplete document containing
+      # just the identity, bookkeeping, and the sourced field.
+      indexer.processor.process([design1], refresh_indices: true)
+
+      expect(component_source("c1")).to eq(
+        "id" => "c1",
+        "__counts" => {},
+        "__sources" => ["design"],
+        "__versions" => {"design" => {"d1" => 1}},
+        "designer_name" => "Alice"
+      )
+
+      indexer.processor.process([component1, component2], refresh_indices: true)
+
+      # `design2` arrives AFTER its component was indexed.
+      indexer.processor.process([design2], refresh_indices: true)
+
+      component1_source = component_source("c1")
+      expect(component1_source).to include("id" => "c1", "name" => "C1", "designer_name" => "Alice")
+      expect(component1_source.fetch("__sources")).to contain_exactly("__self", "design")
+      # Top-level sourced fields record their versions under the bare relationship name (nested ones
+      # use element-qualified keys), and involve none of the nested bookkeeping.
+      expect(component1_source.fetch("__versions")).to eq("__self" => {"c1" => 1}, "design" => {"d1" => 1})
+      expect(component1_source).not_to have_key("__nested_sourced_data")
+
+      component2_source = component_source("c2")
+      expect(component2_source).to include("id" => "c2", "name" => "C2", "designer_name" => "Bob")
+      expect(component2_source.fetch("__sources")).to contain_exactly("__self", "design")
+      expect(component2_source.fetch("__versions")).to eq("__self" => {"c2" => 1}, "design" => {"d2" => 1})
+
+      # `ComponentDesign` is pure-source (non-indexed), so its events update component documents only--
+      # no standalone design documents get written.
+      design_hits = main_datastore_client
+        .msearch(body: [{index: "component_designs*"}, {query: {match_all: {}}}])
+        .dig("responses", 0, "hits", "hits")
+      expect(design_hits).to eq []
+    end
+
     it "is compatible with custom shard routing and rollover indices, so long as `equivalent_field` is used on the schema definition" do
       # Use timestamps with explicit 3-digit millisecond precision to match what the indexer normalizes to
       timestamp_in_2023 = "2023-08-09T10:12:14.000Z"
@@ -168,6 +212,12 @@ module ElasticGraph
         "workspace_id2" => "wid_23",
         "workspace_name" => "Garage" # the sourced_from field copied from the `WidgetWorkspace`
       })
+    end
+
+    def component_source(id)
+      main_datastore_client
+        .msearch(body: [{index: "components*"}, {query: {ids: {values: [id]}}}])
+        .dig("responses", 0, "hits", "hits", 0, "_source")
     end
 
     def search_components

--- a/spec_support/lib/elastic_graph/spec_support/factories/widgets.rb
+++ b/spec_support/lib/elastic_graph/spec_support/factories/widgets.rb
@@ -213,6 +213,12 @@ FactoryBot.define do
     end
   end
 
+  factory :component_design, parent: :indexed_type do
+    __typename { "ComponentDesign" }
+    component_id { Faker::Alphanumeric.alpha(number: 20) }
+    designer_name { Faker::Name.name }
+  end
+
   factory :online_store, parent: :indexed_type do
     __typename { "OnlineStore" }
     established_on { Faker::Date.between(from: recent_date - 365, to: recent_date).iso8601 }


### PR DESCRIPTION
Part of #1273. The nested `sourced_from` case is covered end-to-end by the `CoachProfile`/`GeneralManagerProfile` types, but we had no coverage proving a *top-level* `sourced_from` field can be fed by a pure-source (non-indexed) type.

This adds `ComponentDesign` — a small pure-source type (no `t.index`) whose events feed a new top-level `Component.designer_name` field via an `indexing_only: true` relationship — plus acceptance coverage in `top_level_multi_source_indexing_spec.rb`.

No library changes were needed — the prior PRs in this stack already handle everything, so this is purely test schema + factory + spec additions and the resulting artifact churn.