### PR TITLE
Add `customize_config` API for customizing index datastore configuration

### DIFF
--- a/config/schema/artifacts/datastore_config.yaml
+++ b/config/schema/artifacts/datastore_config.yaml
@@ -6,7 +6,12 @@ index_templates:
     index_patterns:
     - teams_rollover__*
     template:
-      aliases: {}
+      aliases:
+        teams_all: {}
+        teams_nfl:
+          filter:
+            term:
+              league: NFL
       mappings:
         dynamic: strict
         properties:
@@ -1268,6 +1273,9 @@ index_templates:
           __typename:
             type: constant_keyword
             value: Team
+          formed:
+            type: alias
+            path: formed_on
         _routing:
           required: true
         _size:

--- a/config/schema/artifacts_with_apollo/datastore_config.yaml
+++ b/config/schema/artifacts_with_apollo/datastore_config.yaml
@@ -6,7 +6,12 @@ index_templates:
     index_patterns:
     - teams_rollover__*
     template:
-      aliases: {}
+      aliases:
+        teams_all: {}
+        teams_nfl:
+          filter:
+            term:
+              league: NFL
       mappings:
         dynamic: strict
         properties:
@@ -1268,6 +1273,9 @@ index_templates:
           __typename:
             type: constant_keyword
             value: Team
+          formed:
+            type: alias
+            path: formed_on
         _routing:
           required: true
         _size:

--- a/config/schema/teams.rb
+++ b/config/schema/teams.rb
@@ -100,6 +100,15 @@ ElasticGraph.define_schema do |schema|
       i.route_with "league"
       i.rollover :yearly, "formed_on"
       i.has_had_multiple_sources!
+      # Exercises `customize_config` with both index aliases (plain and filtered) and a field alias.
+      i.customize_config do |config|
+        config["aliases"] = {
+          "teams_all" => {},
+          "teams_nfl" => {"filter" => {"term" => {"league" => "NFL"}}}
+        }
+
+        config["mappings"]["properties"]["formed"] = {"type" => "alias", "path" => "formed_on"}
+      end
     end
   end
 

--- a/elasticgraph-admin/lib/elastic_graph/admin/datastore_client_dry_run_decorator.rb
+++ b/elasticgraph-admin/lib/elastic_graph/admin/datastore_client_dry_run_decorator.rb
@@ -65,6 +65,8 @@ module ElasticGraph
 
       def put_index_settings(*) = nil
 
+      def update_index_aliases(*) = nil
+
       # Document APIs
       def_delegators :@wrapped_client, :get, :search, :msearch
 

--- a/elasticgraph-admin/lib/elastic_graph/admin/index_definition_configurator/for_index.rb
+++ b/elasticgraph-admin/lib/elastic_graph/admin/index_definition_configurator/for_index.rb
@@ -93,6 +93,8 @@ module ElasticGraph
         end
 
         def update_aliases
+          # An `add` action is an upsert: when the named alias already exists on the index, the
+          # datastore replaces its definition with the one provided here (rather than merging).
           actions = alias_updates.map do |name, definition|
             {"add" => definition.merge({"index" => @index.name, "alias" => name})}
           end

--- a/elasticgraph-admin/lib/elastic_graph/admin/index_definition_configurator/for_index.rb
+++ b/elasticgraph-admin/lib/elastic_graph/admin/index_definition_configurator/for_index.rb
@@ -32,12 +32,14 @@ module ElasticGraph
         # exposed by the `IndexDefinition` object. Based on the configuration of the passed index
         # and the state of the index in the datastore, does one of the following:
         #
-        #   - If the index did not already exist: creates the index with the desired mappings and settings.
+        #   - If the index did not already exist: creates the index with the desired aliases, mappings and settings.
         #   - If the desired mapping has fewer fields than what is in the index: leaves the existing fields
         #     alone, because the datastore provides no way to remove fields from a mapping.
         #   - If the settings have desired changes: updates the settings, restoring any setting that
         #     no longer has a desired value to its default.
         #   - If the mapping has desired changes: updates the mappings.
+        #   - If the aliases have desired changes: adds or updates the desired aliases, leaving aliases
+        #     that were not declared (e.g. ones created outside of ElasticGraph) alone.
         #
         # Note that any of the writes to the index may fail. There are many things that cannot
         # be changed on an existing index (such as static settings, field mapping types, etc). We do not attempt
@@ -57,6 +59,10 @@ module ElasticGraph
           update_settings if settings_updates.any?
 
           update_mapping if has_mapping_updates?
+
+          # Update aliases after mappings, since an alias with a `filter` can reference fields that are
+          # only available once the mapping updates have been applied.
+          update_aliases if alias_updates.any?
         end
 
         def validate
@@ -84,6 +90,15 @@ module ElasticGraph
         def update_settings
           @datastore_client.put_index_settings(index: @index.name, body: settings_updates)
           report_action "Updated settings for index `#{@index.name}`:\n#{settings_diff}"
+        end
+
+        def update_aliases
+          actions = alias_updates.map do |name, definition|
+            {"add" => definition.merge({"index" => @index.name, "alias" => name})}
+          end
+
+          @datastore_client.update_index_aliases(body: {"actions" => actions})
+          report_action "Updated aliases for index `#{@index.name}`:\n#{alias_diff}"
         end
 
         def cannot_modify_mapping_field_type_error
@@ -116,6 +131,22 @@ module ElasticGraph
             restore_to_defaults = (current_settings.keys - desired_settings.keys).to_h { |key| [key, nil] }
             desired_settings.select { |key, value| current_settings[key] != value }.merge(restore_to_defaults)
           end
+        end
+
+        # Note: aliases that exist on the index but are not desired are intentionally left alone rather
+        # than removed. Undeclared aliases may have been created outside of ElasticGraph (which does
+        # nothing with aliases itself), so their absence from our desired configuration just means
+        # ElasticGraph doesn't manage them.
+        def alias_updates
+          @alias_updates ||= desired_aliases.reject { |name, definition| current_aliases[name] == definition }
+        end
+
+        def desired_aliases
+          desired_config["aliases"] || {}
+        end
+
+        def current_aliases
+          current_config["aliases"] || {}
         end
 
         def desired_mapping_for_update
@@ -167,6 +198,10 @@ module ElasticGraph
 
         def settings_diff
           @settings_diff ||= Indexer::HashDiffer.diff(current_settings, desired_settings) || "(no diff)"
+        end
+
+        def alias_diff
+          @alias_diff ||= Indexer::HashDiffer.diff(current_aliases, current_aliases.merge(alias_updates)) || "(no diff)"
         end
 
         def report_action(message)

--- a/elasticgraph-admin/lib/elastic_graph/admin/index_definition_configurator/for_index_template.rb
+++ b/elasticgraph-admin/lib/elastic_graph/admin/index_definition_configurator/for_index_template.rb
@@ -36,12 +36,14 @@ module ElasticGraph
         # exposed by the `IndexDefinition` object. Based on the configuration of the passed index
         # and the state of the index in the datastore, does one of the following:
         #
