### PR TITLE
Document validateSource's rejection cases in index_data.painless

### DIFF
--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -2218,7 +2218,7 @@ scripts:
 
         // No timestamp values matched the params, so return `false`.
         return false;
-  update_index_data_27fac9da6430f05440528c771880c7e6:
+  update_index_data_0d2f593f4c3c3084ec4533148311dfca:
     context: update
     script:
       lang: painless
@@ -2348,6 +2348,10 @@ scripts:
           }
         }
 
+        // Refuses the update in two cases:
+        // 1. The data comes from a different source document than the one that has fed this document's
+        //    sourced fields before (e.g. an order's `customer` link switching to another customer).
+        // 2. The event is older than one already applied.
         void validateSource(Map doc, String id, String relationship, String sourceId, long eventVersion, String sourceKey) {
           Map versionsMap = doc.__versions[sourceKey];
           List previousSourceIdsForRelationship = versionsMap.keySet().stream().filter(key -> key != sourceId).collect(Collectors.toList());

--- a/config/schema/artifacts/runtime_metadata.yaml
+++ b/config/schema/artifacts/runtime_metadata.yaml
@@ -3152,7 +3152,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         full_address:
           cardinality: one
@@ -3342,7 +3342,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -3430,7 +3430,7 @@ object_types_by_name:
       relationship: staff.coaches.profile
       rollover_timestamp_value_source: team_formed_on
       routing_value_source: team_league
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       sourced_from_nested_params:
         field_params:
           salary:
@@ -3472,7 +3472,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -3575,7 +3575,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         created_at:
           cardinality: one
@@ -3702,7 +3702,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: design
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         designer_name:
           cardinality: one
@@ -3922,7 +3922,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -4095,7 +4095,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         created_at:
           cardinality: one
@@ -4305,7 +4305,7 @@ object_types_by_name:
       relationship: staff.general_manager.profile
       rollover_timestamp_value_source: team_formed_on
       routing_value_source: team_league
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       sourced_from_nested_params:
         field_params:
           salary:
@@ -4640,7 +4640,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         ceo:
           cardinality: one
@@ -4798,7 +4798,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         created_at:
           cardinality: one
@@ -5769,7 +5769,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -5968,7 +5968,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -6035,7 +6035,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         active:
           cardinality: one
@@ -6572,7 +6572,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         name:
           cardinality: one
@@ -6951,7 +6951,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: formed_on
       routing_value_source: league
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         country_code:
           cardinality: one
@@ -8090,7 +8090,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: created_at
       routing_value_source: workspace_id2
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         amount_cents:
           cardinality: one
@@ -8168,7 +8168,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: widget
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         widget_cost:
           cardinality: one
@@ -8398,7 +8398,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: introduced_on
       routing_value_source: primary_continent
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         details:
           cardinality: one
@@ -9443,7 +9443,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         name:
           cardinality: one
@@ -9465,7 +9465,7 @@ object_types_by_name:
       relationship: workspace
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         workspace_name:
           cardinality: one
@@ -9700,4 +9700,4 @@ static_script_ids_by_scoped_name:
   field/as_day_of_week: field_as_day_of_week_f2b5c7d9e8f75bf2457b52412bfb6537
   field/as_time_of_day: field_as_time_of_day_ed82aba44fc66bff5635bec4305c1c66
   filter/by_time_of_day: filter_by_time_of_day_ea12d0561b24961789ab68ed38435612
-  update/index_data: update_index_data_27fac9da6430f05440528c771880c7e6
+  update/index_data: update_index_data_0d2f593f4c3c3084ec4533148311dfca

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -2218,7 +2218,7 @@ scripts:
 
         // No timestamp values matched the params, so return `false`.
         return false;
-  update_index_data_27fac9da6430f05440528c771880c7e6:
+  update_index_data_0d2f593f4c3c3084ec4533148311dfca:
     context: update
     script:
       lang: painless
@@ -2348,6 +2348,10 @@ scripts:
           }
         }
 