-        #   - If the index did not already exist: creates the index with the desired mappings and settings.
+        #   - If the index template did not already exist: creates the index template with the desired
+        #     aliases, mappings and settings.
         #   - If the desired mapping has fewer fields than what is in the index template: leaves the existing
         #     fields alone (see `put_index_template` for why).
-        #   - If the settings have desired changes: updates the settings, restoring any setting that
-        #     no longer has a desired value to its default.
-        #   - If the mapping has desired changes: updates the mappings.
+        #   - If the aliases have desired changes: adds or updates the desired aliases, leaving aliases
+        #     that were not declared (e.g. ones created outside of ElasticGraph) alone.
+        #   - If any other part of the template configuration (settings, mappings, etc.) has desired
+        #     changes: updates the template.
         #
         # Note that any of the writes to the index may fail. There are many things that cannot
         # be changed on an existing index (such as static settings, field mapping types, etc). We do not attempt
@@ -50,8 +52,10 @@ module ElasticGraph
         def configure!
           related_index_configurators.each(&:configure!)
 
-          # there is no partial update for index template config and the same API both creates and updates it
-          put_index_template if has_mapping_updates? || settings_updates.any?
+          # There is no partial update for index template config and the same API both creates and updates it.
+          # Note that we diff the full template config (rather than just mappings and settings) so that a
+          # change to any part of it--such as `customize_config` customizations--triggers an update.
+          put_index_template if has_config_updates?
         end
 
         def validate
@@ -104,16 +108,8 @@ module ElasticGraph
           end
         end
 
-        def has_mapping_updates?
-          current_mapping != desired_mapping_for_update
-        end
-
-        def settings_updates
-          @settings_updates ||= begin
-            # Updating a setting to null will cause the datastore to restore the default value of the setting.
-            restore_to_defaults = (current_settings.keys - desired_settings.keys).to_h { |key| [key, nil] }
-            desired_settings.select { |key, value| current_settings[key] != value }.merge(restore_to_defaults)
-          end
+        def has_config_updates?
+          desired_config_parent_for_update.fetch("template") != (current_config_parent["template"] || {})
         end
 
         def desired_mapping_for_update
@@ -121,18 +117,37 @@ module ElasticGraph
         end
 
         def desired_config_parent_for_update
-          @desired_config_parent_for_update ||= Support::HashUtil.deep_merge(
-            desired_config_parent,
-            {"template" => {"mappings" => desired_mapping_for_update}}
-          )
+          @desired_config_parent_for_update ||= begin
+            template = DatastoreCore::IndexConfigNormalizer.normalize(
+              desired_config_parent.fetch("template").merge({
+                "mappings" => desired_mapping_for_update,
+                "aliases" => aliases_for_update
+              })
+            )
+
+            desired_config_parent.merge({"template" => template})
+          end
+        end
+
+        # Aliases that exist on the current template but are not desired are preserved rather than removed
+        # (the same policy `MappingUpdate` applies to no-longer-desired mapping fields). Undeclared aliases
+        # may have been created outside of ElasticGraph (which does nothing with aliases itself), and since
+        # `put_index_template` replaces the entire template, omitting them here would silently drop them
+        # from all future rollover indices.
+        def aliases_for_update
+          current_aliases.merge(desired_aliases)
+        end
+
+        def desired_aliases
+          desired_config_parent.fetch("template")["aliases"] || {}
+        end
+
+        def current_aliases
+          current_config_parent.dig("template", "aliases") || {}
         end
 
         def desired_mapping
           desired_config_parent.fetch("template").fetch("mappings")
-        end
-
-        def desired_settings
-          @desired_settings ||= desired_config_parent.fetch("template").fetch("settings")
         end
 
         def desired_config_parent
@@ -157,10 +172,6 @@ module ElasticGraph
 
         def current_mapping
           current_config_parent.dig("template", "mappings") || {}
-        end
-
-        def current_settings
-          @current_settings ||= current_config_parent.dig("template", "settings")
         end
 
         def current_config_parent

--- a/elasticgraph-admin/sig/elastic_graph/admin/index_definition_configurator/for_index.rbs
+++ b/elasticgraph-admin/sig/elastic_graph/admin/index_definition_configurator/for_index.rbs
@@ -25,6 +25,7 @@ module ElasticGraph
         def create_new_index: () -> void
         def update_mapping: () -> void
         def update_settings: () -> void
+        def update_aliases: () -> void
         def cannot_modify_mapping_field_type_error: () -> ::String
         def index_exists?: () -> bool
 
@@ -35,6 +36,13 @@ module ElasticGraph
 
         @settings_updates: DatastoreCore::indexSettingsHash?
         def settings_updates: () -> DatastoreCore::indexSettingsHash
+
+        @alias_updates: DatastoreCore::indexAliasesHash?
+        def alias_updates: () -> DatastoreCore::indexAliasesHash
+
+        def desired_aliases: () -> DatastoreCore::indexAliasesHash
+
+        def current_aliases: () -> DatastoreCore::indexAliasesHash
 
         @desired_mapping_for_update: DatastoreCore::indexMappingHash?
         def desired_mapping_for_update: () -> DatastoreCore::indexMappingHash
@@ -60,6 +68,9 @@ module ElasticGraph
 
         @settings_diff: ::String?
         def settings_diff: () -> ::String
+
+        @alias_diff: ::String?
+        def alias_diff: () -> ::String
 
         def report_action: (::String) -> void
       end

--- a/elasticgraph-admin/sig/elastic_graph/admin/index_definition_configurator/for_index_template.rbs
+++ b/elasticgraph-admin/sig/elastic_graph/admin/index_definition_configurator/for_index_template.rbs
@@ -32,10 +32,7 @@ module ElasticGraph
         @mapping_type_changes: ::Array[::String]?
         def mapping_type_changes: () -> ::Array[::String]
 
-        def has_mapping_updates?: () -> bool
-
-        @settings_updates: DatastoreCore::indexSettingsHash?
-        def settings_updates: () -> DatastoreCore::indexSettingsHash
+        def has_config_updates?: () -> bool
 
         @desired_mapping_for_update: DatastoreCore::indexMappingHash?
         def desired_mapping_for_update: () -> DatastoreCore::indexMappingHash
@@ -43,18 +40,18 @@ module ElasticGraph
         @desired_config_parent_for_update: ::Hash[::String, untyped]?
         def desired_config_parent_for_update: () -> ::Hash[::String, untyped]
 
-        def desired_mapping: () -> DatastoreCore::indexMappingHash
+        def aliases_for_update: () -> DatastoreCore::indexAliasesHash
 
-        @desired_settings: DatastoreCore::indexSettingsHash?
-        def desired_settings: () -> DatastoreCore::indexSettingsHash
+        def desired_aliases: () -> DatastoreCore::indexAliasesHash
+
+        def current_aliases: () -> DatastoreCore::indexAliasesHash
+
+        def desired_mapping: () -> DatastoreCore::indexMappingHash
 
         @desired_config_parent: ::Hash[::String, untyped]
         def desired_config_parent: () -> ::Hash[::String, untyped]
 
         def current_mapping: () -> DatastoreCore::indexMappingHash
-
-        @current_settings: DatastoreCore::indexSettingsHash?
-        def current_settings: () -> DatastoreCore::indexSettingsHash
 
         @current_config_parent: ::Hash[::String, untyped]
         def current_config_parent: () -> ::Hash[::String, untyped]

--- a/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/for_index_spec.rb
+++ b/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/for_index_spec.rb
@@ -25,6 +25,31 @@ module ElasticGraph
               .and log_warning(/Can't update non dynamic setting/)
           end
 
+          it "applies mapping updates before alias updates so that an alias filter can reference a newly declared field" do
+            nested_alias = "#{unique_index_name}_nested"
+            # The datastore rejects a `nested` alias filter when the path is not yet in the index mapping.
+            nested_filter = {"nested" => {"path" => "nested_options", "query" => {"term" => {"nested_options.size" => "large"}}}}
+
+            configure_index_definition(schema_def)
+
+            expect {
+              configure_index_definition(schema_def(
+                configure_widget: ->(t) {
+                  t.field "nested_options", "[WidgetOptions!]!" do |f|
+                    f.mapping type: "nested"
+                  end
+                },
+                configure_index: ->(index) {
+                  index.customize_config do |config|
+                    config["aliases"] = {nested_alias => {"filter" => nested_filter}}
+                  end
+                }
+              ))
+            }.to change { aliases_of(unique_index_name) }
+              .from({})
+              .to({nested_alias => {"filter" => nested_filter}})
+          end
+
           it "handles empty indexed types" do
             schema = schema_def(define_no_widget_fields: true)
 

--- a/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/for_index_spec.rb
+++ b/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/for_index_spec.rb
@@ -39,6 +39,10 @@ module ElasticGraph
             make_datastore_write_calls("main", "PUT #{put_index_definition_url(index_name, subresource)}")
           end
 
+          def make_datastore_calls_to_update_aliases(_index_name)
+            make_datastore_write_calls("main", "POST /_aliases")
+          end
+
           def fetch_artifact_configuration(schema_artifacts, index_def_name)
             schema_artifacts.indices.fetch(index_def_name)
           end

--- a/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/for_index_template_spec.rb
+++ b/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/for_index_template_spec.rb
@@ -68,7 +68,7 @@ module ElasticGraph
             end
           end
 
-          def simulate_presence_of_external_alias(alias_name)
+          def create_external_alias(alias_name)
             template = main_datastore_client.get_index_template(unique_index_name)
             template_body = template.fetch("template")
 

--- a/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/for_index_template_spec.rb
+++ b/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/for_index_template_spec.rb
@@ -68,6 +68,30 @@ module ElasticGraph
             end
           end
 
+          def simulate_presence_of_external_alias(alias_name)
+            template = main_datastore_client.get_index_template(unique_index_name)
+            template_body = template.fetch("template")
+
+            # Note: we only include the writable template properties here, since the datastore rejects a
+            # `put_index_template` payload containing system-managed properties (such as `created_date`).
+            main_datastore_client.put_index_template(name: unique_index_name, body: {
+              "index_patterns" => template.fetch("index_patterns"),
+              "template" => template_body.merge(
+                "aliases" => (template_body["aliases"] || {}).merge(alias_name => {})
+              )
+            })
+          end
+
+          def make_datastore_calls_to_update_aliases(index_name)
+            # Besides updating the template itself, the newly declared alias gets added (via the `_aliases`
+            # API) to the concrete rollover index that already exists from the prior configuration run.
+            make_datastore_write_calls(
+              "main",
+              "PUT #{put_index_definition_url(index_name)}",
+              "POST /_aliases"
+            )
+          end
+
           def fetch_artifact_configuration(schema_artifacts, index_def_name)
             schema_artifacts.index_templates.fetch(index_def_name)
           end
@@ -123,6 +147,20 @@ module ElasticGraph
             # the jan_2020 index being generated from the template by another process concurrently indexing
             # a jan 2020 document.
             expect(index_def_creation_order).to eq([jan_2020_index_name, unique_index_name])
+          end
+
+          it "manages declared aliases on the concrete rollover indices created from the template" do
+            read_alias = "#{unique_index_name}_read"
+            now_index = concrete_index_name_for_now(unique_index_name)
+
+            # A concrete index created from the template config gets the declared aliases stamped at creation.
+            configure_index_definition(schema_def_with_aliases({read_alias => {}}))
+            expect(main_datastore_client.get_index(now_index).fetch("aliases")).to eq({read_alias => {}})
+
+            # A newly declared alias is reconciled onto concrete indices that already exist.
+            active_alias = "#{unique_index_name}_active"
+            configure_index_definition(schema_def_with_aliases({read_alias => {}, active_alias => {}}))
+            expect(main_datastore_client.get_index(now_index).fetch("aliases")).to eq({read_alias => {}, active_alias => {}})
           end
 
           context "when the settings do not force the creation of any concrete indices" do

--- a/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/shared_examples.rb
+++ b/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/shared_examples.rb
@@ -37,7 +37,7 @@ module ElasticGraph
           end
         end
 
-        def simulate_presence_of_external_alias(alias_name)
+        def create_external_alias(alias_name)
           main_datastore_client.update_index_aliases(body: {"actions" => [
             {"add" => {"index" => unique_index_name, "alias" => alias_name}}
           ]})
@@ -316,13 +316,20 @@ module ElasticGraph
           }.to change { aliases_of(unique_index_name) }
             .from({read_alias => {}})
             .to({read_alias => {"filter" => {"term" => {"name" => "active"}}}})
+
+          # A changed definition fully replaces the existing one (the `filter` is dropped, not merged).
+          expect {
+            configure_index_definition(schema_def_with_aliases({read_alias => {}}))
+          }.to change { aliases_of(unique_index_name) }
+            .from({read_alias => {"filter" => {"term" => {"name" => "active"}}}})
+            .to({read_alias => {}})
         end
 
         it "leaves aliases it did not declare alone rather than removing them" do
           external_alias = "#{unique_index_name}_external"
 
           configure_index_definition(schema_def)