+        // Refuses the update in two cases:
+        // 1. The data comes from a different source document than the one that has fed this document's
+        //    sourced fields before (e.g. an order's `customer` link switching to another customer).
+        // 2. The event is older than one already applied.
         void validateSource(Map doc, String id, String relationship, String sourceId, long eventVersion, String sourceKey) {
           Map versionsMap = doc.__versions[sourceKey];
           List previousSourceIdsForRelationship = versionsMap.keySet().stream().filter(key -> key != sourceId).collect(Collectors.toList());

--- a/config/schema/artifacts_with_apollo/runtime_metadata.yaml
+++ b/config/schema/artifacts_with_apollo/runtime_metadata.yaml
@@ -3181,7 +3181,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         full_address:
           cardinality: one
@@ -3371,7 +3371,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -3459,7 +3459,7 @@ object_types_by_name:
       relationship: staff.coaches.profile
       rollover_timestamp_value_source: team_formed_on
       routing_value_source: team_league
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       sourced_from_nested_params:
         field_params:
           salary:
@@ -3501,7 +3501,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -3625,7 +3625,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         created_at:
           cardinality: one
@@ -3752,7 +3752,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: design
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         designer_name:
           cardinality: one
@@ -4024,7 +4024,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -4197,7 +4197,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         created_at:
           cardinality: one
@@ -4407,7 +4407,7 @@ object_types_by_name:
       relationship: staff.general_manager.profile
       rollover_timestamp_value_source: team_formed_on
       routing_value_source: team_league
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       sourced_from_nested_params:
         field_params:
           salary:
@@ -4742,7 +4742,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         ceo:
           cardinality: one
@@ -4900,7 +4900,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         created_at:
           cardinality: one
@@ -5892,7 +5892,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -6091,7 +6091,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         __typename:
           cardinality: one
@@ -6158,7 +6158,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         active:
           cardinality: one
@@ -6701,7 +6701,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         name:
           cardinality: one
@@ -7080,7 +7080,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: formed_on
       routing_value_source: league
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         country_code:
           cardinality: one
@@ -8219,7 +8219,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: created_at
       routing_value_source: workspace_id2
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         amount_cents:
           cardinality: one
@@ -8297,7 +8297,7 @@ object_types_by_name:
         version:
           cardinality: one
       relationship: widget
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         widget_cost:
           cardinality: one
@@ -8527,7 +8527,7 @@ object_types_by_name:
       relationship: __self
       rollover_timestamp_value_source: introduced_on
       routing_value_source: primary_continent
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         details:
           cardinality: one
@@ -9572,7 +9572,7 @@ object_types_by_name:
           cardinality: one
       relationship: __self
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         name:
           cardinality: one
@@ -9594,7 +9594,7 @@ object_types_by_name:
       relationship: workspace
       rollover_timestamp_value_source: widget.created_at
       routing_value_source: id
-      script_id: update_index_data_27fac9da6430f05440528c771880c7e6
+      script_id: update_index_data_0d2f593f4c3c3084ec4533148311dfca
       top_level_fields_params:
         workspace_name:
           cardinality: one
@@ -9872,4 +9872,4 @@ static_script_ids_by_scoped_name:
   field/as_day_of_week: field_as_day_of_week_f2b5c7d9e8f75bf2457b52412bfb6537
   field/as_time_of_day: field_as_time_of_day_ed82aba44fc66bff5635bec4305c1c66
   filter/by_time_of_day: filter_by_time_of_day_ea12d0561b24961789ab68ed38435612
-  update/index_data: update_index_data_27fac9da6430f05440528c771880c7e6
+  update/index_data: update_index_data_0d2f593f4c3c3084ec4533148311dfca

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/scripts/update/index_data.painless
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/scripting/scripts/update/index_data.painless
@@ -123,6 +123,10 @@ void setup(Map doc, String sourceKey, Map counts) {
   }
 }
 
+// Refuses the update in two cases:
+// 1. The data comes from a different source document than the one that has fed this document's
+//    sourced fields before (e.g. an order's `customer` link switching to another customer).
+// 2. The event is older than one already applied.
 void validateSource(Map doc, String id, String relationship, String sourceId, long eventVersion, String sourceKey) {
   Map versionsMap = doc.__versions[sourceKey];
   List previousSourceIdsForRelationship = versionsMap.keySet().stream().filter(key -> key != sourceId).collect(Collectors.toList());

--- a/elasticgraph-support/lib/elastic_graph/constants.rb
+++ b/elasticgraph-support/lib/elastic_graph/constants.rb
@@ -152,7 +152,7 @@ module ElasticGraph
   #
   # Note: this constant is automatically kept up-to-date by our `schema_artifacts:dump` rake task.
   # @private
-  INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_27fac9da6430f05440528c771880c7e6"
+  INDEX_DATA_UPDATE_SCRIPT_ID = "update_index_data_0d2f593f4c3c3084ec4533148311dfca"
 
   # When an update script has a no-op result we often want to communicate more information about
   # why it was a no-op back to ElasticGraph from the script. The only way to do that is to throw


### PR DESCRIPTION
## Summary
- Adds a doc comment to `validateSource` — the one main function in `index_data.painless` without one — describing its two rejection cases (source-document identity change, stale/duplicate event version).
- Comment-only change, no behavior change. Schema artifacts regenerated; `INDEX_DATA_UPDATE_SCRIPT_ID` rolled accordingly (same mechanics as #1308).

## Test plan
- [x] `rake schema_artifacts:dump` run twice — idempotent after the first dump
- [x] `elasticgraph-schema_definition`: static scripts, scripting, and update-targets specs — 134 examples, 0 failures
- [x] `elasticgraph-indexer`: update + datastore-indexing-router specs — 42 examples, 0 failures