-          simulate_presence_of_external_alias(external_alias)
+          create_external_alias(external_alias)
 
           expect {
             configure_index_definition(schema_def)

--- a/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/shared_examples.rb
+++ b/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/shared_examples.rb
@@ -331,6 +331,24 @@ module ElasticGraph
             .and make_no_datastore_write_calls("main")
         end
 
+        it "applies `customize_config` mapping customizations such as field aliases when creating an index or index template, and reconciles them onto existing ones" do
+          field_alias_mapping = {"type" => "alias", "path" => "created_at"}
+
+          configure_index_definition(schema_def_with_field_aliases("created"))
+          expect(mapping_properties_of(unique_index_name)).to include("created" => field_alias_mapping)
+
+          expect {
+            configure_index_definition(schema_def_with_field_aliases("created", "creation_time"))
+          }.to change { mapping_properties_of(unique_index_name)["creation_time"] }
+            .from(nil)
+            .to(field_alias_mapping)
+            .and make_datastore_calls_to_configure_index_def(unique_index_name, :mappings)
+
+          expect {
+            configure_index_definition(schema_def_with_field_aliases("created", "creation_time"))
+          }.to make_no_datastore_write_calls("main")
+        end
+
         def schema_def_with_aliases(aliases)
           schema_def(configure_index: ->(index) {
             index.customize_config do |config|
@@ -339,8 +357,22 @@ module ElasticGraph
           })
         end
 
+        def schema_def_with_field_aliases(*field_alias_names)
+          schema_def(configure_index: ->(index) {
+            index.customize_config do |config|
+              field_alias_names.each do |name|
+                config["mappings"]["properties"][name] = {"type" => "alias", "path" => "created_at"}
+              end
+            end
+          })
+        end
+
         def aliases_of(index_definition_name)
           get_index_definition_configuration(index_definition_name)["aliases"] || {}
+        end
+
+        def mapping_properties_of(index_definition_name)
+          get_index_definition_configuration(index_definition_name).dig("mappings", "properties") || {}
         end
 
         def schema_def(

--- a/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/shared_examples.rb
+++ b/elasticgraph-admin/spec/integration/elastic_graph/admin/index_definition_configurator/shared_examples.rb
@@ -36,6 +36,12 @@ module ElasticGraph
             end
           end
         end
+
+        def simulate_presence_of_external_alias(alias_name)
+          main_datastore_client.update_index_aliases(body: {"actions" => [
+            {"add" => {"index" => unique_index_name, "alias" => alias_name}}
+          ]})
+        end
       end
 
       RSpec.shared_examples_for IndexDefinitionConfigurator, :uses_datastore do
@@ -269,6 +275,72 @@ module ElasticGraph
             settings = get_index_definition_configuration(unique_index_name)["settings"] || {}
             [settings["index.sort.field"], settings["index.sort.order"]]
           }.from([nil, nil]).to([["created_at"], ["asc"]])
+        end
+
+        it "applies `customize_config` customizations when creating an index or index template, and reconciles them idempotently" do
+          read_alias = "#{unique_index_name}_read"
+          active_alias = "#{unique_index_name}_active"
+          schema = schema_def_with_aliases({
+            read_alias => {},
+            active_alias => {"filter" => {"term" => {"name" => "active"}}}
+          })
+
+          expect {
+            configure_index_definition(schema)
+          }.to change { aliases_of(unique_index_name) }
+            .from({})
+            .to({read_alias => {}, active_alias => {"filter" => {"term" => {"name" => "active"}}}})
+
+          expect {
+            configure_index_definition(schema)
+          }.to make_no_datastore_write_calls("main")
+        end
+
+        it "adds newly declared aliases to an existing index or index template, and updates aliases whose desired definition has changed" do
+          read_alias = "#{unique_index_name}_read"
+
+          configure_index_definition(schema_def)
+          output_io.string = +"" # use `+` so it is not a frozen string literal.
+
+          expect {
+            configure_index_definition(schema_def_with_aliases({read_alias => {}}))
+          }.to change { aliases_of(unique_index_name) }
+            .from({})
+            .to({read_alias => {}})
+            .and make_datastore_calls_to_update_aliases(unique_index_name)
+
+          expect(output_io.string).to include(read_alias)
+
+          expect {
+            configure_index_definition(schema_def_with_aliases({read_alias => {"filter" => {"term" => {"name" => "active"}}}}))
+          }.to change { aliases_of(unique_index_name) }
+            .from({read_alias => {}})
+            .to({read_alias => {"filter" => {"term" => {"name" => "active"}}}})
+        end
+
+        it "leaves aliases it did not declare alone rather than removing them" do
+          external_alias = "#{unique_index_name}_external"
+
+          configure_index_definition(schema_def)
+          simulate_presence_of_external_alias(external_alias)
+
+          expect {
+            configure_index_definition(schema_def)
+          }.to maintain { aliases_of(unique_index_name) }
+            .from(a_hash_including(external_alias))
+            .and make_no_datastore_write_calls("main")
+        end
+
+        def schema_def_with_aliases(aliases)
+          schema_def(configure_index: ->(index) {
+            index.customize_config do |config|
+              config["aliases"] = aliases
+            end
+          })
+        end
+
+        def aliases_of(index_definition_name)
+          get_index_definition_configuration(index_definition_name)["aliases"] || {}
         end
 
         def schema_def(

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_config_normalizer.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_config_normalizer.rb
@@ -51,7 +51,7 @@ module ElasticGraph
       # - Drops an empty `aliases` hash. Empty and absent `aliases` both mean "no declared aliases", but the datastore
       #   doesn't consistently echo the key back, so we normalize to the absent form for stable comparisons.
       def self.normalize(index_config)
-        if index_config["aliases"] && index_config["aliases"].empty?
+        if (aliases = index_config["aliases"]) && aliases.empty?
           index_config = index_config.except("aliases")
         end
 

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_config_normalizer.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_config_normalizer.rb
@@ -48,7 +48,13 @@ module ElasticGraph
       #   (e.g. `"false"` or `"7"` instead of `false` or `7`), so this matches that behavior.
       # - Drops `type: object` from a mapping when there are `properties` because the datastore omits it in that
       #   situation, treating it as the default type.
+      # - Drops an empty `aliases` hash. Empty and absent `aliases` both mean "no declared aliases", but the datastore
+      #   doesn't consistently echo the key back, so we normalize to the absent form for stable comparisons.
       def self.normalize(index_config)
+        if (aliases = index_config["aliases"]) && aliases.empty?
+          index_config = index_config.except("aliases")
+        end
+
         if (settings = index_config["settings"])
           index_config = index_config.merge("settings" => normalize_settings(settings))
         end

--- a/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_config_normalizer.rb
+++ b/elasticgraph-datastore_core/lib/elastic_graph/datastore_core/index_config_normalizer.rb
@@ -51,7 +51,7 @@ module ElasticGraph
       # - Drops an empty `aliases` hash. Empty and absent `aliases` both mean "no declared aliases", but the datastore
       #   doesn't consistently echo the key back, so we normalize to the absent form for stable comparisons.
       def self.normalize(index_config)
-        if (aliases = index_config["aliases"]) && aliases.empty?
+        if index_config["aliases"] && index_config["aliases"].empty?
           index_config = index_config.except("aliases")
         end
 

--- a/elasticgraph-datastore_core/sig/elastic_graph/datastore_core/client.rbs
+++ b/elasticgraph-datastore_core/sig/elastic_graph/datastore_core/client.rbs
@@ -2,6 +2,7 @@ module ElasticGraph
   class DatastoreCore
     type indexMappingHash = ::Hash[::String, untyped]
     type indexSettingsHash = ::Hash[::String, untyped]
+    type indexAliasesHash = ::Hash[::String, untyped]
     type indexConfigHash = ::Hash[::String, untyped]
 
     interface _Client
@@ -25,6 +26,7 @@ module ElasticGraph
       def create_index: (index: ::String, body: ::Hash[::String, untyped]) -> void
       def put_index_mapping: (index: ::String, body: ::Hash[::String, untyped]) -> void
       def put_index_settings: (index: ::String, body: ::Hash[::String, untyped]) -> void
+      def update_index_aliases: (body: ::Hash[::String, untyped]) -> void
       def delete_indices: (*::String) -> void
 
       def msearch: (body: ::Array[::Hash[::String | ::Symbol, untyped]], ?headers: ::Hash[::String, untyped]?) -> ::Hash[::String, untyped]

--- a/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/index_config_normalizer_spec.rb
+++ b/elasticgraph-datastore_core/spec/unit/elastic_graph/datastore_core/index_config_normalizer_spec.rb
@@ -92,6 +92,31 @@ module ElasticGraph
         end
       end
 
+      it "drops an empty `aliases` hash since it means the same thing as an absent one and the datastore doesn't consistently echo the key back" do
+        index_config = {
+          "aliases" => {},
+          "settings" => {}
+        }
+
+        normalized = IndexConfigNormalizer.normalize(index_config)
+
+        expect(normalized).to eq({
+          "settings" => {}
+        })
+      end
+
+      it "leaves a non-empty `aliases` hash unchanged" do
+        index_config = {
+          "aliases" => {"my_alias" => {}}
+        }
+
+        normalized = IndexConfigNormalizer.normalize(index_config)
+
+        expect(normalized).to eq({
+          "aliases" => {"my_alias" => {}}
+        })
+      end
+
       it "drops `type: object` when it is alongside `properties` since the datastore treats that as the default type when `properties` are used and omits it" do
         index_config = {
           "mappings" => {

--- a/elasticgraph-elasticsearch/lib/elastic_graph/elasticsearch/client.rb
+++ b/elasticgraph-elasticsearch/lib/elastic_graph/elasticsearch/client.rb
@@ -158,6 +158,10 @@ module ElasticGraph
         transform_errors { |c| c.indices.put_settings(index: index, body: body).body }
       end
 
+      def update_index_aliases(body:)
+        transform_errors { |c| c.indices.update_aliases(body: body).body }
+      end
+
       def delete_indices(*index_names)
         # `allow_no_indices: true` is needed when we attempt to delete a non-existing index to avoid errors. For rollover indices,
         # when we delete the actual indices, we will always perform a wildcard deletion, and `allow_no_indices: true` is needed.

--- a/elasticgraph-elasticsearch/sig/elasticsearch.rbs
+++ b/elasticgraph-elasticsearch/sig/elasticsearch.rbs
@@ -25,6 +25,7 @@ module Elasticsearch
         def create: (index: ::String, body: stringOrSymbolHash) -> Response
         def put_mapping: (index: ::String, body: stringOrSymbolHash) -> Response
         def put_settings: (index: ::String, body: stringOrSymbolHash) -> Response
+        def update_aliases: (body: stringOrSymbolHash) -> Response
         def delete: (index: ::Array[::String], ?ignore_unavailable: bool, ?allow_no_indices: bool) -> Response
       end
     end

--- a/elasticgraph-elasticsearch/spec/unit/elastic_graph/elasticsearch/client_spec.rb
+++ b/elasticgraph-elasticsearch/spec/unit/elastic_graph/elasticsearch/client_spec.rb
@@ -56,6 +56,8 @@ module ElasticGraph
               stub.put("/my_index/_mapping") { |env| response_for(body, env) }
             in :put_index_settings_my_index
               stub.put("/my_index/_settings") { |env| response_for(body, env) }
+            in :update_index_aliases
+              stub.post("/_aliases") { |env| response_for(body, env) }
             in :delete_indices_ind1_ind2
               stub.delete("/ind1,ind2?allow_no_indices=true&ignore_unavailable=true") { |env| response_for(body, env) }
 

--- a/elasticgraph-opensearch/lib/elastic_graph/opensearch/client.rb
+++ b/elasticgraph-opensearch/lib/elastic_graph/opensearch/client.rb
@@ -175,6 +175,10 @@ module ElasticGraph
         transform_errors { |c| c.indices.put_settings(index: index, body: body) }
       end
 
+      def update_index_aliases(body:)
+        transform_errors { |c| c.indices.update_aliases(body: body) }
+      end
+
       def delete_indices(*index_names)
         # `allow_no_indices: true` is needed when we attempt to delete a non-existing index to avoid errors. For rollover indices,
         # when we delete the actual indices, we will always perform a wildcard deletion, and `allow_no_indices: true` is needed.

--- a/elasticgraph-opensearch/sig/opensearch.rbs
+++ b/elasticgraph-opensearch/sig/opensearch.rbs
@@ -25,6 +25,7 @@ module OpenSearch
         def create: (index: ::String, body: stringOrSymbolHash) -> void
         def put_mapping: (index: ::String, body: stringOrSymbolHash) -> void
         def put_settings: (index: ::String, body: stringOrSymbolHash) -> void
+        def update_aliases: (body: stringOrSymbolHash) -> void
         def delete: (index: ::Array[::String], ?ignore_unavailable: bool, ?allow_no_indices: bool) -> void
       end
     end

--- a/elasticgraph-opensearch/spec/unit/elastic_graph/opensearch/client_spec.rb
+++ b/elasticgraph-opensearch/spec/unit/elastic_graph/opensearch/client_spec.rb
@@ -79,6 +79,8 @@ module ElasticGraph
               stub.put("/my_index/_mappings") { |env| response_for(body, env) }
             in :put_index_settings_my_index
               stub.put("/my_index/_settings") { |env| response_for(body, env) }
+            in :update_index_aliases
+              stub.post("/_aliases") { |env| response_for(body, env) }
             in :delete_indices_ind1_ind2
               stub.delete("/ind1,ind2?allow_no_indices=true&ignore_unavailable=true") { |env| response_for(body, env) }
 

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/index.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/index.rb
@@ -247,7 +247,13 @@ module ElasticGraph
         # configuration.
         #
         # @note ElasticGraph does nothing with the customized configuration besides passing it through to the datastore,
-        #   and makes no claims about the safety or correctness of any customization. Use with care!
+        #   and makes no claims about the safety or correctness of any customization. A customization the datastore
+        #   rejects surfaces as an error when `elasticgraph-admin` configures the cluster--after earlier configuration
+        #   steps have been applied--rather than when the schema is defined. Also note that {#rollover} affects what the
+        #   datastore accepts: the customization goes into the index template body, which the datastore validates
+        #   differently than a concrete index, so a customization that works without {#rollover} may be rejected with it.
+        #   **When you add or change a customization, apply it locally against the same datastore version you run in
+        #   production--via `bundle exec rake boot_locally`--to confirm it works as intended.**
         #
         # @yield [Hash<String, Object>] the datastore configuration of the index, to be mutated by the block
         # @return [void]

--- a/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/index.rb
+++ b/elasticgraph-schema_definition/lib/elastic_graph/schema_definition/indexing/index.rb
@@ -42,6 +42,8 @@ module ElasticGraph
       #   @return [Hash<String, Array<SchemaArtifacts::RuntimeMetadata::ListPathSegment, SchemaArtifacts::RuntimeMetadata::ObjectPathSegment>>]
       #     map from a qualified (leaf) relationship to the path segments the painless script uses to navigate from this
       #     root index's documents down to the nested elements that receive `sourced_from` data
+      # @!attribute [r] config_customizations
+      #   @return [Array<Proc>] blocks registered via {#customize_config}, applied to the datastore configuration of this index
       class Index < Struct.new(
         :name,
         :default_sort_pairs,
@@ -51,7 +53,8 @@ module ElasticGraph
         :routing_field_path,
         :rollover_config,
         :has_had_multiple_sources_flag,
-        :sourced_from_nested_paths_by_qualified_relationship
+        :sourced_from_nested_paths_by_qualified_relationship,
+        :config_customizations
       )
         include Mixins::HasReadableToSAndInspect.new { |i| i.name }
 
@@ -69,7 +72,7 @@ module ElasticGraph
 
           settings = DEFAULT_SETTINGS.merge(Support::HashUtil.flatten_and_stringify_keys(settings, prefix: "index"))
 
-          super(name, [], settings, schema_def_state, indexed_type, nil, nil, false, {})
+          super(name, [], settings, schema_def_state, indexed_type, nil, nil, false, {}, [])
 
           schema_def_state.after_user_definition_complete do
             # `id` is the field Elasticsearch/OpenSearch use for routing by default:
@@ -233,6 +236,54 @@ module ElasticGraph
           self.has_had_multiple_sources_flag = true
         end
 
+        # Customizes the datastore configuration of this index (or of the index template, when {#rollover} is used) in ways
+        # ElasticGraph doesn't natively model. The customization block is yielded the index configuration--a hash containing
+        # `aliases`, `mappings`, and `settings`--and is expected to mutate it (the return value is ignored). The customized
+        # configuration is included in the `datastore_config.yaml` schema artifact, and `elasticgraph-admin` applies it to
+        # the datastore just like the rest of the index configuration.
+        #
+        # When {#rollover} is used, the customization applies to the index template body, so every concrete index created
+        # from the template (including rollover indices the datastore auto-creates at indexing time) gets the customized
+        # configuration.
+        #
+        # @note ElasticGraph does nothing with the customized configuration besides passing it through to the datastore,
+        #   and makes no claims about the safety or correctness of any customization. Use with care!
+        #
+        # @yield [Hash<String, Object>] the datastore configuration of the index, to be mutated by the block
+        # @return [void]
+        #
+        # @example Define index aliases and a field alias on a `campaigns` index
+        #   ElasticGraph.define_schema do |schema|
+        #     schema.object_type "Campaign" do |t|
+        #       t.field "id", "ID!"
+        #       t.field "status", "String"
+        #       t.field "createdAt", "DateTime"
+        #
+        #       t.index "campaigns" do |i|
+        #         i.rollover :monthly, "createdAt"
+        #
+        #         i.customize_config do |config|
+        #           # Index aliases, so clients querying the datastore directly can use a stable name
+        #           # (`campaigns_read` fans out across all the rollover indices).
+        #           config["aliases"] = {
+        #             "campaigns_read" => {},
+        #             "campaigns_active" => {"filter" => {"term" => {"status" => "ACTIVE"}}}
+        #           }
+        #
+        #           # A field alias, so direct datastore queries can reference `created` as an alias of `createdAt`.
+        #           config["mappings"]["properties"]["created"] = {"type" => "alias", "path" => "createdAt"}
+        #         end
+        #       end
+        #     end
+        #   end
+        def customize_config(&customization_block)
+          if customization_block.nil?
+            raise Errors::SchemaError, "`customize_config` was called on the `#{name}` index without a block, but a block is required."
+          end
+
+          config_customizations << customization_block
+        end
+
         # @see #route_with
         # @return [Boolean] whether or not this index uses custom shard routing
         def uses_custom_routing?
@@ -241,22 +292,22 @@ module ElasticGraph
 
         # @return [Hash<String, Object>] datastore configuration for this index for when it does not use rollover
         def to_index_config
-          {
+          customized_config({
             "aliases" => {},
             "mappings" => mappings,
             "settings" => settings
-          }.compact
+          }.compact)
         end
 
         # @return [Hash<String, Object>] datastore configuration for the index template that will be defined if rollover is used
         def to_index_template_config
           {
             "index_patterns" => ["#{name}#{ROLLOVER_INDEX_INFIX_MARKER}*"],
-            "template" => {
+            "template" => customized_config({
               "aliases" => {},
               "mappings" => mappings,
               "settings" => settings
-            }
+            })
           }
         end
 
@@ -295,6 +346,16 @@ module ElasticGraph
           # 10K is the default: https://www.elastic.co/guide/en/elasticsearch/reference/8.17/index-modules.html#dynamic-index-settings
           "index.max_result_window" => 10000
         }
+
+        def customized_config(config)
+          return config if config_customizations.empty?
+
+          # Yield a defensive deep copy so that mutations made by customization blocks can't corrupt
+          # ElasticGraph's internal data structures (parts of `mappings` are shared across indices).
+          config = ::Marshal.load(::Marshal.dump(config))
+          config_customizations.each { |customization| customization.call(config) }
+          config
+        end
 
         def mappings
           field_mappings = indexed_type

--- a/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/index.rbs
+++ b/elasticgraph-schema_definition/sig/elastic_graph/schema_definition/indexing/index.rbs
@@ -10,9 +10,11 @@ module ElasticGraph
         attr_reader indexed_type: indexableType
         attr_reader sourced_from_nested_paths_by_qualified_relationship: ::Hash[::String, ::Array[SchemaArtifacts::RuntimeMetadata::sourcedFromNestedPathSegment]]
         attr_reader schema_def_state: State
+        attr_reader config_customizations: ::Array[^(::Hash[::String, untyped]) -> void]
 
         def rollover: (::Symbol, ::String) -> void
         def route_with: (::String) -> void
+        def customize_config: () { (::Hash[::String, untyped]) -> void } -> void
         def uses_custom_routing?: () -> bool
         def to_index_config: () -> ::Hash[::String, untyped]
         def to_index_template_config: () -> ::Hash[::String, untyped]
@@ -21,6 +23,7 @@ module ElasticGraph
 
         private
 
+        def customized_config: (::Hash[::String, untyped]) -> ::Hash[::String, untyped]
         def public_field_path: (::String, explanation: ::String) -> SchemaElements::FieldPath
         def date_and_datetime_types: () -> ::Array[::String]
       end

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/customize_config_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/customize_config_spec.rb
@@ -130,7 +130,7 @@ module ElasticGraph
         expect(campaigns.dig("settings", "index.number_of_shards")).to eq(17)
         expect(campaigns.dig("settings", "index.sort.field")).to eq(["created_at", "id"])
 
-        expect(index&.settings).to include(
+        expect(index.settings).to include(
           "index.number_of_shards" => 1,
           "index.sort.field" => ["created_at"]
         )

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/customize_config_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/customize_config_spec.rb
@@ -104,26 +104,37 @@ module ElasticGraph
         expect(campaigns.dig("mappings", "properties", "created")).to eq({"type" => "alias", "path" => "created_at"})
       end
 
-      it "yields a defensive copy so that customization mutations cannot corrupt the config of other indices" do
-        campaigns, promotions = index_configs_for "campaigns", "promotions" do |s|
+      it "yields a defensive deep copy so that customization mutations cannot corrupt the index's own internal state" do
+        index = nil # : Indexing::Index?
+        sort_fields = ["created_at"]
+
+        campaigns = index_configs_for "campaigns" do |s|
           s.object_type "Campaign" do |t|
             t.field "id", "ID!"
+            t.field "created_at", "DateTime"
 
-            t.index "campaigns" do |i|
+            t.index "campaigns", sort: {field: sort_fields, order: ["asc"]} do |i|
+              index = i
+
               i.customize_config do |config|
-                config["mappings"]["properties"]["id"]["type"] = "text"
+                # Replacing a value one level down requires the copy to not be a bare `dup` of the config hash...
+                config["settings"]["index.number_of_shards"] = 17
+                # ...while mutating this array in place requires the copy to be recursive, since the array is the
+                # very one the caller passed to `sort:` above.
+                config["settings"]["index.sort.field"] << "id"
               end
             end
           end
+        end.first
 
-          s.object_type "Promotion" do |t|
-            t.field "id", "ID!"
-            t.index "promotions"
-          end
-        end
+        expect(campaigns.dig("settings", "index.number_of_shards")).to eq(17)
+        expect(campaigns.dig("settings", "index.sort.field")).to eq(["created_at", "id"])
 
-        expect(campaigns.dig("mappings", "properties", "id", "type")).to eq("text")
-        expect(promotions.dig("mappings", "properties", "id", "type")).to eq("keyword")
+        expect(index&.settings).to include(
+          "index.number_of_shards" => 1,
+          "index.sort.field" => ["created_at"]
+        )
+        expect(sort_fields).to eq(["created_at"])
       end
 
       it "raises a clear error when `customize_config` is called without a block" do

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/customize_config_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/customize_config_spec.rb
@@ -1,0 +1,144 @@
+# Copyright 2024 - 2026 Block, Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require_relative "index_definition_spec_support"
+
+module ElasticGraph
+  module SchemaDefinition
+    RSpec.describe "Datastore config -- customize_config" do
+      include_context "IndexDefinitionSpecSupport"
+
+      it "applies customizations to the config of an index" do
+        campaigns = index_configs_for "campaigns" do |s|
+          s.object_type "Campaign" do |t|
+            t.field "id", "ID!"
+            t.field "status", "String"
+
+            t.index "campaigns" do |i|
+              i.customize_config do |config|
+                config["aliases"] = {
+                  "campaigns_read" => {},
+                  "campaigns_active" => {"filter" => {"term" => {"status" => "ACTIVE"}}}
+                }
+              end
+            end
+          end
+        end.first
+
+        expect(campaigns).to match(
+          "aliases" => {
+            "campaigns_read" => {},
+            "campaigns_active" => {"filter" => {"term" => {"status" => "ACTIVE"}}}
+          },
+          "mappings" => an_instance_of(::Hash),
+          "settings" => an_instance_of(::Hash)
+        )
+      end
+
+      it "applies customizations to the template body of a rollover index" do
+        campaigns = index_template_configs_for "campaigns" do |s|
+          s.object_type "Campaign" do |t|
+            t.field "id", "ID!"
+            t.field "created_at", "DateTime"
+
+            t.index "campaigns" do |i|
+              i.rollover :monthly, "created_at"
+
+              i.customize_config do |config|
+                config["aliases"] = {"campaigns_read" => {}}
+              end
+            end
+          end
+        end.first
+
+        expect(campaigns).to match(
+          "index_patterns" => ["campaigns_rollover__*"],
+          "template" => {
+            "aliases" => {"campaigns_read" => {}},
+            "mappings" => an_instance_of(::Hash),
+            "settings" => an_instance_of(::Hash)
+          }
+        )
+      end
+
+      it "applies multiple customization blocks in the order they were registered, ignoring their return values" do
+        campaigns = index_configs_for "campaigns" do |s|
+          s.object_type "Campaign" do |t|
+            t.field "id", "ID!"
+
+            t.index "campaigns" do |i|
+              i.customize_config do |config|
+                config["aliases"] = {"campaigns_alias1" => {}}
+                :ignored_return_value
+              end
+
+              i.customize_config do |config|
+                config["aliases"] = config["aliases"].merge("campaigns_alias2" => {})
+              end
+            end
+          end
+        end.first
+
+        expect(campaigns.fetch("aliases")).to eq({"campaigns_alias1" => {}, "campaigns_alias2" => {}})
+      end
+
+      it "supports nested customizations such as field aliases" do
+        campaigns = index_configs_for "campaigns" do |s|
+          s.object_type "Campaign" do |t|
+            t.field "id", "ID!"
+            t.field "created_at", "DateTime"
+
+            t.index "campaigns" do |i|
+              i.customize_config do |config|
+                config["mappings"]["properties"]["created"] = {"type" => "alias", "path" => "created_at"}
+              end
+            end
+          end
+        end.first
+
+        expect(campaigns.dig("mappings", "properties", "created")).to eq({"type" => "alias", "path" => "created_at"})
+      end
+
+      it "yields a defensive copy so that customization mutations cannot corrupt the config of other indices" do
+        campaigns, promotions = index_configs_for "campaigns", "promotions" do |s|
+          s.object_type "Campaign" do |t|
+            t.field "id", "ID!"
+
+            t.index "campaigns" do |i|
+              i.customize_config do |config|
+                config["mappings"]["properties"]["id"]["type"] = "text"
+              end
+            end
+          end
+
+          s.object_type "Promotion" do |t|
+            t.field "id", "ID!"
+            t.index "promotions"
+          end
+        end
+
+        expect(campaigns.dig("mappings", "properties", "id", "type")).to eq("text")
+        expect(promotions.dig("mappings", "properties", "id", "type")).to eq("keyword")
+      end
+
+      it "raises a clear error when `customize_config` is called without a block" do
+        expect {
+          index_configs_for "campaigns" do |s|
+            s.object_type "Campaign" do |t|
+              t.field "id", "ID!"
+
+              t.index "campaigns" do |i|
+                i.customize_config
+              end
+            end
+          end
+        }.to raise_error(Errors::SchemaError, a_string_including("customize_config", "campaigns", "block"))
+      end
+    end
+  end
+end

--- a/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/customize_config_spec.rb
+++ b/elasticgraph-schema_definition/spec/unit/elastic_graph/schema_definition/datastore_config/customize_config_spec.rb
@@ -105,7 +105,7 @@ module ElasticGraph
       end
 
       it "yields a defensive deep copy so that customization mutations cannot corrupt the index's own internal state" do
-        index = nil # : Indexing::Index?
+        index = nil
         sort_fields = ["created_at"]
 
         campaigns = index_configs_for "campaigns" do |s|

--- a/spec_support/lib/elastic_graph/spec_support/datastore_client_shared_examples.rb
+++ b/spec_support/lib/elastic_graph/spec_support/datastore_client_shared_examples.rb
@@ -164,6 +164,12 @@ module ElasticGraph
         expect(client.put_index_settings(index: "my_index", body: {"settings" => "config"})).to eq("ok")
       end
 
+      it "supports `update_index_aliases`" do
+        client = build_client({update_index_aliases: "ok"})
+
+        expect(client.update_index_aliases(body: {"actions" => [{"add" => {"index" => "my_index", "alias" => "my_alias"}}]})).to eq("ok")
+      end
+
       it "supports `delete_indices`" do
         client = build_client({delete_indices_ind1_ind2: "ok"})
 

--- a/spec_support/lib/elastic_graph/spec_support/parallel_spec_runner/datastore_client_adapter.rb
+++ b/spec_support/lib/elastic_graph/spec_support/parallel_spec_runner/datastore_client_adapter.rb
@@ -83,6 +83,16 @@ module ElasticGraph
         super(index: index_expression_for_test_env(index), body: body)
       end
 
+      def update_index_aliases(body:)
+        actions = body.fetch("actions").map do |action|
+          action.transform_values do |action_body|
+            action_body.merge("index" => index_expression_for_test_env(action_body.fetch("index")))
+          end
+        end
+
+        super(body: body.merge("actions" => actions))
+      end
+
       def delete_indices(*index_names)
         super(*index_names.map { |index_name| index_expression_for_test_env(index_name) })
       end


### PR DESCRIPTION
Implements the `i.customize_config` proposal from #1364 (https://github.com/block/elasticgraph/discussions/1364#discussioncomment-18110378).

## Schema definition API

```ruby
schema.object_type "Campaign" do |t|
  # ...
  t.index "campaigns" do |i|
    i.rollover :monthly, "createdAt"

    i.customize_config do |config|
      # Index aliases
      config["aliases"] = {
        "campaigns_read" => {},
        "campaigns_active" => {"filter" => {"term" => {"status" => "ACTIVE"}}}
      }

      # Field alias: lets direct datastore queries reference `created` as an alias of `createdAt`
      config["mappings"]["properties"]["created"] = {"type" => "alias", "path" => "createdAt"}
    end
  end
end
```

Semantics match the proposal:

- The block mutates the yielded config hash; the return value is ignored. ElasticGraph yields a defensive deep copy so mutations can't corrupt its internal structures (parts of `mappings` are shared across indices).
- The yielded hash is "the config every concrete index for this index definition gets" — the template body for rollover index defs, the index config otherwise.
- The result is baked into `datastore_config.yaml`, so it's diffable in PRs and `elasticgraph-admin` treats it identically to built-in config.
- Multiple `customize_config` blocks compose in registration order.
- Nested customizations — like the field alias above — work for both indices and index templates, since the block mutates the full config in place. On the admin side they ride the existing mappings reconciliation: included at index/template creation, added to already-existing indices (including pre-existing rollover indices) via the mapping update path, and idempotent on reconvergence.
- The YARD docs carry the "ElasticGraph passes this through and makes no claims about safety/correctness — use with care!" caveat.

## Admin changes so customizations are fully respected

The three changes outlined in the proposal:

1. **Absent means "leave alone".** On template updates, desired aliases are merged over the template's current ones instead of replacing them — the same policy admin already applies to no-longer-desired mapping fields. This fixes the out-of-band alias clobbering regardless of whether anyone uses the new API.
2. **Template update trigger.** `ForIndexTemplate#configure!` now diffs the full desired vs. current template body (not just mappings/settings), so a customization-only change still reaches the datastore. To keep this comparison stable, `IndexConfigNormalizer` now treats an empty `aliases` hash the same as an absent one (the datastore doesn't consistently echo the key back).
3. **Reconciliation of existing concrete indices.** `ForIndex#configure!` gained an `_aliases` step (after mappings, since alias filters can reference newly-added fields): it adds/updates desired aliases and never removes undeclared ones. A newly declared alias now lands on pre-existing rollover indices rather than only on ones created afterward.

Both datastore clients gained an `update_index_aliases` method (plus dry-run decorator no-op, RBS interface entry, and parallel-spec-runner support).

## Testing

- Unit specs for the schema definition API (application to index config vs. template body, block composition, defensive copy, nested customizations, no-block error).
- Shared admin integration specs (run for both `ForIndex` and `ForIndexTemplate`): create-with-aliases + idempotent reconvergence, adding/updating aliases on existing indices and templates, and leaving undeclared (out-of-band) aliases alone. A template-specific spec verifies aliases are stamped onto concrete rollover indices at creation and reconciled onto pre-existing ones.
- A shared integration spec covers field aliases end-to-end for both configurators: declared via `customize_config`, applied at creation, reconciled onto an already-existing index/template via the mapping update path, and idempotent on re-run.
- `datastore_config.yaml` emission is unchanged for schemas that don't use the new API (repo artifacts show no diff after `schema_artifacts:dump`).
- Full suite green (5315 examples, 0 failures), `script/type_check` clean, 100% doc coverage maintained, `site:doctest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
